### PR TITLE
feat: default updateStrategy change from `fingerprint` to `appVersion`

### DIFF
--- a/.changeset/smooth-heads-tickle.md
+++ b/.changeset/smooth-heads-tickle.md
@@ -1,0 +1,10 @@
+---
+"@hot-updater/plugin-core": patch
+"@hot-updater/cloudflare": patch
+"@hot-updater/example-react-native-v81": patch
+"@hot-updater/firebase": patch
+"@hot-updater/supabase": patch
+"@hot-updater/aws": patch
+---
+
+feat: default updateStrategy is 'appVersion'

--- a/docs/docs/guide/channel.mdx
+++ b/docs/docs/guide/channel.mdx
@@ -227,7 +227,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
 })(App);
 ```

--- a/docs/docs/guide/getting-started/quick-start-with-supabase.mdx
+++ b/docs/docs/guide/getting-started/quick-start-with-supabase.mdx
@@ -115,7 +115,7 @@ function App() {
 
 export default HotUpdater.wrap({ 
   source: getUpdateSource("https://<project-id>.supabase.co/functions/v1/update-server", { // [!code ++]
-    updateStrategy: "fingerprint", // or "appVersion" // [!code ++]
+    updateStrategy: "appVersion", // or "fingerprint" // [!code ++]
   }), // [!code ++]
   requestHeaders: {
     // if you want to use the request headers, you can add them here

--- a/docs/docs/guide/hot-updater/checkForUpdate.mdx
+++ b/docs/docs/guide/hot-updater/checkForUpdate.mdx
@@ -15,7 +15,7 @@ async function checkForAppUpdate() {
   try {
     const updateInfo = await HotUpdater.checkForUpdate({
       source: getUpdateSource("<your-update-server-url>", {
-        updateStrategy: "fingerprint", // or "appVersion"
+        updateStrategy: "appVersion", // or "fingerprint"
       }),
       requestHeaders: {
         Authorization: "Bearer <your-access-token>",

--- a/docs/docs/guide/hot-updater/getChannel.mdx
+++ b/docs/docs/guide/hot-updater/getChannel.mdx
@@ -28,7 +28,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   requestHeaders: {
     "Authorization": "Bearer <your-access-token>",

--- a/docs/docs/guide/hot-updater/reload.mdx
+++ b/docs/docs/guide/hot-updater/reload.mdx
@@ -36,7 +36,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {

--- a/docs/docs/guide/hot-updater/runUpdateProcess.mdx
+++ b/docs/docs/guide/hot-updater/runUpdateProcess.mdx
@@ -22,7 +22,7 @@ import { HotUpdater, getUpdateSource } from "@hot-updater/react-native";
 
 const result = await HotUpdater.runUpdateProcess({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   requestHeaders: {
     // Add any necessary request headers here
@@ -38,7 +38,7 @@ When a force update exists, the app will not reload. `shouldForceUpdate` will be
 ```tsx
 const result = await HotUpdater.runUpdateProcess({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   requestHeaders: {
     // Add any necessary request headers here

--- a/docs/docs/guide/hot-updater/updateBundle.mdx
+++ b/docs/docs/guide/hot-updater/updateBundle.mdx
@@ -15,7 +15,7 @@ async function applyAppUpdate(updateInfo: UpdateInfo) {
   try {
     const updateInfo = await HotUpdater.checkForUpdate({
       source: getUpdateSource("<your-update-server-url>", {
-        updateStrategy: "fingerprint", // or "appVersion"
+        updateStrategy: "appVersion", // or "fingerprint"
       }),
       requestHeaders: {
         Authorization: "Bearer <your-access-token>",

--- a/docs/docs/guide/hot-updater/useHotUpdaterStore.mdx
+++ b/docs/docs/guide/hot-updater/useHotUpdaterStore.mdx
@@ -30,7 +30,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {

--- a/docs/docs/guide/hot-updater/wrap.mdx
+++ b/docs/docs/guide/hot-updater/wrap.mdx
@@ -20,7 +20,7 @@ function App() {
 
 export default HotUpdater.wrap({ // [!code hl:10]
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {
@@ -75,7 +75,7 @@ function App() {
 
 export default HotUpdater.wrap({ // [!code hl:26]
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   fallbackComponent: ({ progress, status, message }) => (
       <View
@@ -130,7 +130,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {
@@ -159,7 +159,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {
@@ -202,7 +202,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("<your-update-server-url>", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
   // If you need to send request headers, you can use the `requestHeaders` option.
   requestHeaders: {

--- a/docs/docs/guide/providers/1_supabase.mdx
+++ b/docs/docs/guide/providers/1_supabase.mdx
@@ -117,7 +117,7 @@ function App() {
 
 export default HotUpdater.wrap({ 
   source: getUpdateSource("https://<project-id>.supabase.co/functions/v1/update-server", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }), // [!code ++]
   requestHeaders: {
     // if you want to use the request headers, you can add them here

--- a/docs/docs/guide/providers/2_cloudflare.mdx
+++ b/docs/docs/guide/providers/2_cloudflare.mdx
@@ -118,7 +118,7 @@ function App() {
 
 export default HotUpdater.wrap({ 
   source: getUpdateSource("https://<your-worker-name>.<your-subdomain>.workers.dev/api/check-update", { // [!code ++]
-    updateStrategy: "fingerprint", // or "appVersion" // [!code ++]
+    updateStrategy: "appVersion", // or "fingerprint" // [!code ++]
   }), // [!code ++]
   requestHeaders: {
     // if you want to use the request headers, you can add them here

--- a/docs/docs/guide/providers/3_aws-s3-lambda-edge.mdx
+++ b/docs/docs/guide/providers/3_aws-s3-lambda-edge.mdx
@@ -159,7 +159,7 @@ function App() {
 
 export default HotUpdater.wrap({ 
   source: getUpdateSource("https://<your-cloudfront-distribution-url>/api/check-update", { // [!code ++]
-    updateStrategy: "fingerprint", // or "appVersion" // [!code ++]
+    updateStrategy: "appVersion", // or "fingerprint" // [!code ++]
   }), // [!code ++]
   requestHeaders: {
     // if you want to use the request headers, you can add them here

--- a/docs/docs/guide/providers/4_firebase.mdx
+++ b/docs/docs/guide/providers/4_firebase.mdx
@@ -136,7 +136,7 @@ function App() {
 
 export default HotUpdater.wrap({ 
   source: getUpdateSource("https://<your-firebase-function-url>/api/check-update", { // [!code ++]
-    updateStrategy: "fingerprint", // or "appVersion" // [!code ++]
+    updateStrategy: "appVersion", // or "fingerprint" // [!code ++]
   }), // [!code ++]
   requestHeaders: {
     // if you want to use the request headers, you can add them here

--- a/examples/expo-52/App.tsx
+++ b/examples/expo-52/App.tsx
@@ -94,7 +94,7 @@ export default HotUpdater.wrap({
   source: getUpdateSource(
     `${process.env.EXPO_PUBLIC_HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
     {
-      updateStrategy: "fingerprint", // or "appVersion"
+      updateStrategy: "appVersion", // or "fingerprint"
     },
   ),
   fallbackComponent: ({ progress, status }) => (

--- a/examples/expo-52/hot-updater.config.ts
+++ b/examples/expo-52/hot-updater.config.ts
@@ -16,5 +16,5 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/examples/v0.71.19/App.tsx
+++ b/examples/v0.71.19/App.tsx
@@ -134,7 +134,7 @@ export default HotUpdater.wrap({
   source: getUpdateSource(
     `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
     {
-      updateStrategy: "fingerprint", // or "appVersion"
+      updateStrategy: "appVersion", // or "fingerprint"
     },
   ),
   fallbackComponent: ({ progress, status }) => (

--- a/examples/v0.71.19/hot-updater.config.ts
+++ b/examples/v0.71.19/hot-updater.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
   storage: s3Storage(commonOptions),
   database: s3Database({
     ...commonOptions,
-    cloudfrontDistributionId: process.env.HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID!,
+    cloudfrontDistributionId:
+      process.env.HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/examples/v0.74.1/App.tsx
+++ b/examples/v0.74.1/App.tsx
@@ -108,7 +108,7 @@ export default HotUpdater.wrap({
   source: getUpdateSource(
     `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
     {
-      updateStrategy: "fingerprint", // or "appVersion"
+      updateStrategy: "appVersion", // or "fingerprint"
     },
   ),
   fallbackComponent: ({ progress, status }) => (

--- a/examples/v0.74.1/hot-updater.config.ts
+++ b/examples/v0.74.1/hot-updater.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/examples/v0.76.1-new-arch/App.tsx
+++ b/examples/v0.76.1-new-arch/App.tsx
@@ -108,7 +108,7 @@ export default HotUpdater.wrap({
   source: getUpdateSource(
     `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
     {
-      updateStrategy: "fingerprint", // or "appVersion"
+      updateStrategy: "appVersion", // or "fingerprint"
     },
   ),
   fallbackComponent: ({ progress, status }) => (

--- a/examples/v0.76.1-new-arch/hot-updater.config.ts
+++ b/examples/v0.76.1-new-arch/hot-updater.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/examples/v0.77.0/App.tsx
+++ b/examples/v0.77.0/App.tsx
@@ -108,7 +108,7 @@ export default HotUpdater.wrap({
   source: getUpdateSource(
     `${HOT_UPDATER_SUPABASE_URL}/functions/v1/update-server`,
     {
-      updateStrategy: "fingerprint", // or "appVersion"
+      updateStrategy: "appVersion", // or "fingerprint"
     },
   ),
   fallbackComponent: ({ progress, status }) => (

--- a/examples/v0.77.0/hot-updater.config.ts
+++ b/examples/v0.77.0/hot-updater.config.ts
@@ -17,5 +17,5 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/examples/v0.81.0/hot-updater.config.ts
+++ b/examples/v0.81.0/hot-updater.config.ts
@@ -19,5 +19,5 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion",
 });

--- a/plugins/aws/iac/templates.ts
+++ b/plugins/aws/iac/templates.ts
@@ -67,6 +67,6 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("%%source%%", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
 })(App);`;

--- a/plugins/cloudflare/iac/index.ts
+++ b/plugins/cloudflare/iac/index.ts
@@ -52,7 +52,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("%%source%%", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
 })(App);`;
 

--- a/plugins/firebase/iac/index.ts
+++ b/plugins/firebase/iac/index.ts
@@ -21,7 +21,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("%%source%%", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
 })(App);`;
 

--- a/plugins/plugin-core/src/ConfigBuilder.spec.ts
+++ b/plugins/plugin-core/src/ConfigBuilder.spec.ts
@@ -172,7 +172,7 @@ export default defineConfig({
     ...commonOptions,
     cloudfrontDistributionId: process.env.HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);
@@ -206,7 +206,7 @@ export default defineConfig({
     ...commonOptions,
     cloudfrontDistributionId: process.env.HOT_UPDATER_CLOUDFRONT_DISTRIBUTION_ID!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);
@@ -234,7 +234,7 @@ export default defineConfig({
     supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
     supabaseAnonKey: process.env.HOT_UPDATER_SUPABASE_ANON_KEY!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);
@@ -263,7 +263,7 @@ export default defineConfig({
     accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
     cloudflareApiToken: process.env.HOT_UPDATER_CLOUDFLARE_API_TOKEN!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);
@@ -292,7 +292,7 @@ export default defineConfig({
     accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
     cloudflareApiToken: process.env.HOT_UPDATER_CLOUDFLARE_API_TOKEN!,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);
@@ -326,7 +326,7 @@ export default defineConfig({
     projectId: process.env.HOT_UPDATER_FIREBASE_PROJECT_ID!,
     credential,
   }),
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });`;
 
     expect(result).toBe(expectedConfig);

--- a/plugins/plugin-core/src/ConfigBuilder.ts
+++ b/plugins/plugin-core/src/ConfigBuilder.ts
@@ -210,7 +210,7 @@ export default defineConfig({
   build: ${buildConfigString},
   storage: ${this.storageInfo.configString},
   database: ${this.databaseInfo.configString},
-  updateStrategy: "fingerprint",
+  updateStrategy: "appVersion", // or "fingerprint"
 });
 `.trim(); // Ensure trailing newline
   }

--- a/plugins/plugin-core/src/loadConfig.ts
+++ b/plugins/plugin-core/src/loadConfig.ts
@@ -73,7 +73,6 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
 const getDefaultConfig = (): ConfigInput => {
   return {
     releaseChannel: "production",
-    updateStrategy: "fingerprint",
     fingerprint: {
       extraSources: [],
       ignorePaths: [],

--- a/plugins/plugin-core/src/loadConfig.ts
+++ b/plugins/plugin-core/src/loadConfig.ts
@@ -73,6 +73,7 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
 const getDefaultConfig = (): ConfigInput => {
   return {
     releaseChannel: "production",
+    updateStrategy: "appVersion",
     fingerprint: {
       extraSources: [],
       ignorePaths: [],

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -149,7 +149,9 @@ export type ConfigInput = {
    * The strategy used to update the app.
    *
    * If `fingerprint`, the bundle will be updated if the fingerprint of the app is changed.
-   * If `app-version`, the bundle will be updated if the target app version is valid.
+   * @docs https://hot-updater.dev/guide/update-strategy/1_fingerprint
+   * If `appVersion`, the bundle will be updated if the target app version is valid.
+   * @docs https://hot-updater.dev/guide/update-strategy/2_app-version
    *
    * @default "fingerprint"
    */

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -153,7 +153,7 @@ export type ConfigInput = {
    * If `appVersion`, the bundle will be updated if the target app version is valid.
    * @docs https://hot-updater.dev/guide/update-strategy/2_app-version
    *
-   * @default "fingerprint"
+   * @default "appVersion"
    */
   updateStrategy: "fingerprint" | "appVersion";
   /**

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -49,7 +49,7 @@ function App() {
 
 export default HotUpdater.wrap({
   source: getUpdateSource("%%source%%", {
-    updateStrategy: "fingerprint", // or "appVersion"
+    updateStrategy: "appVersion", // or "fingerprint"
   }),
 })(App);`;
 


### PR DESCRIPTION
Fingerprint changes too frequently and requires a higher level of expertise. Therefore, for now, since it can be confusing to use as a default, we use the more familiar appVersion as the default.