### PR TITLE
fix(bare): add CocoaPods hermesc path for React Native 0.82+

### DIFF
--- a/plugins/bare/src/hermes.ts
+++ b/plugins/bare/src/hermes.ts
@@ -72,6 +72,7 @@ export async function getHermesCommand(cwd: string): Promise<string> {
   };
 
   // Since react-native 0.69, Hermes is bundled with it.
+  // Note: This path was removed in react-native 0.82+
   const bundledHermesEngine = path.join(
     getReactNativePackagePath(cwd),
     "sdks",
@@ -81,6 +82,23 @@ export async function getHermesCommand(cwd: string): Promise<string> {
   );
   if (fileExists(bundledHermesEngine)) {
     return bundledHermesEngine;
+  }
+
+  // React Native 0.82+: hermesc is distributed via CocoaPods on macOS/iOS
+  // Reference: https://github.com/facebook/react-native/commit/2e0bd13a25
+  if (process.platform === "darwin") {
+    const podsHermesEngine = path.join(
+      cwd,
+      "ios",
+      "Pods",
+      "hermes-engine",
+      "destroot",
+      "bin",
+      "hermesc",
+    );
+    if (fileExists(podsHermesEngine)) {
+      return podsHermesEngine;
+    }
   }
 
   // Prefer hermes-engine if it exists.


### PR DESCRIPTION
## Summary

React Native 0.82+ changed how Hermes is distributed:
- The `sdks/hermesc/` folder was removed from the react-native npm package
- hermesc is now distributed via CocoaPods at `ios/Pods/hermes-engine/destroot/bin/hermesc`

This PR adds support for the new CocoaPods path on macOS/iOS, fixing the "spawn node_modules/hermesvm/osx-bin/hermes ENOENT" error when using hot-updater with React Native 0.82+.

## Problem

When running `hot-updater deploy` with React Native 0.83, users get:

```
ExecaError: Command failed with ENOENT: node_modules/hermesvm/osx-bin/hermes --version
spawn node_modules/hermesvm/osx-bin/hermes ENOENT
```

The current `getHermesCommand()` function looks for hermesc at:
1. `react-native/sdks/hermesc/{os-bin}/hermesc` - ❌ Removed in RN 0.82+
2. `node_modules/hermes-engine/{os-bin}/hermesc` - ❌ Not installed by default
3. `node_modules/hermesvm/{os-bin}/hermes` - ❌ Fallback fails

## Solution

Added a check for the CocoaPods path (`ios/Pods/hermes-engine/destroot/bin/hermesc`) on macOS before falling back to the npm package paths.

## References

- [facebook/react-native@2e0bd13](https://github.com/facebook/react-native/commit/2e0bd13a2533fe7ab64125a95b9215b806018c6e) - RN 0.82: "Changed the source of hermesc binary to be an npm package"
- [facebook/react-native@27bb34c](https://github.com/facebook/react-native/commit/27bb34c006bb5daaac639d065aaa4c963528814e) - RN 0.83: "Use Hermes artifacts published independently from React Native"

## Test Plan

- [x] Tested with React Native 0.83.0 on macOS
- [x] Verified `hot-updater deploy` successfully finds hermesc at CocoaPods path
- [x] Confirmed Hermes compilation works (v0.14.0, HBC bytecode version 96)