### PR TITLE
fix(react-native): store duplicate progress updates

### DIFF
--- a/.changeset/calm-bikes-sip.md
+++ b/.changeset/calm-bikes-sip.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Prevent duplicate progress events from notifying the React Native store when
+the computed update state has not changed.

--- a/packages/react-native/src/store.spec.ts
+++ b/packages/react-native/src/store.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const addListenerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./native", () => ({
+  addListener: addListenerMock,
+}));
+
+const importStore = async () => {
+  const { hotUpdaterStore } = await import("./store");
+  return hotUpdaterStore;
+};
+
+describe("hotUpdaterStore", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    addListenerMock.mockReset();
+  });
+
+  it("does not notify subscribers when state values are unchanged", async () => {
+    const store = await importStore();
+    const listener = vi.fn();
+
+    const unsubscribe = store.subscribe(listener);
+
+    store.setState({});
+    store.setState({ progress: 0 });
+    store.setState({ isUpdateDownloaded: false });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it("notifies subscribers only when progress events change the snapshot", async () => {
+    const store = await importStore();
+    const listener = vi.fn();
+    const progressListener = addListenerMock.mock.calls[0][1] as (state: {
+      progress: number;
+    }) => void;
+
+    const unsubscribe = store.subscribe(listener);
+
+    progressListener({ progress: 0.5 });
+    progressListener({ progress: 0.5 });
+    progressListener({ progress: 1 });
+    store.setState({ isUpdateDownloaded: true });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(store.getSnapshot()).toEqual({
+      isUpdateDownloaded: true,
+      progress: 1,
+    });
+
+    unsubscribe();
+  });
+});

--- a/packages/react-native/src/store.ts
+++ b/packages/react-native/src/store.ts
@@ -46,6 +46,13 @@ const createHotUpdaterStore = () => {
       nextState.isUpdateDownloaded = newState.isUpdateDownloaded;
     }
 
+    if (
+      state.progress === nextState.progress &&
+      state.isUpdateDownloaded === nextState.isUpdateDownloaded
+    ) {
+      return;
+    }
+
     state = nextState;
     emitChange();
   };


### PR DESCRIPTION
## Summary

 #960.

Prevents the React Native hot updater store from notifying subscribers when the computed snapshot has not changed.

## Root cause

`setState()` always created a new state object and called `emitChange()`, even when repeated native `onProgress` events reported the same `progress` value. In Fabric/bridgeless environments, those synchronous store notifications can repeatedly force React renders during update progress handling and contribute to `Maximum update depth exceeded` crashes.

## Changes

- Bail out in `packages/react-native/src/store.ts` when `progress` and `isUpdateDownloaded` are unchanged after deriving state.
- Add focused Vitest coverage for unchanged state updates and duplicate native `onProgress` events.
- Add a patch changeset for `@hot-updater/react-native`.
