### PR TITLE
chore: update getting started doc for react-native 0.82

### DIFF
--- a/docs/docs/guide/getting-started/quick-start-with-supabase.mdx
+++ b/docs/docs/guide/getting-started/quick-start-with-supabase.mdx
@@ -303,7 +303,7 @@ class MainApplication : Application(), ReactApplication {
 }
 ```
 </Tab>
-    <Tab label="Kotlin RN>0.82">
+    <Tab label="Kotlin (RN 0.82+)">
 ```kt title=android/app/src/main/java/com/<your-app-name>/MainApplication.kt
 package com.hotupdaterexample
 


### PR DESCRIPTION
I was updating my react-native app and noticed that there are no instructions in documentation for the new android native part in Kotlin.

Added another tab for react-native versions higher than 0.82

<img width="1096" height="902" alt="image" src="https://github.com/user-attachments/assets/793ab454-91ed-4744-a6c3-2efce314228b" />
