### PR TITLE
fix(datadog): set correct JS bundle filename for iOS

### DIFF
--- a/.changeset/thin-stars-shave.md
+++ b/.changeset/thin-stars-shave.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/datadog-plugin": patch
+---
+
+fix(datadog): set correct JS bundle filename for iOS

--- a/plugins/datadog-plugin/src/withDatadog.ts
+++ b/plugins/datadog-plugin/src/withDatadog.ts
@@ -43,7 +43,7 @@ export const withDatadog =
             recursive: true,
           });
 
-          const javascriptBundleFilename = `index.${args.platform}.bundle`;
+          const javascriptBundleFilename = args.platform === 'ios' ? 'main.jsbundle' : `index.${args.platform}.bundle`;
           const javascriptBundleSourcemapFilename = `${javascriptBundleFilename}.map`;
           const hermesBundleFilename = `${javascriptBundleFilename}.hbc`;
           const hermesBundleSourcemapFilename = `${javascriptBundleFilename}.hbc.map`;


### PR DESCRIPTION
Fixes the JS bundle filename for iOS in the Datadog plugin to ensure proper sourcemap handling.

* Closes #640