### PR TITLE
fix(babel): make sure the backend can handle channel changes for a bundle and still receive updates correctly

### DIFF
--- a/examples/rnef-repack/App.tsx
+++ b/examples/rnef-repack/App.tsx
@@ -41,7 +41,6 @@ function App(): React.JSX.Element {
   return (
     <SafeAreaView>
       <Text>Babel {HotUpdater.getBundleId()}</Text>
-      <Text>Release Channel "{HotUpdater.getReleaseChannel()}"</Text>
       <Text>Channel "{HotUpdater.getChannel()}"</Text>
       <Text>App Version "{HotUpdater.getAppVersion()}"</Text>
       <Text>Fingerprint: {HotUpdater.getFingerprintHash()}</Text>

--- a/examples/v0.71.19/App.tsx
+++ b/examples/v0.71.19/App.tsx
@@ -63,7 +63,7 @@ function App(): React.JSX.Element {
     <SafeAreaView>
       <Text>Babel {HotUpdater.getBundleId()}</Text>
       <Text>Channel "{HotUpdater.getChannel()}"</Text>
-      <Text>Release Channel "{HotUpdater.getReleaseChannel()}"</Text>
+      <Text>Release Channel "{HotUpdater.()}"</Text>
       <Text>App Version "{HotUpdater.getAppVersion()}"</Text>
 
       <Text>{extractFormatDateFromUUIDv7(HotUpdater.getBundleId())}</Text>

--- a/packages/hot-updater/src/plugins/babel.ts
+++ b/packages/hot-updater/src/plugins/babel.ts
@@ -70,16 +70,11 @@ const getFingerprintJson = () => {
   }
 };
 
-const getOverTheAirChannel = () => {
-  return process.env["HOT_UPDATER_CHANNEL"];
-};
-
 export default function ({
   types: t,
 }: { types: typeof babelTypes }): PluginObj {
   const bundleId = getBundleId();
   const fingerprint = getFingerprintJson();
-  const channel = getOverTheAirChannel();
   const { updateStrategy } = memoizeLoadConfig(null);
   return {
     name: "hot-updater-babel-plugin",
@@ -87,11 +82,6 @@ export default function ({
       Identifier(path: NodePath<babelTypes.Identifier>) {
         if (path.node.name === "__HOT_UPDATER_BUNDLE_ID") {
           path.replaceWith(t.stringLiteral(bundleId));
-        }
-        if (path.node.name === "__HOT_UPDATER_CHANNEL") {
-          path.replaceWith(
-            channel ? t.stringLiteral(channel) : t.nullLiteral(),
-          );
         }
         if (path.node.name === "__HOT_UPDATER_FINGERPRINT_HASH_IOS") {
           fingerprint?.iosHash

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -6,7 +6,6 @@ import {
   getChannel,
   getFingerprintHash,
   getMinBundleId,
-  getReleaseChannel,
   reload,
   updateBundle,
 } from "./native";
@@ -79,18 +78,6 @@ export const HotUpdater = {
    * ```
    */
   getChannel,
-  /**
-   * The initial channel of the native app.
-   *
-   * @returns {string} The current release channel of the app
-   * @default "production"
-   * @example
-   * ```ts
-   * const channel = HotUpdater.getReleaseChannel();
-   * console.log(`Current release channel: ${channel}`);
-   * ```
-   */
-  getReleaseChannel,
   /**
    * Adds a listener to HotUpdater events.
    *

--- a/packages/react-native/src/native.ts
+++ b/packages/react-native/src/native.ts
@@ -10,10 +10,8 @@ declare const __HOT_UPDATER_BUNDLE_ID: string | undefined;
 declare const __HOT_UPDATER_FINGERPRINT_HASH_IOS: string | null;
 declare const __HOT_UPDATER_FINGERPRINT_HASH_ANDROID: string | null;
 declare const __HOT_UPDATER_UPDATE_STRATEGY: UpdateStrategy;
-declare const __HOT_UPDATER_CHANNEL: string | null;
 
 export const HotUpdaterConstants = {
-  OVER_THE_AIR_CHANNEL: __HOT_UPDATER_CHANNEL,
   HOT_UPDATER_BUNDLE_ID: __HOT_UPDATER_BUNDLE_ID || NIL_UUID,
   FINGERPRINT_HASH: Platform.select({
     ios: __HOT_UPDATER_FINGERPRINT_HASH_IOS,
@@ -141,14 +139,6 @@ export const getBundleId = (): string => {
  * @returns {string} Resolves with the channel or null if not available.
  */
 export const getChannel = (): string => {
-  if (HotUpdaterConstants.OVER_THE_AIR_CHANNEL) {
-    return HotUpdaterConstants.OVER_THE_AIR_CHANNEL;
-  }
-  const constants = HotUpdaterNative.getConstants();
-  return constants.CHANNEL;
-};
-
-export const getReleaseChannel = (): string => {
   const constants = HotUpdaterNative.getConstants();
   return constants.CHANNEL;
 };

--- a/plugins/repack/src/index.ts
+++ b/plugins/repack/src/index.ts
@@ -66,10 +66,6 @@ const getFingerprintJson = () => {
   }
 };
 
-const getOverTheAirChannel = () => {
-  return process.env?.["HOT_UPDATER_CHANNEL"] ?? null;
-};
-
 export class HotUpdaterPlugin implements RspackPluginInstance {
   apply(compiler: Compiler) {
     const fingerprint = getFingerprintJson();
@@ -77,7 +73,6 @@ export class HotUpdaterPlugin implements RspackPluginInstance {
 
     new compiler.webpack.DefinePlugin({
       __HOT_UPDATER_BUNDLE_ID: JSON.stringify(getBundleId()),
-      __HOT_UPDATER_CHANNEL: JSON.stringify(getOverTheAirChannel()),
       __HOT_UPDATER_FINGERPRINT_HASH_IOS: JSON.stringify(
         fingerprint?.iosHash ?? null,
       ),


### PR DESCRIPTION
Preliminary work for #389

For this to be possible, there must be no loaded channels or fingerprint-related hashes within the bundle. That layer must only be handled externally to the bundle.