### PR TITLE
fix: pagenation

### DIFF
--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -9,6 +9,13 @@ import type {
 export interface BaseDatabaseUtils {
   cwd: string;
 }
+export interface PagenationInfo {
+  total: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  currentPage: number;
+  totalPages: number;
+}
 
 export interface AbstractDatabasePlugin<TContext = object> {
   getContext?: () => TContext;
@@ -19,14 +26,14 @@ export interface AbstractDatabasePlugin<TContext = object> {
   getBundles: (
     context: TContext,
     options?: {
-      where?: {
-        channel?: string;
-        platform?: string;
-      };
+      where?: { channel?: string; platform?: string };
       limit?: number;
       offset?: number;
     },
-  ) => Promise<Bundle[]>;
+  ) => Promise<{
+    data: Bundle[];
+    pagenation: PagenationInfo;
+  }>;
   getChannels: (context: TContext) => Promise<string[]>;
   onUnmount?: (context: TContext) => void;
   commitBundle: (

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { Bundle, Platform } from "@hot-updater/core";
+import type { PagenationInfo } from "../createDatabasePlugin";
 
 export type { Platform, Bundle } from "@hot-updater/core";
 
@@ -14,13 +15,13 @@ export interface DatabasePlugin {
   getChannels: () => Promise<string[]>;
   getBundleById: (bundleId: string) => Promise<Bundle | null>;
   getBundles: (options?: {
-    where?: {
-      channel?: string;
-      platform?: Platform;
-    };
+    where?: { channel?: string; platform?: string };
     limit?: number;
     offset?: number;
-  }) => Promise<Bundle[]>;
+  }) => Promise<{
+    data: Bundle[];
+    pagenation: PagenationInfo;
+  }>;
   updateBundle: (
     targetBundleId: string,
     newBundle: Partial<Bundle>,
@@ -36,10 +37,7 @@ export interface DatabasePluginHooks {
 }
 
 export interface BuildPlugin {
-  build: (args: {
-    platform: Platform;
-    channel: string;
-  }) => Promise<{
+  build: (args: { platform: Platform; channel: string }) => Promise<{
     buildPath: string;
     bundleId: string;
     channel: string;


### PR DESCRIPTION
## Problem
Currently, the console does not implement proper pagination functionality. The getBundles method only returns bundle data without pagination metadata, making it impossible to implement navigation controls or determine if additional pages are available.

## Solution
To enable proper pagination in the console interface, this PR implements comprehensive changes to the data layer and providers

1. Update getBundles API specification
Before: getBundles() returns Promise<Bundle[]>
After: getBundles() returns Promise<{ data: Bundle[]; pagination: PaginationInfo }>

2. Update all database providers
Modify all existing database plugin implementations to support the new pagination response format
Ensure backward compatibility during the transition
Update type definitions across all affected modules

3. Update frontend queries
Modify createBundlesQuery to handle the new pagination data structure
Update console UI components to display pagination controls
Implement proper page navigation functionality