### PR TITLE
Define workspace TypeScript version in settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit",
     "source.organizeImports.biome": "explicit"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Setting the TypeScript version in the settings should allow for more consistency during development and make it less susceptible to the internal version of VS Code.