### PR TITLE
docs: fix .easignore example for keys directory

### DIFF
--- a/docs/content/docs/guides/bundle-signing.mdx
+++ b/docs/content/docs/guides/bundle-signing.mdx
@@ -173,7 +173,7 @@ The plugin automatically extracts the public key from `HOT_UPDATER_PRIVATE_KEY` 
 For simpler setup, include the keys directory in EAS builds:
 
 ```txt title=".easignore"
-!keys/
+!/keys
 ```
 
 This tells EAS to include the `keys/` directory even though it's in `.gitignore`. The plugin will use the private key file directly during prebuild.


### PR DESCRIPTION
## What changed
- update the `.easignore` example in the bundle-signing guide from `!keys/` to `!/keys`

## Why
- according to the Expo EAS CLI discussion, patterns with a trailing slash like `hooks/` or `scripts/` in `.easignore` can match nested directories unexpectedly in monorepos
- anchoring the path with `/` and removing the trailing slash makes the ignore exception root-relative, which is the safer example for `keys`
- reference: https://github.com/expo/eas-cli/issues/3198#issuecomment-4183243928

## Impact
- helps readers avoid excluding or including the wrong directories when following the bundle signing guide
- makes the docs align with the behavior validated via `eas build:inspect` in the linked Expo comment

## Validation
- verified the docs diff only changes this example
- no tests run because this is a docs-only change
