### PR TITLE
fix: delete previous bundle when previous bundle access is needed

### DIFF
--- a/.changeset/plain-roses-tickle.md
+++ b/.changeset/plain-roses-tickle.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+fix: delete previous bundle when previous bundle access is needed

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -218,14 +218,14 @@ class BundleFileStorageService(
      */
     private fun cleanupOldBundles(
         bundleStoreDir: File,
-        currentBundleId: String,
-        newBundleId: String,
+        previousBundleId: String,
+        bundleId: String,
     ) {
         // List only directories that are not .tmp
         val bundles = bundleStoreDir.listFiles { file -> file.isDirectory && !file.name.endsWith(".tmp") }?.toList() ?: return
 
         // Keep only the specified bundle IDs
-        val bundleIdsToKeep = setOfNotNull(currentBundleId, newBundleId)
+        val bundleIdsToKeep = setOfNotNull(previousBundleId, bundleId)
 
         bundles.forEach { bundle ->
             if (bundle.name !in bundleIdsToKeep) {

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -100,14 +100,15 @@ class BundleFileStorageService(
             bundleStoreDir.mkdirs()
         }
 
-        val currentBundleId = getCachedBundleURL()?.let { cachedUrl ->
-            // Only consider cached bundles, not fallback bundles
-            if (!cachedUrl.startsWith("assets://")) {
-                File(cachedUrl).parentFile?.name
-            } else {
-                null
+        val currentBundleId =
+            getCachedBundleURL()?.let { cachedUrl ->
+                // Only consider cached bundles, not fallback bundles
+                if (!cachedUrl.startsWith("assets://")) {
+                    File(cachedUrl).parentFile?.name
+                } else {
+                    null
+                }
             }
-        }
         val finalBundleDir = File(bundleStoreDir, bundleId)
         if (finalBundleDir.exists()) {
             Log.d("BundleStorage", "Bundle for bundleId $bundleId already exists. Using cached bundle.")
@@ -230,9 +231,11 @@ class BundleFileStorageService(
     ) {
         try {
             // List only directories that are not .tmp
-            val bundles = bundleStoreDir.listFiles { file -> 
-                file.isDirectory && !file.name.endsWith(".tmp") 
-            }?.toList() ?: return
+            val bundles =
+                bundleStoreDir
+                    .listFiles { file ->
+                        file.isDirectory && !file.name.endsWith(".tmp")
+                    }?.toList() ?: return
 
             // Keep only the specified bundle IDs (filter out null values)
             val bundleIdsToKeep = setOfNotNull(currentBundleId, bundleId).filter { it.isNotBlank() }
@@ -255,20 +258,21 @@ class BundleFileStorageService(
             }
 
             // Remove any leftover .tmp directories
-            bundleStoreDir.listFiles { file -> 
-                file.isDirectory && file.name.endsWith(".tmp") 
-            }?.forEach { staleTmp ->
-                try {
-                    Log.d("BundleStorage", "Removing stale tmp directory: ${staleTmp.name}")
-                    if (staleTmp.deleteRecursively()) {
-                        Log.d("BundleStorage", "Successfully removed tmp directory: ${staleTmp.name}")
-                    } else {
-                        Log.w("BundleStorage", "Failed to remove tmp directory: ${staleTmp.name}")
+            bundleStoreDir
+                .listFiles { file ->
+                    file.isDirectory && file.name.endsWith(".tmp")
+                }?.forEach { staleTmp ->
+                    try {
+                        Log.d("BundleStorage", "Removing stale tmp directory: ${staleTmp.name}")
+                        if (staleTmp.deleteRecursively()) {
+                            Log.d("BundleStorage", "Successfully removed tmp directory: ${staleTmp.name}")
+                        } else {
+                            Log.w("BundleStorage", "Failed to remove tmp directory: ${staleTmp.name}")
+                        }
+                    } catch (e: Exception) {
+                        Log.e("BundleStorage", "Error removing tmp directory ${staleTmp.name}: ${e.message}")
                     }
-                } catch (e: Exception) {
-                    Log.e("BundleStorage", "Error removing tmp directory ${staleTmp.name}: ${e.message}")
                 }
-            }
         } catch (e: Exception) {
             Log.e("BundleStorage", "Error during cleanup: ${e.message}")
         }

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -100,6 +100,7 @@ class BundleFileStorageService(
             bundleStoreDir.mkdirs()
         }
 
+        val previousBundleId = getBundleURL()?.let { File(it).parentFile?.name }        
         val finalBundleDir = File(bundleStoreDir, bundleId)
         if (finalBundleDir.exists()) {
             Log.d("BundleStorage", "Bundle for bundleId $bundleId already exists. Using cached bundle.")
@@ -108,7 +109,7 @@ class BundleFileStorageService(
                 // Update last modified time and set the cached bundle URL
                 finalBundleDir.setLastModified(System.currentTimeMillis())
                 setBundleURL(existingIndexFile.absolutePath)
-                cleanupOldBundles(bundleStoreDir)
+                cleanupOldBundles(bundleStoreDir, Pair(previousBundleId, bundleId))
                 return true
             } else {
                 // If index.android.bundle is missing, delete and re-download
@@ -203,7 +204,7 @@ class BundleFileStorageService(
                     tempDir.deleteRecursively()
 
                     // 10) Remove old bundles
-                    cleanupOldBundles(bundleStoreDir)
+                    cleanupOldBundles(bundleStoreDir, Pair(previousBundleId, bundleId))
 
                     Log.d("BundleStorage", "Downloaded and activated bundle successfully.")
                     return@withContext true
@@ -213,18 +214,21 @@ class BundleFileStorageService(
     }
 
     /**
-     * Removes older bundles and any leftover .tmp directories
+     * Removes old bundles except for the specified bundle IDs, and any leftover .tmp directories
      */
-    private fun cleanupOldBundles(bundleStoreDir: File) {
+    private fun cleanupOldBundles(bundleStoreDir: File, bundlesToKeep: Pair<String?, String>) {
         // List only directories that are not .tmp
         val bundles = bundleStoreDir.listFiles { file -> file.isDirectory && !file.name.endsWith(".tmp") }?.toList() ?: return
-        // Sort bundles by last modified (newest first)
-        val sortedBundles = bundles.sortedByDescending { it.lastModified() }
-        if (sortedBundles.size > 1) {
-            // Keep the most recent bundle, delete the rest
-            sortedBundles.drop(1).forEach { oldBundle ->
-                Log.d("BundleStorage", "Removing old bundle: ${oldBundle.name}")
-                oldBundle.deleteRecursively()
+        
+        // Keep only the specified bundle IDs
+        val bundleIdsToKeep = setOfNotNull(bundlesToKeep.first, bundlesToKeep.second)
+        
+        bundles.forEach { bundle ->
+            if (bundle.name !in bundleIdsToKeep) {
+                Log.d("BundleStorage", "Removing old bundle: ${bundle.name}")
+                bundle.deleteRecursively()
+            } else {
+                Log.d("BundleStorage", "Keeping bundle: ${bundle.name}")
             }
         }
 

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -159,115 +159,67 @@ class BundleFileStorageService: BundleStorageService {
             return .failure(error)
         }
     }
-    
+        
     /**
-     * Cleans up old bundles, keeping only the current and latest bundles.
-     * Executes synchronously on the calling thread.
-     * @param currentBundleId ID of the current active bundle (optional)
-     * @return Result of operation
-     */
-    func cleanupOldBundles(currentBundleId: String?) -> Result<Void, Error> {
+    * Cleans up old bundles, keeping only the previous and current bundles.
+    * Executes synchronously on the calling thread.
+    * @param previousBundleId ID of the previous active bundle (optional)
+    * @param bundleId ID of the current bundle to keep (optional)
+    * @return Result of operation
+    */
+    func cleanupOldBundles(previousBundleId: String?, bundleId: String?) -> Result<Void, Error> {
         let storeDirResult = bundleStoreDir()
         
         guard case .success(let storeDir) = storeDirResult else {
             return .failure(storeDirResult.failureError ?? BundleStorageError.unknown(nil))
         }
         
+        // List only directories that are not .tmp
+        let contents: [String]
         do {
-            var contents: [String]
-            do {
-                contents = try self.fileSystem.contentsOfDirectory(atPath: storeDir)
-            } catch let error {
-                NSLog("[BundleStorage] Failed to list contents of bundle store directory: \(storeDir)")
-                return .failure(BundleStorageError.fileSystemError(error))
-            }
-            
-            if contents.isEmpty {
-                NSLog("[BundleStorage] No bundles to clean up.")
-                return .success(())
-            }
-            
-            let currentBundlePath = currentBundleId != nil ?
-            (storeDir as NSString).appendingPathComponent(currentBundleId!) : nil
-            
-            var latestBundlePath: String? = nil
-            var latestModDate: Date = .distantPast
-            
-            for item in contents {
-                let fullPath = (storeDir as NSString).appendingPathComponent(item)
-                
-                // Skip .tmp directories
-                if item.hasSuffix(".tmp") {
-                    continue
-                }
-                
-                if let currentPath = currentBundlePath, fullPath == currentPath {
-                    continue
-                }
-                
-                if self.fileSystem.fileExists(atPath: fullPath) {
-                    do {
-                        let attributes = try self.fileSystem.attributesOfItem(atPath: fullPath)
-                        if let modDate = attributes[FileAttributeKey.modificationDate] as? Date {
-                            if modDate > latestModDate {
-                                latestModDate = modDate
-                                latestBundlePath = fullPath
-                            }
-                        }
-                    } catch {
-                        NSLog("[BundleStorage] Warning: Could not get attributes for \(fullPath): \(error)")
-                    }
-                }
-            }
-            
-            var bundlesToKeep = Set<String>()
-            
-            if let currentPath = currentBundlePath, self.fileSystem.fileExists(atPath: currentPath) {
-                bundlesToKeep.insert(currentPath)
-                NSLog("[BundleStorage] Keeping current bundle: \(currentBundleId!)")
-            }
-            
-            if let latestPath = latestBundlePath {
-                bundlesToKeep.insert(latestPath)
-                NSLog("[BundleStorage] Keeping latest bundle: \((latestPath as NSString).lastPathComponent)")
-            }
-            
-            var removedCount = 0
-            for item in contents {
-                let fullPath = (storeDir as NSString).appendingPathComponent(item)
-                // Skip .tmp directories as well
-                if item.hasSuffix(".tmp") {
-                    // Clean up any stale .tmp directories
-                    do {
-                        try self.fileSystem.removeItem(atPath: fullPath)
-                        NSLog("[BundleStorage] Removed stale tmp directory: \(fullPath)")
-                    } catch {
-                        NSLog("[BundleStorage] Failed to remove stale tmp directory \(fullPath): \(error)")
-                    }
-                    continue
-                }
-                
-                if !bundlesToKeep.contains(fullPath) {
-                    do {
-                        try self.fileSystem.removeItem(atPath: fullPath)
-                        removedCount += 1
-                        NSLog("[BundleStorage] Removed old bundle: \(item)")
-                    } catch {
-                        NSLog("[BundleStorage] Failed to remove old bundle at \(fullPath): \(error)")
-                    }
-                }
-            }
-            
-            if removedCount == 0 {
-                NSLog("[BundleStorage] No old bundles to remove.")
-            } else {
-                NSLog("[BundleStorage] Removed \(removedCount) old bundle(s).")
-            }
-            
-            return .success(())
+            contents = try self.fileSystem.contentsOfDirectory(atPath: storeDir)
         } catch let error {
-            return .failure(error)
+            NSLog("[BundleStorage] Failed to list contents of bundle store directory: \(storeDir)")
+            return .failure(BundleStorageError.fileSystemError(error))
         }
+        
+        let bundles = contents.compactMap { item -> String? in
+            let fullPath = (storeDir as NSString).appendingPathComponent(item)
+            return (!item.hasSuffix(".tmp") && self.fileSystem.fileExists(atPath: fullPath)) ? fullPath : nil
+        }
+        
+        // Keep only the specified bundle IDs
+        let bundleIdsToKeep = Set([previousBundleId, bundleId].compactMap { $0 })
+        
+        bundles.forEach { bundlePath in
+            let bundleName = (bundlePath as NSString).lastPathComponent
+            
+            if !bundleIdsToKeep.contains(bundleName) {
+                do {
+                    try self.fileSystem.removeItem(atPath: bundlePath)
+                    NSLog("[BundleStorage] Removing old bundle: \(bundleName)")
+                } catch {
+                    NSLog("[BundleStorage] Failed to remove old bundle at \(bundlePath): \(error)")
+                }
+            } else {
+                NSLog("[BundleStorage] Keeping bundle: \(bundleName)")
+            }
+        }
+        
+        // Remove any leftover .tmp directories
+        contents.forEach { item in
+            if item.hasSuffix(".tmp") {
+                let fullPath = (storeDir as NSString).appendingPathComponent(item)
+                do {
+                    try self.fileSystem.removeItem(atPath: fullPath)
+                    NSLog("[BundleStorage] Removing stale tmp directory: \(item)")
+                } catch {
+                    NSLog("[BundleStorage] Failed to remove stale tmp directory \(fullPath): \(error)")
+                }
+            }
+        }
+        
+        return .success(())
     }
     
     /**
@@ -324,6 +276,9 @@ class BundleFileStorageService: BundleStorageService {
      * @param completion Callback with result of the operation
      */
     func updateBundle(bundleId: String, fileUrl: URL?, completion: @escaping (Result<Bool, Error>) -> Void) {
+        // Get the previous bundle ID from the current bundle URL
+        let previousBundleId = self.getBundleURL()?.deletingLastPathComponent().lastPathComponent
+        
         guard let validFileUrl = fileUrl else {
             NSLog("[BundleStorage] fileUrl is nil, resetting bundle URL.")
             // Dispatch the sequence to the file operation queue to ensure completion is called asynchronously
@@ -332,7 +287,7 @@ class BundleFileStorageService: BundleStorageService {
                 let setResult = self.setBundleURL(localPath: nil)
                 switch setResult {
                 case .success:
-                    let cleanupResult = self.cleanupOldBundles(currentBundleId: nil)
+                    let cleanupResult = self.cleanupOldBundles(previousBundleId: previousBundleId, bundleId: bundleId)
                     switch cleanupResult {
                     case .success:
                         completion(.success(true))
@@ -350,6 +305,7 @@ class BundleFileStorageService: BundleStorageService {
         
         // Start the bundle update process on a background queue
         fileOperationQueue.async {
+            
             let storeDirResult = self.bundleStoreDir()
             guard case .success(let storeDir) = storeDirResult else {
                 completion(.failure(storeDirResult.failureError ?? BundleStorageError.unknown(nil)))
@@ -368,7 +324,7 @@ class BundleFileStorageService: BundleStorageService {
                             let setResult = self.setBundleURL(localPath: bundlePath)
                             switch setResult {
                             case .success:
-                                let cleanupResult = self.cleanupOldBundles(currentBundleId: bundleId)
+                                let cleanupResult = self.cleanupOldBundles(previousBundleId: previousBundleId, bundleId: bundleId)
                                 switch cleanupResult {
                                 case .success:
                                     completion(.success(true))
@@ -495,6 +451,7 @@ class BundleFileStorageService: BundleStorageService {
         tempDirectory: String,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
+        let previousBundleId = self.getBundleURL()?.deletingLastPathComponent().lastPathComponent
         NSLog("[BundleStorage] Processing downloaded file atPath: \(location.path)")
         
         // 1) Ensure the ZIP file exists
@@ -556,7 +513,7 @@ class BundleFileStorageService: BundleStorageService {
                         self.cleanupTemporaryFiles([tempDirectory])
                         
                         // 13) Clean up old bundles, preserving current and latest
-                        let _ = self.cleanupOldBundles(currentBundleId: bundleId)
+                        let _ = self.cleanupOldBundles(previousBundleId: previousBundleId, bundleId: bundleId)
                         
                         // 14) Complete with success
                         completion(.success(true))


### PR DESCRIPTION
## Problem
1. The app starts up by loading the existing bundle and launches based on it.
2. The hot-updater downloads a new bundle and deletes the existing bundle.
3. Since the assets that the existing bundle was accessing have disappeared, local images are no longer displayed.

## Solution
1. Records of existing bundleIds and records of newly added bundleIds during the update process
2. In cleanupOldBundles, instead of keeping only the latest bundle as before, bundles corresponding to the above two parameters are not deleted

## to-do list
1. [x] - android
2. [x] - ios