### PR TITLE
platform specific config file location

### DIFF
--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -30,12 +30,7 @@ export interface DeployOptions {
 
 export const deploy = async (options: DeployOptions) => {
   printBanner();
-
-  const config = await loadConfig();
-  if (!config) {
-    console.error("No config found. Please run `hot-updater init` first.");
-    process.exit(1);
-  }
+  
   const cwd = getCwd();
 
   const [gitCommitHash, gitMessage] = await Promise.all([
@@ -60,6 +55,12 @@ export const deploy = async (options: DeployOptions) => {
     return;
   }
 
+  const config = await loadConfig(platform);
+  if (!config) {
+    console.error("No config found. Please run `code-updater init` first.");
+    process.exit(1);
+  }
+  
   const defaultTargetAppVersion =
     (await getDefaultTargetAppVersion(cwd, platform)) ?? "1.0.0";
 

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -30,7 +30,7 @@ export interface DeployOptions {
 
 export const deploy = async (options: DeployOptions) => {
   printBanner();
-  
+
   const cwd = getCwd();
 
   const [gitCommitHash, gitMessage] = await Promise.all([
@@ -60,7 +60,7 @@ export const deploy = async (options: DeployOptions) => {
     console.error("No config found. Please run `code-updater init` first.");
     process.exit(1);
   }
-  
+
   const defaultTargetAppVersion =
     (await getDefaultTargetAppVersion(cwd, platform)) ?? "1.0.0";
 

--- a/plugins/plugin-core/src/loadConfig.ts
+++ b/plugins/plugin-core/src/loadConfig.ts
@@ -3,17 +3,26 @@ import { TypeScriptLoader } from "cosmiconfig-typescript-loader";
 import { getCwd } from "./cwd.js";
 import type { Config } from "./types.js";
 
-export const loadConfig = async (): Promise<Config | null> => {
-  const result = await cosmiconfig("hot-updater", {
+export const loadConfig = async (platform = ""): Promise<Config | null> => {
+  const searchPathList = [
+    "code-updater.config.js",
+    "code-updater.config.cjs",
+    "code-updater.config.ts",
+    "code-updater.config.cts",
+    "code-updater.config.mjs",
+  ];
+
+  if (platform === "ios" || platform === "android") {
+    searchPathList.unshift(`code-updater.config.${platform}.js`);
+    searchPathList.unshift(`code-updater.config.${platform}.cjs`);
+    searchPathList.unshift(`code-updater.config.${platform}.ts`);
+    searchPathList.unshift(`code-updater.config.${platform}.cts`);
+    searchPathList.unshift(`code-updater.config.${platform}.mjs`);
+  }
+
+  const result = await cosmiconfig("code-updater", {
     stopDir: getCwd(),
-    searchPlaces: [
-      "hot-updater.config.js",
-      "hot-updater.config.cjs",
-      "hot-updater.config.ts",
-      "hot-updater.config.cts",
-      "hot-updater.config.mjs",
-      "hot-updater.config.cjs",
-    ],
+    searchPlaces: searchPathList,
     ignoreEmptySearchPlaces: false,
     loaders: {
       ".ts": TypeScriptLoader(),


### PR DESCRIPTION
There is no platform-based control in config file control. Since it is called with console and run with nodejs, it is not possible to use platform in ts. Therefore, after checking the platform with console, a platform-specific config file path list was added.

Why is it necessary? 
we use hermes for ios in our project but not for android. we need to check and change hermes on platform basis.