### PR TITLE
loading assetloader synchronously, cause crash, load async instead

### DIFF
--- a/packages/react-native/android/src/main/java/com/hotupdater/ReactIntegrationManagerBase.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/ReactIntegrationManagerBase.kt
@@ -16,7 +16,7 @@ open class ReactIntegrationManagerBase(
                 JSBundleLoader.createAssetLoader(
                     context,
                     bundleFileUrl,
-                    true,
+                    false,
                 )
         } else {
             bundleLoader = JSBundleLoader.createFileLoader(bundleFileUrl)


### PR DESCRIPTION
https://github.com/gronxb/hot-updater/issues/278