### PR TITLE
fix(android): keep a stable minBundleId on Android

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -67,6 +67,7 @@ android {
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     consumerProguardFiles 'proguard-rules.pro'
+    buildConfigField "long", "BUILD_TIMESTAMP", "${System.currentTimeMillis()}L"
   }
 
   buildFeatures {

--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
@@ -277,8 +277,7 @@ class HotUpdater : ReactPackage {
 
         fun getMinBundleId(context: Context): String =
             try {
-                val apkFile = File(context.applicationInfo.sourceDir)
-                val buildTimestampMs = apkFile.lastModified()
+                val buildTimestampMs = BuildConfig.BUILD_TIMESTAMP
                 val bytes =
                     ByteArray(16).apply {
                         this[0] = ((buildTimestampMs shr 40) and 0xFF).toByte()


### PR DESCRIPTION
* As-is
getMinBundleId is based on the APK’s modification date, so when the app is freshly installed from the Play Store, it always gets updated to the latest version. As a result, update bundles created before the installation are ignored.
* To-be
getMinBundleId is fixed based on the build time, ensuring consistency regardless of the installation date.