### PR TITLE
Ensure CJS-only build for Lambda@Edge and return null instead of error before target-app-versions.json creation

### DIFF
--- a/plugins/aws/lambda/index.ts
+++ b/plugins/aws/lambda/index.ts
@@ -2,7 +2,11 @@ import type { Bundle } from "@hot-updater/core";
 import { filterCompatibleAppVersions, getUpdateInfo } from "@hot-updater/js";
 import type { CloudFrontRequestHandler } from "aws-lambda";
 
-export const handler: CloudFrontRequestHandler = async (event, context, callback) => {
+export const handler: CloudFrontRequestHandler = async (
+  event,
+  context,
+  callback,
+) => {
   const request = event.Records[0].cf.request;
   const headers = request.headers;
 
@@ -13,7 +17,9 @@ export const handler: CloudFrontRequestHandler = async (event, context, callback
   const distributionDomain = headers["host"][0]?.value;
 
   const bundleId = headers["x-bundle-id"]?.[0]?.value as string;
-  const appPlatform = headers["x-app-platform"]?.[0]?.value as "ios" | "android";
+  const appPlatform = headers["x-app-platform"]?.[0]?.value as
+    | "ios"
+    | "android";
   const appVersion = headers["x-app-version"]?.[0]?.value as string;
 
   if (!bundleId || !appPlatform || !appVersion) {

--- a/plugins/aws/lambda/index.ts
+++ b/plugins/aws/lambda/index.ts
@@ -2,11 +2,7 @@ import type { Bundle } from "@hot-updater/core";
 import { filterCompatibleAppVersions, getUpdateInfo } from "@hot-updater/js";
 import type { CloudFrontRequestHandler } from "aws-lambda";
 
-export const handler: CloudFrontRequestHandler = async (
-  event,
-  context,
-  callback,
-) => {
+export const handler: CloudFrontRequestHandler = async (event, context, callback) => {
   const request = event.Records[0].cf.request;
   const headers = request.headers;
 
@@ -17,9 +13,7 @@ export const handler: CloudFrontRequestHandler = async (
   const distributionDomain = headers["host"][0]?.value;
 
   const bundleId = headers["x-bundle-id"]?.[0]?.value as string;
-  const appPlatform = headers["x-app-platform"]?.[0]?.value as
-    | "ios"
-    | "android";
+  const appPlatform = headers["x-app-platform"]?.[0]?.value as "ios" | "android";
   const appVersion = headers["x-app-version"]?.[0]?.value as string;
 
   if (!bundleId || !appPlatform || !appVersion) {
@@ -38,11 +32,13 @@ export const handler: CloudFrontRequestHandler = async (
     method: "GET",
   });
   if (!targetAppVersionListResponse.ok) {
+    // target-app-versions.json has not been created yet
     callback(null, {
-      status: "404",
-      body: JSON.stringify({
-        error: `Failed to fetch ${appPlatform}/target-app-versions.json`,
-      }),
+      status: "200",
+      headers: {
+        "Content-Type": [{ key: "Content-Type", value: "application/json" }],
+      },
+      body: JSON.stringify(null),
     });
     return;
   }

--- a/plugins/aws/tsup.config.ts
+++ b/plugins/aws/tsup.config.ts
@@ -1,15 +1,18 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig([{
-  entry: ["src/index.ts", "sdk/index.ts"],
-  format: ["esm", "cjs"],
-  outDir: "dist",
-  dts: true,
-  banner: {
-    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+export default defineConfig([
+  {
+    entry: ["src/index.ts", "sdk/index.ts"],
+    format: ["esm", "cjs"],
+    outDir: "dist",
+    dts: true,
+    banner: {
+      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+    },
   },
-},{
-  entry: ["lambda/index.ts"],
-  format: ["cjs"],
-  outDir: "dist/lambda",
-}]);
+  {
+    entry: ["lambda/index.ts"],
+    format: ["cjs"],
+    outDir: "dist/lambda",
+  },
+]);

--- a/plugins/aws/tsup.config.ts
+++ b/plugins/aws/tsup.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts", "sdk/index.ts", "lambda/index.ts"],
+export default defineConfig([{
+  entry: ["src/index.ts", "sdk/index.ts"],
   format: ["esm", "cjs"],
   outDir: "dist",
   dts: true,
   banner: {
     js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
   },
-});
+},{
+  entry: ["lambda/index.ts"],
+  format: ["cjs"],
+  outDir: "dist/lambda",
+}]);


### PR DESCRIPTION
This PR includes the following changes:
	1.	Modify build output to generate only CJS
	•	Lambda@Edge supports only CommonJS (CJS), so the build process is adjusted to produce only CJS output.
	2.	Return null instead of throwing an error when target-app-versions.json is not yet created
	•	Previously, an error was thrown if target-app-versions.json was missing.
	•	Now, it returns null to prevent unnecessary failures.

These changes improve compatibility with Lambda@Edge and enhance error handling. 🚀