### PR TITLE
feat(cli): check infra in `hot-updater doctor`

### DIFF
--- a/.changeset/wise-parrots-cut.md
+++ b/.changeset/wise-parrots-cut.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+feat(cli): check infra in hot-updater doctor

--- a/docs/content/docs/guides/doctor.mdx
+++ b/docs/content/docs/guides/doctor.mdx
@@ -50,6 +50,12 @@ Required infrastructure version: x.x.x
 Doctor check complete.
 ```
 
+## Update Package Versions
+
+If `doctor` reports version mismatches, update every Hot Updater package in
+`package.json` to the same compatible version, then run your package manager
+install command.
+
 ## Update Outdated Infrastructure
 
 If your server is outdated, `doctor` prints:
@@ -65,9 +71,6 @@ How to fix it depends on how you run Hot Updater:
 - **Managed providers (`aws`, `cloudflare`, `supabase`, `firebase`)**: run
   `npx hot-updater init` again and redeploy the generated provider
   infrastructure.
-
-`--fix` only updates package versions in `package.json`. It does not update or
-redeploy infrastructure.
 
 ## Options
 

--- a/docs/content/docs/guides/doctor.mdx
+++ b/docs/content/docs/guides/doctor.mdx
@@ -1,0 +1,76 @@
+---
+title: "Doctor"
+description: "Check Hot Updater package versions and server infrastructure."
+icon: Stethoscope
+version: "v0.30.0"
+---
+
+## Overview
+
+Use `hot-updater doctor` to check two things:
+
+- All Hot Updater packages use compatible versions
+- Your deployed infrastructure server is not outdated
+
+Run it after upgrading Hot Updater, or when OTA updates behave differently after
+a package update.
+
+```package-install
+npx hot-updater doctor
+```
+
+In an interactive terminal, the command asks for your server base URL. Press
+Enter to skip the server check.
+
+## Check Infrastructure
+
+To check the deployed server in CI or a non-interactive shell, pass the public
+update-check base URL.
+
+```package-install
+npx hot-updater doctor --server-base-url https://updates.example.com/api/check-update
+```
+
+`doctor` appends `/version` and checks:
+
+```txt
+https://updates.example.com/api/check-update/version
+```
+
+Example success output:
+
+```txt
+Checking the health of Hot Updater.
+hot-updater CLI version: x.x.x
+Server version endpoint: https://updates.example.com/api/check-update/version
+Server version: x.x.x
+Required infrastructure version: x.x.x
+✅ Server infrastructure is up to date.
+✅ All Hot Updater checks passed!
+Doctor check complete.
+```
+
+## Update Outdated Infrastructure
+
+If your server is outdated, `doctor` prints:
+
+```txt
+Infrastructure update required. Deploy server infrastructure version x.x.x or newer.
+```
+
+How to fix it depends on how you run Hot Updater:
+
+- **Self-hosted server using `createHotUpdater`**: update all Hot Updater
+  packages together, including `@hot-updater/server`, then redeploy your server.
+- **Managed providers (`aws`, `cloudflare`, `supabase`, `firebase`)**: run
+  `npx hot-updater init` again and redeploy the generated provider
+  infrastructure.
+
+`--fix` only updates package versions in `package.json`. It does not update or
+redeploy infrastructure.
+
+## Options
+
+| Option                    | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `--server-base-url <url>` | Check deployed infrastructure at `<url>/version`. |

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -11,6 +11,7 @@
     "runtime-channel-switch",
     "update-strategies",
     "compression",
+    "doctor",
     "bundle-signing"
   ]
 }

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -1,7 +1,13 @@
 import { readPackageUp } from "read-package-up";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { areVersionsCompatible, doctor } from "./doctor";
+import {
+  areVersionsCompatible,
+  doctor,
+  getRequiredInfrastructureVersion,
+  isInfrastructureUpdateRequired,
+  resolveVersionEndpoint,
+} from "./doctor";
 
 vi.mock("read-package-up", () => ({
   readPackageUp: vi.fn(),
@@ -78,6 +84,42 @@ describe("areVersionsCompatible", () => {
     expect(areVersionsCompatible("1.0.0", "^1.0.0-alpha.1")).toBe(true);
     expect(areVersionsCompatible("^1.0.0-alpha.1", "1.0.0")).toBe(true);
     expect(areVersionsCompatible("2.0.0-alpha.1", "^1.0.0")).toBe(false);
+  });
+});
+
+describe("infrastructure version helpers", () => {
+  it("resolves the latest infrastructure target required by a package version", () => {
+    expect(getRequiredInfrastructureVersion("0.28.0")).toBe("0.21.0");
+    expect(getRequiredInfrastructureVersion("0.29.8")).toBe("0.29.0");
+    expect(getRequiredInfrastructureVersion("0.30.0")).toBe("0.30.0");
+    expect(getRequiredInfrastructureVersion("0.30.1")).toBe("0.30.0");
+  });
+
+  it("does not require an update just because the server package version is newer", () => {
+    expect(
+      isInfrastructureUpdateRequired({
+        serverVersion: "0.30.1",
+        requiredVersion: "0.30.0",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires an update when the server is below the required infrastructure target", () => {
+    expect(
+      isInfrastructureUpdateRequired({
+        serverVersion: "0.29.8",
+        requiredVersion: "0.30.0",
+      }),
+    ).toBe(true);
+  });
+
+  it("resolves the version endpoint from the server base URL", () => {
+    expect(resolveVersionEndpoint("https://example.com/api/check-update")).toBe(
+      "https://example.com/api/check-update/version",
+    );
+    expect(
+      resolveVersionEndpoint("https://example.com/api/check-update/"),
+    ).toBe("https://example.com/api/check-update/version");
   });
 });
 
@@ -317,6 +359,149 @@ describe("doctor", () => {
     expect(result3).toEqual({
       success: false,
       error: "hot-updater CLI not found. Please install it first.",
+    });
+  });
+
+  it("should pass when server infrastructure is on the required target", async () => {
+    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.30.0",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      return new Response(JSON.stringify({ version: "0.30.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await doctor({
+      serverBaseUrl: "https://example.com/api/check-update",
+      fetch: fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.com/api/check-update/version",
+      {
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+    expect(result).toEqual({
+      success: true,
+      details: {
+        hotUpdaterVersion: "0.30.0",
+        installedHotUpdaterPackages: [],
+        packageJsonPath: "/mock/cwd/package.json",
+        infrastructure: {
+          baseUrl: "https://example.com/api/check-update",
+          versionEndpoint: "https://example.com/api/check-update/version",
+          serverVersion: "0.30.0",
+          requiredVersion: "0.30.0",
+          needsUpdate: false,
+        },
+      },
+    });
+  });
+
+  it("should pass when server version is newer than the required infrastructure target", async () => {
+    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.30.0",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      return new Response(JSON.stringify({ version: "0.30.1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await doctor({
+      serverBaseUrl: "https://example.com/api/check-update",
+      fetch: fetchImpl,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      details: {
+        infrastructure: {
+          serverVersion: "0.30.1",
+          requiredVersion: "0.30.0",
+          needsUpdate: false,
+        },
+      },
+    });
+  });
+
+  it("should fail when server infrastructure is below the required target", async () => {
+    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.30.0",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      return new Response(JSON.stringify({ version: "0.29.8" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await doctor({
+      serverBaseUrl: "https://example.com/api/check-update",
+      fetch: fetchImpl,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      details: {
+        infrastructure: {
+          serverVersion: "0.29.8",
+          requiredVersion: "0.30.0",
+          needsUpdate: true,
+        },
+      },
+    });
+  });
+
+  it("should require an update when server version endpoint is unavailable", async () => {
+    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.30.0",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await doctor({
+      serverBaseUrl: "https://example.com/api/check-update",
+      fetch: fetchImpl,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      details: {
+        infrastructure: {
+          versionEndpoint: "https://example.com/api/check-update/version",
+          requiredVersion: "0.30.0",
+          needsUpdate: true,
+          updateReason: "Version endpoint not found",
+        },
+      },
     });
   });
 });

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -472,14 +472,14 @@ export const handleDoctor = async ({
 
     if (infrastructure.needsUpdate) {
       p.log.error(
-        `❌ Infrastructure update required. ` +
+        `Infrastructure update required. ` +
           `Deploy server infrastructure version ${infrastructure.requiredVersion} or newer.`,
       );
       if (infrastructure.updateReason) {
         p.log.info(`Reason: ${infrastructure.updateReason}`);
       }
     } else if (infrastructure.error) {
-      p.log.error(`❌ Infrastructure check failed: ${infrastructure.error}`);
+      p.log.error(`Infrastructure check failed: ${infrastructure.error}`);
     } else {
       p.log.success("✅ Server infrastructure is up to date.");
     }

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -16,10 +16,21 @@ interface VersionMismatch {
   expectedVersion: string;
 }
 
+interface InfrastructureStatus {
+  baseUrl: string;
+  versionEndpoint: string;
+  serverVersion?: string;
+  requiredVersion: string;
+  needsUpdate?: boolean;
+  updateReason?: string;
+  error?: string;
+}
+
 interface DoctorDetails {
   // Version related
   hotUpdaterVersion?: string;
   versionMismatches?: VersionMismatch[];
+  infrastructure?: InfrastructureStatus;
 
   // Package info
   packageJsonPath?: string;
@@ -35,6 +46,58 @@ interface DoctorResult {
   error?: string;
   details?: DoctorDetails;
 }
+
+interface DoctorOptions {
+  cwd?: string;
+  serverBaseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+interface ServerVersionResponse {
+  version?: unknown;
+}
+
+interface InfrastructureUpdateTarget {
+  version: string;
+  note: string;
+}
+
+// Only versions that require deployed server/infrastructure changes belong here.
+// Regular package releases must not be added unless existing infrastructure needs
+// to be redeployed or migrated for compatibility.
+export const INFRASTRUCTURE_UPDATE_TARGETS = [
+  {
+    version: "0.13.0",
+    note: "Initial provider infrastructure migrations",
+  },
+  {
+    version: "0.18.0",
+    note: "Provider infrastructure migration",
+  },
+  {
+    version: "0.21.0",
+    note: "ORM schema version target",
+  },
+  {
+    version: "0.29.0",
+    note: "Rollout infrastructure fields",
+  },
+  {
+    version: "0.30.0",
+    note: "Target cohort rollout behavior",
+  },
+] as const satisfies readonly [
+  InfrastructureUpdateTarget,
+  ...InfrastructureUpdateTarget[],
+];
+
+const getInfrastructureTargetVersionAt = (index: number): string => {
+  const target = INFRASTRUCTURE_UPDATE_TARGETS.at(index);
+  if (!target) {
+    throw new Error("INFRASTRUCTURE_UPDATE_TARGETS must not be empty");
+  }
+  return target.version;
+};
 
 /**
  * Checks if two versions (or version and range) are compatible.
@@ -73,15 +136,134 @@ export function areVersionsCompatible(
   return false;
 }
 
+export function getRequiredInfrastructureVersion(
+  hotUpdaterVersion: string = getInfrastructureTargetVersionAt(-1),
+): string {
+  const current = semver.coerce(hotUpdaterVersion)?.version;
+
+  if (!current) {
+    return getInfrastructureTargetVersionAt(-1);
+  }
+
+  let requiredVersion = getInfrastructureTargetVersionAt(0);
+
+  for (const target of INFRASTRUCTURE_UPDATE_TARGETS) {
+    if (semver.lte(target.version, current)) {
+      requiredVersion = target.version;
+    }
+  }
+
+  return requiredVersion;
+}
+
+export function isInfrastructureUpdateRequired({
+  serverVersion,
+  requiredVersion = getRequiredInfrastructureVersion(),
+}: {
+  serverVersion: string;
+  requiredVersion?: string;
+}): boolean {
+  const normalizedServerVersion = semver.valid(serverVersion);
+  const normalizedRequiredVersion = semver.valid(requiredVersion);
+
+  if (!normalizedServerVersion || !normalizedRequiredVersion) {
+    throw new Error("Invalid infrastructure version");
+  }
+
+  return semver.lt(normalizedServerVersion, normalizedRequiredVersion);
+}
+
+export function resolveVersionEndpoint(serverBaseUrl: string): string {
+  const url = new URL(serverBaseUrl.trim());
+  const pathname = url.pathname.replace(/\/+$/, "");
+
+  url.hash = "";
+  url.search = "";
+  url.pathname = `${pathname}/version`;
+  return url.toString();
+}
+
+async function checkInfrastructureStatus({
+  serverBaseUrl,
+  fetchImpl = fetch,
+  requiredVersion = getRequiredInfrastructureVersion(),
+}: {
+  serverBaseUrl: string;
+  fetchImpl?: typeof fetch;
+  requiredVersion?: string;
+}): Promise<InfrastructureStatus> {
+  const versionEndpoint = resolveVersionEndpoint(serverBaseUrl);
+  const baseUrl = serverBaseUrl.trim();
+
+  try {
+    const response = await fetchImpl(versionEndpoint, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return {
+          baseUrl,
+          versionEndpoint,
+          requiredVersion,
+          needsUpdate: true,
+          updateReason: "Version endpoint not found",
+        };
+      }
+
+      return {
+        baseUrl,
+        versionEndpoint,
+        requiredVersion,
+        error: `Version endpoint returned ${response.status}`,
+      };
+    }
+
+    const data = (await response.json()) as ServerVersionResponse;
+    if (typeof data.version !== "string") {
+      return {
+        baseUrl,
+        versionEndpoint,
+        requiredVersion,
+        error: "Version endpoint response must include a string version",
+      };
+    }
+
+    const needsUpdate = isInfrastructureUpdateRequired({
+      serverVersion: data.version,
+      requiredVersion,
+    });
+
+    return {
+      baseUrl,
+      versionEndpoint,
+      serverVersion: data.version,
+      requiredVersion,
+      needsUpdate,
+    };
+  } catch (error) {
+    return {
+      baseUrl,
+      versionEndpoint,
+      requiredVersion,
+      error: (error as Error).message,
+    };
+  }
+}
+
 /**
  * Performs health check on Hot Updater installation
- * @param cwd - Current working directory (optional)
+ * @param options - Doctor check options
  * @returns true if everything is healthy, or DoctorResult with details if there are issues
  */
 export async function doctor(
-  cwd: string = getCwd(),
+  options: DoctorOptions = {},
 ): Promise<true | DoctorResult> {
   try {
+    const { cwd = getCwd(), serverBaseUrl, fetch: fetchImpl } = options;
+
     // Read package.json
     const packageResult = await readPackageUp({ cwd });
 
@@ -141,18 +323,36 @@ export async function doctor(
       installedHotUpdaterPackages: hotUpdaterPackages,
     };
 
+    if (serverBaseUrl) {
+      details.infrastructure = await checkInfrastructureStatus({
+        serverBaseUrl,
+        fetchImpl,
+        requiredVersion: getRequiredInfrastructureVersion(hotUpdaterVersion),
+      });
+    }
+
     // Add version mismatches if any
     if (versionMismatches.length > 0) {
       details.versionMismatches = versionMismatches;
     }
 
     // Check if there are any issues
-    const hasIssues = versionMismatches.length > 0;
+    const hasInfrastructureIssue =
+      details.infrastructure?.error !== undefined ||
+      details.infrastructure?.needsUpdate === true;
+    const hasIssues = versionMismatches.length > 0 || hasInfrastructureIssue;
     // Future: || configurationIssues.length > 0 || etc.
 
     if (hasIssues) {
       return {
         success: false,
+        details,
+      };
+    }
+
+    if (details.infrastructure) {
+      return {
+        success: true,
         details,
       };
     }
@@ -195,10 +395,48 @@ export async function fixVersionMismatches(
   await fs.promises.writeFile(packageJsonPath, content);
 }
 
-export const handleDoctor = async ({ fix }: { fix: boolean }) => {
+const promptServerBaseUrl = async () => {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return undefined;
+  }
+
+  const serverBaseUrl = await p.text({
+    message: "Server base URL for infrastructure check (Enter to skip)",
+    placeholder: "https://example.com/api/check-update",
+    validate(value) {
+      const trimmed = value?.trim() ?? "";
+      if (!trimmed) return;
+
+      try {
+        new URL(trimmed);
+      } catch {
+        return "Enter a valid URL";
+      }
+
+      return;
+    },
+  });
+
+  if (p.isCancel(serverBaseUrl)) {
+    p.cancel("Doctor check cancelled");
+    process.exit(0);
+  }
+
+  const trimmed = serverBaseUrl.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export const handleDoctor = async ({
+  fix,
+  serverBaseUrl,
+}: {
+  fix: boolean;
+  serverBaseUrl?: string;
+}) => {
   p.intro("Checking the health of Hot Updater.");
 
-  const result = await doctor();
+  const resolvedServerBaseUrl = serverBaseUrl ?? (await promptServerBaseUrl());
+  const result = await doctor({ serverBaseUrl: resolvedServerBaseUrl });
 
   if (result === true) {
     p.log.success("✅ All Hot Updater checks passed!");
@@ -215,9 +453,36 @@ export const handleDoctor = async ({ fix }: { fix: boolean }) => {
 
   // Handle issues with details
   const { details } = result;
+  let shouldExitWithFailure = !result.success;
 
   if (details?.hotUpdaterVersion) {
     p.log.info(`hot-updater CLI version: ${details.hotUpdaterVersion}`);
+  }
+
+  if (details?.infrastructure) {
+    const infrastructure = details.infrastructure;
+    p.log.info(`Server version endpoint: ${infrastructure.versionEndpoint}`);
+
+    if (infrastructure.serverVersion) {
+      p.log.info(`Server version: ${infrastructure.serverVersion}`);
+      p.log.info(
+        `Required infrastructure version: ${infrastructure.requiredVersion}`,
+      );
+    }
+
+    if (infrastructure.needsUpdate) {
+      p.log.error(
+        `❌ Infrastructure update required. ` +
+          `Deploy server infrastructure version ${infrastructure.requiredVersion} or newer.`,
+      );
+      if (infrastructure.updateReason) {
+        p.log.info(`Reason: ${infrastructure.updateReason}`);
+      }
+    } else if (infrastructure.error) {
+      p.log.error(`❌ Infrastructure check failed: ${infrastructure.error}`);
+    } else {
+      p.log.success("✅ Server infrastructure is up to date.");
+    }
   }
 
   if (details?.versionMismatches && details.versionMismatches.length > 0) {
@@ -238,8 +503,12 @@ export const handleDoctor = async ({ fix }: { fix: boolean }) => {
         );
         p.log.success("✅ Fixed version mismatches in package.json");
         p.log.info("Run your package manager to install the updated versions.");
+        shouldExitWithFailure =
+          details.infrastructure?.error !== undefined ||
+          details.infrastructure?.needsUpdate === true;
       } catch (error) {
         p.log.error(`Failed to fix versions: ${(error as Error).message}`);
+        shouldExitWithFailure = true;
       }
     } else if (!fix) {
       p.log.info("Run with --fix to automatically update versions.");
@@ -247,5 +516,10 @@ export const handleDoctor = async ({ fix }: { fix: boolean }) => {
     }
   }
 
+  if (shouldExitWithFailure) {
+    process.exit(1);
+  }
+
+  p.log.success("✅ All Hot Updater checks passed!");
   p.outro("Doctor check complete.");
 };

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 import { getCwd, p } from "@hot-updater/cli-tools";
 import { merge } from "es-toolkit";
 import { readPackageUp } from "read-package-up";
@@ -367,34 +365,6 @@ export async function doctor(
   }
 }
 
-/**
- * Fix version mismatches in package.json
- * This is a separate utility function for CLI usage
- */
-export async function fixVersionMismatches(
-  packageJsonPath: string,
-  versionMismatches: VersionMismatch[],
-): Promise<void> {
-  const packageResult = await fs.promises.readFile(packageJsonPath, "utf-8");
-  if (!packageResult) {
-    throw new Error("Could not read package.json");
-  }
-
-  const packageJson = JSON.parse(packageResult) as PackageJson;
-
-  for (const mismatch of versionMismatches) {
-    if (packageJson.dependencies?.[mismatch.packageName]) {
-      packageJson.dependencies[mismatch.packageName] = mismatch.expectedVersion;
-    } else if (packageJson.devDependencies?.[mismatch.packageName]) {
-      packageJson.devDependencies[mismatch.packageName] =
-        mismatch.expectedVersion;
-    }
-  }
-
-  const content = `${JSON.stringify(packageJson, null, 2)}\n`;
-  await fs.promises.writeFile(packageJsonPath, content);
-}
-
 const promptServerBaseUrl = async () => {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return undefined;
@@ -427,12 +397,10 @@ const promptServerBaseUrl = async () => {
 };
 
 export const handleDoctor = async ({
-  fix,
   serverBaseUrl,
 }: {
-  fix: boolean;
   serverBaseUrl?: string;
-}) => {
+} = {}) => {
   p.intro("Checking the health of Hot Updater.");
 
   const resolvedServerBaseUrl = serverBaseUrl ?? (await promptServerBaseUrl());
@@ -495,25 +463,10 @@ export const handleDoctor = async ({
       );
     }
 
-    if (fix && details.packageJsonPath) {
-      try {
-        await fixVersionMismatches(
-          details.packageJsonPath,
-          details.versionMismatches,
-        );
-        p.log.success("✅ Fixed version mismatches in package.json");
-        p.log.info("Run your package manager to install the updated versions.");
-        shouldExitWithFailure =
-          details.infrastructure?.error !== undefined ||
-          details.infrastructure?.needsUpdate === true;
-      } catch (error) {
-        p.log.error(`Failed to fix versions: ${(error as Error).message}`);
-        shouldExitWithFailure = true;
-      }
-    } else if (!fix) {
-      p.log.info("Run with --fix to automatically update versions.");
-      process.exit(1);
-    }
+    p.log.info(
+      "Update every Hot Updater package to the same compatible version, " +
+        "then run your package manager install command.",
+    );
   }
 
   if (shouldExitWithFailure) {

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -54,6 +54,10 @@ program
   .command("doctor")
   .description("Check the health of Hot Updater")
   .option("-f, --fix", "fix the issues", false)
+  .option(
+    "--server-base-url <url>",
+    "server base URL used by update checks (doctor appends /version)",
+  )
   .action(handleDoctor);
 
 const fingerprintCommand = program

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -53,7 +53,6 @@ program.command("init").description("Initialize Hot Updater").action(init);
 program
   .command("doctor")
   .description("Check the health of Hot Updater")
-  .option("-f, --fix", "fix the issues", false)
   .option(
     "--server-base-url <url>",
     "server base URL used by update checks (doctor appends /version)",


### PR DESCRIPTION
## What changed

- Added an optional server infrastructure check to `hot-updater doctor`.
- The CLI now accepts `--server-base-url <url>` and appends `/version` to inspect the deployed server version.
- Added an explicit infrastructure update target list so version increases only require action when the current CLI version crosses a release that actually needs infrastructure redeploy or migration.
- Added unit coverage for endpoint resolution, required infrastructure target selection, newer non-actionable server versions, outdated server versions, and unavailable version endpoints.

## Why

Package versions can increase without requiring deployed infrastructure to be updated. The doctor check now distinguishes ordinary package releases from releases that require infrastructure changes.

```
pnpm hot-updater doctor
┌  Checking the health of Hot Updater.
│
◇  Server base URL for infrastructure check 
(Enter to skip)
│  https://hot-updater-gg4mc35mza-du.a.run.app/ap
i/check-update
│
●  hot-updater CLI version: workspace:*
│
●  Server version endpoint: https://hot-updater-gg4mc35mza-du.a.run.app/api/check-update/version
│
●  Server version: 0.29.8
│
●  Required infrastructure version: 0.30.0
│
■  Infrastructure update required. Deploy server infrastructure version 0.30.0 or newer.
```