### PR TITLE
feat(react-native): add `status` to fallbackComponent in wrap function

### DIFF
--- a/docs/docs/guide/hot-updater/wrap.mdx
+++ b/docs/docs/guide/hot-updater/wrap.mdx
@@ -40,7 +40,7 @@ The `fallbackComponent` receives two props: `progress` and `shouldForceUpdate`.
 
 - **progress**: This prop indicates the download progress of the new bundle. You can use this to display a progress bar or percentage to the user.
   
-- **status**: This prop indicates the current status of the update process. It can be one of the following: `"IDLE"`, `"CHECK_FOR_UPDATE"`, `"UPDATING"`, or `"UPDATE_PROCESS_COMPLETED"`. You can use this to display different messages or UI elements based on the update status.
+- **status**: This prop indicates the current status of the update process. It can be one of the following: `CHECK_FOR_UPDATE`, `UPDATING`. You can use this to display different messages or UI elements based on the update status.
 
 By using these props, you can customize the user interface to provide feedback during the update process, ensuring a smooth transition to the updated version of your app.
 
@@ -58,7 +58,7 @@ function App() {
 
 export default HotUpdater.wrap({ // [!code hl:22]
   source: "<your-update-server-url>",
-  fallbackComponent: ({ progress = 0, status }) => (
+  fallbackComponent: ({ progress, status }) => (
       <View
         style={{
           flex: 1,
@@ -69,8 +69,10 @@ export default HotUpdater.wrap({ // [!code hl:22]
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}
       >
+        {/* You can put a splash image here. */}
+
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-          {status === "UPDATING" ? "Updating..." : "Preparing Update..."}
+          {status === "UPDATING" ? "Updating..." : "Checking for Update..."}
         </Text>
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
           {Math.round(progress * 100)}%

--- a/docs/docs/guide/hot-updater/wrap.mdx
+++ b/docs/docs/guide/hot-updater/wrap.mdx
@@ -36,6 +36,15 @@ This allows you to show the progress while downloading the new bundle and safely
 
 If you don't define a `fallbackComponent`, the bundle will be downloaded without blocking the screen.
 
+The `fallbackComponent` receives two props: `progress` and `shouldForceUpdate`.
+
+- **progress**: This prop indicates the download progress of the new bundle. You can use this to display a progress bar or percentage to the user.
+  
+- **shouldForceUpdate**: This boolean prop indicates whether a force update is required. If `true`, it means the update is critical, and you should ensure the user cannot bypass the update process.
+
+- **status**: This prop indicates the current status of the update process. It can be one of the following: `"IDLE"`, `"CHECK_FOR_UPDATE"`, `"UPDATING"`, or `"UPDATE_PROCESS_COMPLETED"`. You can use this to display different messages or UI elements based on the update status.
+
+By using these props, you can customize the user interface to provide feedback during the update process, ensuring a smooth transition to the updated version of your app.
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
@@ -51,25 +60,28 @@ function App() {
 
 export default HotUpdater.wrap({ // [!code hl:22]
   source: "<your-update-server-url>",
-  fallbackComponent: ({ progress = 0 }) => (
-    <View
-      style={{
-        flex: 1,
-        padding: 20,
-        borderRadius: 10,
-        justifyContent: "center",
-        alignItems: "center",
-        backgroundColor: "rgba(0, 0, 0, 0.5)",
-      }}
-    >
-      <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-        Updating...
-      </Text>
-      <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-        {Math.round(progress * 100)}%
-      </Text>
-    </View>
-  ),
+  fallbackComponent: ({ progress = 0, shouldForceUpdate }) => {
+    if(!shouldForceUpdate) return null;
+    return (
+      <View
+        style={{
+          flex: 1,
+          padding: 20,
+          borderRadius: 10,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+        }}
+      >
+        <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
+          {status === "UPDATING" ? "Updating..." : "Preparing Update..."}
+        </Text>
+        <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
+          {Math.round(progress * 100)}%
+        </Text>
+      </View>
+    );
+  },
 })(App);
 ```
 

--- a/docs/docs/guide/hot-updater/wrap.mdx
+++ b/docs/docs/guide/hot-updater/wrap.mdx
@@ -40,8 +40,6 @@ The `fallbackComponent` receives two props: `progress` and `shouldForceUpdate`.
 
 - **progress**: This prop indicates the download progress of the new bundle. You can use this to display a progress bar or percentage to the user.
   
-- **shouldForceUpdate**: This boolean prop indicates whether a force update is required. If `true`, it means the update is critical, and you should ensure the user cannot bypass the update process.
-
 - **status**: This prop indicates the current status of the update process. It can be one of the following: `"IDLE"`, `"CHECK_FOR_UPDATE"`, `"UPDATING"`, or `"UPDATE_PROCESS_COMPLETED"`. You can use this to display different messages or UI elements based on the update status.
 
 By using these props, you can customize the user interface to provide feedback during the update process, ensuring a smooth transition to the updated version of your app.
@@ -60,9 +58,7 @@ function App() {
 
 export default HotUpdater.wrap({ // [!code hl:22]
   source: "<your-update-server-url>",
-  fallbackComponent: ({ progress = 0, shouldForceUpdate }) => {
-    if(!shouldForceUpdate) return null;
-    return (
+  fallbackComponent: ({ progress = 0, status }) => (
       <View
         style={{
           flex: 1,
@@ -81,8 +77,7 @@ export default HotUpdater.wrap({ // [!code hl:22]
         </Text>
       </View>
     );
-  },
-})(App);
+  })(App);
 ```
 
 ## `reloadOnForceUpdate`

--- a/examples/v0.71.19/App.tsx
+++ b/examples/v0.71.19/App.tsx
@@ -85,7 +85,7 @@ function App(): React.JSX.Element {
 
 export default HotUpdater.wrap({
   source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
-  fallbackComponent: ({ progress = 0 }) => (
+  fallbackComponent: ({ progress, status }) => (
     <Modal transparent visible={true}>
       <View
         style={{
@@ -97,8 +97,10 @@ export default HotUpdater.wrap({
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}
       >
+        {/* You can put a splash image here. */}
+
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-          Updating...
+          {status === "UPDATING" ? "Updating..." : "Checking for Update..."}
         </Text>
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
           {Math.round(progress * 100)}%

--- a/examples/v0.71.19/App.tsx
+++ b/examples/v0.71.19/App.tsx
@@ -73,7 +73,7 @@ function App(): React.JSX.Element {
         title="HotUpdater.runUpdateProcess()"
         onPress={() =>
           HotUpdater.runUpdateProcess({
-            source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+            source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
           }).then((status) => {
             console.log("Update process completed", JSON.stringify(status));
           })
@@ -84,7 +84,7 @@ function App(): React.JSX.Element {
 }
 
 export default HotUpdater.wrap({
-  source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+  source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
   fallbackComponent: ({ progress = 0 }) => (
     <Modal transparent visible={true}>
       <View

--- a/examples/v0.74.1/App.tsx
+++ b/examples/v0.74.1/App.tsx
@@ -85,7 +85,7 @@ function App(): React.JSX.Element {
 
 export default HotUpdater.wrap({
   source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
-  fallbackComponent: ({ progress = 0 }) => (
+  fallbackComponent: ({ progress, status }) => (
     <Modal transparent visible={true}>
       <View
         style={{
@@ -97,8 +97,10 @@ export default HotUpdater.wrap({
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}
       >
+        {/* You can put a splash image here. */}
+
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-          Updating...
+          {status === "UPDATING" ? "Updating..." : "Checking for Update..."}
         </Text>
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
           {Math.round(progress * 100)}%

--- a/examples/v0.74.1/App.tsx
+++ b/examples/v0.74.1/App.tsx
@@ -73,7 +73,7 @@ function App(): React.JSX.Element {
         title="HotUpdater.runUpdateProcess()"
         onPress={() =>
           HotUpdater.runUpdateProcess({
-            source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+            source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
           }).then((status) => {
             console.log("Update process completed", JSON.stringify(status));
           })
@@ -84,7 +84,7 @@ function App(): React.JSX.Element {
 }
 
 export default HotUpdater.wrap({
-  source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+  source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
   fallbackComponent: ({ progress = 0 }) => (
     <Modal transparent visible={true}>
       <View

--- a/examples/v0.76.1-new-arch/App.tsx
+++ b/examples/v0.76.1-new-arch/App.tsx
@@ -85,7 +85,7 @@ function App(): React.JSX.Element {
 
 export default HotUpdater.wrap({
   source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
-  fallbackComponent: ({ progress = 0 }) => (
+  fallbackComponent: ({ progress, status }) => (
     <Modal transparent visible={true}>
       <View
         style={{
@@ -97,8 +97,10 @@ export default HotUpdater.wrap({
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}
       >
+        {/* You can put a splash image here. */}
+
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-          Updating...
+          {status === "UPDATING" ? "Updating..." : "Checking for Update..."}
         </Text>
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
           {Math.round(progress * 100)}%

--- a/examples/v0.76.1-new-arch/App.tsx
+++ b/examples/v0.76.1-new-arch/App.tsx
@@ -73,7 +73,7 @@ function App(): React.JSX.Element {
         title="HotUpdater.runUpdateProcess()"
         onPress={() =>
           HotUpdater.runUpdateProcess({
-            source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+            source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
           }).then((status) => {
             console.log("Update process completed", JSON.stringify(status));
           })
@@ -84,7 +84,7 @@ function App(): React.JSX.Element {
 }
 
 export default HotUpdater.wrap({
-  source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+  source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
   fallbackComponent: ({ progress = 0 }) => (
     <Modal transparent visible={true}>
       <View

--- a/examples/v0.77.0/App.tsx
+++ b/examples/v0.77.0/App.tsx
@@ -85,7 +85,7 @@ function App(): React.JSX.Element {
 
 export default HotUpdater.wrap({
   source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
-  fallbackComponent: ({ progress = 0 }) => (
+  fallbackComponent: ({ progress, status }) => (
     <Modal transparent visible={true}>
       <View
         style={{
@@ -97,8 +97,10 @@ export default HotUpdater.wrap({
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}
       >
+        {/* You can put a splash image here. */}
+
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
-          Updating...
+          {status === "UPDATING" ? "Updating..." : "Checking for Update..."}
         </Text>
         <Text style={{ color: "white", fontSize: 20, fontWeight: "bold" }}>
           {Math.round(progress * 100)}%

--- a/examples/v0.77.0/App.tsx
+++ b/examples/v0.77.0/App.tsx
@@ -73,7 +73,7 @@ function App(): React.JSX.Element {
         title="HotUpdater.runUpdateProcess()"
         onPress={() =>
           HotUpdater.runUpdateProcess({
-            source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+            source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
           }).then((status) => {
             console.log("Update process completed", JSON.stringify(status));
           })
@@ -84,7 +84,7 @@ function App(): React.JSX.Element {
 }
 
 export default HotUpdater.wrap({
-  source: `https://${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
+  source: `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
   fallbackComponent: ({ progress = 0 }) => (
     <Modal transparent visible={true}>
       <View

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -7,7 +7,11 @@ import { reload, updateBundle } from "./native";
 import type { RunUpdateProcessResponse } from "./runUpdateProcess";
 import { useHotUpdaterStore } from "./store";
 
-type StatusType = "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED";
+type StatusType =
+  | "IDLE"
+  | "CHECK_FOR_UPDATE"
+  | "UPDATING"
+  | "UPDATE_PROCESS_COMPLETED";
 
 export interface HotUpdaterConfig extends CheckForUpdateConfig {
   /**
@@ -31,12 +35,10 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    *
    * If not defined, the bundle will download in the background without blocking the screen.
    */
-  fallbackComponent?: React.FC<
-    { 
-      status: StatusType;
-      progress: number;
-    }
-  >;
+  fallbackComponent?: React.FC<{
+    status: StatusType;
+    progress: number;
+  }>;
   onError?: (error: HotUpdaterError) => void;
   onProgress?: (progress: number) => void;
   /**
@@ -61,7 +63,7 @@ export function wrap<P>(
   return (WrappedComponent) => {
     const HotUpdaterHOC: React.FC<P> = () => {
       const { progress } = useHotUpdaterStore();
-      const [status, setStatus] = useState<StatusType>("IDLE"); 
+      const [status, setStatus] = useState<StatusType>("IDLE");
 
       const initHotUpdater = useEventCallback(async () => {
         try {

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -5,10 +5,7 @@ import { HotUpdaterError } from "./error";
 import { useEventCallback } from "./hooks/useEventCallback";
 import { reload, updateBundle } from "./native";
 import type { RunUpdateProcessResponse } from "./runUpdateProcess";
-import { useHotUpdaterStore } from "./store";
-
-
-type StatusType = "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED";
+import { type HotUpdaterState, useHotUpdaterStore } from "./store";
 
 export interface HotUpdaterConfig extends CheckForUpdateConfig {
   /**
@@ -33,10 +30,8 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    * If not defined, the bundle will download in the background without blocking the screen.
    */
   fallbackComponent?: React.FC<
-    {
-      progress: number;
+    Pick<HotUpdaterState, "progress"> & {
       shouldForceUpdate: boolean;
-      status: StatusType;
     }
   >;
   onError?: (error: HotUpdaterError) => void;
@@ -63,7 +58,9 @@ export function wrap<P>(
   return (WrappedComponent) => {
     const HotUpdaterHOC: React.FC<P> = () => {
       const { progress } = useHotUpdaterStore();
-      const [status, setStatus] = useState<StatusType>("IDLE"); 
+      const [status, setStatus] = useState<
+        "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED"
+      >("IDLE");
       const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
 
       const initHotUpdater = useEventCallback(async () => {

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -29,7 +29,11 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    *
    * If not defined, the bundle will download in the background without blocking the screen.
    */
-  fallbackComponent?: React.FC<Pick<HotUpdaterState, "progress">>;
+  fallbackComponent?: React.FC<
+    Pick<HotUpdaterState, "progress"> & {
+      shouldForceUpdate: boolean;
+    }
+  >;
   onError?: (error: HotUpdaterError) => void;
   onProgress?: (progress: number) => void;
   /**
@@ -57,6 +61,7 @@ export function wrap<P>(
       const [status, setStatus] = useState<
         "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED"
       >("IDLE");
+      const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
 
       const initHotUpdater = useEventCallback(async () => {
         try {
@@ -72,6 +77,8 @@ export function wrap<P>(
             setStatus("UPDATE_PROCESS_COMPLETED");
             return;
           }
+
+          setShouldForceUpdate(updateInfo.shouldForceUpdate);
 
           setStatus("UPDATING");
 
@@ -117,7 +124,7 @@ export function wrap<P>(
         status !== "UPDATE_PROCESS_COMPLETED"
       ) {
         const Fallback = restConfig.fallbackComponent;
-        return <Fallback progress={progress} />;
+        return <Fallback progress={progress} shouldForceUpdate={shouldForceUpdate} />;
       }
 
       return <WrappedComponent />;

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -5,7 +5,10 @@ import { HotUpdaterError } from "./error";
 import { useEventCallback } from "./hooks/useEventCallback";
 import { reload, updateBundle } from "./native";
 import type { RunUpdateProcessResponse } from "./runUpdateProcess";
-import { type HotUpdaterState, useHotUpdaterStore } from "./store";
+import { useHotUpdaterStore } from "./store";
+
+
+type StatusType = "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED";
 
 export interface HotUpdaterConfig extends CheckForUpdateConfig {
   /**
@@ -30,8 +33,10 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    * If not defined, the bundle will download in the background without blocking the screen.
    */
   fallbackComponent?: React.FC<
-    Pick<HotUpdaterState, "progress"> & {
+    {
+      progress: number;
       shouldForceUpdate: boolean;
+      status: StatusType;
     }
   >;
   onError?: (error: HotUpdaterError) => void;
@@ -58,9 +63,7 @@ export function wrap<P>(
   return (WrappedComponent) => {
     const HotUpdaterHOC: React.FC<P> = () => {
       const { progress } = useHotUpdaterStore();
-      const [status, setStatus] = useState<
-        "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED"
-      >("IDLE");
+      const [status, setStatus] = useState<StatusType>("IDLE"); 
       const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
 
       const initHotUpdater = useEventCallback(async () => {

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -32,8 +32,7 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    * If not defined, the bundle will download in the background without blocking the screen.
    */
   fallbackComponent?: React.FC<
-    {
-      shouldForceUpdate: boolean;
+    { 
       status: StatusType;
       progress: number;
     }
@@ -62,8 +61,7 @@ export function wrap<P>(
   return (WrappedComponent) => {
     const HotUpdaterHOC: React.FC<P> = () => {
       const { progress } = useHotUpdaterStore();
-      const [status, setStatus] = useState<StatusType>("IDLE");
-      const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
+      const [status, setStatus] = useState<StatusType>("IDLE"); 
 
       const initHotUpdater = useEventCallback(async () => {
         try {
@@ -79,8 +77,6 @@ export function wrap<P>(
             setStatus("UPDATE_PROCESS_COMPLETED");
             return;
           }
-
-          setShouldForceUpdate(updateInfo.shouldForceUpdate);
 
           setStatus("UPDATING");
 
@@ -126,7 +122,7 @@ export function wrap<P>(
         status !== "UPDATE_PROCESS_COMPLETED"
       ) {
         const Fallback = restConfig.fallbackComponent;
-        return <Fallback progress={progress} shouldForceUpdate={shouldForceUpdate} status={status} />;
+        return <Fallback progress={progress} status={status} />;
       }
 
       return <WrappedComponent />;

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -29,8 +29,8 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    *
    * If not defined, the bundle will download in the background without blocking the screen.
    */
-  fallbackComponent?: React.FC<{
-      progress: number;
+  fallbackComponent?: React.FC<
+    Pick<HotUpdaterState, "progress"> & {
       shouldForceUpdate: boolean;
     }
   >;
@@ -61,7 +61,7 @@ export function wrap<P>(
       const [status, setStatus] = useState<
         "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED"
       >("IDLE");
-      let shouldForceUpdate = false;
+      const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
 
       const initHotUpdater = useEventCallback(async () => {
         try {
@@ -78,7 +78,7 @@ export function wrap<P>(
             return;
           }
 
-          shouldForceUpdate = updateInfo.shouldForceUpdate;
+          setShouldForceUpdate(updateInfo.shouldForceUpdate);
 
           setStatus("UPDATING");
 

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -29,8 +29,8 @@ export interface HotUpdaterConfig extends CheckForUpdateConfig {
    *
    * If not defined, the bundle will download in the background without blocking the screen.
    */
-  fallbackComponent?: React.FC<
-    Pick<HotUpdaterState, "progress"> & {
+  fallbackComponent?: React.FC<{
+      progress: number;
       shouldForceUpdate: boolean;
     }
   >;
@@ -61,7 +61,7 @@ export function wrap<P>(
       const [status, setStatus] = useState<
         "IDLE" | "CHECK_FOR_UPDATE" | "UPDATING" | "UPDATE_PROCESS_COMPLETED"
       >("IDLE");
-      const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
+      let shouldForceUpdate = false;
 
       const initHotUpdater = useEventCallback(async () => {
         try {
@@ -78,7 +78,7 @@ export function wrap<P>(
             return;
           }
 
-          setShouldForceUpdate(updateInfo.shouldForceUpdate);
+          shouldForceUpdate = updateInfo.shouldForceUpdate;
 
           setStatus("UPDATING");
 


### PR DESCRIPTION
**Description**
In this PR, I have added status as a prop to the line 
`return <Fallback progress={progress} status={status} />; `
in the wrap.tsx file.

The purpose of adding the status prop is to allow the fallbackComponent to provide more dynamic and informative UI feedback based on the current update process.