### PR TITLE
feat(console): guard pending bundle dialogs in console

### DIFF
--- a/.changeset/mighty-ducks-design.md
+++ b/.changeset/mighty-ducks-design.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+guard pending bundle dialogs in console

--- a/packages/console/src/components/features/bundles/BundleEditorForm.spec.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorForm.spec.tsx
@@ -135,6 +135,28 @@ describe("BundleEditorForm", () => {
     expect(saveButton.hasAttribute("disabled")).toBe(true);
   });
 
+  it("disables secondary actions while the save mutation is pending", () => {
+    mockUpdateBundleMutation.isPending = true;
+
+    render(<BundleEditorForm bundle={bundle} onClose={() => {}} />);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Promote to Channel" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("button", { name: "Download Bundle" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("button", { name: "Delete Bundle" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
   it("shows normalized semver ranges and blocks invalid target app versions", () => {
     render(<BundleEditorForm bundle={bundle} onClose={() => {}} />);
 

--- a/packages/console/src/components/features/bundles/BundleEditorForm.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorForm.tsx
@@ -7,7 +7,7 @@ import {
 import type { Bundle } from "@hot-updater/plugin-core";
 import { useForm, useStore } from "@tanstack/react-form";
 import { Download, Plus, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
 
@@ -31,6 +31,7 @@ import { RolloutCohortsDialog } from "./RolloutCohortsDialog";
 interface BundleEditorFormProps {
   bundle: Bundle;
   onClose: () => void;
+  onBusyChange?: (busy: boolean) => void;
 }
 
 type BundleEditorFormValues = {
@@ -82,7 +83,11 @@ function getDefaultValues(bundle: Bundle): BundleEditorFormValues {
 const formatRolloutPercentage = (rolloutCohortCount: number) =>
   (rolloutCohortCount / 10).toFixed(1);
 
-export function BundleEditorForm({ bundle, onClose }: BundleEditorFormProps) {
+export function BundleEditorForm({
+  bundle,
+  onClose,
+  onBusyChange,
+}: BundleEditorFormProps) {
   const bundleDownloadUrlMutation = useBundleDownloadUrlMutation();
   const updateBundleMutation = useUpdateBundleMutation();
   const [showPromoteDialog, setShowPromoteDialog] = useState(false);
@@ -158,6 +163,16 @@ export function BundleEditorForm({ bundle, onClose }: BundleEditorFormProps) {
       };
   const hasTargetAppVersionError = Boolean(targetAppVersionValidation.error);
   const isDownloading = bundleDownloadUrlMutation.isPending;
+
+  useEffect(() => {
+    onBusyChange?.(isSaving);
+  }, [isSaving, onBusyChange]);
+
+  useEffect(() => {
+    return () => {
+      onBusyChange?.(false);
+    };
+  }, [onBusyChange]);
 
   const handleAddCohort = () => {
     const normalizedCohort = normalizeCohortValue(newCohort);
@@ -428,6 +443,7 @@ export function BundleEditorForm({ bundle, onClose }: BundleEditorFormProps) {
           size="sm"
           className="w-full"
           onClick={() => setShowPromoteDialog(true)}
+          disabled={isSaving}
         >
           Promote to Channel
         </Button>
@@ -437,7 +453,7 @@ export function BundleEditorForm({ bundle, onClose }: BundleEditorFormProps) {
           size="sm"
           className="w-full"
           onClick={handleDownloadBundle}
-          disabled={isDownloading}
+          disabled={isSaving || isDownloading}
         >
           <Download className="h-4 w-4" />
           {isDownloading ? "Preparing Download..." : "Download Bundle"}
@@ -448,6 +464,7 @@ export function BundleEditorForm({ bundle, onClose }: BundleEditorFormProps) {
           size="sm"
           className="w-full"
           onClick={() => setShowDeleteDialog(true)}
+          disabled={isSaving}
         >
           Delete Bundle
         </Button>

--- a/packages/console/src/components/features/bundles/BundleEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorSheet.spec.tsx
@@ -1,0 +1,132 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BundleEditorSheet } from "./BundleEditorSheet";
+
+const mockBundleEditorForm = vi.fn();
+
+vi.mock("./BundleEditorForm", () => ({
+  BundleEditorForm: (props: {
+    onBusyChange?: (busy: boolean) => void;
+    onClose: () => void;
+  }) => {
+    mockBundleEditorForm(props);
+
+    return (
+      <div>
+        <button onClick={() => props.onBusyChange?.(true)}>Mark busy</button>
+        <button onClick={() => props.onBusyChange?.(false)}>Mark idle</button>
+        <button onClick={props.onClose}>Finish save</button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("./BundleBasicInfo", () => ({
+  BundleBasicInfo: () => <div>Bundle basic info</div>,
+}));
+
+vi.mock("./BundleMetadata", () => ({
+  BundleMetadata: () => <div>Bundle metadata</div>,
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <button onClick={() => onOpenChange?.(false)}>Dismiss sheet</button>
+        {children}
+      </div>
+    ) : null,
+  SheetContent: ({
+    children,
+    showCloseButton = true,
+  }: {
+    children: ReactNode;
+    showCloseButton?: boolean;
+  }) => (
+    <div>
+      {showCloseButton ? <button>Sheet close</button> : null}
+      {children}
+    </div>
+  ),
+  SheetDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => <div>Skeleton</div>,
+}));
+
+const bundle: Bundle = {
+  id: "0195a408-8f13-7d9b-8df4-123456789abc",
+  channel: "production",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeef",
+  message: "Initial message",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+};
+
+describe("BundleEditorSheet", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnOpenChange.mockReset();
+    mockBundleEditorForm.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("ignores dismiss requests while the editor is saving", () => {
+    render(
+      <BundleEditorSheet
+        bundle={bundle}
+        open
+        onOpenChange={mockOnOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark busy" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss sheet" }));
+
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Sheet close" })).toBeNull();
+  });
+
+  it("allows successful saves to close the sheet even after entering a busy state", () => {
+    render(
+      <BundleEditorSheet
+        bundle={bundle}
+        open
+        onOpenChange={mockOnOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark busy" }));
+    fireEvent.click(screen.getByRole("button", { name: "Finish save" }));
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/console/src/components/features/bundles/BundleEditorSheet.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorSheet.tsx
@@ -1,4 +1,5 @@
 import type { Bundle } from "@hot-updater/plugin-core";
+import { useEffect, useState } from "react";
 
 import {
   Sheet,
@@ -28,9 +29,47 @@ export function BundleEditorSheet({
   open,
   onOpenChange,
 }: BundleEditorSheetProps) {
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setIsSaving(false);
+    }
+  }, [open]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isSaving) {
+      return;
+    }
+
+    if (!nextOpen) {
+      setIsSaving(false);
+    }
+
+    onOpenChange(nextOpen);
+  };
+
+  const closeSheet = () => {
+    setIsSaving(false);
+    onOpenChange(false);
+  };
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-[600px] sm:max-w-[600px] overflow-y-auto">
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent
+        className="w-[600px] sm:max-w-[600px] overflow-y-auto"
+        showCloseButton={!isSaving}
+        onEscapeKeyDown={(event) => {
+          if (isSaving) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isSaving) {
+            event.preventDefault();
+          }
+        }}
+      >
         <SheetHeader>
           <SheetTitle>{bundle ? "Edit Bundle" : "Bundle Details"}</SheetTitle>
           <SheetDescription>
@@ -57,7 +96,8 @@ export function BundleEditorSheet({
             <BundleEditorForm
               key={bundle.id}
               bundle={bundle}
-              onClose={() => onOpenChange(false)}
+              onClose={closeSheet}
+              onBusyChange={setIsSaving}
             />
             <BundleMetadata bundle={bundle} />
           </div>

--- a/packages/console/src/components/features/bundles/DeleteBundleDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/DeleteBundleDialog.spec.tsx
@@ -1,0 +1,216 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteBundleDialog } from "./DeleteBundleDialog";
+
+const { mockDeleteBundleMutation, mockToastSuccess, mockToastError } =
+  vi.hoisted(() => ({
+    mockDeleteBundleMutation: {
+      isPending: false,
+      mutateAsync: vi.fn(),
+    },
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+  }));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  useDeleteBundleMutation: () => mockDeleteBundleMutation,
+}));
+
+vi.mock("@/components/ui/alert-dialog", async () => {
+  const React = await import("react");
+
+  const DialogContext = React.createContext<{
+    onOpenChange?: (open: boolean) => void;
+  }>({});
+
+  return {
+    AlertDialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange?: (open: boolean) => void;
+      children: ReactNode;
+    }) =>
+      open ? (
+        <DialogContext.Provider value={{ onOpenChange }}>
+          <div>{children}</div>
+        </DialogContext.Provider>
+      ) : null,
+    AlertDialogAction: ({
+      children,
+      disabled,
+      onClick,
+    }: {
+      children: ReactNode;
+      disabled?: boolean;
+      onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    }) => {
+      const { onOpenChange } = React.useContext(DialogContext);
+
+      return (
+        <button
+          disabled={disabled}
+          onClick={() => {
+            const event = {
+              defaultPrevented: false,
+              preventDefault() {
+                this.defaultPrevented = true;
+              },
+            } as React.MouseEvent<HTMLButtonElement> & {
+              defaultPrevented: boolean;
+            };
+
+            onClick?.(event);
+
+            if (!event.defaultPrevented) {
+              onOpenChange?.(false);
+            }
+          }}
+        >
+          {children}
+        </button>
+      );
+    },
+    AlertDialogCancel: ({
+      children,
+      disabled,
+    }: {
+      children: ReactNode;
+      disabled?: boolean;
+    }) => {
+      const { onOpenChange } = React.useContext(DialogContext);
+
+      return (
+        <button disabled={disabled} onClick={() => onOpenChange?.(false)}>
+          {children}
+        </button>
+      );
+    },
+    AlertDialogContent: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+      <p>{children}</p>
+    ),
+    AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+      <h2>{children}</h2>
+    ),
+  };
+});
+
+const bundle: Bundle = {
+  id: "0195a408-8f13-7d9b-8df4-123456789abc",
+  channel: "stable",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeef",
+  message: "Initial message",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+};
+
+describe("DeleteBundleDialog", () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    mockDeleteBundleMutation.isPending = false;
+    mockDeleteBundleMutation.mutateAsync.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    mockOnOpenChange.mockReset();
+    mockOnSuccess.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the dialog open until the delete request finishes", async () => {
+    let resolveDelete: (() => void) | undefined;
+
+    mockDeleteBundleMutation.mutateAsync.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+
+    render(
+      <DeleteBundleDialog
+        bundle={bundle}
+        open
+        onOpenChange={mockOnOpenChange}
+        onSuccess={mockOnSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledWith({
+      bundleId: bundle.id,
+    });
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+
+    resolveDelete?.();
+
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Bundle deleted successfully",
+    );
+  });
+
+  it("ignores cancel requests while deletion is pending", () => {
+    mockDeleteBundleMutation.isPending = true;
+
+    render(
+      <DeleteBundleDialog
+        bundle={bundle}
+        open
+        onOpenChange={mockOnOpenChange}
+        onSuccess={mockOnSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Cancel" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});

--- a/packages/console/src/components/features/bundles/DeleteBundleDialog.tsx
+++ b/packages/console/src/components/features/bundles/DeleteBundleDialog.tsx
@@ -27,8 +27,21 @@ export function DeleteBundleDialog({
   onSuccess,
 }: DeleteBundleDialogProps) {
   const deleteBundleMutation = useDeleteBundleMutation();
+  const isDeleting = deleteBundleMutation.isPending;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isDeleting) {
+      return;
+    }
+
+    onOpenChange(nextOpen);
+  };
 
   const handleDelete = async () => {
+    if (isDeleting) {
+      return;
+    }
+
     try {
       await deleteBundleMutation.mutateAsync({ bundleId: bundle.id });
       toast.success("Bundle deleted successfully");
@@ -41,8 +54,14 @@ export function DeleteBundleDialog({
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent
+        onEscapeKeyDown={(event) => {
+          if (isDeleting) {
+            event.preventDefault();
+          }
+        }}
+      >
         <AlertDialogHeader>
           <AlertDialogTitle>Are you sure?</AlertDialogTitle>
           <AlertDialogDescription>
@@ -61,13 +80,16 @@ export function DeleteBundleDialog({
         </div>
 
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            onClick={handleDelete}
+            onClick={(event) => {
+              event.preventDefault();
+              void handleDelete();
+            }}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            disabled={deleteBundleMutation.isPending}
+            disabled={isDeleting}
           >
-            {deleteBundleMutation.isPending ? "Deleting..." : "Delete"}
+            {isDeleting ? "Deleting..." : "Delete"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/console/src/components/features/bundles/PromoteChannelDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/PromoteChannelDialog.spec.tsx
@@ -51,8 +51,21 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
-    open ? <div>{children}</div> : null,
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <button onClick={() => onOpenChange?.(false)}>Dismiss dialog</button>
+        {children}
+      </div>
+    ) : null,
   DialogContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
@@ -330,5 +343,26 @@ describe("PromoteChannelDialog", () => {
         "Legacy bundle without manifest.json",
       );
     });
+  });
+
+  it("ignores dismiss requests while promotion is pending", () => {
+    mockPromoteBundleMutation.isPending = true;
+    const mockOnOpenChange = vi.fn();
+
+    render(
+      <PromoteChannelDialog
+        bundle={bundle}
+        open
+        onOpenChange={mockOnOpenChange}
+        onSuccess={mockOnSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss dialog" }));
+
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Cancel" }).hasAttribute("disabled"),
+    ).toBe(true);
   });
 });

--- a/packages/console/src/components/features/bundles/PromoteChannelDialog.tsx
+++ b/packages/console/src/components/features/bundles/PromoteChannelDialog.tsx
@@ -46,19 +46,34 @@ export function PromoteChannelDialog({
   const { setBundleId } = useFilterParams();
   const { data: channels = [] } = useChannelsQuery();
   const promoteBundleMutation = usePromoteBundleMutation();
+  const isPromoting = promoteBundleMutation.isPending;
 
   const availableChannels = channels.filter((c) => c !== bundle.channel);
   const isCopy = action === "copy";
   const normalizedTargetChannel = targetChannel.trim();
   const isSameChannel = normalizedTargetChannel === bundle.channel;
   const displayedCopyBundleId = copyBundleId || "Generating bundle ID...";
+
+  const resetDialogState = () => {
+    setTargetChannel("");
+    setAction("move");
+    setCopyBundleId("");
+  };
+
+  const closeDialog = () => {
+    onOpenChange(false);
+    resetDialogState();
+  };
+
   const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isPromoting) {
+      return;
+    }
+
     onOpenChange(nextOpen);
 
     if (!nextOpen) {
-      setTargetChannel("");
-      setAction("move");
-      setCopyBundleId("");
+      resetDialogState();
     }
   };
 
@@ -101,7 +116,7 @@ export function PromoteChannelDialog({
         });
       const promotedBundleId = promotedBundle.id;
 
-      handleOpenChange(false);
+      closeDialog();
       onSuccess?.();
       toast.success(
         isCopy
@@ -126,7 +141,19 @@ export function PromoteChannelDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
+      <DialogContent
+        showCloseButton={!isPromoting}
+        onEscapeKeyDown={(event) => {
+          if (isPromoting) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isPromoting) {
+            event.preventDefault();
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Promote to Channel</DialogTitle>
           <DialogDescription>
@@ -137,8 +164,12 @@ export function PromoteChannelDialog({
         <div className="space-y-4 py-4">
           <div className="space-y-2">
             <Label htmlFor="promote-action">Action</Label>
-            <Select value={action} onValueChange={handleActionChange}>
-              <SelectTrigger id="promote-action">
+            <Select
+              value={action}
+              onValueChange={handleActionChange}
+              disabled={isPromoting}
+            >
+              <SelectTrigger id="promote-action" disabled={isPromoting}>
                 <SelectValue placeholder="Select an action" />
               </SelectTrigger>
               <SelectContent>
@@ -160,6 +191,7 @@ export function PromoteChannelDialog({
                 id="copy-bundle-id"
                 value={displayedCopyBundleId}
                 readOnly
+                disabled={isPromoting}
               />
               <p className="font-mono text-xs text-muted-foreground">
                 {displayedCopyBundleId}
@@ -176,6 +208,7 @@ export function PromoteChannelDialog({
               placeholder="Enter a channel name"
               list="available-channels"
               aria-invalid={isSameChannel}
+              disabled={isPromoting}
             />
             <datalist id="available-channels">
               {availableChannels.map((channel) => (
@@ -191,6 +224,7 @@ export function PromoteChannelDialog({
                     variant="outline"
                     size="xs"
                     onClick={() => setTargetChannel(channel)}
+                    disabled={isPromoting}
                   >
                     {channel}
                   </Button>
@@ -209,7 +243,11 @@ export function PromoteChannelDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isPromoting}
+          >
             Cancel
           </Button>
           <Button
@@ -218,10 +256,16 @@ export function PromoteChannelDialog({
               !normalizedTargetChannel ||
               (isCopy && !copyBundleId) ||
               isSameChannel ||
-              promoteBundleMutation.isPending
+              isPromoting
             }
           >
-            {isCopy ? "Copy" : "Move"}
+            {isPromoting
+              ? isCopy
+                ? "Copying..."
+                : "Moving..."
+              : isCopy
+                ? "Copy"
+                : "Move"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## What changed

This PR hardens the bundle action dialogs in `packages/console` so they cannot be dismissed while a destructive or mutating action is still in flight.

- block `Promote to Channel` from closing via overlay click, escape, close button, or cancel while promote is pending
- disable promote form controls while the request is in progress and show an in-progress action label
- keep `Delete Bundle` open until the delete mutation actually resolves instead of letting the alert dialog close immediately
- add regression coverage for both pending-state behaviors

## Why

The console bundle actions had two UX race conditions:

1. the promote dialog could still be dismissed from the dimmer or other close paths after the action button became disabled
2. the delete dialog did not wait for the async delete to finish before closing, which made the UI look complete before the operation actually completed

## Impact

Bundle action flows are now consistent with their pending state. Users cannot accidentally escape a running promote/delete operation, and the delete confirmation now only closes after the delete request succeeds.

## Root cause

Both dialogs relied on Radix default dismiss behavior while using async mutations. That left non-button dismiss paths active during pending states, and `AlertDialogAction` was able to close before the async delete finished.

## Validation

- `.agents/skills/fix-ci/scripts/run_fixci.sh all`
- `pnpm --filter @hot-updater/console test -- --run PromoteChannelDialog.spec.tsx DeleteBundleDialog.spec.tsx BundleEditorForm.spec.tsx`
- `pnpm --filter @hot-updater/console exec tsc --noEmit`
