### PR TITLE
fix(firebase): index default

### DIFF
--- a/.changeset/tough-baboons-buy.md
+++ b/.changeset/tough-baboons-buy.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/firebase": patch
+---
+
+fix: add default value to index

--- a/plugins/firebase/iac/index.ts
+++ b/plugins/firebase/iac/index.ts
@@ -77,8 +77,27 @@ interface FirebaseFunction {
 
 type FirebaseIndex = {
   collectionGroup: string;
-  queryScope: string;
-  fields: { fieldPath: string; order: string }[];
+  queryScope: "COLLECTION" | "COLLECTION_GROUP";
+  fields: Array<{
+    fieldPath: string;
+    order?: "ASCENDING" | "DESCENDING";
+    arrayConfig?: "CONTAINS";
+    vectorConfig?: {
+      dimension: number;
+      flat: Record<string, never>;
+    };
+  }>;
+};
+
+type FieldOverride = {
+  collectionGroup: string;
+  fieldPath: string;
+  indexes: Array<{
+    queryScope: "COLLECTION" | "COLLECTION_GROUP";
+    order?: "ASCENDING" | "DESCENDING";
+    arrayConfig?: "CONTAINS";
+  }>;
+  ttl?: boolean;
 };
 
 function normalizeIndex(index: FirebaseIndex) {
@@ -90,8 +109,11 @@ function normalizeIndex(index: FirebaseIndex) {
 }
 
 const mergeIndexes = (
-  originalIndexes: { indexes: FirebaseIndex[]; fieldOverrides: any[] },
-  newIndexes: { indexes: FirebaseIndex[]; fieldOverrides: any[] },
+  originalIndexes: {
+    indexes: FirebaseIndex[];
+    fieldOverrides: FieldOverride[];
+  },
+  newIndexes: { indexes: FirebaseIndex[]; fieldOverrides: FieldOverride[] },
 ) => {
   const mergedIndexes = originalIndexes.indexes.concat(newIndexes.indexes);
   const uniqueIndexes = uniqWith(mergedIndexes, (a, b) =>
@@ -112,10 +134,16 @@ const deployFirestore = async (cwd: string) => {
     shell: true,
   });
 
-  let originalIndexes = [];
+  let originalIndexes: {
+    indexes: FirebaseIndex[];
+    fieldOverrides: FieldOverride[];
+  } = {
+    indexes: [],
+    fieldOverrides: [],
+  };
   try {
     const originalStdout = JSON.parse(original.stdout);
-    originalIndexes = originalStdout ?? [];
+    originalIndexes = originalStdout ?? { indexes: [], fieldOverrides: [] };
   } catch {}
 
   const newIndexes = JSON.parse(

--- a/plugins/firebase/iac/index.ts
+++ b/plugins/firebase/iac/index.ts
@@ -78,7 +78,7 @@ interface FirebaseFunction {
 type FirebaseIndex = {
   collectionGroup: string;
   queryScope: "COLLECTION" | "COLLECTION_GROUP";
-  fields: Array<{
+  fields: {
     fieldPath: string;
     order?: "ASCENDING" | "DESCENDING";
     arrayConfig?: "CONTAINS";
@@ -86,7 +86,7 @@ type FirebaseIndex = {
       dimension: number;
       flat: Record<string, never>;
     };
-  }>;
+  }[];
 };
 
 type FieldOverride = {


### PR DESCRIPTION
## Before
There is not default value of fieldoverrides.
It occurred concat error

## after 

```typescript
originalIndexes = originalStdout ?? { indexes: [], fieldOverrides: [] };
```

and add exact type for index
https://firebase.google.com/docs/reference/firestore/indexes?hl=ko

closed #407 