### PR TITLE
chore: ignore some paths from semgrep security scan

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+examples
+docs
+node_modules
+**/*.spec.*


### PR DESCRIPTION
# Overview
[semgrep](https://semgrep.dev/docs/ignoring-files-folders-code) is a security scanner platform detects security issues from the source. We can include some paths to reduce the generated amount of security warning by semgrep.

I don't this is meaningful but resolve #338 partially.

The rule-based ignore seems impossible with `.semgrepignore` since it's a feature more open to user not library author. 

# Result

more than 90 issues -> 66 issues
5 supply chain issue -> gone

![image](https://github.com/user-attachments/assets/6a2e5dc0-ad33-4219-9279-32a692fca1b0)
