### PR TITLE
refactor(apple-helper): use npx pod-install for CocoaPods installation

### DIFF
--- a/packages/apple-helper/src/utils/cocoapods.ts
+++ b/packages/apple-helper/src/utils/cocoapods.ts
@@ -1,4 +1,4 @@
-import { getCwd, getReactNativeMetadatas, p } from "@hot-updater/cli-tools";
+import { getReactNativeMetadatas, p } from "@hot-updater/cli-tools";
 import { execa } from "execa";
 import fs from "fs";
 import path from "path";
@@ -14,54 +14,21 @@ export const installPodsIfNeeded = async (sourceDir: string): Promise<void> => {
     return;
   }
 
-  const gemfilePaths = [
-    path.join(sourceDir, "Gemfile"),
-    path.join(getCwd(), "Gemfile"),
-  ];
-  const shouldUseBundler = (
-    await Promise.all(gemfilePaths.map(checkShouldUseBundler))
-  ).some(Boolean);
-
   try {
-    if (shouldUseBundler) {
-      p.log.info("Using bundler for CocoaPods installation");
-
-      const bundleSpinner = p.spinner();
-      bundleSpinner.start("Installing Ruby gems");
-      await execa("bundle", ["install"], { cwd: sourceDir });
-      bundleSpinner.stop("Ruby gems installed");
-
-      const podSpinner = p.spinner();
-      podSpinner.start("Installing CocoaPods dependencies");
-      await execa("bundle", ["exec", "pod", "install"], {
-        cwd: sourceDir,
-        env: preparePodInstallEnvVars(),
-      });
-      podSpinner.stop("CocoaPods dependencies installed");
-    } else {
-      const spinner = p.spinner();
-      spinner.start("Installing CocoaPods dependencies");
-      await execa("pod", ["install"], {
-        cwd: sourceDir,
-        env: preparePodInstallEnvVars(),
-      });
-      spinner.stop("CocoaPods dependencies installed");
-    }
-  } catch (error) {
-    throw new Error(`pod install failed: ${error}`);
-  }
-};
-
-const checkShouldUseBundler = async (gemfilePath: string): Promise<boolean> => {
-  try {
-    if (!fs.existsSync(gemfilePath)) {
-      return false;
-    }
-
-    const gemfileContent = await fs.promises.readFile(gemfilePath, "utf-8");
-    return gemfileContent.includes("cocoapods");
-  } catch (_error) {
-    return false;
+    p.log.info("Installing CocoaPods started");
+    await execa("npx", ["-y", "pod-install", "--non-interactive"], {
+      cwd: sourceDir,
+      env: preparePodInstallEnvVars(),
+      stdin: "ignore",
+      stdout: "inherit",
+      stderr: "inherit",
+      timeout: 5 * 60 * 1000, // 5 min timeout,
+    });
+    p.log.success("CocoaPods dependencies installed");
+  } catch (_) {
+    // Don't print error because it is printed by `pod-install` itself.
+    p.log.error(`pod-install failed`);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## Summary
- Replace manual Gemfile/bundler detection and `pod install` / `bundle exec pod install` branching logic with `npx pod-install`
- Add 5-minute