### PR TITLE
docs: fix ios expo simulate release build command

### DIFF
--- a/docs/docs/guide/simulator-test.mdx
+++ b/docs/docs/guide/simulator-test.mdx
@@ -71,9 +71,9 @@ Use the commands below to simulate downloading from the app store. Running in Re
         <Tab label="iOS">
           <PackageManagerTabs command={
             {
-              npm: "npx expo run:ios --variant release",
-              pnpm: "pnpm expo run:ios --variant release",
-              yarn: "yarn expo run:ios --variant release",
+              npm: "npx expo run:ios --configuration Release",
+              pnpm: "pnpm expo run:ios --configuration Release",
+              yarn: "yarn expo run:ios --configuration Release",
             }
           } />
         </Tab>


### PR DESCRIPTION
```sh
λ platform main ✗ pnpm expo run:ios -h            

  Info
    Run the iOS app binary locally

  Usage
    $ npx expo run:ios

  Options
    --no-build-cache                 Clear the native derived data before building
    --no-install                     Skip installing dependencies
    --no-bundler                     Skip starting the Metro bundler
    --scheme [scheme]                Scheme to build
    --binary <path>                  Path to existing .app or .ipa to install.
    --configuration <configuration>  Xcode configuration to use. Debug or Release. Default: Debug
    -d, --device [device]            Device name or UDID to build the app on
    -p, --port <port>                Port to start the Metro bundler on. Default: 8081
    -h, --help                       Usage info

  Build for production (unsigned) with the Release configuration:
    $ npx expo run:ios --configuration Release

```