### PR TITLE
fix(android): prevent ProGuard from blocking access to `mBundleLoader`

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -65,7 +65,7 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-
+    consumerProguardFiles 'proguard-rules.pro'
   }
 
   buildFeatures {

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /usr/local/Cellar/android-sdk/24.3.3/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Invoked via reflection, when setting js bundle.
+-keepclassmembers class com.facebook.react.ReactInstanceManager {
+    private final ** mBundleLoader;
+}
+
+# Can't find referenced class org.bouncycastle.**
+-dontwarn com.nimbusds.jose.**

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -20,6 +20,3 @@
 -keepclassmembers class com.facebook.react.ReactInstanceManager {
     private final ** mBundleLoader;
 }
-
-# Can't find referenced class org.bouncycastle.**
--dontwarn com.nimbusds.jose.**


### PR DESCRIPTION
No field mBundleLoader in class Lcom/facebook/react/ issue fixed

Closed #105 