### PR TITLE
feat(metro): `enableHermes` options

### DIFF
--- a/examples/v0.71.19/App.tsx
+++ b/examples/v0.71.19/App.tsx
@@ -21,8 +21,11 @@ function App(): React.JSX.Element {
     setBundleId(bundleId);
   }, []);
 
-  // @ts-expect-error
+  // @ts-ignore
   const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+  // @ts-ignore
+  const isHermes = () => !!global.HermesInternal;
 
   const { progress } = useHotUpdaterStore();
   return (
@@ -69,6 +72,16 @@ function App(): React.JSX.Element {
         }}
       >
         isTurboModuleEnabled: {isTurboModuleEnabled ? "true" : "false"}
+      </Text>
+      <Text
+        style={{
+          marginVertical: 20,
+          fontSize: 20,
+          fontWeight: "bold",
+          textAlign: "center",
+        }}
+      >
+        isHermes: {isHermes() ? "true" : "false"}
       </Text>
 
       <Image

--- a/examples/v0.71.19/hot-updater.config.ts
+++ b/examples/v0.71.19/hot-updater.config.ts
@@ -5,7 +5,7 @@ import "dotenv/config";
 
 export default defineConfig({
   build: metro({
-    useHermes: true,
+    enableHermes: true,
   }),
   storage: supabaseStorage({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,

--- a/examples/v0.71.19/hot-updater.config.ts
+++ b/examples/v0.71.19/hot-updater.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from "hot-updater";
 import "dotenv/config";
 
 export default defineConfig({
-  build: metro(),
+  build: metro({
+    useHermes: true,
+  }),
   storage: supabaseStorage({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,

--- a/examples/v0.74.1/App.tsx
+++ b/examples/v0.74.1/App.tsx
@@ -21,8 +21,11 @@ function App(): React.JSX.Element {
     setBundleId(bundleId);
   }, []);
 
-  // @ts-expect-error
+  // @ts-ignore
   const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+  // @ts-ignore
+  const isHermes = () => !!global.HermesInternal;
 
   const { progress } = useHotUpdaterStore();
   return (
@@ -69,6 +72,16 @@ function App(): React.JSX.Element {
         }}
       >
         isTurboModuleEnabled: {isTurboModuleEnabled ? "true" : "false"}
+      </Text>
+      <Text
+        style={{
+          marginVertical: 20,
+          fontSize: 20,
+          fontWeight: "bold",
+          textAlign: "center",
+        }}
+      >
+        isHermes: {isHermes() ? "true" : "false"}
       </Text>
 
       <Image

--- a/examples/v0.74.1/hot-updater.config.ts
+++ b/examples/v0.74.1/hot-updater.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from "hot-updater";
 import "dotenv/config";
 
 export default defineConfig({
-  build: metro(),
+  build: metro({
+    enableHermes: true,
+  }),
   storage: supabaseStorage({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,

--- a/examples/v0.76.1-new-arch/App.tsx
+++ b/examples/v0.76.1-new-arch/App.tsx
@@ -21,8 +21,11 @@ function App(): React.JSX.Element {
     setBundleId(bundleId);
   }, []);
 
-  // @ts-expect-error
+  // @ts-ignore
   const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+  // @ts-ignore
+  const isHermes = () => !!global.HermesInternal;
 
   const { progress } = useHotUpdaterStore();
   return (
@@ -69,6 +72,16 @@ function App(): React.JSX.Element {
         }}
       >
         isTurboModuleEnabled: {isTurboModuleEnabled ? "true" : "false"}
+      </Text>
+      <Text
+        style={{
+          marginVertical: 20,
+          fontSize: 20,
+          fontWeight: "bold",
+          textAlign: "center",
+        }}
+      >
+        isHermes: {isHermes() ? "true" : "false"}
       </Text>
 
       <Image

--- a/examples/v0.76.1-new-arch/hot-updater.config.ts
+++ b/examples/v0.76.1-new-arch/hot-updater.config.ts
@@ -1,11 +1,12 @@
-
 import { metro } from "@hot-updater/metro";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
 import { defineConfig } from "hot-updater";
 import "dotenv/config";
 
 export default defineConfig({
-  build: metro(),
+  build: metro({
+    enableHermes: true,
+  }),
   storage: supabaseStorage({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,

--- a/examples/v0.77.0/App.tsx
+++ b/examples/v0.77.0/App.tsx
@@ -23,6 +23,9 @@ function App(): React.JSX.Element {
 
   const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
+  // @ts-ignore
+  const isHermes = () => !!global.HermesInternal;
+
   const { progress } = useHotUpdaterStore();
   return (
     <SafeAreaView>
@@ -68,6 +71,16 @@ function App(): React.JSX.Element {
         }}
       >
         isTurboModuleEnabled: {isTurboModuleEnabled ? "true" : "false"}
+      </Text>
+      <Text
+        style={{
+          marginVertical: 20,
+          fontSize: 20,
+          fontWeight: "bold",
+          textAlign: "center",
+        }}
+      >
+        isHermes: {isHermes() ? "true" : "false"}
       </Text>
 
       <Image

--- a/examples/v0.77.0/hot-updater.config.ts
+++ b/examples/v0.77.0/hot-updater.config.ts
@@ -1,11 +1,12 @@
-
 import { metro } from "@hot-updater/metro";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
 import { defineConfig } from "hot-updater";
 import "dotenv/config";
 
 export default defineConfig({
-  build: metro(),
+  build: metro({
+    enableHermes: true,
+  }),
   storage: supabaseStorage({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,

--- a/examples/v0.77.0/ios/Podfile.lock
+++ b/examples/v0.77.0/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.77.0):
     - hermes-engine/Pre-built (= 0.77.0)
   - hermes-engine/Pre-built (0.77.0)
-  - HotUpdater (0.6.0):
+  - HotUpdater (0.9.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1746,7 +1746,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 1f783c3d53940aed0d2c84586f0b7a85ab7827ef
-  HotUpdater: 1928a508634c7d6d97005d6143bd097fbe16343f
+  HotUpdater: 20de0dee7a75f256313e94d1cb8ca0c89121e4e4
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: f5c19ebdb8804b53ed029123eb69914356192fc8
   RCTRequired: 6ae6cebe470486e0e0ce89c1c0eabb998e7c51f4

--- a/packages/hot-updater/src/commands/init/cloudflareD1R2Worker/index.ts
+++ b/packages/hot-updater/src/commands/init/cloudflareD1R2Worker/index.ts
@@ -48,7 +48,9 @@ const deployWorker = async (
     d1DatabaseName,
   }: { d1DatabaseId: string; d1DatabaseName: string },
 ) => {
-  const workerPath = require.resolve("@hot-updater/cloudflare/worker");
+  const workerPath = require.resolve("@hot-updater/cloudflare/worker", {
+    paths: [getCwd()],
+  });
   const workerDir = path.dirname(workerPath);
   const { tmpDir, removeTmpDir } = await copyDirToTmp(workerDir);
 

--- a/plugins/metro/package.json
+++ b/plugins/metro/package.json
@@ -28,8 +28,8 @@
     "@hot-updater/plugin-core": "0.9.0"
   },
   "devDependencies": {
+    "@types/node": "^22.8.7",
     "execa": "^9.5.2",
-    "uuidv7": "^1.0.2",
-    "@types/node": "^22.8.7"
+    "uuidv7": "^1.0.2"
   }
 }

--- a/plugins/metro/src/hermes.ts
+++ b/plugins/metro/src/hermes.ts
@@ -1,0 +1,171 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execa } from "execa";
+
+/**
+ * Returns the Hermes OS binary folder name for the current platform.
+ */
+function getHermesOSBin(): string {
+  switch (process.platform) {
+    case "win32":
+      return "win64-bin";
+    case "darwin":
+      return "osx-bin";
+    default:
+      return "linux64-bin";
+  }
+}
+
+/**
+ * Returns the Hermes executable name for the current platform.
+ */
+function getHermesOSExe(): string {
+  const hermesExecutableName = "hermesc";
+  return process.platform === "win32"
+    ? `${hermesExecutableName}.exe`
+    : hermesExecutableName;
+}
+
+/**
+ * Returns the path to the react-native package.
+ * Uses require.resolve to locate the path directly.
+ */
+function getReactNativePackagePath(): string {
+  try {
+    return path.dirname(require.resolve("react-native/package.json"));
+  } catch (error) {
+    return path.join("node_modules", "react-native");
+  }
+}
+
+/**
+ * Returns the path to the react-native compose-source-maps.js script.
+ */
+function getComposeSourceMapsPath(): string | null {
+  const rnPackagePath = getReactNativePackagePath();
+  const composeSourceMaps = path.join(
+    rnPackagePath,
+    "scripts",
+    "compose-source-maps.js",
+  );
+  return fs.existsSync(composeSourceMaps) ? composeSourceMaps : null;
+}
+
+/**
+ * Finds the Hermes command.
+ * If Hermes is bundled with react-native, returns the hermesc path.
+ * Otherwise, returns the path from node_modules/hermes-engine or hermesvm.
+ *
+ * @returns Full path to the Hermes executable
+ */
+export async function getHermesCommand(): Promise<string> {
+  const fileExists = (file: string): boolean => {
+    try {
+      return fs.statSync(file).isFile();
+    } catch {
+      return false;
+    }
+  };
+
+  // Since react-native 0.69, Hermes is bundled with it.
+  const bundledHermesEngine = path.join(
+    getReactNativePackagePath(),
+    "sdks",
+    "hermesc",
+    getHermesOSBin(),
+    getHermesOSExe(),
+  );
+  if (fileExists(bundledHermesEngine)) {
+    return bundledHermesEngine;
+  }
+
+  // Prefer hermes-engine if it exists.
+  const hermesEngine = path.join(
+    "node_modules",
+    "hermes-engine",
+    getHermesOSBin(),
+    getHermesOSExe(),
+  );
+  if (fileExists(hermesEngine)) {
+    return hermesEngine;
+  }
+
+  // Otherwise, fallback to hermesvm.
+  return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
+}
+
+/**
+ * Compiles a JS bundle into an HBC file using the Hermes compiler,
+ * and merges the source maps if enabled.
+ *
+ * @param inputJsFile - Path to the input JS file
+ * @param outDir - Output directory path
+ * @param fileName - Output HBC file name (created inside outDir)
+ * @param sourcemapOutput - (Optional) Final sourcemap file path
+ * @returns The full path to the compiled HBC file
+ */
+export async function compileHermes({
+  fileName,
+  outDir,
+  sourcemapOutput,
+  inputJsFile,
+}: {
+  fileName: string;
+  outDir: string;
+  sourcemapOutput?: string;
+  inputJsFile: string;
+}): Promise<string> {
+  const outputHbcFilePath = path.join(outDir, fileName);
+  const hermesArgs = ["-emit-binary", "-out", outputHbcFilePath, inputJsFile];
+
+  // If sourcemapOutput is provided, enable sourcemap generation.
+  if (sourcemapOutput) {
+    hermesArgs.push("-output-source-map");
+  }
+
+  const hermesCommand = await getHermesCommand();
+
+  try {
+    await execa(hermesCommand, hermesArgs, { stdio: "inherit" });
+  } catch (error: any) {
+    throw new Error(`Failed to compile with Hermes: ${error.message}`);
+  }
+
+  // If sourcemapOutput is enabled, use compose-source-maps to generate the final sourcemap.
+  if (sourcemapOutput) {
+    // Hermes-generated sourcemap is located at outputHbcFilePath + ".map".
+    const hermesSourceMapFile = `${outputHbcFilePath}.map`;
+    if (!fs.existsSync(hermesSourceMapFile)) {
+      throw new Error(
+        `Hermes-generated sourcemap file (${hermesSourceMapFile}) not found.`,
+      );
+    }
+    const composeSourceMapsPath = getComposeSourceMapsPath();
+    if (!composeSourceMapsPath) {
+      throw new Error(
+        "Could not find react-native's compose-source-maps.js script.",
+      );
+    }
+    try {
+      await execa(
+        "node",
+        [
+          composeSourceMapsPath,
+          sourcemapOutput,
+          hermesSourceMapFile,
+          "-o",
+          sourcemapOutput,
+        ],
+        { stdio: "inherit" },
+      );
+      // Remove the temporary Hermes sourcemap file.
+      fs.unlinkSync(hermesSourceMapFile);
+    } catch (error: any) {
+      throw new Error(
+        `Failed to run compose-source-maps script: ${error.message}`,
+      );
+    }
+  }
+
+  return outputHbcFilePath;
+}

--- a/plugins/metro/src/hermes.ts
+++ b/plugins/metro/src/hermes.ts
@@ -179,7 +179,7 @@ export async function compileHermes({
     }
   }
 
-  // outputHbcFile을 inputJsFile로 덮어씌우기
+  // Overwrite inputJsFile with outputHbcFile
   fs.unlinkSync(inputJsFile);
   fs.renameSync(outputHbcFile, inputJsFile);
 

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -82,8 +82,6 @@ Example:
       inputJsFile: bundleOutput,
       sourcemapOutput: sourcemap ? `${bundleOutput}.map` : undefined,
     });
-
-    console.log("hbcFile", hbcFile);
   }
 
   return bundleId;

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -77,10 +77,8 @@ Example:
   }
 
   if (useHermes) {
-    const hbcOutput = path.join(buildPath, `${filename}.hbc`);
     const hbcFile = await compileHermes({
-      fileName: hbcOutput,
-      outDir: buildPath,
+      outputHbcFile: bundleOutput,
       inputJsFile: bundleOutput,
       sourcemapOutput: sourcemap ? `${bundleOutput}.map` : undefined,
     });

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -99,26 +99,22 @@ export interface MetroPluginConfig extends BuildPluginConfig {
    */
   sourcemap?: boolean;
   /**
-   * Whether to use Hermes to compile the bundle.
-   * @default false
+   * Whether to use Hermes to compile the bundle
+   * Since React Native v0.70+, Hermes is enabled by default, so it's recommended to enable it.
+   * @link https://reactnative.dev/docs/hermes
+   * @recommended true
    */
-  enableHermes?: boolean;
+  enableHermes: boolean;
 }
 
 export const metro =
-  (
-    config: MetroPluginConfig = {
-      entryFile: "index.js",
-      outDir: "dist",
-      sourcemap: false,
-    },
-  ) =>
+  (config: MetroPluginConfig) =>
   ({ cwd }: BasePluginArgs): BuildPlugin => {
     const {
       outDir = "dist",
       sourcemap = false,
       entryFile = "index.js",
-      enableHermes = false,
+      enableHermes,
     } = config;
     return {
       build: async ({ platform }) => {

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -26,8 +26,8 @@ const runBundle = async ({
   sourcemap,
   enableHermes,
 }: RunBundleArgs) => {
-  const reactNativePath = require.resolve("react-native");
-  const cliPath = path.resolve(reactNativePath, "..", "cli.js");
+  const reactNativePath = require.resolve("react-native/package.json");
+  const cliPath = path.join(path.dirname(reactNativePath), "cli.js");
 
   const filename = `index.${platform}`;
   const bundleOutput = path.join(buildPath, `${filename}.bundle`);

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -77,7 +77,7 @@ Example:
   }
 
   if (useHermes) {
-    const hbcFile = await compileHermes({
+    await compileHermes({
       outputHbcFile: bundleOutput,
       inputJsFile: bundleOutput,
       sourcemapOutput: sourcemap ? `${bundleOutput}.map` : undefined,

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -15,7 +15,7 @@ interface RunBundleArgs {
   platform: string;
   buildPath: string;
   sourcemap: boolean;
-  useHermes: boolean;
+  enableHermes: boolean;
 }
 
 const runBundle = async ({
@@ -24,7 +24,7 @@ const runBundle = async ({
   platform,
   buildPath,
   sourcemap,
-  useHermes,
+  enableHermes,
 }: RunBundleArgs) => {
   const reactNativePath = require.resolve("react-native");
   const cliPath = path.resolve(reactNativePath, "..", "cli.js");
@@ -76,7 +76,7 @@ Example:
 }`);
   }
 
-  if (useHermes) {
+  if (enableHermes) {
     await compileHermes({
       outputHbcFile: bundleOutput,
       inputJsFile: bundleOutput,
@@ -102,7 +102,7 @@ export interface MetroPluginConfig extends BuildPluginConfig {
    * Whether to use Hermes to compile the bundle.
    * @default false
    */
-  useHermes?: boolean;
+  enableHermes?: boolean;
 }
 
 export const metro =
@@ -118,7 +118,7 @@ export const metro =
       outDir = "dist",
       sourcemap = false,
       entryFile = "index.js",
-      useHermes = false,
+      enableHermes = false,
     } = config;
     return {
       build: async ({ platform }) => {
@@ -133,7 +133,7 @@ export const metro =
           platform,
           buildPath,
           sourcemap,
-          useHermes,
+          enableHermes,
         });
 
         return {

--- a/plugins/metro/src/index.ts
+++ b/plugins/metro/src/index.ts
@@ -81,9 +81,8 @@ Example:
   if (enableHermes) {
     const { hermesVersion } = await compileHermes({
       cwd,
-      outputHbcFile: bundleOutput,
       inputJsFile: bundleOutput,
-      sourcemapOutput: sourcemap ? `${bundleOutput}.map` : undefined,
+      sourcemap,
     });
 
     return {

--- a/plugins/plugin-core/src/types.ts
+++ b/plugins/plugin-core/src/types.ts
@@ -31,6 +31,7 @@ export interface BuildPlugin {
   build: (args: { platform: Platform }) => Promise<{
     buildPath: string;
     bundleId: string;
+    stdout: string | null;
   }>;
   name: string;
 }


### PR DESCRIPTION
Enabling Hermes compiles JavaScript to bytecode, improving performance and memory efficiency. If you’re using Hermes, it is recommended to enable this flag.

https://reactnative.dev/docs/hermes

```tsx
import { metro } from "@hot-updater/metro";
import { defineConfig } from "hot-updater";
import "dotenv/config";

export default defineConfig({
  build: metro({
    enableHermes: true,
  }),
  ...
});
```

