### PR TITLE
feat(cli): makeEnv to `.env.hotupdater`

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,17 +40,6 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
-
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
           

--- a/docs/docs/guide/security.mdx
+++ b/docs/docs/guide/security.mdx
@@ -67,7 +67,7 @@ module.exports = {
         envName: 'APP_ENV',
         allowlist: ['HOT_UPDATER_SUPABASE_ANON_KEY', 'HOT_UPDATER_CLOUDFLARE_API_TOKEN'], ❌ Do not add private keys to allowlist // [!code --]
         allowlist: ['HOT_UPDATER_SUPABASE_URL'], // ✅ Only add public keys that are safe to expose to allowlist // [!code ++]
-        path: '.env',
+        path: '.env.hotupdater', // ✅ Use .env.hotupdater file separate from .env file
       },
     ],
   ],

--- a/examples/expo-52/.gitignore
+++ b/examples/expo-52/.gitignore
@@ -34,3 +34,8 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# hot-updater
+.hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/expo-52/hot-updater.config.ts
+++ b/examples/expo-52/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { expo } from "@hot-updater/expo";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
-import "dotenv/config";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   build: expo(),

--- a/examples/rnef-repack/.gitignore
+++ b/examples/rnef-repack/.gitignore
@@ -76,3 +76,8 @@ yarn-error.log
 
 # RNEF
 .rnef/
+
+# hot-updater
+.hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/rnef-repack/hot-updater.config.ts
+++ b/examples/rnef-repack/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { rnef } from "@hot-updater/rnef";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
-import "dotenv/config";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   build: rnef(),

--- a/examples/v0.71.19/.gitignore
+++ b/examples/v0.71.19/.gitignore
@@ -61,3 +61,7 @@ yarn-error.log
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
+# hot-updater
+.env.hotupdater
+# hot-updater
+.hot-updater/output

--- a/examples/v0.71.19/babel.config.js
+++ b/examples/v0.71.19/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
         envName: 'APP_ENV',
         moduleName: '@env',
         allowlist: ['HOT_UPDATER_SUPABASE_URL', 'HOT_UPDATER_SENTRY_DSN'],
-        path: '.env',
+        path: '.env.hotupdater',
       },
     ],
   ],

--- a/examples/v0.71.19/hot-updater.config.ts
+++ b/examples/v0.71.19/hot-updater.config.ts
@@ -1,20 +1,27 @@
+import { s3Database, s3Storage } from "@hot-updater/aws";
 import { bare } from "@hot-updater/bare";
-import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
-import "dotenv/config";
+
+config({ path: ".env.hotupdater" });
+
+const commonOptions = {
+  bucketName: process.env.HOT_UPDATER_S3_BUCKET_NAME!,
+  region: process.env.HOT_UPDATER_S3_REGION!,
+  credentials: {
+    accessKeyId: process.env.HOT_UPDATER_S3_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.HOT_UPDATER_S3_SECRET_ACCESS_KEY!,
+    // This token may expire. For permanent use, it's recommended to use a key with S3FullAccess and CloudFrontFullAccess permission and remove this field.
+    sessionToken: process.env.HOT_UPDATER_S3_SESSION_TOKEN!,
+  },
+};
 
 export default defineConfig({
-  build: bare({
-    enableHermes: true,
-  }),
-  storage: supabaseStorage({
-    supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
-    supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
-    bucketName: process.env.HOT_UPDATER_SUPABASE_BUCKET_NAME!,
-  }),
-  database: supabaseDatabase({
-    supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
-    supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
+  build: bare({ enableHermes: true }),
+  storage: s3Storage(commonOptions),
+  database: s3Database({
+    ...commonOptions,
+    cloudfrontDistributionId: process.env.HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID!,
   }),
   updateStrategy: "fingerprint",
 });

--- a/examples/v0.74.1/.gitignore
+++ b/examples/v0.74.1/.gitignore
@@ -72,3 +72,9 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+
+# hot-updater
+.hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/v0.74.1/babel.config.js
+++ b/examples/v0.74.1/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
         envName: 'APP_ENV',
         moduleName: '@env',
         allowlist: ['HOT_UPDATER_SUPABASE_URL'],
-        path: '.env',
+        path: '.env.hotupdater',
       },
     ],
   ],

--- a/examples/v0.74.1/hot-updater.config.ts
+++ b/examples/v0.74.1/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { bare } from "@hot-updater/bare";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
-import "dotenv/config";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   build: bare({

--- a/examples/v0.76.1-new-arch/.gitignore
+++ b/examples/v0.76.1-new-arch/.gitignore
@@ -72,3 +72,8 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# hot-updater
+.hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/v0.76.1-new-arch/babel.config.js
+++ b/examples/v0.76.1-new-arch/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
         envName: 'APP_ENV',
         moduleName: '@env',
         allowlist: ['HOT_UPDATER_SUPABASE_URL'],
-        path: '.env',
+        path: '.env.hotupdater',
       },
     ],
   ],

--- a/examples/v0.76.1-new-arch/hot-updater.config.ts
+++ b/examples/v0.76.1-new-arch/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { bare } from "@hot-updater/bare";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
-import "dotenv/config";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   build: bare({

--- a/examples/v0.77.0/.gitignore
+++ b/examples/v0.77.0/.gitignore
@@ -74,3 +74,5 @@ yarn-error.log
 !.yarn/versions
 # hot-updater
 .hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/v0.77.0/babel.config.js
+++ b/examples/v0.77.0/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
         envName: 'APP_ENV',
         moduleName: '@env',
         allowlist: ['HOT_UPDATER_SUPABASE_URL'],
-        path: '.env',
+        path: '.env.hotupdater',
       },
     ],
   ],

--- a/examples/v0.77.0/hot-updater.config.ts
+++ b/examples/v0.77.0/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { bare } from "@hot-updater/bare";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   nativeBuild: { android: { aab: false } },

--- a/examples/v0.81.0/.gitignore
+++ b/examples/v0.81.0/.gitignore
@@ -75,3 +75,5 @@ yarn-error.log
 !.yarn/versions
 # hot-updater
 .hot-updater/output
+# hot-updater
+.env.hotupdater

--- a/examples/v0.81.0/babel.config.js
+++ b/examples/v0.81.0/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
         envName: 'APP_ENV',
         moduleName: '@env',
         allowlist: ['HOT_UPDATER_SUPABASE_URL'],
-        path: '.env',
+        path: '.env.hotupdater',
       },
     ],
   ],

--- a/examples/v0.81.0/hot-updater.config.ts
+++ b/examples/v0.81.0/hot-updater.config.ts
@@ -1,7 +1,9 @@
 import { bare } from "@hot-updater/bare";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 export default defineConfig({
   nativeBuild: { android: { aab: false } },

--- a/examples/v0.81.0/package.json
+++ b/examples/v0.81.0/package.json
@@ -39,6 +39,7 @@
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
+    "dotenv": "^16.4.5",
     "eslint": "^8.19.0",
     "hot-updater": "workspace:*",
     "jest": "^29.6.3",

--- a/packages/hot-updater/src/commands/init.ts
+++ b/packages/hot-updater/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { ensureInstallPackages } from "@/utils/ensureInstallPackages";
+import { appendToProjectRootGitignore } from "@/utils/git";
 import { appendOutputDirectoryIntoGitignore } from "@/utils/output/appendOutputDirectoryIntoGitignore";
 import { printBanner } from "@/utils/printBanner";
 import * as p from "@clack/prompts";
@@ -136,6 +137,11 @@ export const init = async () => {
     }
     default:
       throw new Error("Invalid provider");
+  }
+
+  // Add .env.hotupdater to .gitignore
+  if (appendToProjectRootGitignore({ globLines: [".env.hotupdater"] })) {
+    p.log.info(".gitignore has been modified to include .env.hotupdater");
   }
 
   if (appendOutputDirectoryIntoGitignore()) {

--- a/packages/hot-updater/src/utils/git.spec.ts
+++ b/packages/hot-updater/src/utils/git.spec.ts
@@ -36,7 +36,8 @@ describe("appendToProjectRootGitignore", () => {
 
     expect(fs.readFileSync(gitIgnorePath(), { encoding: "utf8" })).toBe(
       `# hot-updater
-.hot-updater/output`,
+.hot-updater/output
+`,
     );
   });
 

--- a/packages/hot-updater/src/utils/git.ts
+++ b/packages/hot-updater/src/utils/git.ts
@@ -49,15 +49,19 @@ export const appendToProjectRootGitignore = ({
       return false;
     }
 
+    // Ensure there's a newline before appending if the file doesn't end with one
+    const needsNewlineBefore = content.length > 0 && !content.endsWith("\n");
+    const textToAppend = [comment, ...willAppendedLines].join("\n");
+
     fs.appendFileSync(
       gitIgnorePath,
-      [comment, ...willAppendedLines].join("\n"),
+      `${needsNewlineBefore ? "\n" : ""}${textToAppend}\n`,
       {
         encoding: "utf8",
       },
     );
   } else {
-    fs.writeFileSync(gitIgnorePath, [comment, ...globLines].join("\n"), {
+    fs.writeFileSync(gitIgnorePath, `${[comment, ...globLines].join("\n")}\n`, {
       encoding: "utf8",
     });
   }

--- a/plugins/aws/iac/index.ts
+++ b/plugins/aws/iac/index.ts
@@ -262,7 +262,7 @@ export const runInit = async ({
     }),
     HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID: distributionId,
   });
-  p.log.success("Generated '.env' file with AWS settings.");
+  p.log.success("Generated '.env.hotupdater' file with AWS settings.");
   p.log.success("Generated 'hot-updater.config.ts' file with AWS settings.");
 
   // Provide API URL for client use (using CloudFront domain)

--- a/plugins/cloudflare/iac/index.ts
+++ b/plugins/cloudflare/iac/index.ts
@@ -432,7 +432,7 @@ export const runInit = async ({
     HOT_UPDATER_CLOUDFLARE_R2_BUCKET_NAME: selectedBucketName,
     HOT_UPDATER_CLOUDFLARE_D1_DATABASE_ID: selectedD1DatabaseId,
   });
-  p.log.success("Generated '.env' file with Cloudflare settings.");
+  p.log.success("Generated '.env.hotupdater' file with Cloudflare settings.");
   p.log.success(
     "Generated 'hot-updater.config.ts' file with Cloudflare settings.",
   );

--- a/plugins/plugin-core/src/ConfigBuilder.spec.ts
+++ b/plugins/plugin-core/src/ConfigBuilder.spec.ts
@@ -217,8 +217,10 @@ export default defineConfig({
 
     const expectedConfig = `import { bare } from "@hot-updater/bare";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 
 export default defineConfig({
@@ -243,8 +245,10 @@ export default defineConfig({
 
     const expectedConfig = `import { bare } from "@hot-updater/bare";
 import { d1Database, r2Storage } from "@hot-updater/cloudflare";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 
 export default defineConfig({
@@ -270,8 +274,10 @@ export default defineConfig({
 
     const expectedConfig = `import { d1Database, r2Storage } from "@hot-updater/cloudflare";
 import { rnef } from "@hot-updater/rnef";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 
 export default defineConfig({
@@ -297,9 +303,11 @@ export default defineConfig({
 
     const expectedConfig = `import { bare } from "@hot-updater/bare";
 import { firebaseDatabase, firebaseStorage } from "@hot-updater/firebase";
-import "dotenv/config";
 import * as admin from "firebase-admin";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
 // Check your .env.hotupdater file and add the credentials
@@ -323,35 +331,4 @@ export default defineConfig({
 
     expect(result).toBe(expectedConfig);
   });
-
-  //   it("should build a Firebase config with rnef", () => {
-  //     const result = getFirebaseConfigTemplate("rnef");
-
-  //     const expectedConfig = `import { firebaseDatabase, firebaseStorage } from "@hot-updater/firebase";
-  // import { rnef } from "@hot-updater/rnef";
-  // import admin from "firebase-admin";
-  // import "dotenv/config";
-  // import { defineConfig } from "hot-updater";
-
-  // // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
-  // // Check your .env.hotupdater file and add the credentials
-  // // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
-  // // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-  // const credential = admin.credential.applicationDefault();
-
-  // export default defineConfig({
-  //   build: rnef(),
-  //   storage: firebaseStorage({
-  //     projectId: process.env.HOT_UPDATER_FIREBASE_PROJECT_ID!,
-  //     storageBucket: process.env.HOT_UPDATER_FIREBASE_STORAGE_BUCKET!,
-  //     credential,
-  //   }),
-  //   database: firebaseDatabase({
-  //     projectId: process.env.HOT_UPDATER_FIREBASE_PROJECT_ID!,
-  //     credential,
-  //   }),
-  // });`;
-
-  //     expect(result).toBe(expectedConfig);
-  //   });
 });

--- a/plugins/plugin-core/src/ConfigBuilder.spec.ts
+++ b/plugins/plugin-core/src/ConfigBuilder.spec.ts
@@ -127,7 +127,7 @@ const getFirebaseConfigTemplate = (build: BuildType) => {
 
   const intermediate = `
 // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
-// Check your .env file and add the credentials
+// Check your .env.hotupdater file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
 const credential = admin.credential.applicationDefault();`.trim();
@@ -149,8 +149,10 @@ describe("ConfigBuilder", () => {
 
     const expectedConfig = `import { s3Database, s3Storage } from "@hot-updater/aws";
 import { bare } from "@hot-updater/bare";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 const commonOptions = {
   bucketName: process.env.HOT_UPDATER_S3_BUCKET_NAME!,
@@ -183,8 +185,10 @@ export default defineConfig({
 
     const expectedConfig = `import { s3Database, s3Storage } from "@hot-updater/aws";
 import { bare } from "@hot-updater/bare";
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
+
+config({ path: ".env.hotupdater" });
 
 const commonOptions = {
   bucketName: process.env.HOT_UPDATER_S3_BUCKET_NAME!,
@@ -298,7 +302,7 @@ import * as admin from "firebase-admin";
 import { defineConfig } from "hot-updater";
 
 // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
-// Check your .env file and add the credentials
+// Check your .env.hotupdater file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
 const credential = admin.credential.applicationDefault();
@@ -330,7 +334,7 @@ export default defineConfig({
   // import { defineConfig } from "hot-updater";
 
   // // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
-  // // Check your .env file and add the credentials
+  // // Check your .env.hotupdater file and add the credentials
   // // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
   // // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
   // const credential = admin.credential.applicationDefault();

--- a/plugins/plugin-core/src/ConfigBuilder.ts
+++ b/plugins/plugin-core/src/ConfigBuilder.ts
@@ -46,7 +46,7 @@ export class ConfigBuilder implements IConfigBuilder {
 
   constructor() {
     // Add common imports needed by almost all configurations by default
-    this.addImport({ pkg: "dotenv/config", sideEffect: true });
+    this.addImport({ pkg: "dotenv", named: ["config"] });
     this.addImport({ pkg: "hot-updater", named: ["defineConfig"] });
   }
 
@@ -202,6 +202,8 @@ export class ConfigBuilder implements IConfigBuilder {
     // Assemble the final string
     return `
 ${importStatements}
+
+config({ path: ".env.hotupdater" });
 
 ${this.intermediateCode ? `${this.intermediateCode}\n` : ""}
 export default defineConfig({

--- a/plugins/plugin-core/src/makeEnv.spec.ts
+++ b/plugins/plugin-core/src/makeEnv.spec.ts
@@ -13,7 +13,7 @@ describe("makeEnv", () => {
     vi.resetAllMocks();
   });
 
-  it("adds new environment variables while preserving existing .env content", async () => {
+  it("adds new environment variables while preserving existing .env.hotupdater content", async () => {
     vi.mocked(fs.readFile).mockResolvedValueOnce("EXISTING_KEY=existing_value");
     const newEnvVars = {
       NEW_KEY: "new_value",

--- a/plugins/plugin-core/src/makeEnv.ts
+++ b/plugins/plugin-core/src/makeEnv.ts
@@ -4,10 +4,10 @@ type EnvVarValue = string | { comment: string; value: string };
 
 export const makeEnv = async (
   newEnvVars: Record<string, EnvVarValue>,
-  filePath = ".env",
+  filePath = ".env.hotupdater",
 ): Promise<string> => {
   try {
-    // Read the existing .env file or initialize with an empty string if not found
+    // Read the existing .env.hotupdater file or initialize with an empty string if not found
     const existingContent = await fs
       .readFile(filePath, "utf-8")
       .catch(() => "");
@@ -84,7 +84,7 @@ export const makeEnv = async (
     await fs.writeFile(filePath, updatedContent, "utf-8");
     return updatedContent;
   } catch (error) {
-    console.error("Error while updating .env file:", error);
+    console.error("Error while updating .env.hotupdater file:", error);
     throw error;
   }
 };

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -413,7 +413,7 @@ export const runInit = async ({ build }: { build: BuildType }) => {
     HOT_UPDATER_SUPABASE_BUCKET_NAME: bucket.name,
     HOT_UPDATER_SUPABASE_URL: `https://${project.id}.supabase.co`,
   });
-  p.log.success("Generated '.env' file with Supabase settings.");
+  p.log.success("Generated '.env.hotupdater' file with Supabase settings.");
   p.log.success(
     "Generated 'hot-updater.config.ts' file with Supabase settings.",
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,13 +416,13 @@ importers:
         version: 0.74.83
       '@react-native/metro-config':
         specifier: 0.74.83
-        version: 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)
+        version: 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
       '@react-native/typescript-config':
         specifier: 0.74.83
         version: 0.74.83
       '@rnx-kit/metro-config':
         specifier: ^2.0.1
-        version: 2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@rnx-kit/metro-resolver-symlinks':
         specifier: ^0.2.1
         version: 0.2.1
@@ -759,6 +759,9 @@ importers:
       '@types/react-test-renderer':
         specifier: ^19.1.0
         version: 19.1.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       eslint:
         specifier: ^8.19.0
         version: 8.57.0
@@ -1064,7 +1067,7 @@ importers:
         version: 0.79.1(@babel/core@7.26.0)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.3)(react@19.1.0)
       react-native-builder-bob:
         specifier: ^0.40.10
-        version: 0.40.10
+        version: 0.40.10(encoding@0.1.13)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -3750,7 +3753,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.17.13':
     resolution: {integrity: sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==}
@@ -24937,7 +24940,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)':
+  '@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))':
     dependencies:
       '@react-native/js-polyfills': 0.74.83
       '@react-native/metro-babel-transformer': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
@@ -24946,10 +24949,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
 
   '@react-native/metro-config@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))':
     dependencies:
@@ -25211,7 +25211,7 @@ snapshots:
 
   '@rnx-kit/console@2.0.0': {}
 
-  '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@rnx-kit/tools-node': 3.0.0
       '@rnx-kit/tools-react-native': 2.0.0
@@ -25219,7 +25219,7 @@ snapshots:
       react: 18.2.0
       react-native: 0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0)
     optionalDependencies:
-      '@react-native/metro-config': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)
+      '@react-native/metro-config': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
 
   '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@20.0.0)(@types/react@18.3.20)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -37129,7 +37129,7 @@ snapshots:
 
   react-lazy-with-preload@2.2.1: {}
 
-  react-native-builder-bob@0.40.10:
+  react-native-builder-bob@0.40.10(encoding@0.1.13):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.26.0)
@@ -37155,7 +37155,10 @@ snapshots:
       which: 2.0.2
       yargs: 17.7.2
     transitivePeerDependencies:
+      - bufferutil
+      - encoding
       - supports-color
+      - utf-8-validate
 
   react-native-codegen@0.71.6(@babel/preset-env@7.26.0(@babel/core@7.26.0)):
     dependencies:


### PR DESCRIPTION
Since `.env` is created during `hot-updater init`, it may conflict with an existing `.env` file. Moreover, if `react-native-dotenv` is used, there is a security risk that tokens could be included in the bundle. Therefore, during `hot-updater init`, a separate `.env.hotupdater` file is generated to isolate it from `.env`.