### PR TITLE
docs(aws): add CloudFront invalidation permission details and error m…

### DIFF
--- a/docs/content/docs/managed/aws.mdx
+++ b/docs/content/docs/managed/aws.mdx
@@ -33,8 +33,25 @@ Used for `hot-updater init`:
 
 Used for `hot-updater deploy` and `hot-updater console`:
 * `AmazonS3FullAccess`: Manage bundles and metadata in the S3 bucket.
+* `cloudfront:CreateInvalidation`: Invalidate CloudFront cache after deployments.
 
-For ongoing usage, create a separate access token with limited permissions.
+For ongoing usage, create a separate access token with limited permissions. Here's a minimal policy example for CloudFront invalidation:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "cloudfront:CreateInvalidation"
+  ],
+  "Resource": "arn:aws:cloudfront::<ACCOUNT_ID>:distribution/<DISTRIBUTION_ID>"
+}
+```
+
+If this permission is missing, you may encounter the following error:
+
+```
+AccessDenied: User: arn:aws:sts::***:assumed-role/***/*** is not authorized to perform: cloudfront:CreateInvalidation on resource: arn:aws:cloudfront::***:distribution/*** because no identity-based policy allows the cloudfront:CreateInvalidation action
+```
 
 ## Step 1: Install Required Packages
 


### PR DESCRIPTION
# docs: Add CloudFront invalidation permission requirement for AWS deployment

## Description

This PR updates the AWS S3 + Lambda@Edge documentation to clarify a critical IAM permission requirement for ongoing deployments.

Hot Updater requires `cloudfront:CreateInvalidation` permission to invalidate CloudFront cache after deploying bundle updates. Without this permission, deployments fail silently or with cryptic access denied errors. This documentation addition ensures developers configure their IAM policies correctly from the start.

## Key Changes

- **Added `cloudfront:CreateInvalidation` permission** to the "Ongoing Usage" section for `hot-updater deploy` and `hot-updater console` commands.
- **Provided minimal IAM policy example** showing the exact JSON structure needed with placeholders for `<ACCOUNT_ID>` and `<DISTRIBUTION_ID>`.
- **Included common error message** that developers will encounter if this permission is missing, helping with debugging and troubleshooting.

## Why This Matters

For ongoing usage, if users only have AmazonS3FullAccess, they will encounter the following issue:

<img width="1118" height="568" alt="image" src="https://github.com/user-attachments/assets/3d7b9786-ac26-4deb-a222-09965cba1cbb" />




