### PR TITLE
refactor(native): keep bundle latest bundle

### DIFF
--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
@@ -258,7 +258,7 @@ class HotUpdater : ReactPackage {
             return true
         }
 
-        // Helper function to delete old bundles, keeping only up to 2 bundles in the bundle-store folder
+        // Helper function to delete old bundles, keeping only up to 1 bundles in the bundle-store folder
         private fun cleanupOldBundles(bundleStoreDir: File) {
             // Get list of all directories in bundle-store folder
             val bundles = bundleStoreDir.listFiles { file -> file.isDirectory }?.toList() ?: return
@@ -266,9 +266,9 @@ class HotUpdater : ReactPackage {
             // Sort by last modified time in descending order to keep most recently updated bundles at the top
             val sortedBundles = bundles.sortedByDescending { it.lastModified() }
 
-            // Delete all bundles except the top 2
-            if (sortedBundles.size > 2) {
-                sortedBundles.drop(2).forEach { oldBundle ->
+            // Delete all bundles except the top 1
+            if (sortedBundles.size > 1) {
+                sortedBundles.drop(1).forEach { oldBundle ->
                     Log.d("HotUpdater", "Removing old bundle: ${oldBundle.name}")
                     oldBundle.deleteRecursively()
                 }

--- a/packages/react-native/ios/HotUpdater/HotUpdater.mm
+++ b/packages/react-native/ios/HotUpdater/HotUpdater.mm
@@ -152,7 +152,7 @@ RCT_EXPORT_MODULE();
         }
     }
     
-    // Sort in descending order by modification time (keep latest 2)
+    // Sort in descending order by modification time (keep latest 1)
     [bundleDirs sortUsingComparator:^NSComparisonResult(NSString *path1, NSString *path2) {
         NSDictionary *attr1 = [fileManager attributesOfItemAtPath:path1 error:nil];
         NSDictionary *attr2 = [fileManager attributesOfItemAtPath:path2 error:nil];
@@ -161,8 +161,8 @@ RCT_EXPORT_MODULE();
         return [date2 compare:date1];
     }];
     
-    if (bundleDirs.count > 2) {
-        NSArray *oldBundles = [bundleDirs subarrayWithRange:NSMakeRange(2, bundleDirs.count - 2)];
+    if (bundleDirs.count > 1) {
+        NSArray *oldBundles = [bundleDirs subarrayWithRange:NSMakeRange(1, bundleDirs.count - 1)];
         for (NSString *oldBundle in oldBundles) {
             NSError *delError = nil;
             if ([fileManager removeItemAtPath:oldBundle error:&delError]) {


### PR DESCRIPTION
Each download can contain up to two bundles, but this PR changes it to hold only one bundle.