### PR TITLE
feat: add internal files directory retrieval in FileManagerService

### DIFF
--- a/.changeset/yellow-kids-build.md
+++ b/.changeset/yellow-kids-build.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+feat: add internal files directory retrieval in FileManagerService

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -150,7 +150,7 @@ class BundleFileStorageService(
     // MARK: - Bundle Store Directory
 
     private fun getBundleStoreDir(): File {
-        val baseDir = fileSystem.getExternalFilesDir()
+        val baseDir = fileSystem.getInternalFilesDir()
         return File(baseDir, "bundle-store")
     }
 
@@ -688,7 +688,7 @@ class BundleFileStorageService(
                 Log.d(TAG, "Created initial metadata during updateBundle")
             }
 
-        val baseDir = fileSystem.getExternalFilesDir()
+        val baseDir = fileSystem.getInternalFilesDir()
         val bundleStoreDir = getBundleStoreDir()
         if (!bundleStoreDir.exists()) {
             bundleStoreDir.mkdirs()

--- a/packages/react-native/android/src/main/java/com/hotupdater/FileManagerService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/FileManagerService.kt
@@ -47,6 +47,11 @@ interface FileSystemService {
      * Gets the external files directory for the application
      */
     fun getExternalFilesDir(): File?
+
+    /**
+     * Gets the internal files directory for the application
+     */
+    fun getInternalFilesDir(): File?
 }
 
 /**
@@ -101,4 +106,6 @@ class FileManagerService(
     }
 
     override fun getExternalFilesDir(): File? = context.getExternalFilesDir(null)
+
+    override fun getInternalFilesDir(): File? = context.filesDir
 }


### PR DESCRIPTION
This pull request updates the file storage location for bundles in the Android implementation of the HotUpdater module. The main change is switching from using the external files directory to the internal files directory for storing bundles, which improves data privacy and security. Additionally, the file system service interface and implementation are updated to support this change.

**File storage location update:**

* Changed the bundle storage location in `BundleFileStorageService` from the external files directory to the internal files directory by replacing usages of `getExternalFilesDir()` with `filesDir()`. [[1]](diffhunk://#diff-f1f20ea5ba3b8a5329f9c71c05c03a8ff7b3c4a38d93ec68c0e39cd91aa257f4L153-R153) [[2]](diffhunk://#diff-f1f20ea5ba3b8a5329f9c71c05c03a8ff7b3c4a38d93ec68c0e39cd91aa257f4L691-R691)

**File system service enhancements:**

* Added a new `filesDir()` method to the `FileSystemService` interface to provide access to the internal files directory.
* Implemented the new `filesDir()` method in `FileManagerService` to return the application's internal files directory.