### PR TITLE
fix: pagination

### DIFF
--- a/.changeset/upset-mammals-bake.md
+++ b/.changeset/upset-mammals-bake.md
@@ -1,0 +1,13 @@
+---
+"@hot-updater/plugin-core": patch
+"@hot-updater/cloudflare": patch
+"@hot-updater/standalone": patch
+"@hot-updater/console": patch
+"@hot-updater/firebase": patch
+"@hot-updater/postgres": patch
+"@hot-updater/supabase": patch
+"@hot-updater/mock": patch
+"@hot-updater/aws": patch
+---
+
+fix: pagination doesn't work (edit database spec)

--- a/packages/console/src-server/rpc.ts
+++ b/packages/console/src-server/rpc.ts
@@ -85,8 +85,8 @@ export const rpc = new Hono()
           channel: query.channel ?? undefined,
           platform: query.platform ?? undefined,
         },
-        limit: query.limit ? Number(query.limit) : undefined,
-        offset: query.offset ? Number(query.offset) : undefined,
+        limit: query.limit ? Number(query.limit) : 20,
+        offset: query.offset ? Number(query.offset) : 0,
       });
       return c.json(bundles ?? []);
     } catch (error) {

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -205,7 +205,7 @@ describe("s3Database plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["2.0.0"]);
 
     // Update bundle and commit
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     await plugin.updateBundle("00000000-0000-0000-0000-000000000002", {
       enabled: false,
     });
@@ -277,7 +277,7 @@ describe("s3Database plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
     // Load all bundle info from S3 into memory cache
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Update targetAppVersion of one bundle from ios/1.x.x to 1.0.2
     await plugin.updateBundle("00000000-0000-0000-0000-000000000003", {
@@ -380,7 +380,7 @@ describe("s3Database plugin", () => {
     // Set initial state of target-app-versions.json
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
 
     await plugin.updateBundle("00000000-0000-0000-0000-000000000004", {
       targetAppVersion: "1.x.x",
@@ -479,7 +479,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Force reload bundle info from S3
-    const bundles = await plugin.getBundles({ limit: 20 });
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Assert: Returned bundle list should only include valid bundles
     expect(bundles).toHaveLength(3);
@@ -548,7 +548,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Load all bundles from S3
-    const bundles = await plugin.getBundles({ limit: 20 });
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Assert: All bundles from all channels should be loaded
     expect(bundles).toHaveLength(5);
@@ -599,7 +599,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Load bundles, update channel, and commit
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     await plugin.updateBundle("channel-move-test", {
       channel: "production",
     });
@@ -676,7 +676,7 @@ describe("s3Database plugin", () => {
     ]);
     fakeStore["production/ios/2.0.0/update.json"] = JSON.stringify([bundleC]);
 
-    const bundles = await plugin.getBundles({ limit: 20 });
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Descending order: "C" > "B" > "A"
     expect(bundles).toEqual([bundleC, bundleB, bundleA]);
@@ -693,7 +693,7 @@ describe("s3Database plugin", () => {
     fakeStore["production/android/2.0.0/update.json"] = JSON.stringify([
       bundle,
     ]);
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     const fetchedBundle = await plugin.getBundleById("internal-test");
     expect(fetchedBundle).not.toHaveProperty("_updateJsonKey");
     expect(fetchedBundle).not.toHaveProperty("_oldUpdateJsonKey");
@@ -726,7 +726,7 @@ describe("s3Database plugin", () => {
   it("should return an empty array when no update.json files exist in S3", async () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
-    const bundles = await plugin.getBundles({ limit: 20 });
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
     expect(bundles).toEqual([]);
   });
 

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -482,8 +482,8 @@ describe("s3Database plugin", () => {
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Assert: Returned bundle list should only include valid bundles
-    expect(bundles).toHaveLength(3);
-    expect(bundles).toEqual(
+    expect(bundles.data).toHaveLength(3);
+    expect(bundles.data).toEqual(
       expect.arrayContaining([iosBundle1, iosBundle2, androidBundle1]),
     );
   });
@@ -551,8 +551,8 @@ describe("s3Database plugin", () => {
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Assert: All bundles from all channels should be loaded
-    expect(bundles).toHaveLength(5);
-    expect(bundles).toEqual(
+    expect(bundles.data).toHaveLength(5);
+    expect(bundles.data).toEqual(
       expect.arrayContaining([
         productionIosBundle,
         betaIosBundle,
@@ -679,7 +679,7 @@ describe("s3Database plugin", () => {
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Descending order: "C" > "B" > "A"
-    expect(bundles).toEqual([bundleC, bundleB, bundleA]);
+    expect(bundles.data).toEqual([bundleC, bundleB, bundleA]);
   });
 
   it("should return a bundle without internal keys from getBundleById", async () => {
@@ -727,7 +727,7 @@ describe("s3Database plugin", () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
-    expect(bundles).toEqual([]);
+    expect(bundles.data).toEqual([]);
   });
 
   it("should append multiple bundles and commit them to the correct update.json files", async () => {
@@ -827,8 +827,8 @@ describe("s3Database plugin", () => {
     });
 
     // Assert: Both bundles should be loaded
-    expect(bundles).toHaveLength(3);
-    expect(bundles).toEqual([iosBundle2, androidBundle, iosBundle]);
+    expect(bundles.data).toHaveLength(3);
+    expect(bundles.data).toEqual([iosBundle2, androidBundle, iosBundle]);
 
     // Sanity check: getBundleById works for both
     const foundIos = await plugin.getBundleById(

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -205,7 +205,7 @@ describe("s3Database plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["2.0.0"]);
 
     // Update bundle and commit
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     await plugin.updateBundle("00000000-0000-0000-0000-000000000002", {
       enabled: false,
     });
@@ -277,7 +277,7 @@ describe("s3Database plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
     // Load all bundle info from S3 into memory cache
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
 
     // Update targetAppVersion of one bundle from ios/1.x.x to 1.0.2
     await plugin.updateBundle("00000000-0000-0000-0000-000000000003", {
@@ -380,7 +380,7 @@ describe("s3Database plugin", () => {
     // Set initial state of target-app-versions.json
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
 
     await plugin.updateBundle("00000000-0000-0000-0000-000000000004", {
       targetAppVersion: "1.x.x",
@@ -479,7 +479,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Force reload bundle info from S3
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20 });
 
     // Assert: Returned bundle list should only include valid bundles
     expect(bundles).toHaveLength(3);
@@ -548,7 +548,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Load all bundles from S3
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20 });
 
     // Assert: All bundles from all channels should be loaded
     expect(bundles).toHaveLength(5);
@@ -599,7 +599,7 @@ describe("s3Database plugin", () => {
     ]);
 
     // Act: Load bundles, update channel, and commit
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     await plugin.updateBundle("channel-move-test", {
       channel: "production",
     });
@@ -676,7 +676,7 @@ describe("s3Database plugin", () => {
     ]);
     fakeStore["production/ios/2.0.0/update.json"] = JSON.stringify([bundleC]);
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20 });
 
     // Descending order: "C" > "B" > "A"
     expect(bundles).toEqual([bundleC, bundleB, bundleA]);
@@ -693,7 +693,7 @@ describe("s3Database plugin", () => {
     fakeStore["production/android/2.0.0/update.json"] = JSON.stringify([
       bundle,
     ]);
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     const fetchedBundle = await plugin.getBundleById("internal-test");
     expect(fetchedBundle).not.toHaveProperty("_updateJsonKey");
     expect(fetchedBundle).not.toHaveProperty("_oldUpdateJsonKey");
@@ -726,7 +726,7 @@ describe("s3Database plugin", () => {
   it("should return an empty array when no update.json files exist in S3", async () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20 });
     expect(bundles).toEqual([]);
   });
 

--- a/plugins/firebase/src/firebaseDatabase.spec.ts
+++ b/plugins/firebase/src/firebaseDatabase.spec.ts
@@ -111,7 +111,8 @@ describe("firebaseDatabase plugin", () => {
 
     const bundles = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 5,
+      limit: 20,
+      offset: 0,
     });
     expect(bundles.data).toHaveLength(2);
     expect(bundles.data[0].id).toBe("bundle2");
@@ -265,7 +266,7 @@ describe("firebaseDatabase plugin", () => {
     await plugin.appendBundle(bundleC);
     await plugin.commitBundle();
 
-    const bundles = await plugin.getBundles({ limit: 5 });
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
     expect(bundles.data).toHaveLength(3);
     expect(bundles.data[0].id).toBe("bundleC");
     expect(bundles.data[1].id).toBe("bundleB");
@@ -321,7 +322,8 @@ describe("firebaseDatabase plugin", () => {
 
     const result = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 5,
+      limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(2);
@@ -387,7 +389,8 @@ describe("firebaseDatabase plugin", () => {
 
     const firstPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 5,
+      limit: 20,
+      offset: 0,
     });
 
     expect(firstPage.data).toHaveLength(2);
@@ -401,7 +404,8 @@ describe("firebaseDatabase plugin", () => {
 
     const secondPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 5,
+      limit: 20,
+      offset: 0,
     });
 
     expect(secondPage.data).toHaveLength(1);
@@ -464,7 +468,8 @@ describe("firebaseDatabase plugin", () => {
 
     const filteredBundles = await plugin.getBundles({
       where: { channel: "production", platform: "ios" },
-      limit: 5,
+      limit: 20,
+      offset: 0,
     });
     expect(filteredBundles.data).toHaveLength(1);
     expect(filteredBundles.data[0].id).toBe("bundleX");

--- a/plugins/firebase/src/firebaseDatabase.spec.ts
+++ b/plugins/firebase/src/firebaseDatabase.spec.ts
@@ -111,6 +111,7 @@ describe("firebaseDatabase plugin", () => {
 
     const bundles = await plugin.getBundles({
       where: { channel: "production" },
+      limit: 5,
     });
     expect(bundles.data).toHaveLength(2);
     expect(bundles.data[0].id).toBe("bundle2");
@@ -264,7 +265,7 @@ describe("firebaseDatabase plugin", () => {
     await plugin.appendBundle(bundleC);
     await plugin.commitBundle();
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 5 });
     expect(bundles.data).toHaveLength(3);
     expect(bundles.data[0].id).toBe("bundleC");
     expect(bundles.data[1].id).toBe("bundleB");
@@ -320,6 +321,7 @@ describe("firebaseDatabase plugin", () => {
 
     const result = await plugin.getBundles({
       where: { channel: "production" },
+      limit: 5,
     });
 
     expect(result.data).toHaveLength(2);
@@ -385,8 +387,7 @@ describe("firebaseDatabase plugin", () => {
 
     const firstPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 2,
-      offset: 0,
+      limit: 5,
     });
 
     expect(firstPage.data).toHaveLength(2);
@@ -400,8 +401,7 @@ describe("firebaseDatabase plugin", () => {
 
     const secondPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 2,
-      offset: 2,
+      limit: 5,
     });
 
     expect(secondPage.data).toHaveLength(1);
@@ -464,6 +464,7 @@ describe("firebaseDatabase plugin", () => {
 
     const filteredBundles = await plugin.getBundles({
       where: { channel: "production", platform: "ios" },
+      limit: 5,
     });
     expect(filteredBundles.data).toHaveLength(1);
     expect(filteredBundles.data[0].id).toBe("bundleX");

--- a/plugins/firebase/src/firebaseDatabase.spec.ts
+++ b/plugins/firebase/src/firebaseDatabase.spec.ts
@@ -389,7 +389,7 @@ describe("firebaseDatabase plugin", () => {
 
     const firstPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 20,
+      limit: 2,
       offset: 0,
     });
 
@@ -404,8 +404,8 @@ describe("firebaseDatabase plugin", () => {
 
     const secondPage = await plugin.getBundles({
       where: { channel: "production" },
-      limit: 20,
-      offset: 0,
+      limit: 2,
+      offset: 2,
     });
 
     expect(secondPage.data).toHaveLength(1);

--- a/plugins/firebase/src/firebaseDatabase.spec.ts
+++ b/plugins/firebase/src/firebaseDatabase.spec.ts
@@ -112,9 +112,9 @@ describe("firebaseDatabase plugin", () => {
     const bundles = await plugin.getBundles({
       where: { channel: "production" },
     });
-    expect(bundles).toHaveLength(2);
-    expect(bundles[0].id).toBe("bundle2");
-    expect(bundles[1].id).toBe("bundle1");
+    expect(bundles.data).toHaveLength(2);
+    expect(bundles.data[0].id).toBe("bundle2");
+    expect(bundles.data[1].id).toBe("bundle1");
   });
 
   it("should get distinct channels", async () => {
@@ -265,93 +265,153 @@ describe("firebaseDatabase plugin", () => {
     await plugin.commitBundle();
 
     const bundles = await plugin.getBundles();
-    expect(bundles).toHaveLength(3);
-    expect(bundles[0].id).toBe("bundleC");
-    expect(bundles[1].id).toBe("bundleB");
-    expect(bundles[2].id).toBe("bundleA");
+    expect(bundles.data).toHaveLength(3);
+    expect(bundles.data[0].id).toBe("bundleC");
+    expect(bundles.data[1].id).toBe("bundleB");
+    expect(bundles.data[2].id).toBe("bundleA");
+  });
+  it("should return correct pagination info for single page", async () => {
+    const bundle1 = {
+      id: "bundle1",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: true,
+      fileHash: "hash1",
+      gitCommitHash: "commit1",
+      message: "bundle 1",
+      platform: "android",
+      targetAppVersion: "2.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle2 = {
+      id: "bundle2",
+      channel: "production",
+      enabled: false,
+      shouldForceUpdate: false,
+      fileHash: "hash2",
+      gitCommitHash: "commit2",
+      message: "bundle 2",
+      platform: "ios",
+      targetAppVersion: "1.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle3 = {
+      id: "bundle3",
+      channel: "staging",
+      enabled: true,
+      shouldForceUpdate: false,
+      fileHash: "hash3",
+      gitCommitHash: "commit3",
+      message: "bundle 3",
+      platform: "android",
+      targetAppVersion: "1.5.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    await plugin.appendBundle(bundle1);
+    await plugin.appendBundle(bundle2);
+    await plugin.appendBundle(bundle3);
+    await plugin.commitBundle();
+
+    const result = await plugin.getBundles({
+      where: { channel: "production" },
+    });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].id).toBe("bundle2");
+    expect(result.data[1].id).toBe("bundle1");
+
+    expect(result.pagination).toEqual({
+      total: 2,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
   });
 
-  it("should paginate bundles correctly", async () => {
-    const bundlesData = [
-      {
-        id: "bundleA",
-        channel: "test",
-        enabled: true,
-        shouldForceUpdate: true,
-        fileHash: "hashA",
-        gitCommitHash: "commitA",
-        message: "A",
-        platform: "ios",
-        targetAppVersion: "1.0.0",
-        storageUri: "gs://test-bucket/test-key",
-        fingerprintHash: null,
-      },
-      {
-        id: "bundleB",
-        channel: "test",
-        enabled: true,
-        shouldForceUpdate: true,
-        fileHash: "hashB",
-        gitCommitHash: "commitB",
-        message: "B",
-        platform: "ios",
-        targetAppVersion: "1.0.0",
-        storageUri: "gs://test-bucket/test-key",
-        fingerprintHash: null,
-      },
-      {
-        id: "bundleC",
-        channel: "test",
-        enabled: true,
-        shouldForceUpdate: true,
-        fileHash: "hashC",
-        gitCommitHash: "commitC",
-        message: "C",
-        platform: "ios",
-        targetAppVersion: "1.0.0",
-        storageUri: "gs://test-bucket/test-key",
-        fingerprintHash: null,
-      },
-      {
-        id: "bundleD",
-        channel: "test",
-        enabled: true,
-        shouldForceUpdate: true,
-        fileHash: "hashD",
-        gitCommitHash: "commitD",
-        message: "D",
-        platform: "ios",
-        targetAppVersion: "1.0.0",
-        storageUri: "gs://test-bucket/test-key",
-        fingerprintHash: null,
-      },
-      {
-        id: "bundleE",
-        channel: "test",
-        enabled: true,
-        shouldForceUpdate: true,
-        fileHash: "hashE",
-        gitCommitHash: "commitE",
-        message: "E",
-        platform: "ios",
-        targetAppVersion: "1.0.0",
-        storageUri: "gs://test-bucket/test-key",
-        fingerprintHash: null,
-      },
-    ] as const;
+  it("should return correct pagination info for multiple pages", async () => {
+    const bundle1 = {
+      id: "bundle1",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: true,
+      fileHash: "hash1",
+      gitCommitHash: "commit1",
+      message: "bundle 1",
+      platform: "android",
+      targetAppVersion: "2.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
 
-    for (const b of bundlesData) {
-      await plugin.appendBundle(b);
-    }
+    const bundle2 = {
+      id: "bundle2",
+      channel: "production",
+      enabled: false,
+      shouldForceUpdate: false,
+      fileHash: "hash2",
+      gitCommitHash: "commit2",
+      message: "bundle 2",
+      platform: "ios",
+      targetAppVersion: "1.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle3 = {
+      id: "bundle3",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: false,
+      fileHash: "hash3",
+      gitCommitHash: "commit3",
+      message: "bundle 3",
+      platform: "android",
+      targetAppVersion: "1.5.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    await plugin.appendBundle(bundle1);
+    await plugin.appendBundle(bundle2);
+    await plugin.appendBundle(bundle3);
     await plugin.commitBundle();
-    const paginatedBundles = await plugin.getBundles({
-      where: { channel: "test" },
+
+    const firstPage = await plugin.getBundles({
+      where: { channel: "production" },
       limit: 2,
-      offset: 1,
+      offset: 0,
     });
-    expect(paginatedBundles).toHaveLength(2);
-    expect(paginatedBundles[0].id).toBe("bundleD");
-    expect(paginatedBundles[1].id).toBe("bundleC");
+
+    expect(firstPage.data).toHaveLength(2);
+    expect(firstPage.pagination).toEqual({
+      total: 3,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 2,
+    });
+
+    const secondPage = await plugin.getBundles({
+      where: { channel: "production" },
+      limit: 2,
+      offset: 2,
+    });
+
+    expect(secondPage.data).toHaveLength(1);
+    expect(secondPage.pagination).toEqual({
+      total: 3,
+      hasNextPage: false,
+      hasPreviousPage: true,
+      currentPage: 2,
+      totalPages: 2,
+    });
   });
 
   it("should filter bundles by both channel and platform", async () => {
@@ -405,8 +465,8 @@ describe("firebaseDatabase plugin", () => {
     const filteredBundles = await plugin.getBundles({
       where: { channel: "production", platform: "ios" },
     });
-    expect(filteredBundles).toHaveLength(1);
-    expect(filteredBundles[0].id).toBe("bundleX");
+    expect(filteredBundles.data).toHaveLength(1);
+    expect(filteredBundles.data[0].id).toBe("bundleX");
   });
 
   it("should not modify data when commitBundle is called with no pending changes", async () => {

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -67,7 +67,7 @@ export const firebaseDatabase = (
       },
 
       async getBundles(context, options) {
-        const { where, limit, offset } = options;
+        const { where, limit, offset = 0 } = options;
 
         let query: admin.firestore.Query<FirestoreData> =
           context.bundlesCollection;

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -1,9 +1,5 @@
 import type { SnakeCaseBundle } from "@hot-updater/core";
-import type {
-  Bundle,
-  DatabasePluginHooks,
-  PaginationInfo,
-} from "@hot-updater/plugin-core";
+import type { Bundle, DatabasePluginHooks } from "@hot-updater/plugin-core";
 import {
   createDatabasePlugin,
   calculatePagination,
@@ -11,14 +7,6 @@ import {
 import * as admin from "firebase-admin";
 
 type FirestoreData = admin.firestore.DocumentData;
-
-const DEFAULT_PAGINATION: PaginationInfo = {
-  total: 0,
-  hasNextPage: false,
-  hasPreviousPage: false,
-  currentPage: 1,
-  totalPages: 1,
-};
 
 const convertToBundle = (firestoreData: SnakeCaseBundle): Bundle => ({
   channel: firestoreData.channel,
@@ -79,7 +67,8 @@ export const firebaseDatabase = (
       },
 
       async getBundles(context, options) {
-        const { where, limit, offset = 0 } = options ?? {};
+        const { where, limit, offset } = options;
+
         let query: admin.firestore.Query<FirestoreData> =
           context.bundlesCollection;
 
@@ -109,9 +98,14 @@ export const firebaseDatabase = (
           convertToBundle(doc.data() as SnakeCaseBundle),
         );
 
+        const paginationOptions = {
+          limit: limit,
+          offset: offset,
+        };
+
         return {
           data: bundles,
-          pagination: calculatePagination(total, options),
+          pagination: calculatePagination(total, paginationOptions),
         };
       },
 

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -67,7 +67,7 @@ export const firebaseDatabase = (
       },
 
       async getBundles(context, options) {
-        const { where, limit, offset = 0 } = options;
+        const { where, limit, offset } = options;
 
         let query: admin.firestore.Query<FirestoreData> =
           context.bundlesCollection;

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -1,8 +1,8 @@
 import type { SnakeCaseBundle } from "@hot-updater/core";
 import type { Bundle, DatabasePluginHooks } from "@hot-updater/plugin-core";
 import {
-  createDatabasePlugin,
   calculatePagination,
+  createDatabasePlugin,
 } from "@hot-updater/plugin-core";
 import * as admin from "firebase-admin";
 

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -98,14 +98,12 @@ export const firebaseDatabase = (
           convertToBundle(doc.data() as SnakeCaseBundle),
         );
 
-        const paginationOptions = {
-          limit: limit,
-          offset: offset,
-        };
-
         return {
           data: bundles,
-          pagination: calculatePagination(total, paginationOptions),
+          pagination: calculatePagination(total, {
+            limit,
+            offset,
+          }),
         };
       },
 

--- a/plugins/mock/src/mockDatabase.ts
+++ b/plugins/mock/src/mockDatabase.ts
@@ -1,8 +1,9 @@
-import type {
-  BasePluginArgs,
-  Bundle,
-  DatabasePlugin,
-  DatabasePluginHooks,
+import {
+  calculatePagination,
+  type BasePluginArgs,
+  type Bundle,
+  type DatabasePlugin,
+  type DatabasePluginHooks,
 } from "@hot-updater/plugin-core";
 import { minMax, sleep } from "./util/utils";
 
@@ -40,9 +41,9 @@ export const mockDatabase =
         return bundles.find((b) => b.id === bundleId) ?? null;
       },
       async getBundles(options) {
-        const { where, limit, offset = 0 } = options ?? {};
-
+        const { where, limit, offset } = options ?? {};
         await sleep(minMax(latency.min, latency.max));
+
         const filteredBundles = bundles.filter((b) => {
           if (where?.channel && b.channel !== where.channel) {
             return false;
@@ -52,10 +53,18 @@ export const mockDatabase =
           }
           return true;
         });
-        if (limit) {
-          return filteredBundles.slice(offset, offset + limit);
-        }
-        return filteredBundles;
+
+        const total = filteredBundles.length;
+        const data = limit
+          ? filteredBundles.slice(offset, offset + limit)
+          : filteredBundles;
+
+        const pagination = calculatePagination(total, { limit, offset });
+
+        return {
+          data,
+          pagination,
+        };
       },
       async getChannels() {
         await sleep(minMax(latency.min, latency.max));

--- a/plugins/mock/src/mockDatabase.ts
+++ b/plugins/mock/src/mockDatabase.ts
@@ -1,9 +1,9 @@
 import {
-  calculatePagination,
   type BasePluginArgs,
   type Bundle,
   type DatabasePlugin,
   type DatabasePluginHooks,
+  calculatePagination,
 } from "@hot-updater/plugin-core";
 import { minMax, sleep } from "./util/utils";
 

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -1,5 +1,5 @@
 import type { Bundle } from "@hot-updater/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { mockDatabase } from "../mockDatabase";
 
 const DEFAULT_BUNDLES_MOCK: Bundle[] = [
@@ -36,28 +36,179 @@ const DEFAULT_BUNDLES_MOCK: Bundle[] = [
 const DEFAULT_LATENCY = { min: 0, max: 0 };
 
 describe("mockDatabase", () => {
-  it("should return a database plugin", async () => {
-    const plugin = mockDatabase({ latency: DEFAULT_LATENCY })({ cwd: "" });
+  let plugin: ReturnType<ReturnType<typeof mockDatabase>>;
+  let pluginWithBundles: ReturnType<ReturnType<typeof mockDatabase>>;
 
+  beforeEach(() => {
+    plugin = mockDatabase({ latency: DEFAULT_LATENCY })({ cwd: "" });
+    pluginWithBundles = mockDatabase({
+      latency: DEFAULT_LATENCY,
+      initialBundles: DEFAULT_BUNDLES_MOCK,
+    })({ cwd: "" });
+  });
+
+  it("should return a database plugin", async () => {
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles.data).toEqual([]);
   });
 
   it("should return a database plugin with initial bundles", async () => {
-    const plugin = mockDatabase({
-      latency: DEFAULT_LATENCY,
-      initialBundles: DEFAULT_BUNDLES_MOCK,
-    })({ cwd: "" });
-
-    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
+    const bundles = await pluginWithBundles.getBundles({
+      limit: 20,
+      offset: 0,
+    });
 
     expect(bundles.data).toEqual(DEFAULT_BUNDLES_MOCK);
   });
 
-  it("should append a bundle", async () => {
-    const plugin = mockDatabase({ latency: DEFAULT_LATENCY })({ cwd: "" });
+  it("should return correct pagination info for single page", async () => {
+    const bundle1 = {
+      id: "bundle1",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: true,
+      fileHash: "hash1",
+      gitCommitHash: "commit1",
+      message: "bundle 1",
+      platform: "android",
+      targetAppVersion: "2.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
 
+    const bundle2 = {
+      id: "bundle2",
+      channel: "production",
+      enabled: false,
+      shouldForceUpdate: false,
+      fileHash: "hash2",
+      gitCommitHash: "commit2",
+      message: "bundle 2",
+      platform: "ios",
+      targetAppVersion: "1.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle3 = {
+      id: "bundle3",
+      channel: "staging",
+      enabled: true,
+      shouldForceUpdate: false,
+      fileHash: "hash3",
+      gitCommitHash: "commit3",
+      message: "bundle 3",
+      platform: "android",
+      targetAppVersion: "1.5.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    await plugin.appendBundle(bundle1);
+    await plugin.appendBundle(bundle2);
+    await plugin.appendBundle(bundle3);
+    await plugin.commitBundle();
+
+    const result = await plugin.getBundles({
+      where: { channel: "production" },
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].id).toBe("bundle2");
+    expect(result.data[1].id).toBe("bundle1");
+
+    expect(result.pagination).toEqual({
+      total: 2,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("should return correct pagination info for multiple pages", async () => {
+    const bundle1 = {
+      id: "bundle1",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: true,
+      fileHash: "hash1",
+      gitCommitHash: "commit1",
+      message: "bundle 1",
+      platform: "android",
+      targetAppVersion: "2.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle2 = {
+      id: "bundle2",
+      channel: "production",
+      enabled: false,
+      shouldForceUpdate: false,
+      fileHash: "hash2",
+      gitCommitHash: "commit2",
+      message: "bundle 2",
+      platform: "ios",
+      targetAppVersion: "1.0.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    const bundle3 = {
+      id: "bundle3",
+      channel: "production",
+      enabled: true,
+      shouldForceUpdate: false,
+      fileHash: "hash3",
+      gitCommitHash: "commit3",
+      message: "bundle 3",
+      platform: "android",
+      targetAppVersion: "1.5.0",
+      storageUri: "gs://test-bucket/test-key",
+      fingerprintHash: null,
+    } as const;
+
+    await plugin.appendBundle(bundle1);
+    await plugin.appendBundle(bundle2);
+    await plugin.appendBundle(bundle3);
+    await plugin.commitBundle();
+
+    const firstPage = await plugin.getBundles({
+      where: { channel: "production" },
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(firstPage.data).toHaveLength(2);
+    expect(firstPage.pagination).toEqual({
+      total: 3,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 2,
+    });
+
+    const secondPage = await plugin.getBundles({
+      where: { channel: "production" },
+      limit: 2,
+      offset: 2,
+    });
+
+    expect(secondPage.data).toHaveLength(1);
+    expect(secondPage.pagination).toEqual({
+      total: 3,
+      hasNextPage: false,
+      hasPreviousPage: true,
+      currentPage: 2,
+      totalPages: 2,
+    });
+  });
+
+  it("should append a bundle", async () => {
     await plugin.appendBundle(DEFAULT_BUNDLES_MOCK[0]);
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
@@ -66,16 +217,19 @@ describe("mockDatabase", () => {
   });
 
   it("should update a bundle", async () => {
-    const plugin = mockDatabase({
+    const singleBundlePlugin = mockDatabase({
       latency: DEFAULT_LATENCY,
       initialBundles: [DEFAULT_BUNDLES_MOCK[0]],
     })({ cwd: "" });
 
-    await plugin.updateBundle(DEFAULT_BUNDLES_MOCK[0].id, {
+    await singleBundlePlugin.updateBundle(DEFAULT_BUNDLES_MOCK[0].id, {
       enabled: false,
     });
 
-    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
+    const bundles = await singleBundlePlugin.getBundles({
+      limit: 20,
+      offset: 0,
+    });
 
     expect(bundles.data).toEqual([
       {
@@ -86,36 +240,31 @@ describe("mockDatabase", () => {
   });
 
   it("should get bundle by id", async () => {
-    const plugin = mockDatabase({
-      latency: DEFAULT_LATENCY,
-      initialBundles: DEFAULT_BUNDLES_MOCK,
-    })({ cwd: "" });
-
-    const bundle = await plugin.getBundleById(DEFAULT_BUNDLES_MOCK[0].id);
+    const bundle = await pluginWithBundles.getBundleById(
+      DEFAULT_BUNDLES_MOCK[0].id,
+    );
 
     expect(bundle).toEqual(DEFAULT_BUNDLES_MOCK[0]);
   });
 
   it("should throw error, if targetBundleId not found", async () => {
-    const plugin = mockDatabase({
+    const singleBundlePlugin = mockDatabase({
       latency: DEFAULT_LATENCY,
       initialBundles: [DEFAULT_BUNDLES_MOCK[0]],
     })({ cwd: "" });
 
     await expect(
-      plugin.updateBundle("00000000-0000-0000-0000-000000000001", {
+      singleBundlePlugin.updateBundle("00000000-0000-0000-0000-000000000001", {
         enabled: false,
       }),
     ).rejects.toThrowError("targetBundleId not found");
   });
 
   it("should sort bundles by id", async () => {
-    const plugin = mockDatabase({
-      latency: DEFAULT_LATENCY,
-      initialBundles: DEFAULT_BUNDLES_MOCK,
-    })({ cwd: "" });
-
-    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
+    const bundles = await pluginWithBundles.getBundles({
+      limit: 20,
+      offset: 0,
+    });
 
     expect(bundles.data).toEqual(DEFAULT_BUNDLES_MOCK);
   });

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -1,5 +1,5 @@
 import type { Bundle } from "@hot-updater/core";
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockDatabase } from "../mockDatabase";
 
 const DEFAULT_BUNDLES_MOCK: Bundle[] = [

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -39,7 +39,7 @@ describe("mockDatabase", () => {
   it("should return a database plugin", async () => {
     const plugin = mockDatabase({ latency: DEFAULT_LATENCY })({ cwd: "" });
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles).toEqual([]);
   });
@@ -50,7 +50,7 @@ describe("mockDatabase", () => {
       initialBundles: DEFAULT_BUNDLES_MOCK,
     })({ cwd: "" });
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles).toEqual(DEFAULT_BUNDLES_MOCK);
   });
@@ -60,7 +60,7 @@ describe("mockDatabase", () => {
 
     await plugin.appendBundle(DEFAULT_BUNDLES_MOCK[0]);
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles).toEqual([DEFAULT_BUNDLES_MOCK[0]]);
   });
@@ -75,7 +75,7 @@ describe("mockDatabase", () => {
       enabled: false,
     });
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles).toEqual([
       {
@@ -115,7 +115,7 @@ describe("mockDatabase", () => {
       initialBundles: DEFAULT_BUNDLES_MOCK,
     })({ cwd: "" });
 
-    const bundles = await plugin.getBundles();
+    const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
     expect(bundles).toEqual(DEFAULT_BUNDLES_MOCK);
   });

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -41,7 +41,7 @@ describe("mockDatabase", () => {
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
-    expect(bundles).toEqual([]);
+    expect(bundles.data).toEqual([]);
   });
 
   it("should return a database plugin with initial bundles", async () => {
@@ -52,7 +52,7 @@ describe("mockDatabase", () => {
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
-    expect(bundles).toEqual(DEFAULT_BUNDLES_MOCK);
+    expect(bundles.data).toEqual(DEFAULT_BUNDLES_MOCK);
   });
 
   it("should append a bundle", async () => {
@@ -62,7 +62,7 @@ describe("mockDatabase", () => {
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
-    expect(bundles).toEqual([DEFAULT_BUNDLES_MOCK[0]]);
+    expect(bundles.data).toEqual([DEFAULT_BUNDLES_MOCK[0]]);
   });
 
   it("should update a bundle", async () => {
@@ -77,7 +77,7 @@ describe("mockDatabase", () => {
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
-    expect(bundles).toEqual([
+    expect(bundles.data).toEqual([
       {
         ...DEFAULT_BUNDLES_MOCK[0],
         enabled: false,
@@ -117,6 +117,6 @@ describe("mockDatabase", () => {
 
     const bundles = await plugin.getBundles({ limit: 20, offset: 0 });
 
-    expect(bundles).toEqual(DEFAULT_BUNDLES_MOCK);
+    expect(bundles.data).toEqual(DEFAULT_BUNDLES_MOCK);
   });
 });

--- a/plugins/plugin-core/src/calculatePagination.ts
+++ b/plugins/plugin-core/src/calculatePagination.ts
@@ -1,8 +1,8 @@
 import type { Bundle, PaginationInfo } from "./types";
 
 export interface PaginationOptions {
-  limit?: number;
-  offset?: number;
+  limit: number;
+  offset: number;
 }
 
 export interface PaginatedResult {
@@ -15,9 +15,9 @@ export interface PaginatedResult {
  */
 export function calculatePagination(
   total: number,
-  options?: PaginationOptions,
+  options: PaginationOptions,
 ): PaginationInfo {
-  const { limit, offset = 0 } = options ?? {};
+  const { limit, offset } = options;
 
   if (total === 0) {
     return {
@@ -29,9 +29,9 @@ export function calculatePagination(
     };
   }
 
-  const currentPage = Math.floor(offset / (limit || 1)) + 1;
-  const totalPages = limit ? Math.ceil(total / limit) : 1;
-  const hasNextPage = offset + (limit || 0) < total;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const totalPages = Math.ceil(total / limit);
+  const hasNextPage = offset + limit < total;
   const hasPreviousPage = offset > 0;
 
   return {

--- a/plugins/plugin-core/src/calculatePagination.ts
+++ b/plugins/plugin-core/src/calculatePagination.ts
@@ -1,0 +1,44 @@
+import type { Bundle, PaginationInfo } from "./types";
+
+export interface PaginationOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedResult {
+  data: Bundle[];
+  pagination: PaginationInfo;
+}
+
+/**
+ * Calculate pagination information based on total count, limit, and offset
+ */
+export function calculatePagination(
+  total: number,
+  options?: PaginationOptions,
+): PaginationInfo {
+  const { limit, offset = 0 } = options ?? {};
+
+  if (total === 0) {
+    return {
+      total: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 0,
+    };
+  }
+
+  const currentPage = Math.floor(offset / (limit || 1)) + 1;
+  const totalPages = limit ? Math.ceil(total / limit) : 1;
+  const hasNextPage = offset + (limit || 0) < total;
+  const hasPreviousPage = offset > 0;
+
+  return {
+    total,
+    hasNextPage,
+    hasPreviousPage,
+    currentPage,
+    totalPages,
+  };
+}

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -142,7 +142,7 @@ describe("blobDatabase plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["2.0.0"]);
 
     // Update bundle and commit
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     await plugin.updateBundle("00000000-0000-0000-0000-000000000002", {
       enabled: false,
     });
@@ -214,7 +214,7 @@ describe("blobDatabase plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
     // Load all bundle info from S3 into memory cache
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
 
     // Update targetAppVersion of one bundle from ios/1.x.x to 1.0.2
     await plugin.updateBundle("00000000-0000-0000-0000-000000000003", {
@@ -317,7 +317,7 @@ describe("blobDatabase plugin", () => {
     // Set initial state of target-app-versions.json
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
 
     await plugin.updateBundle("00000000-0000-0000-0000-000000000004", {
       targetAppVersion: "1.x.x",
@@ -415,7 +415,7 @@ describe("blobDatabase plugin", () => {
       ),
     ]);
 
-    const result = await plugin.getBundles();
+    const result = await plugin.getBundles({ limit: 20 });
     // Assert: Returned bundle list should only include valid bundles
     expect(result.data).toHaveLength(3);
     expect(result.data).toEqual(
@@ -490,7 +490,7 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load all bundles from S3
-    const result = await plugin.getBundles();
+    const result = await plugin.getBundles({ limit: 20 });
     // Assert: All bundles from all channels should be loaded
     expect(result.data).toHaveLength(5);
     expect(result.data).toEqual(
@@ -547,7 +547,7 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load bundles, update channel, and commit
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     await plugin.updateBundle("channel-move-test", {
       channel: "production",
     });
@@ -627,7 +627,7 @@ describe("blobDatabase plugin", () => {
       bundleA,
     ]);
     fakeStore["production/ios/2.0.0/update.json"] = JSON.stringify([bundleC]);
-    const result = await plugin.getBundles();
+    const result = await plugin.getBundles({ limit: 20 });
     // Descending order: "C" > "B" > "A"
     expect(result.data).toEqual([bundleC, bundleB, bundleA]);
     expect(result.pagination).toEqual({
@@ -650,7 +650,7 @@ describe("blobDatabase plugin", () => {
     fakeStore["production/android/2.0.0/update.json"] = JSON.stringify([
       bundle,
     ]);
-    await plugin.getBundles();
+    await plugin.getBundles({ limit: 20 });
     const fetchedBundle = await plugin.getBundleById("internal-test");
     expect(fetchedBundle).not.toHaveProperty("_updateJsonKey");
     expect(fetchedBundle).not.toHaveProperty("_oldUpdateJsonKey");
@@ -683,7 +683,7 @@ describe("blobDatabase plugin", () => {
   it("should return an empty array when no update.json files exist in S3", async () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
-    const result = await plugin.getBundles();
+    const result = await plugin.getBundles({ limit: 20 });
     expect(result.data).toEqual([]);
     expect(result.pagination).toEqual({
       total: 0,

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -142,7 +142,7 @@ describe("blobDatabase plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["2.0.0"]);
 
     // Update bundle and commit
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     await plugin.updateBundle("00000000-0000-0000-0000-000000000002", {
       enabled: false,
     });
@@ -214,7 +214,7 @@ describe("blobDatabase plugin", () => {
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
     // Load all bundle info from S3 into memory cache
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
 
     // Update targetAppVersion of one bundle from ios/1.x.x to 1.0.2
     await plugin.updateBundle("00000000-0000-0000-0000-000000000003", {
@@ -317,7 +317,7 @@ describe("blobDatabase plugin", () => {
     // Set initial state of target-app-versions.json
     fakeStore[targetVersionsKey] = JSON.stringify(["1.x.x", "1.0.2"]);
 
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
 
     await plugin.updateBundle("00000000-0000-0000-0000-000000000004", {
       targetAppVersion: "1.x.x",
@@ -415,7 +415,7 @@ describe("blobDatabase plugin", () => {
       ),
     ]);
 
-    const result = await plugin.getBundles({ limit: 20 });
+    const result = await plugin.getBundles({ limit: 20, offset: 0 });
     // Assert: Returned bundle list should only include valid bundles
     expect(result.data).toHaveLength(3);
     expect(result.data).toEqual(
@@ -490,7 +490,7 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load all bundles from S3
-    const result = await plugin.getBundles({ limit: 20 });
+    const result = await plugin.getBundles({ limit: 20, offset: 0 });
     // Assert: All bundles from all channels should be loaded
     expect(result.data).toHaveLength(5);
     expect(result.data).toEqual(
@@ -547,7 +547,7 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load bundles, update channel, and commit
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     await plugin.updateBundle("channel-move-test", {
       channel: "production",
     });
@@ -627,7 +627,7 @@ describe("blobDatabase plugin", () => {
       bundleA,
     ]);
     fakeStore["production/ios/2.0.0/update.json"] = JSON.stringify([bundleC]);
-    const result = await plugin.getBundles({ limit: 20 });
+    const result = await plugin.getBundles({ limit: 20, offset: 0 });
     // Descending order: "C" > "B" > "A"
     expect(result.data).toEqual([bundleC, bundleB, bundleA]);
     expect(result.pagination).toEqual({
@@ -650,7 +650,7 @@ describe("blobDatabase plugin", () => {
     fakeStore["production/android/2.0.0/update.json"] = JSON.stringify([
       bundle,
     ]);
-    await plugin.getBundles({ limit: 20 });
+    await plugin.getBundles({ limit: 20, offset: 0 });
     const fetchedBundle = await plugin.getBundleById("internal-test");
     expect(fetchedBundle).not.toHaveProperty("_updateJsonKey");
     expect(fetchedBundle).not.toHaveProperty("_oldUpdateJsonKey");
@@ -683,7 +683,7 @@ describe("blobDatabase plugin", () => {
   it("should return an empty array when no update.json files exist in S3", async () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
-    const result = await plugin.getBundles({ limit: 20 });
+    const result = await plugin.getBundles({ limit: 20, offset: 0 });
     expect(result.data).toEqual([]);
     expect(result.pagination).toEqual({
       total: 0,

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -415,14 +415,19 @@ describe("blobDatabase plugin", () => {
       ),
     ]);
 
-    // Act: Force reload bundle info from S3
-    const bundles = await plugin.getBundles();
-
+    const result = await plugin.getBundles();
     // Assert: Returned bundle list should only include valid bundles
-    expect(bundles).toHaveLength(3);
-    expect(bundles).toEqual(
+    expect(result.data).toHaveLength(3);
+    expect(result.data).toEqual(
       expect.arrayContaining([iosBundle1, iosBundle2, androidBundle1]),
     );
+    expect(result.pagination).toEqual({
+      total: 3,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
   });
 
   it("should handle bundles from multiple channels correctly", async () => {
@@ -485,11 +490,10 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load all bundles from S3
-    const bundles = await plugin.getBundles();
-
+    const result = await plugin.getBundles();
     // Assert: All bundles from all channels should be loaded
-    expect(bundles).toHaveLength(5);
-    expect(bundles).toEqual(
+    expect(result.data).toHaveLength(5);
+    expect(result.data).toEqual(
       expect.arrayContaining([
         productionIosBundle,
         betaIosBundle,
@@ -498,6 +502,13 @@ describe("blobDatabase plugin", () => {
         betaAndroidBundle,
       ]),
     );
+    expect(result.pagination).toEqual({
+      total: 5,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
 
     // Test updating a bundle in a specific channel
     await plugin.updateBundle("beta-ios-1", {
@@ -616,11 +627,16 @@ describe("blobDatabase plugin", () => {
       bundleA,
     ]);
     fakeStore["production/ios/2.0.0/update.json"] = JSON.stringify([bundleC]);
-
-    const bundles = await plugin.getBundles();
-
+    const result = await plugin.getBundles();
     // Descending order: "C" > "B" > "A"
-    expect(bundles).toEqual([bundleC, bundleB, bundleA]);
+    expect(result.data).toEqual([bundleC, bundleB, bundleA]);
+    expect(result.pagination).toEqual({
+      total: 3,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
   });
 
   it("should return a bundle without internal keys from getBundleById", async () => {
@@ -667,8 +683,15 @@ describe("blobDatabase plugin", () => {
   it("should return an empty array when no update.json files exist in S3", async () => {
     // Verify empty array is returned when no update.json files exist in S3
     fakeStore = {}; // Initialize S3 store
-    const bundles = await plugin.getBundles();
-    expect(bundles).toEqual([]);
+    const result = await plugin.getBundles();
+    expect(result.data).toEqual([]);
+    expect(result.pagination).toEqual({
+      total: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 0,
+    });
   });
 
   it("should append multiple bundles and commit them to the correct update.json files", async () => {
@@ -758,7 +781,7 @@ describe("blobDatabase plugin", () => {
     ]);
 
     // Act: Load all bundles
-    const bundles = await plugin.getBundles({
+    const result = await plugin.getBundles({
       limit: 10,
       offset: 0,
       where: {
@@ -766,10 +789,16 @@ describe("blobDatabase plugin", () => {
         channel: "production",
       },
     });
-
     // Assert: Both bundles should be loaded
-    expect(bundles).toHaveLength(3);
-    expect(bundles).toEqual([iosBundle2, androidBundle, iosBundle]);
+    expect(result.data).toHaveLength(3);
+    expect(result.data).toEqual([iosBundle2, androidBundle, iosBundle]);
+    expect(result.pagination).toEqual({
+      total: 3,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      currentPage: 1,
+      totalPages: 1,
+    });
 
     // Sanity check: getBundleById works for both
     const foundIos = await plugin.getBundleById(

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -215,14 +215,12 @@ export const createBlobDatabasePlugin = <TContext = object>({
           paginatedData = paginatedData.slice(0, limit);
         }
 
-        const paginationOptions = {
-          limit,
-          offset,
-        };
-
         return {
           data: paginatedData,
-          pagination: calculatePagination(total, paginationOptions),
+          pagination: calculatePagination(total, {
+            limit,
+            offset,
+          }),
         };
       },
 

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -189,7 +189,7 @@ export const createBlobDatabasePlugin = <TContext = object>({
       async getBundles(context, options) {
         // Always load the latest data from S3.
         let allBundles = await reloadBundles(context);
-        const { where, limit, offset = 0 } = options ?? {};
+        const { where, limit, offset = 0 } = options;
 
         // Apply filtering conditions first to get the total count after filtering
         if (where) {
@@ -215,9 +215,14 @@ export const createBlobDatabasePlugin = <TContext = object>({
           paginatedData = paginatedData.slice(0, limit);
         }
 
+        const paginationOptions = {
+          limit,
+          offset,
+        };
+
         return {
           data: paginatedData,
-          pagination: calculatePagination(total, options),
+          pagination: calculatePagination(total, paginationOptions),
         };
       },
 

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -1,18 +1,10 @@
 import { orderBy } from "es-toolkit";
 import { createDatabasePlugin } from "./createDatabasePlugin";
-import type { Bundle, DatabasePluginHooks } from "./types";
+import type { Bundle, DatabasePluginHooks, PaginationInfo } from "./types";
 
 interface BundleWithUpdateJsonKey extends Bundle {
   _updateJsonKey: string;
   _oldUpdateJsonKey?: string;
-}
-
-export interface PaginationInfo {
-  total: number;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  currentPage: number;
-  totalPages: number;
 }
 
 // Helper function to remove internal management keys

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -1,7 +1,7 @@
 import { orderBy } from "es-toolkit";
+import { calculatePagination } from "./calculatePagination";
 import { createDatabasePlugin } from "./createDatabasePlugin";
 import type { Bundle, DatabasePluginHooks } from "./types";
-import { calculatePagination } from "./calculatePagination";
 
 interface BundleWithUpdateJsonKey extends Bundle {
   _updateJsonKey: string;

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -189,7 +189,7 @@ export const createBlobDatabasePlugin = <TContext = object>({
       async getBundles(context, options) {
         // Always load the latest data from S3.
         let allBundles = await reloadBundles(context);
-        const { where, limit, offset = 0 } = options;
+        const { where, limit, offset } = options;
 
         // Apply filtering conditions first to get the total count after filtering
         if (where) {

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -222,7 +222,12 @@ export const createBlobDatabasePlugin = <TContext = object>({
       },
 
       async getChannels(context) {
-        const result = await this.getBundles(context);
+        const allBundles = await reloadBundles(context);
+        const total = allBundles.length;
+        const result = await this.getBundles(context, {
+          limit: total,
+          offset: 0,
+        });
         return [...new Set(result.data.map((bundle) => bundle.channel))];
       },
 

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -22,7 +22,7 @@ export interface AbstractDatabasePlugin<TContext = object> {
     options: {
       where?: { channel?: string; platform?: string };
       limit: number;
-      offset?: number;
+      offset: number;
     },
   ) => Promise<{
     data: Bundle[];

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -22,7 +22,7 @@ export interface AbstractDatabasePlugin<TContext = object> {
     options: {
       where?: { channel?: string; platform?: string };
       limit: number;
-      offset: number;
+      offset?: number;
     },
   ) => Promise<{
     data: Bundle[];

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -4,17 +4,11 @@ import type {
   BasePluginArgs,
   DatabasePlugin,
   DatabasePluginHooks,
+  PaginationInfo,
 } from "./types";
 
 export interface BaseDatabaseUtils {
   cwd: string;
-}
-export interface PaginationInfo {
-  total: number;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  currentPage: number;
-  totalPages: number;
 }
 
 export interface AbstractDatabasePlugin<TContext = object> {

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -19,10 +19,10 @@ export interface AbstractDatabasePlugin<TContext = object> {
   ) => Promise<Bundle | null>;
   getBundles: (
     context: TContext,
-    options?: {
+    options: {
       where?: { channel?: string; platform?: string };
-      limit?: number;
-      offset?: number;
+      limit: number;
+      offset: number;
     },
   ) => Promise<{
     data: Bundle[];

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -9,6 +9,13 @@ import type {
 export interface BaseDatabaseUtils {
   cwd: string;
 }
+export interface PaginationInfo {
+  total: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  currentPage: number;
+  totalPages: number;
+}
 
 export interface AbstractDatabasePlugin<TContext = object> {
   getContext?: () => TContext;
@@ -19,14 +26,14 @@ export interface AbstractDatabasePlugin<TContext = object> {
   getBundles: (
     context: TContext,
     options?: {
-      where?: {
-        channel?: string;
-        platform?: string;
-      };
+      where?: { channel?: string; platform?: string };
       limit?: number;
       offset?: number;
     },
-  ) => Promise<Bundle[]>;
+  ) => Promise<{
+    data: Bundle[];
+    pagination: PaginationInfo;
+  }>;
   getChannels: (context: TContext) => Promise<string[]>;
   onUnmount?: (context: TContext) => void;
   commitBundle: (

--- a/plugins/plugin-core/src/index.ts
+++ b/plugins/plugin-core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./makeEnv";
 export * from "./createZip";
 export * from "./createBlobDatabasePlugin";
 export * from "./ConfigBuilder";
+export * from "./calculatePagination";

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -1,10 +1,17 @@
 import type { Bundle, Platform } from "@hot-updater/core";
-import type { PaginationInfo } from "../createDatabasePlugin";
 
 export type { Platform, Bundle } from "@hot-updater/core";
 
 export interface BasePluginArgs {
   cwd: string;
+}
+
+export interface PaginationInfo {
+  total: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  currentPage: number;
+  totalPages: number;
 }
 
 export interface BuildPluginConfig {

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { Bundle, Platform } from "@hot-updater/core";
+import type { PaginationInfo } from "../createDatabasePlugin";
 
 export type { Platform, Bundle } from "@hot-updater/core";
 
@@ -14,13 +15,13 @@ export interface DatabasePlugin {
   getChannels: () => Promise<string[]>;
   getBundleById: (bundleId: string) => Promise<Bundle | null>;
   getBundles: (options?: {
-    where?: {
-      channel?: string;
-      platform?: Platform;
-    };
+    where?: { channel?: string; platform?: string };
     limit?: number;
     offset?: number;
-  }) => Promise<Bundle[]>;
+  }) => Promise<{
+    data: Bundle[];
+    pagination: PaginationInfo;
+  }>;
   updateBundle: (
     targetBundleId: string,
     newBundle: Partial<Bundle>,
@@ -36,10 +37,7 @@ export interface DatabasePluginHooks {
 }
 
 export interface BuildPlugin {
-  build: (args: {
-    platform: Platform;
-    channel: string;
-  }) => Promise<{
+  build: (args: { platform: Platform; channel: string }) => Promise<{
     buildPath: string;
     bundleId: string;
     channel: string;

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -21,10 +21,10 @@ export interface BuildPluginConfig {
 export interface DatabasePlugin {
   getChannels: () => Promise<string[]>;
   getBundleById: (bundleId: string) => Promise<Bundle | null>;
-  getBundles: (options?: {
+  getBundles: (options: {
     where?: { channel?: string; platform?: string };
-    limit?: number;
-    offset?: number;
+    limit: number;
+    offset: number;
   }) => Promise<{
     data: Bundle[];
     pagination: PaginationInfo;

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -24,7 +24,7 @@ export interface DatabasePlugin {
   getBundles: (options: {
     where?: { channel?: string; platform?: string };
     limit: number;
-    offset?: number;
+    offset: number;
   }) => Promise<{
     data: Bundle[];
     pagination: PaginationInfo;

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -24,7 +24,7 @@ export interface DatabasePlugin {
   getBundles: (options: {
     where?: { channel?: string; platform?: string };
     limit: number;
-    offset: number;
+    offset?: number;
   }) => Promise<{
     data: Bundle[];
     pagination: PaginationInfo;

--- a/plugins/standalone/src/standaloneRepository.spec.ts
+++ b/plugins/standalone/src/standaloneRepository.spec.ts
@@ -69,7 +69,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
     );
 
     const bundles = await repo.getBundles({ limit: 20, offset: 0 });
-    expect(bundles).toEqual(testBundles);
+    expect(bundles.data).toEqual(testBundles);
     expect(callCount).toBe(1);
   });
 
@@ -293,7 +293,7 @@ describe("Standalone Repository Plugin (Custom Routes)", () => {
     );
 
     const bundles = await customRepo.getBundles({ limit: 20, offset: 0 });
-    expect(bundles).toEqual(testBundles);
+    expect(bundles.data).toEqual(testBundles);
   });
 
   it("getBundleById: uses custom retrieve route and headers", async () => {

--- a/plugins/standalone/src/standaloneRepository.spec.ts
+++ b/plugins/standalone/src/standaloneRepository.spec.ts
@@ -68,7 +68,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
       }),
     );
 
-    const bundles = await repo.getBundles();
+    const bundles = await repo.getBundles({ limit: 20, offset: 0 });
     expect(bundles).toEqual(testBundles);
     expect(callCount).toBe(1);
   });
@@ -82,8 +82,8 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
       }),
     );
 
-    await repo.getBundles();
-    const refreshed = await repo.getBundles();
+    await repo.getBundles({ limit: 20, offset: 0 });
+    const refreshed = await repo.getBundles({ limit: 20, offset: 0 });
     expect(refreshed).toEqual(testBundles);
     expect(callCount).toBe(2);
   });
@@ -140,7 +140,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
       }),
     );
 
-    await expect(repo.getBundles()).rejects.toThrow(
+    await expect(repo.getBundles({ limit: 20, offset: 0 })).rejects.toThrow(
       "API Error: Internal Server Error",
     );
   });
@@ -292,7 +292,7 @@ describe("Standalone Repository Plugin (Custom Routes)", () => {
       }),
     );
 
-    const bundles = await customRepo.getBundles();
+    const bundles = await customRepo.getBundles({ limit: 20, offset: 0 });
     expect(bundles).toEqual(testBundles);
   });
 

--- a/plugins/standalone/src/standaloneRepository.spec.ts
+++ b/plugins/standalone/src/standaloneRepository.spec.ts
@@ -84,7 +84,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
 
     await repo.getBundles({ limit: 20, offset: 0 });
     const refreshed = await repo.getBundles({ limit: 20, offset: 0 });
-    expect(refreshed).toEqual(testBundles);
+    expect(refreshed.data).toEqual(testBundles);
     expect(callCount).toBe(2);
   });
 

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -337,11 +337,7 @@ const deployEdgeFunction = async (workdir: string, projectId: string) => {
   ]);
 };
 
-export const runInit = async ({
-  build,
-}: {
-  build: BuildType;
-}) => {
+export const runInit = async ({ build }: { build: BuildType }) => {
   const project = await selectProject();
 
   const spinner = p.spinner();
@@ -368,7 +364,7 @@ export const runInit = async ({
 
   const serviceRoleKey = apiKeys.find((key) => key.name === "service_role");
   if (!serviceRoleKey) {
-    throw new Error("Service role key not found");
+    throw new Error("Service role key not found, is your project paused?");
   }
 
   const api = supabaseApi(

--- a/plugins/supabase/src/supabaseDatabase.ts
+++ b/plugins/supabase/src/supabaseDatabase.ts
@@ -1,5 +1,8 @@
 import type { Bundle, DatabasePluginHooks } from "@hot-updater/plugin-core";
-import { createDatabasePlugin } from "@hot-updater/plugin-core";
+import {
+  calculatePagination,
+  createDatabasePlugin,
+} from "@hot-updater/plugin-core";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
@@ -48,7 +51,21 @@ export const supabaseDatabase = (
       },
 
       async getBundles(context, options) {
-        const { where, limit, offset = 0 } = options ?? {};
+        const { where, limit, offset } = options ?? {};
+
+        let countQuery = context.supabase
+          .from("bundles")
+          .select("*", { count: "exact", head: true });
+
+        if (where?.channel) {
+          countQuery = countQuery.eq("channel", where.channel);
+        }
+        if (where?.platform) {
+          countQuery = countQuery.eq("platform", where.platform);
+        }
+
+        const { count: total } = await countQuery;
+
         let query = context.supabase
           .from("bundles")
           .select("*")
@@ -72,24 +89,29 @@ export const supabaseDatabase = (
 
         const { data } = await query;
 
-        if (!data) {
-          return [];
-        }
+        const bundles = data
+          ? data.map((bundle) => ({
+              channel: bundle.channel,
+              enabled: bundle.enabled,
+              shouldForceUpdate: bundle.should_force_update,
+              fileHash: bundle.file_hash,
+              gitCommitHash: bundle.git_commit_hash,
+              id: bundle.id,
+              message: bundle.message,
+              platform: bundle.platform,
+              targetAppVersion: bundle.target_app_version,
+              fingerprintHash: bundle.fingerprint_hash,
+              storageUri: bundle.storage_uri,
+              metadata: bundle.metadata ?? {},
+            }))
+          : [];
 
-        return data.map((bundle) => ({
-          channel: bundle.channel,
-          enabled: bundle.enabled,
-          shouldForceUpdate: bundle.should_force_update,
-          fileHash: bundle.file_hash,
-          gitCommitHash: bundle.git_commit_hash,
-          id: bundle.id,
-          message: bundle.message,
-          platform: bundle.platform,
-          targetAppVersion: bundle.target_app_version,
-          fingerprintHash: bundle.fingerprint_hash,
-          storageUri: bundle.storage_uri,
-          metadata: bundle.metadata ?? {},
-        })) as Bundle[];
+        const pagination = calculatePagination(total || 0, { limit, offset });
+
+        return {
+          data: bundles,
+          pagination,
+        };
       },
 
       async getChannels(context) {

--- a/plugins/supabase/src/supabaseDatabase.ts
+++ b/plugins/supabase/src/supabaseDatabase.ts
@@ -64,7 +64,7 @@ export const supabaseDatabase = (
           countQuery = countQuery.eq("platform", where.platform);
         }
 
-        const { count: total } = await countQuery;
+        const { count: total = 0 } = await countQuery;
 
         let query = context.supabase
           .from("bundles")
@@ -106,7 +106,7 @@ export const supabaseDatabase = (
             }))
           : [];
 
-        const pagination = calculatePagination(total || 0, { limit, offset });
+        const pagination = calculatePagination(total ?? 0, { limit, offset });
 
         return {
           data: bundles,


### PR DESCRIPTION
## Problem
Currently, the console does not implement proper pagination functionality. The getBundles method only returns bundle data without pagination metadata, making it impossible to implement navigation controls or determine if additional pages are available.

---

## Solution
To enable proper pagination in the console interface, this PR implements comprehensive changes to the data layer and providers

1. Update getBundles API specification
Before: getBundles() returns Promise<Bundle[]>
After: getBundles() returns Promise<{ data: Bundle[]; pagination: PaginationInfo }>

2. Update all database providers
Modify all existing database plugin implementations to support the new pagination response format
Ensure backward compatibility during the transition
Update type definitions across all affected modules

3. Update frontend queries
Modify createBundlesQuery to handle the new pagination data structure
Update console UI components to display pagination controls
Implement proper page navigation functionality

---

## to-do list

1. [x] createDatabase.ts
2. [x] console
3. [x] firebase
4. [x] aws
5. [x] cloudflare
6. [x] mock
7. [x] postgres
8. [x] standalone
9. [x] supabase
