### PR TITLE
fix(ios): Update bundleUrl Before Reload for Custom RCTBridges

### DIFF
--- a/packages/react-native/ios/HotUpdater/HotUpdater.mm
+++ b/packages/react-native/ios/HotUpdater/HotUpdater.mm
@@ -252,6 +252,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(reload) {
     NSLog(@"HotUpdater requested a reload");
     dispatch_async(dispatch_get_main_queue(), ^{
+        [super.bridge setValue:[HotUpdater bundleURL] forKey:@"bundleURL"];
         RCTTriggerReloadCommandListeners(@"HotUpdater requested a reload");
     });
 }


### PR DESCRIPTION
# Issue
We have a brownfield app, meaning it originally started as a native app, and React Native was integrated later. As a result:
- The entry point is not React Native.
- We manually create the RCTBridge.
- Our AppDelegate does not conform to RCTAppDelegate.

During a forced OTA update (when reload = true), hot-updater triggers `RCTTriggerReloadCommandListeners` this leads to the following issue:
- `RCTTriggerReloadCommandListeners` reaches the registered bridge, which still points to the old bundle URL.
- App reloads the last set bundleUrl on that bridge, which is not the new one.
- The old bundle is loaded again triggering an update check and another reload.
- This creates an infinite reload loop, despite the new bundle being downloaded correctly.
Note that If reload is not triggered, the new bundle loads correctly on the second run without any issues which makes sense.

This scenario is handled by CodePush by updating the super bridge's bundle URL before triggering the reload. This PR does the same thing. 

I believe this change should have no impact on other typical React Native setups.