### PR TITLE
fix(react-native): prevent potential infinite loop when same bundle i…

### DIFF
--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt
@@ -142,12 +142,12 @@ class HotUpdater : ReactPackage {
         suspend fun updateBundle(
             context: Context,
             bundleId: String,
-            zipUrl: String?,
+            fileUrl: String?,
             progressCallback: ((Double) -> Unit),
         ): Boolean {
-            Log.d("HotUpdater", "updateBundle bundleId $bundleId zipUrl $zipUrl")
+            Log.d("HotUpdater", "updateBundle bundleId $bundleId fileUrl $fileUrl")
 
-            if (zipUrl.isNullOrEmpty()) {
+            if (fileUrl.isNullOrEmpty()) {
                 setBundleURL(context, null)
                 return true
             }
@@ -184,7 +184,7 @@ class HotUpdater : ReactPackage {
 
             val isSuccess =
                 withContext(Dispatchers.IO) {
-                    val downloadUrl = URL(zipUrl)
+                    val downloadUrl = URL(fileUrl)
                     val conn =
                         try {
                             downloadUrl.openConnection() as HttpURLConnection
@@ -223,7 +223,7 @@ class HotUpdater : ReactPackage {
                             }
                         }
                     } catch (e: Exception) {
-                        Log.d("HotUpdater", "Failed to download data from URL: $zipUrl, Error: ${e.message}")
+                        Log.d("HotUpdater", "Failed to download data from URL: $fileUrl, Error: ${e.message}")
                         tempDir.deleteRecursively()
                         return@withContext false
                     } finally {

--- a/packages/react-native/android/src/newarch/HotUpdaterModule.kt
+++ b/packages/react-native/android/src/newarch/HotUpdaterModule.kt
@@ -45,12 +45,12 @@ class HotUpdaterModule internal constructor(
         (currentActivity as? FragmentActivity)?.lifecycleScope?.launch {
             try {
                 val bundleId = bundleData.getString("bundleId")!!
-                val zipUrl = bundleData.getString("zipUrl")
+                val fileUrl = bundleData.getString("fileUrl")
                 val isSuccess =
                     HotUpdater.updateBundle(
                         mReactApplicationContext,
                         bundleId,
-                        zipUrl,
+                        fileUrl,
                     ) { progress ->
                         val params =
                             WritableNativeMap().apply {

--- a/packages/react-native/android/src/oldarch/HotUpdaterModule.kt
+++ b/packages/react-native/android/src/oldarch/HotUpdaterModule.kt
@@ -45,13 +45,13 @@ class HotUpdaterModule internal constructor(
         (currentActivity as? FragmentActivity)?.lifecycleScope?.launch {
             try {
                 val bundleId = bundleData.getString("bundleId")!!
-                val zipUrl = bundleData.getString("zipUrl")
+                val fileUrl = bundleData.getString("fileUrl")
 
                 val isSuccess =
                     HotUpdater.updateBundle(
                         mReactApplicationContext,
                         bundleId,
-                        zipUrl,
+                        fileUrl,
                     ) { progress ->
                         val params =
                             WritableNativeMap().apply {

--- a/packages/react-native/ios/HotUpdater/Internal/HotUpdater.mm
+++ b/packages/react-native/ios/HotUpdater/Internal/HotUpdater.mm
@@ -221,7 +221,7 @@ RCT_EXPORT_METHOD(updateBundle:(JS::NativeHotUpdater::UpdateBundleParams &)param
     NSLog(@"[HotUpdater.mm] updateBundle called. Delegating to Swift Impl.");
     NSDictionary *paramDict = @{
         @"bundleId": params.bundleId(),
-        @"zipUrl": params.zipUrl(),
+        @"fileUrl": params.fileUrl(),
     };
     [_hotUpdaterImpl updateBundleFromJS:paramDict resolver:resolve rejecter:reject];
 }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -169,7 +169,7 @@ export const HotUpdater = {
    *
    * @param {UpdateBundleParams} params - Parameters object required for bundle update
    * @param {string} params.bundleId - The bundle ID of the app
-   * @param {string|null} params.zipUrl - The URL of the zip file
+   * @param {string|null} params.fileUrl - The URL of the zip file
    *
    * @returns {Promise<boolean>} Whether the update was successful
    *
@@ -190,7 +190,7 @@ export const HotUpdater = {
    *
    * await HotUpdater.updateBundle({
    *   bundleId: updateInfo.id,
-   *   zipUrl: updateInfo.fileUrl
+   *   fileUrl: updateInfo.fileUrl
    * });
    * if (updateInfo.shouldForceUpdate) {
    *   HotUpdater.reload();

--- a/packages/react-native/src/runUpdateProcess.ts
+++ b/packages/react-native/src/runUpdateProcess.ts
@@ -65,7 +65,7 @@ export const runUpdateProcess = async ({
 
   const isUpdated = await updateBundle({
     bundleId: updateInfo.id,
-    zipUrl: updateInfo.fileUrl,
+    fileUrl: updateInfo.fileUrl,
   });
   if (isUpdated && updateInfo.shouldForceUpdate && reloadOnForceUpdate) {
     reload();

--- a/packages/react-native/src/specs/NativeHotUpdater.ts
+++ b/packages/react-native/src/specs/NativeHotUpdater.ts
@@ -3,19 +3,13 @@ import { TurboModuleRegistry } from "react-native";
 
 export interface UpdateBundleParams {
   bundleId: string;
-  zipUrl: string | null;
+  fileUrl: string | null;
 }
 
 export interface Spec extends TurboModule {
   // Methods
   reload(): void;
   updateBundle(params: UpdateBundleParams): Promise<boolean>;
-
-  /**
-   * @deprecated
-   * use getConstants().APP_VERSION instead
-   */
-  getAppVersion(): Promise<string | null>;
 
   setChannel(channel: string): Promise<void>;
 


### PR DESCRIPTION
Instead of solving this issue using maxRetries, we compare the current bundleId and throw an error if there’s an attempt to download an older bundle. In this case, only onError is triggered or updateBundle is rejected, but the existing app does not perform an update.


#277 