### PR TITLE
feat(mock): add delay to api calls

### DIFF
--- a/packages/console/hot-updater.config.ts
+++ b/packages/console/hot-updater.config.ts
@@ -2,6 +2,7 @@ import { mockDatabase } from "@hot-updater/mock";
 
 export default {
   database: mockDatabase({
+    maxLatency: 700,
     initialBundles: [
       {
         id: "1",

--- a/plugins/mock/src/mockDatabase.ts
+++ b/plugins/mock/src/mockDatabase.ts
@@ -4,36 +4,50 @@ import type {
   DatabasePlugin,
   DatabasePluginHooks,
 } from "@hot-updater/plugin-core";
+import { sleepMaxLimit } from "./util/utils";
 
 export interface MockDatabaseConfig {
   initialBundles?: Bundle[];
+  maxLatency: number;
 }
 
 export const mockDatabase =
   (config: MockDatabaseConfig, hooks?: DatabasePluginHooks) =>
   (_: BasePluginArgs): DatabasePlugin => {
     const bundles: Bundle[] = config.initialBundles ?? [];
-
+    const maxLatency = config.maxLatency ?? 1000;
     return {
       name: "mockDatabase",
       async commitBundle() {
-        hooks?.onDatabaseUpdated?.();
+        await sleepMaxLimit(maxLatency).then(() => {
+          hooks?.onDatabaseUpdated?.();
+        });
       },
       async updateBundle(targetBundleId: string, newBundle: Partial<Bundle>) {
+        await sleepMaxLimit(maxLatency);
         const targetIndex = bundles.findIndex((u) => u.id === targetBundleId);
         if (targetIndex === -1) {
           throw new Error("target bundle version not found");
         }
         Object.assign(bundles[targetIndex], newBundle);
+        await hooks?.onDatabaseUpdated?.();
       },
       async appendBundle(inputBundle: Bundle) {
+        await sleepMaxLimit(maxLatency);
         bundles.unshift(inputBundle);
+        await hooks?.onDatabaseUpdated?.();
       },
       async getBundleById(bundleId: string) {
-        return bundles.find((b) => b.id === bundleId) ?? null;
+        let result: Bundle | null = null;
+        await sleepMaxLimit(maxLatency);
+        result = bundles.find((b) => b.id === bundleId) ?? null;
+        return await result;
       },
       async getBundles() {
-        return bundles.sort((a, b) => a.id.localeCompare(b.id));
+        let result: Bundle[] = [];
+        await sleepMaxLimit(maxLatency);
+        result = bundles.sort((a, b) => a.id.localeCompare(b.id));
+        return await result;
       },
     };
   };

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -27,9 +27,11 @@ const DEFAULT_BUNDLES_MOCK: Bundle[] = [
   },
 ];
 
+const DEFAULT_LATENCY: number = 0;
+
 describe("mockDatabase", () => {
   it("should return a database plugin", async () => {
-    const plugin = mockDatabase({})({ cwd: "" });
+    const plugin = mockDatabase({ maxLatency: DEFAULT_LATENCY })({ cwd: "" });
 
     const bundles = await plugin.getBundles();
 
@@ -38,6 +40,7 @@ describe("mockDatabase", () => {
 
   it("should return a database plugin with initial bundles", async () => {
     const plugin = mockDatabase({
+      maxLatency: DEFAULT_LATENCY,
       initialBundles: DEFAULT_BUNDLES_MOCK,
     })({ cwd: "" });
 
@@ -47,7 +50,7 @@ describe("mockDatabase", () => {
   });
 
   it("should append a bundle", async () => {
-    const plugin = mockDatabase({})({ cwd: "" });
+    const plugin = mockDatabase({ maxLatency: DEFAULT_LATENCY })({ cwd: "" });
 
     await plugin.appendBundle(DEFAULT_BUNDLES_MOCK[0]);
 
@@ -58,6 +61,7 @@ describe("mockDatabase", () => {
 
   it("should update a bundle", async () => {
     const plugin = mockDatabase({
+      maxLatency: DEFAULT_LATENCY,
       initialBundles: [DEFAULT_BUNDLES_MOCK[0]],
     })({ cwd: "" });
 
@@ -77,6 +81,7 @@ describe("mockDatabase", () => {
 
   it("should get bundle by id", async () => {
     const plugin = mockDatabase({
+      maxLatency: DEFAULT_LATENCY,
       initialBundles: DEFAULT_BUNDLES_MOCK,
     })({ cwd: "" });
 
@@ -87,6 +92,7 @@ describe("mockDatabase", () => {
 
   it("should throw error, if target bundle version not found", async () => {
     const plugin = mockDatabase({
+      maxLatency: DEFAULT_LATENCY,
       initialBundles: [DEFAULT_BUNDLES_MOCK[0]],
     })({ cwd: "" });
 
@@ -99,6 +105,7 @@ describe("mockDatabase", () => {
 
   it("should sort bundles by id", async () => {
     const plugin = mockDatabase({
+      maxLatency: DEFAULT_LATENCY,
       initialBundles: [DEFAULT_BUNDLES_MOCK[1], DEFAULT_BUNDLES_MOCK[0]],
     })({ cwd: "" });
 

--- a/plugins/mock/src/util/utils.ts
+++ b/plugins/mock/src/util/utils.ts
@@ -1,0 +1,2 @@
+export const sleepMaxLimit = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, Math.floor(Math.random() * ms)));


### PR DESCRIPTION
After enabling HRM in the console, I realized the development environment felt unrealistic due to the lack of latency when using mock data.
To better simulate the production environment, I've added latency.