### PR TITLE
feat(config): platform injected to config

### DIFF
--- a/packages/console/src-server/rpc.ts
+++ b/packages/console/src-server/rpc.ts
@@ -26,7 +26,9 @@ let databasePlugin: DatabasePlugin | null = null;
 
 const prepareConfig = async () => {
   if (!config) {
-    config = await loadConfig();
+    config = await loadConfig({
+      platform: "console",
+    });
     databasePlugin =
       (await config?.database({
         cwd: getCwd(),

--- a/packages/hot-updater/src/commands/console.ts
+++ b/packages/hot-updater/src/commands/console.ts
@@ -9,7 +9,9 @@ export const CONSOLE_DEFAULT_PORT = 1422;
 export const getConsolePort = async (config?: Config) => {
   let $config: Config | undefined | null = config;
   if (!$config) {
-    $config = await loadConfig();
+    $config = await loadConfig({
+      platform: "console",
+    });
   }
   return $config?.console?.port ?? CONSOLE_DEFAULT_PORT;
 };

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -31,11 +31,6 @@ export interface DeployOptions {
 export const deploy = async (options: DeployOptions) => {
   printBanner();
 
-  const config = await loadConfig();
-  if (!config) {
-    console.error("No config found. Please run `hot-updater init` first.");
-    process.exit(1);
-  }
   const cwd = getCwd();
 
   const [gitCommitHash, gitMessage] = await Promise.all([
@@ -58,6 +53,12 @@ export const deploy = async (options: DeployOptions) => {
       "Platform not found. -p <ios | android> or --platform <ios | android>",
     );
     return;
+  }
+
+  const config = await loadConfig({ platform: platform });
+  if (!config) {
+    console.error("No config found. Please run `hot-updater init` first.");
+    process.exit(1);
   }
 
   const defaultTargetAppVersion =

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -55,7 +55,7 @@ export const deploy = async (options: DeployOptions) => {
     return;
   }
 
-  const config = await loadConfig({ platform: platform });
+  const config = await loadConfig({ platform });
   if (!config) {
     console.error("No config found. Please run `hot-updater init` first.");
     process.exit(1);

--- a/packages/hot-updater/src/config.ts
+++ b/packages/hot-updater/src/config.ts
@@ -1,8 +1,4 @@
-import type { Config, Platform } from "@hot-updater/plugin-core";
-
-export interface HotUpdaterConfigOptions {
-  platform: Platform | "console";
-}
+import type { Config, HotUpdaterConfigOptions } from "@hot-updater/plugin-core";
 
 export const defineConfig = async (
   config:

--- a/packages/hot-updater/src/config.ts
+++ b/packages/hot-updater/src/config.ts
@@ -1,5 +1,14 @@
-import type { Config } from "@hot-updater/plugin-core";
+import type { Config, Platform } from "@hot-updater/plugin-core";
+
+export interface HotUpdaterConfigOptions {
+  platform: Platform | "console";
+}
 
 export const defineConfig = async (
-  config: Config | (() => Config) | (() => Promise<Config>),
-): Promise<Config> => (typeof config === "function" ? await config() : config);
+  config:
+    | Config
+    | ((options: HotUpdaterConfigOptions) => Config)
+    | ((options: HotUpdaterConfigOptions) => Promise<Config>),
+) => {
+  return config;
+};

--- a/plugins/plugin-core/src/loadConfig.ts
+++ b/plugins/plugin-core/src/loadConfig.ts
@@ -1,9 +1,15 @@
 import { cosmiconfig } from "cosmiconfig";
 import { TypeScriptLoader } from "cosmiconfig-typescript-loader";
 import { getCwd } from "./cwd.js";
-import type { Config } from "./types.js";
+import type { Config, Platform } from "./types.js";
 
-export const loadConfig = async (): Promise<Config | null> => {
+export interface HotUpdaterConfigOptions {
+  platform: Platform | "console";
+}
+
+export const loadConfig = async (
+  options: HotUpdaterConfigOptions,
+): Promise<Config | null> => {
   const result = await cosmiconfig("hot-updater", {
     stopDir: getCwd(),
     searchPlaces: [
@@ -24,6 +30,10 @@ export const loadConfig = async (): Promise<Config | null> => {
 
   if (!result?.config) {
     return null;
+  }
+
+  if (typeof result.config === "function") {
+    return await result.config(options);
   }
 
   return result.config as Config;


### PR DESCRIPTION
allow platform

```tsx
import { metro } from "@hot-updater/metro";
import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
import { defineConfig } from "hot-updater";
import "dotenv/config";

export default defineConfig(({ platform }) => { // Can be use platform
  return {
    build: metro({
      enableHermes: platform === "ios",
    }),
    storage: supabaseStorage({
      supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
      supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
      bucketName: process.env.HOT_UPDATER_SUPABASE_BUCKET_NAME!,
    }),
    database: supabaseDatabase({
      supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
      supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
    }),
  };
});

```