### PR TITLE
chore: Remove wrongly injected banner in cjs bundles

### DIFF
--- a/plugins/aws/tsup.config.ts
+++ b/plugins/aws/tsup.config.ts
@@ -1,4 +1,12 @@
+import type { Options } from "tsup";
 import { defineConfig } from "tsup";
+
+const getBanner: Options["banner"] = ({ format }) => ({
+  js:
+    format === "esm"
+      ? `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`
+      : "",
+});
 
 export default defineConfig([
   {
@@ -6,9 +14,7 @@ export default defineConfig([
     format: ["esm", "cjs"],
     outDir: "dist",
     dts: true,
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: getBanner,
   },
   {
     entry: ["lambda/index.ts"],
@@ -21,8 +27,6 @@ export default defineConfig([
     dts: true,
     outDir: "dist/iac",
     external: ["@hot-updater/aws"],
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: getBanner,
   },
 ]);

--- a/plugins/cloudflare/tsup.config.ts
+++ b/plugins/cloudflare/tsup.config.ts
@@ -1,13 +1,19 @@
+import type { Options } from "tsup";
 import { defineConfig } from "tsup";
+
+const getBanner: Options["banner"] = ({ format }) => ({
+  js:
+    format === "esm"
+      ? `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`
+      : "",
+});
 
 export default defineConfig([
   {
     entry: ["src/index.ts", "src/utils/index.ts"],
     format: ["esm", "cjs"],
     dts: true,
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: getBanner,
   },
   {
     entry: ["iac/index.ts"],
@@ -15,8 +21,6 @@ export default defineConfig([
     dts: true,
     outDir: "dist/iac",
     external: ["@hot-updater/cloudflare"],
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: getBanner,
   },
 ]);

--- a/plugins/firebase/tsup.config.ts
+++ b/plugins/firebase/tsup.config.ts
@@ -21,8 +21,11 @@ export default defineConfig([
     dts: true,
     outDir: "dist/iac",
     external: ["@hot-updater/firebase"],
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: ({ format }) => ({
+      js:
+        format === "esm"
+          ? `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`
+          : "",
+    }),
   },
 ]);

--- a/plugins/supabase/tsup.config.ts
+++ b/plugins/supabase/tsup.config.ts
@@ -6,9 +6,6 @@ export default defineConfig([
     format: ["esm", "cjs"],
     outDir: "dist",
     dts: true,
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
   },
   {
     entry: ["iac/index.ts"],
@@ -16,8 +13,11 @@ export default defineConfig([
     dts: true,
     outDir: "dist/iac",
     external: ["@hot-updater/supabase"],
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
+    banner: ({ format }) => ({
+      js:
+        format === "esm"
+          ? `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`
+          : "",
+    }),
   },
 ]);


### PR DESCRIPTION
A banner with `import` syntax is injected in CommonJS modules, breaking the evaluation. The following are some evidences

<img width="733" alt="image" src="https://github.com/user-attachments/assets/5fcdc0b3-d454-4155-aea6-bf3933ef5ace" />

<img width="654" alt="image" src="https://github.com/user-attachments/assets/fc240c2b-90c2-4633-92de-82203d6aed9b" />

