### PR TITLE
fix: native android code generation fails on expo 54

### DIFF
--- a/.changeset/khaki-pillows-film.md
+++ b/.changeset/khaki-pillows-film.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Fix native code generation for Android when using Expo 54

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -140,6 +140,8 @@ const withHotUpdaterNativeCode = (config: ExpoConfig) => {
       /^\s*override fun getJSBundleFile\(\): String\?\s*\{[\s\S]*?^\s*\}/gm;
     const kotlinHermesAnchor =
       "override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED";
+    const kotlinNewArchAnchor =
+      "override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED";
     const kotlinNewMethod = `
           override fun getJSBundleFile(): String? {
               return HotUpdater.getJSBundleFile(applicationContext)
@@ -178,6 +180,11 @@ const withHotUpdaterNativeCode = (config: ExpoConfig) => {
           contents = contents.replace(
             kotlinHermesAnchor,
             `${kotlinHermesAnchor}\n${kotlinNewMethod}`,
+          );
+        } else if (contents.includes(kotlinNewArchAnchor)) {
+          contents = contents.replace(
+            kotlinNewArchAnchor,
+            `${kotlinNewArchAnchor}\n${kotlinNewMethod}`
           );
         } else {
           // Fallback: Add before the closing brace of the object if anchor not found

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -184,7 +184,7 @@ const withHotUpdaterNativeCode = (config: ExpoConfig) => {
         } else if (contents.includes(kotlinNewArchAnchor)) {
           contents = contents.replace(
             kotlinNewArchAnchor,
-            `${kotlinNewArchAnchor}\n${kotlinNewMethod}`
+            `${kotlinNewArchAnchor}\n${kotlinNewMethod}`,
           );
         } else {
           // Fallback: Add before the closing brace of the object if anchor not found


### PR DESCRIPTION
In expo/expo#38576 the Android code template was changed slightly which causes hot-updater to inject it's kotlin code in an invalid location. When using the latest version of expo and trying to create an android build locally, the following error occurs:

```
[RUN_GRADLEW] > Task :app:compileReleaseKotlin FAILED
[RUN_GRADLEW] e: file:///private/var/folders/mn/pdfyttks06gf9tjjmxgrsxhh0000gn/T/eas-build-local-nodejs/66a2930f-0719-41f9-90b7-83d3f7fe369c/build/android/app/src/main/java/com/brongle/svag/MainApplication.kt:31:11 Modifier 'override' is not applicable to 'local function'.
```

And if we look at the generated MainApplication.kt file it's obvious our code was injected in the incorrect location:

```kotlin
        override fun getPackages(): List<ReactPackage> =
            PackageList(this).packages.apply {
              // Packages that cannot be autolinked yet can be added manually here, for example:
              // add(MyReactNativePackage())

          override fun getJSBundleFile(): String? {
              return HotUpdater.getJSBundleFile(applicationContext)
          }
            }
```

I believe this fails because the fallback regex doesn't properly handle additional braces within the main function. To fix this I simply added another supported case which should work with the latest template, and injects the code after the "isNewArchEnabled" flag;

```kotlin

          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED

          override fun getJSBundleFile(): String? {
              return HotUpdater.getJSBundleFile(applicationContext)
          }
```

Ideally the fallback regex should be adjusted or another approach should be used for properly identifying the end of the RN host function when the main approaches fail. I only chose not to do that here as this fixes my problem and avoids me having to disect the somewhat gnarly regexes.