### PR TITLE
feat: delete storage objects on bundle deletion (console)

### DIFF
--- a/packages/console/src-server/rpc.ts
+++ b/packages/console/src-server/rpc.ts
@@ -169,13 +169,29 @@ export const rpc = new Hono()
       try {
         const { bundleId } = c.req.valid("param");
 
-        const { databasePlugin } = await prepareConfig();
+        const { databasePlugin, storagePlugin } = await prepareConfig();
         const deleteBundle = await databasePlugin.getBundleById(bundleId);
         if (!deleteBundle) {
           return c.json({ error: "Bundle not found" }, 404);
         }
         await databasePlugin.deleteBundle(deleteBundle);
         await databasePlugin.commitBundle();
+
+        try {
+          if (storagePlugin && deleteBundle.storageUri) {
+            const { data: remaining } = await databasePlugin.getBundles({
+              where: { storageUri: deleteBundle.storageUri },
+              limit: 1,
+              offset: 0,
+            });
+            if (remaining.length === 0) {
+              await storagePlugin.delete(deleteBundle.storageUri);
+            }
+          }
+        } catch (e) {
+          console.error("Failed to delete storage object:", e);
+        }
+
         return c.json({ success: true });
       } catch (error) {
         console.error("Error during bundle deletion:", error);

--- a/plugins/cloudflare/sql/bundles.sql
+++ b/plugins/cloudflare/sql/bundles.sql
@@ -17,3 +17,4 @@ CREATE TABLE bundles (
 
 CREATE INDEX bundles_target_app_version_idx ON bundles(target_app_version);
 CREATE INDEX bundles_fingerprint_hash_idx ON bundles(fingerprint_hash);
+CREATE INDEX bundles_storage_uri_idx ON bundles(storage_uri);

--- a/plugins/cloudflare/src/d1Database.ts
+++ b/plugins/cloudflare/src/d1Database.ts
@@ -17,6 +17,7 @@ export interface D1DatabaseConfig {
 interface QueryConditions {
   channel?: string;
   platform?: string;
+  storageUri?: string;
 }
 
 interface BuildQueryResult {
@@ -46,6 +47,11 @@ function buildWhereClause(conditions: QueryConditions): BuildQueryResult {
   if (conditions.platform) {
     clauses.push("platform = ?");
     params.push(conditions.platform);
+  }
+
+  if (conditions.storageUri) {
+    clauses.push("storage_uri = ?");
+    params.push(conditions.storageUri);
   }
 
   const whereClause =

--- a/plugins/cloudflare/worker/migrations/0004_add_storage_uri_index.sql
+++ b/plugins/cloudflare/worker/migrations/0004_add_storage_uri_index.sql
@@ -1,0 +1,4 @@
+-- Migration number: 0004
+-- HotUpdater.bundles
+
+CREATE INDEX IF NOT EXISTS bundles_storage_uri_idx ON bundles(storage_uri);

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -67,6 +67,9 @@ export const firebaseDatabase = createDatabasePlugin<admin.AppOptions>({
         if (where?.platform) {
           query = query.where("platform", "==", where.platform);
         }
+        if (where?.storageUri) {
+          query = query.where("storage_uri", "==", where.storageUri);
+        }
 
         query = query.orderBy("id", "desc");
 

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -9,7 +9,7 @@ import type {
 export interface AbstractDatabasePlugin {
   getBundleById: (bundleId: string) => Promise<Bundle | null>;
   getBundles: (options: {
-    where?: { channel?: string; platform?: string };
+    where?: { channel?: string; platform?: string; storageUri?: string };
     limit: number;
     offset: number;
   }) => Promise<{

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -24,7 +24,7 @@ export interface DatabasePlugin {
   getChannels: () => Promise<string[]>;
   getBundleById: (bundleId: string) => Promise<Bundle | null>;
   getBundles: (options: {
-    where?: { channel?: string; platform?: string };
+    where?: { channel?: string; platform?: string; storageUri?: string };
     limit: number;
     offset: number;
   }) => Promise<{

--- a/plugins/postgres/sql/bundles.sql
+++ b/plugins/postgres/sql/bundles.sql
@@ -23,3 +23,4 @@ CREATE TABLE bundles (
 CREATE INDEX bundles_target_app_version_idx ON bundles(target_app_version);
 CREATE INDEX bundles_fingerprint_hash_idx ON bundles(fingerprint_hash);
 CREATE INDEX bundles_channel_idx ON bundles(channel);
+CREATE INDEX bundles_storage_uri_idx ON bundles(storage_uri);

--- a/plugins/postgres/src/postgres.ts
+++ b/plugins/postgres/src/postgres.ts
@@ -60,6 +60,9 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
             where.platform as Platform,
           );
         }
+        if (where?.storageUri) {
+          countQuery = countQuery.where("storage_uri", "=", where.storageUri);
+        }
 
         const countResult = await countQuery
           .select(db.fn.count<number>("id").as("total"))
@@ -73,6 +76,9 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
 
         if (where?.platform) {
           query = query.where("platform", "=", where.platform as Platform);
+        }
+        if (where?.storageUri) {
+          query = query.where("storage_uri", "=", where.storageUri);
         }
 
         if (limit) {

--- a/plugins/standalone/src/standaloneRepository.ts
+++ b/plugins/standalone/src/standaloneRepository.ts
@@ -119,6 +119,11 @@ export const standaloneRepository =
               (b) => b.platform === where.platform,
             );
           }
+          if (where?.storageUri) {
+            filteredBundles = filteredBundles.filter(
+              (b) => b.storageUri === where.storageUri,
+            );
+          }
 
           const total = filteredBundles.length;
           const data = limit

--- a/plugins/supabase/src/supabaseDatabase.ts
+++ b/plugins/supabase/src/supabaseDatabase.ts
@@ -61,6 +61,9 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
         if (where?.platform) {
           countQuery = countQuery.eq("platform", where.platform as Platform);
         }
+        if (where?.storageUri) {
+          countQuery = countQuery.eq("storage_uri", where.storageUri);
+        }
 
         const { count: total = 0 } = await countQuery;
 
@@ -77,6 +80,9 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
 
         if (where?.platform) {
           query = query.eq("platform", where.platform as Platform);
+        }
+        if (where?.storageUri) {
+          query = query.eq("storage_uri", where.storageUri);
         }
 
         if (limit) {

--- a/plugins/supabase/supabase/migrations/20260311000000_add_storage_uri_index.sql
+++ b/plugins/supabase/supabase/migrations/20260311000000_add_storage_uri_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS bundles_storage_uri_idx ON bundles(storage_uri);


### PR DESCRIPTION
> **⚠️ This PR was opened by mistake** — it was meant for a personal fork, not upstream. Apologies for the noise. Please ignore.

---

<details>
<summary>Original description (not relevant)</summary>

## Summary

When deleting a bundle from the console, the storage object (e.g., R2/S3 file) is now also deleted — but only if no other bundle references the same `storageUri`. This addresses the orphaned storage files issue caused by the soft-delete approach introduced in #706.

### Changes
- Added `storageUri` as an optional filter in `getBundles` `where` clause across all database plugins
- Console delete handler (`rpc.ts`) now checks for remaining references before deleting storage
- Added `storage_uri` index migration for D1, Supabase, and PostgreSQL

### How it works
```
DELETE /bundles/:bundleId
1. databasePlugin.deleteBundle() + commitBundle()   // existing flow
2. databasePlugin.getBundles({ where: { storageUri } })  // check references
3. if no references remain → storagePlugin.delete()      // clean up storage
```

Storage deletion failure is caught silently — DB deletion still succeeds, matching the previous soft-delete behavior as fallback.

## Remaining issues

### 1. Abstraction inconsistency between console and server handler

This PR only covers **console (`rpc.ts`)** deletion. The server handler (`packages/server/src/handler.ts`) used by `createHotUpdater()` also exposes `deleteBundleById`, but does **not** clean up storage.

`createHotUpdater()` already receives `storages` (storage plugins) — they're used for `resolveFileUrl` (download URL generation) but not passed to the handler's delete flow. Extending this would require changes to `HandlerAPI` interface and both `pluginCore.ts` / `ormCore.ts` adapters.

This means:
- **Console delete** = DB + storage cleanup ✅
- **Server handler delete** = DB only (soft delete) ⚠️
- Same operation, different behavior depending on entry point

### 2. Migration awareness

The `storage_uri` index migrations are included but:
- **Cloudflare D1**: Only applied during `hot-updater init` (worker deploy). Existing users need to manually run `wrangler d1 migrations apply`.
- **Supabase**: Applied via `supabase migration up`.
- **PostgreSQL**: No migration system — users must manually run `CREATE INDEX`.

The index is optional for correctness (queries work without it), but recommended for performance at scale.

### 3. Alternative approach: CLI garbage collection

A cleaner architectural solution may be a **separate `storage gc` CLI command** that:
1. Collects all `storageUri` values from the database
2. Lists all objects in storage (`StoragePlugin.list()` — currently not in the interface)
3. Deletes orphaned storage objects not referenced by any bundle

This approach:
- Keeps the delete flow simple (soft delete everywhere)
- Works consistently across console and server handler
- Requires adding an optional `list()` method to `StoragePlugin` interface

Related: #706

</details>