### PR TITLE
fix(console): reference commit hash within git url hyperlink

### DIFF
--- a/packages/console/hot-updater.config.ts
+++ b/packages/console/hot-updater.config.ts
@@ -46,4 +46,7 @@ export default {
       },
     ],
   }),
+  console: {
+    gitUrl: "https://github.com/gronxb/hot-updater",
+  },
 };

--- a/packages/console/src/routes/_components/edit-bundle-sheet-form.tsx
+++ b/packages/console/src/routes/_components/edit-bundle-sheet-form.tsx
@@ -269,7 +269,7 @@ export const EditBundleSheetForm = ({
               Commit Hash:{" "}
               {gitUrl() ? (
                 <a
-                  href={`${gitUrl()}/commit/${gitCommitHash}`}
+                  href={`${gitUrl()}/commit/${gitCommitHash()}`}
                   target="_blank"
                   rel="noreferrer"
                   class="ml-2"


### PR DESCRIPTION
When providing a `gitUrl` within the `console` configuration, it is improperly referenced within the Console UI. Rather than the commit hash being used, the function is used within the `href`.

<img width="601" height="109" alt="Screenshot 2026-01-31 at 10 40 06 AM" src="https://github.com/user-attachments/assets/ea1030d8-30f3-4c91-9df6-a9775cbc08af" />

----

Fixed this by calling the function when generating the `href` url.

https://github.com/user-attachments/assets/c05502aa-8ad2-4f39-a04e-f3b772179613


