### PR TITLE
fix(docs): use static import for xterm CSS to fix Safari mobile

### DIFF
--- a/docs/src/components/terminal/terminal-emulator.tsx
+++ b/docs/src/components/terminal/terminal-emulator.tsx
@@ -1,4 +1,5 @@
 "use client";
+import "@xterm/xterm/css/xterm.css";
 import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef, useState } from "react";
 import type { TerminalEmulatorProps } from "./types";
@@ -76,7 +77,6 @@ export function TerminalEmulator({ config, onReady }: TerminalEmulatorProps) {
 
     const init = async () => {
       const { Terminal } = await import("@xterm/xterm");
-      await import("@xterm/xterm/css/xterm.css");
 
       if (!terminalRef.current || xtermRef.current) return;
 


### PR DESCRIPTION
Safari (especially iOS Safari) doesn't support dynamic CSS imports via
`await import("...css")` as CSS files are not valid ES modules.

Changed from dynamic import inside useEffect to static import at module
level, which is safe since this is a "use client" component.