### PR TITLE
feat: add debug option while creating fingerprint

### DIFF
--- a/.changeset/flat-actors-ring.md
+++ b/.changeset/flat-actors-ring.md
@@ -1,0 +1,6 @@
+---
+"hot-updater": patch
+"@hot-updater/plugin-core": patch
+---
+
+Add debug option while creating fingerprint

--- a/packages/hot-updater/src/utils/fingerprint/index.ts
+++ b/packages/hot-updater/src/utils/fingerprint/index.ts
@@ -15,6 +15,7 @@ export type FingerprintOptions = {
   platform: "ios" | "android";
   extraSources: string[];
   ignorePaths: string[];
+  debug?: boolean
 };
 
 export type FingerprintResult = {
@@ -42,6 +43,7 @@ export async function nativeFingerprint(
       path,
       options.ignorePaths,
     ),
+    debug: options.debug,
   });
 }
 

--- a/packages/hot-updater/src/utils/fingerprint/index.ts
+++ b/packages/hot-updater/src/utils/fingerprint/index.ts
@@ -15,7 +15,7 @@ export type FingerprintOptions = {
   platform: "ios" | "android";
   extraSources: string[];
   ignorePaths: string[];
-  debug?: boolean
+  debug?: boolean;
 };
 
 export type FingerprintResult = {

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -92,8 +92,17 @@ export type ConfigInput = {
    * The fingerprint configuration.
    */
   fingerprint?: {
+    /**
+     * The extra sources to be included in the fingerprint.
+     */
     extraSources?: string[];
+    /**
+     * The paths to be ignored in the fingerprint.
+     */
     ignorePaths?: string[];
+    /**
+     * When debug mode is enabled, more detailed information will be exposed in fingerprint.json.
+     */
     debug?: boolean;
   };
   console?: {

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -94,6 +94,7 @@ export type ConfigInput = {
   fingerprint?: {
     extraSources?: string[];
     ignorePaths?: string[];
+    debug?: boolean;
   };
   console?: {
     /**


### PR DESCRIPTION
# Requirements
Sometime I'd like to know which files or folders causing the fingerprint changed, I need to add debug option to show it

# Solutions
Add debug option when configuring hot updater

```
export default defineConfig({
  build: bare({ enableHermes: true }),
  ...
  fingerprint: {
    debug: true,
  }
});
```