### PR TITLE
fix(cli): getCwd bundle failed on cloudflareD1R2Worker

### DIFF
--- a/packages/hot-updater/src/commands/init/cloudflareD1R2Worker/index.ts
+++ b/packages/hot-updater/src/commands/init/cloudflareD1R2Worker/index.ts
@@ -48,8 +48,9 @@ const deployWorker = async (
     d1DatabaseName,
   }: { d1DatabaseId: string; d1DatabaseName: string },
 ) => {
+  const cwd = getCwd();
   const workerPath = require.resolve("@hot-updater/cloudflare/worker", {
-    paths: [getCwd()],
+    paths: [cwd],
   });
   const workerDir = path.dirname(workerPath);
   const { tmpDir, removeTmpDir } = await copyDirToTmp(workerDir);


### PR DESCRIPTION
After version 0.10.1, @gronxb added enableHermes options in the pull request https://github.com/gronxb/hot-updater/pull/120 that introduces a build failure.

I get the error when init the hot-updater using command `yarn hot-updater init`.

```
file:///Users/minhhieu76qng/dev/dsv/my-project/node_modules/hot-updater/dist/index.js:22416
        paths: [
               ^

ReferenceError: getCwd is not defined
    at deployWorker (file:///Users/minhhieu76qng/dev/dsv/my-project/node_modules/hot-updater/dist/index.js:22416:16)
    at initCloudflareD1R2Worker (file:///Users/minhhieu76qng/dev/dsv/my-project/node_modules/hot-updater/dist/index.js:22633:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.init_init (file:///Users/minhhieu76qng/dev/dsv/my-project/node_modules/hot-updater/dist/index.js:22889:13)
```

After checking the bundle, I found that the getCwd() function is not built.
![image](https://github.com/user-attachments/assets/db5018da-be65-4dbf-9f4a-b462ddd89d13)
And I change the code which is presented in my PR, the getCwd() is built successfully.
![image](https://github.com/user-attachments/assets/99d04b7d-8d3e-472d-8f48-b568550bb603)