### PR TITLE
fix(android): use _jsBundleLoader backing field for Expo SDK 55+ compatibility

### DIFF
--- a/packages/react-native/android/src/newarch/ReactIntegrationManager.kt
+++ b/packages/react-native/android/src/newarch/ReactIntegrationManager.kt
@@ -40,7 +40,14 @@ class ReactIntegrationManager(
 
             reactHostDelegateField.isAccessible = true
             val reactHostDelegate = reactHostDelegateField.get(reactHost)
-            val jsBundleLoaderField = reactHostDelegate::class.java.getDeclaredField("jsBundleLoader")
+            // Expo SDK 55+: jsBundleLoader is a Kotlin computed property without a backing field.
+            // The actual backing field is _jsBundleLoader.
+            val jsBundleLoaderField =
+                try {
+                    reactHostDelegate::class.java.getDeclaredField("_jsBundleLoader")
+                } catch (e: NoSuchFieldException) {
+                    reactHostDelegate::class.java.getDeclaredField("jsBundleLoader")
+                }
             jsBundleLoaderField.isAccessible = true
             jsBundleLoaderField.set(reactHostDelegate, getJSBundlerLoader(bundleURL))
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary

- In Expo SDK 55, `ExpoReactHostFactory$ExpoReactHostDelegate`'s `jsBundleLoader` was changed from a Java field to a Kotlin computed property (getter only, no backing field). This causes hot-updater's reflection-based field access to fail with `NoSuchFieldException`, resulting in an infinite reload loop on Android.
- The actual backing field is `_jsBundleLoader`. The Expo source code explicitly documents this: *"Keeps this `_jsBundleLoader` backing property for DevLauncher to replace its internal value"*.
- This PR updates the reflection logic to first try `_jsBundleLoader` (for Expo SDK 55+), then fall back to `jsBundleLoader` (for older Expo versions and non-Expo setups), maintaining backward compatibility.

## Changes

In `ReactIntegrationManager.kt` → `setJSBundleInternal()`:

```kotlin
// Before: directly access jsBundleLoader (fails on Expo SDK 55+)
val jsBundleLoaderField = reactHostDelegate::class.java.getDeclaredField("jsBundleLoader")

// After: try _jsBundleLoader first, fall back to jsBundleLoader
val jsBundleLoaderField =
    try {
        reactHostDelegate::class.java.getDeclaredField("_jsBundleLoader")
    } catch (e: NoSuchFieldException) {
        reactHostDelegate::class.java.getDeclaredField("jsBundleLoader")
    }
```

## Test Plan

- [x] Tested on a production app using Expo SDK 55 + hot-updater
- [x] Before fix: OTA update triggered infinite reload loop (reflection failed silently, bundle never applied)
- [x] After fix: OTA update applies correctly and app loads the new bundle as expected
- [x] Verified backward compatibility: the fallback to `jsBundleLoader` ensures older Expo versions and non-Expo setups continue to work

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)