### PR TITLE
fix(cli): run hot-updater as native ESM

### DIFF
--- a/.changeset/fair-tools-dream.md
+++ b/.changeset/fair-tools-dream.md
@@ -1,0 +1,18 @@
+---
+"@hot-updater/apple-helper": patch
+"@hot-updater/cli-tools": patch
+"@hot-updater/react-native": patch
+"hot-updater": patch
+---
+
+Run the `hot-updater` CLI from native ESM on Node 20 so TypeScript config
+files load through ESM import conditions.
+
+Require Node.js 20.19.0 or newer for the CLI package surface.
+
+Run the `hot-updater` CLI bin from the native ESM entrypoint and stop emitting
+a CommonJS build for the CLI entry.
+
+Bump the `hot-updater` CLI package's vulnerable `kysely` and
+`fast-xml-parser` dependency entries to patched versions without pnpm
+overrides.

--- a/examples-server/elysia-drizzle-libsql/package.json
+++ b/examples-server/elysia-drizzle-libsql/package.json
@@ -17,9 +17,9 @@
     "@hot-updater/core": "workspace:*",
     "@hot-updater/mock": "workspace:*",
     "@hot-updater/server": "workspace:*",
-    "@libsql/client": "^0.15.15",
+    "@libsql/client": "catalog:db",
     "dotenv": "^16.6.1",
-    "drizzle-orm": "^0.44.7",
+    "drizzle-orm": "catalog:db",
     "elysia": "^1.2.17",
     "memoirist": "^0.4.0"
   },
@@ -29,7 +29,7 @@
     "drizzle-kit": "^0.31.6",
     "execa": "catalog:tools",
     "hot-updater": "workspace:*",
-    "prisma": "^6.4.1",
+    "prisma": "catalog:db",
     "tsx": "^4.20.6",
     "typescript": "^6.0.2"
   }

--- a/examples-server/elysia-drizzle-libsql/src/handler.integration.spec.ts
+++ b/examples-server/elysia-drizzle-libsql/src/handler.integration.spec.ts
@@ -45,7 +45,7 @@ describe("Hot Updater Handler Integration Tests (Elysia)", () => {
     const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
     const hotUpdaterCli = path.join(
       path.dirname(hotUpdaterPkgPath),
-      "dist/index.cjs",
+      "dist/index.mjs",
     );
 
     // Generate Drizzle schema from hotUpdater instance

--- a/examples-server/express-prisma-sqlite/package.json
+++ b/examples-server/express-prisma-sqlite/package.json
@@ -17,7 +17,7 @@
     "@hot-updater/core": "workspace:*",
     "@hot-updater/mock": "workspace:*",
     "@hot-updater/server": "workspace:*",
-    "@prisma/client": "^6.18.0",
+    "@prisma/client": "catalog:db",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.21.2"
@@ -29,7 +29,7 @@
     "@types/node": "^20.11.17",
     "execa": "catalog:tools",
     "hot-updater": "workspace:*",
-    "prisma": "^6.4.1",
+    "prisma": "catalog:db",
     "tsx": "^4.20.6",
     "typescript": "^6.0.2"
   }

--- a/examples-server/express-prisma-sqlite/src/handler.integration.spec.ts
+++ b/examples-server/express-prisma-sqlite/src/handler.integration.spec.ts
@@ -46,7 +46,7 @@ describe("Hot Updater Handler Integration Tests (Express)", () => {
     const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
     const hotUpdaterCli = path.join(
       path.dirname(hotUpdaterPkgPath),
-      "dist/index.cjs",
+      "dist/index.mjs",
     );
 
     // Generate Prisma Client first from existing schema

--- a/examples-server/hono-drizzle-pglite/package.json
+++ b/examples-server/hono-drizzle-pglite/package.json
@@ -12,14 +12,14 @@
     "db:push": "npx drizzle-kit push"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.17",
+    "@electric-sql/pglite": "catalog:db",
     "@hono/node-server": "catalog:hono",
     "@hot-updater/aws": "workspace:*",
     "@hot-updater/core": "workspace:*",
     "@hot-updater/mock": "workspace:*",
     "@hot-updater/server": "workspace:*",
     "dotenv": "^16.6.1",
-    "drizzle-orm": "^0.44.7",
+    "drizzle-orm": "catalog:db",
     "hono": "catalog:hono"
   },
   "devDependencies": {

--- a/examples-server/hono-drizzle-pglite/src/handler.integration.spec.ts
+++ b/examples-server/hono-drizzle-pglite/src/handler.integration.spec.ts
@@ -45,7 +45,7 @@ describe("Hot Updater Handler Integration Tests (Hono + Drizzle + PGlite)", () =
     const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
     const hotUpdaterCli = path.join(
       path.dirname(hotUpdaterPkgPath),
-      "dist/index.cjs",
+      "dist/index.mjs",
     );
 
     // Generate Drizzle schema from hotUpdater instance

--- a/examples-server/hono-e2e-local/package.json
+++ b/examples-server/hono-e2e-local/package.json
@@ -10,13 +10,13 @@
     "test:type": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.17",
+    "@electric-sql/pglite": "catalog:db",
     "@hono/node-server": "catalog:hono",
     "@hot-updater/server": "workspace:*",
     "dotenv": "^16.4.7",
     "hono": "catalog:hono",
-    "kysely": "0.28.9",
-    "kysely-pglite-dialect": "^1.2.0"
+    "kysely": "catalog:db",
+    "kysely-pglite-dialect": "catalog:db"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",

--- a/examples-server/hono-kysely-mysql/package.json
+++ b/examples-server/hono-kysely-mysql/package.json
@@ -20,8 +20,8 @@
     "@hot-updater/server": "workspace:*",
     "dotenv": "^16.4.7",
     "hono": "catalog:hono",
-    "kysely": "0.28.9",
-    "mysql2": "^3.11.5"
+    "kysely": "catalog:db",
+    "mysql2": "catalog:db"
   },
   "devDependencies": {
     "@hot-updater/test-utils": "workspace:*",

--- a/examples-server/hono-kysely-pglite/package.json
+++ b/examples-server/hono-kysely-pglite/package.json
@@ -10,7 +10,7 @@
     "test:type": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.17",
+    "@electric-sql/pglite": "catalog:db",
     "@hono/node-server": "catalog:hono",
     "@hot-updater/aws": "workspace:*",
     "@hot-updater/core": "workspace:*",
@@ -18,8 +18,8 @@
     "@hot-updater/server": "workspace:*",
     "dotenv": "^16.4.7",
     "hono": "catalog:hono",
-    "kysely": "0.28.9",
-    "kysely-pglite-dialect": "^1.2.0"
+    "kysely": "catalog:db",
+    "kysely-pglite-dialect": "catalog:db"
   },
   "devDependencies": {
     "@hot-updater/test-utils": "workspace:*",

--- a/examples-server/hono-kysely-pglite/src/handler.integration.spec.ts
+++ b/examples-server/hono-kysely-pglite/src/handler.integration.spec.ts
@@ -45,7 +45,7 @@ describe("Hot Updater Handler Integration Tests (Hono)", () => {
     const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
     const hotUpdaterCli = path.join(
       path.dirname(hotUpdaterPkgPath),
-      "dist/index.cjs",
+      "dist/index.mjs",
     );
 
     // Then apply migrations to database

--- a/examples-server/hono-mongodb/package.json
+++ b/examples-server/hono-mongodb/package.json
@@ -21,9 +21,9 @@
     "@hot-updater/server": "workspace:*",
     "@hot-updater/supabase": "workspace:*",
     "dotenv": "^16.6.1",
-    "firebase-admin": "13.6.0",
+    "firebase-admin": "catalog:db",
     "hono": "catalog:hono",
-    "mongodb": "^6.12.0"
+    "mongodb": "catalog:db"
   },
   "devDependencies": {
     "@hot-updater/test-utils": "workspace:*",

--- a/examples-server/hono-mongodb/package.json
+++ b/examples-server/hono-mongodb/package.json
@@ -21,7 +21,7 @@
     "@hot-updater/server": "workspace:*",
     "@hot-updater/supabase": "workspace:*",
     "dotenv": "^16.6.1",
-    "firebase-admin": "catalog:db",
+    "firebase-admin": "catalog:firebase",
     "hono": "catalog:hono",
     "mongodb": "catalog:db"
   },

--- a/examples-server/hono-mongodb/src/handler.integration.spec.ts
+++ b/examples-server/hono-mongodb/src/handler.integration.spec.ts
@@ -58,7 +58,7 @@ describe(
       const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
       const hotUpdaterCli = path.join(
         path.dirname(hotUpdaterPkgPath),
-        "dist/index.cjs",
+        "dist/index.mjs",
       );
 
       await execa(

--- a/examples-server/hono-prisma-postgres/package.json
+++ b/examples-server/hono-prisma-postgres/package.json
@@ -20,7 +20,7 @@
     "@hot-updater/core": "workspace:*",
     "@hot-updater/mock": "workspace:*",
     "@hot-updater/server": "workspace:*",
-    "@prisma/client": "^6.18.0",
+    "@prisma/client": "catalog:db",
     "dotenv": "^16.6.1",
     "hono": "catalog:hono"
   },
@@ -29,7 +29,7 @@
     "@types/node": "^20.11.17",
     "execa": "catalog:tools",
     "hot-updater": "workspace:*",
-    "prisma": "^6.4.1",
+    "prisma": "catalog:db",
     "tsx": "^4.20.6",
     "typescript": "^6.0.2"
   }

--- a/examples-server/hono-prisma-postgres/src/handler.integration.spec.ts
+++ b/examples-server/hono-prisma-postgres/src/handler.integration.spec.ts
@@ -133,7 +133,7 @@ describe(
       const hotUpdaterPkgPath = require.resolve("hot-updater/package.json");
       const hotUpdaterCli = path.join(
         path.dirname(hotUpdaterPkgPath),
-        "dist/index.cjs",
+        "dist/index.mjs",
       );
 
       // Generate Prisma Client first from existing schema

--- a/examples/v0.81.0/package.json
+++ b/examples/v0.81.0/package.json
@@ -47,7 +47,7 @@
     "@types/react-test-renderer": "^19.1.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.19.0",
-    "firebase-admin": "catalog:db",
+    "firebase-admin": "catalog:firebase",
     "firebase-tools": "^13.35.1",
     "hot-updater": "workspace:*",
     "jest": "^29.6.3",

--- a/examples/v0.81.0/package.json
+++ b/examples/v0.81.0/package.json
@@ -47,7 +47,7 @@
     "@types/react-test-renderer": "^19.1.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.19.0",
-    "firebase-admin": "13.6.0",
+    "firebase-admin": "catalog:db",
     "firebase-tools": "^13.35.1",
     "hot-updater": "workspace:*",
     "jest": "^29.6.3",

--- a/packages/apple-helper/package.json
+++ b/packages/apple-helper/package.json
@@ -31,7 +31,7 @@
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
     "execa": "catalog:tools",
-    "fast-xml-parser": "5.4.1"
+    "fast-xml-parser": "5.7.2"
   },
   "devDependencies": {
     "@types/node": "catalog:"

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -2,15 +2,19 @@
   "name": "@hot-updater/cli-tools",
   "version": "0.30.6",
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "description": "CLI utilities for Hot Updater",
   "sideEffects": false,
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/cli-tools/tsdown.config.ts
+++ b/packages/cli-tools/tsdown.config.ts
@@ -3,10 +3,9 @@ import { defineConfig } from "tsdown";
 export default defineConfig([
   {
     entry: ["./src/index.ts"],
-    format: ["esm", "cjs"],
+    format: ["esm"],
     outDir: "dist",
     dts: true,
-    exports: true,
     failOnWarn: true,
   },
 ]);

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -2,18 +2,20 @@
   "name": "hot-updater",
   "type": "module",
   "version": "0.30.6",
-  "bin": {
-    "hot-updater": "./dist/index.cjs"
+  "engines": {
+    "node": ">=20.19.0"
   },
-  "main": "dist/config.cjs",
+  "bin": {
+    "hot-updater": "./dist/index.mjs"
+  },
+  "main": "dist/config.mjs",
   "module": "dist/config.mjs",
-  "types": "dist/config.d.cts",
+  "types": "dist/config.d.mts",
   "exports": {
     ".": {
-      "node": "./dist/config.cjs",
+      "types": "./dist/config.d.mts",
       "import": "./dist/config.mjs",
-      "require": "./dist/config.cjs",
-      "types": "./dist/config.d.cts"
+      "require": "./dist/config.mjs"
     },
     "./package.json": "./package.json"
   },
@@ -56,7 +58,7 @@
     "@hot-updater/plugin-core": "workspace:*",
     "@hot-updater/server": "workspace:*",
     "jiti": "2.6.1",
-    "kysely": "0.28.9",
+    "kysely": "0.28.16",
     "sql-formatter": "15.6.10"
   },
   "devDependencies": {
@@ -76,7 +78,7 @@
     "es-toolkit": "^1.32.0",
     "execa": "catalog:tools",
     "fast-glob": "3.3.3",
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "5.7.2",
     "is-port-reachable": "^4.0.0",
     "open": "^10.1.0",
     "plist": "^3.1.0",

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -58,7 +58,7 @@
     "@hot-updater/plugin-core": "workspace:*",
     "@hot-updater/server": "workspace:*",
     "jiti": "2.6.1",
-    "kysely": "0.28.16",
+    "kysely": "catalog:db",
     "sql-formatter": "15.6.10"
   },
   "devDependencies": {

--- a/packages/hot-updater/tsdown.config.ts
+++ b/packages/hot-updater/tsdown.config.ts
@@ -4,11 +4,21 @@ export default defineConfig([
   {
     entry: {
       index: "./src/index.ts",
-      config: "./src/config.ts",
     },
-    format: ["esm", "cjs"],
+    format: ["esm"],
     outDir: "dist",
     dts: true,
+    failOnWarn: true,
+    shims: true,
+  },
+  {
+    entry: {
+      config: "./src/config.ts",
+    },
+    format: ["esm"],
+    outDir: "dist",
+    dts: true,
+    clean: false,
     failOnWarn: true,
     shims: true,
   },

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "path";
 
-import { loadConfig } from "@hot-updater/cli-tools";
 import type { ExpoConfig } from "expo/config";
 import {
   createRunOncePlugin,
@@ -11,24 +10,26 @@ import {
   withPlugins,
   withStringsXml,
 } from "expo/config-plugins";
-import {
-  createFingerprintJSON,
-  generateFingerprints,
-  getPublicKeyFromPrivate,
-  loadPrivateKey,
-} from "hot-updater";
 
 import pkg from "../../package.json";
 import { transformAndroid, transformIOS } from "./transformers";
 
-let fingerprintCache: Awaited<ReturnType<typeof generateFingerprints>> | null =
-  null;
+const loadCliTools = () => import("@hot-updater/cli-tools");
+const loadHotUpdater = () => import("hot-updater");
+
+type Fingerprints = Awaited<
+  ReturnType<Awaited<ReturnType<typeof loadHotUpdater>>["generateFingerprints"]>
+>;
+
+let fingerprintCache: Fingerprints | null = null;
 
 const getFingerprint = async () => {
   if (fingerprintCache) {
     return fingerprintCache;
   }
 
+  const { createFingerprintJSON, generateFingerprints } =
+    await loadHotUpdater();
   fingerprintCache = await generateFingerprints();
   await createFingerprintJSON(fingerprintCache);
   return fingerprintCache;
@@ -54,6 +55,7 @@ const getPublicKeyFromConfig = async (
   const envPrivateKey = process.env.HOT_UPDATER_PRIVATE_KEY;
   if (envPrivateKey) {
     try {
+      const { getPublicKeyFromPrivate } = await loadHotUpdater();
       const publicKeyPEM = getPublicKeyFromPrivate(envPrivateKey);
       console.log(
         "[hot-updater] Using public key extracted from HOT_UPDATER_PRIVATE_KEY environment variable",
@@ -89,6 +91,7 @@ const getPublicKeyFromConfig = async (
 
   try {
     // Priority 2: Private key file (existing method)
+    const { getPublicKeyFromPrivate, loadPrivateKey } = await loadHotUpdater();
     const privateKeyPEM = await loadPrivateKey(privateKeyPath);
     const publicKeyPEM = getPublicKeyFromPrivate(privateKeyPEM);
     console.log(`[hot-updater] Extracted public key from ${privateKeyPath}`);
@@ -165,6 +168,7 @@ const withHotUpdaterConfigAsync =
     // === iOS: Add channel and fingerprint to Info.plist ===
     modifiedConfig = withInfoPlist(modifiedConfig, async (cfg) => {
       let fingerprintHash = null;
+      const { loadConfig } = await loadCliTools();
       const config = await loadConfig(null);
       if (config.updateStrategy !== "appVersion") {
         const fingerprint = await getFingerprint();
@@ -187,6 +191,7 @@ const withHotUpdaterConfigAsync =
     // === Android: Add channel and fingerprint to strings.xml ===
     modifiedConfig = withStringsXml(modifiedConfig, async (cfg) => {
       let fingerprintHash = null;
+      const { loadConfig } = await loadCliTools();
       const config = await loadConfig(null);
       if (config.updateStrategy !== "appVersion") {
         const fingerprint = await getFingerprint();

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -68,7 +68,7 @@
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
     "execa": "catalog:tools",
-    "kysely": "^0.28.9",
+    "kysely": "0.28.16",
     "kysely-pglite-dialect": "^1.2.0",
     "msw": "^2.7.0",
     "uuidv7": "^1.0.2"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -57,19 +57,19 @@
     "@hot-updater/core": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
     "@hot-updater/js": "workspace:*",
-    "fumadb": "0.2.2",
+    "fumadb": "catalog:db",
     "rou3": "0.7.9",
     "semver": "^7.7.2"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.2.17",
+    "@electric-sql/pglite": "catalog:db",
     "@hot-updater/standalone": "workspace:*",
     "@hot-updater/test-utils": "workspace:*",
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
     "execa": "catalog:tools",
-    "kysely": "0.28.16",
-    "kysely-pglite-dialect": "^1.2.0",
+    "kysely": "catalog:db",
+    "kysely-pglite-dialect": "catalog:db",
     "msw": "^2.7.0",
     "uuidv7": "^1.0.2"
   }

--- a/plugins/firebase/package.json
+++ b/plugins/firebase/package.json
@@ -57,7 +57,7 @@
     "@types/node": "catalog:",
     "es-toolkit": "^1.32.0",
     "execa": "catalog:tools",
-    "firebase-admin": "catalog:db",
+    "firebase-admin": "catalog:firebase",
     "firebase-functions": "^6.3.2",
     "firebase-functions-test": "^3.4.0",
     "firebase-tools": "^13.32.0",

--- a/plugins/firebase/package.json
+++ b/plugins/firebase/package.json
@@ -57,7 +57,7 @@
     "@types/node": "catalog:",
     "es-toolkit": "^1.32.0",
     "execa": "catalog:tools",
-    "firebase-admin": "^13.2.0",
+    "firebase-admin": "catalog:db",
     "firebase-functions": "^6.3.2",
     "firebase-functions-test": "^3.4.0",
     "firebase-tools": "^13.32.0",

--- a/plugins/postgres/package.json
+++ b/plugins/postgres/package.json
@@ -35,11 +35,11 @@
   "dependencies": {
     "@hot-updater/core": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
-    "kysely": "^0.28.5",
-    "pg": "^8.13.1"
+    "kysely": "catalog:db",
+    "pg": "catalog:db"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.2.15",
+    "@electric-sql/pglite": "catalog:db",
     "@hot-updater/js": "workspace:*",
     "@hot-updater/test-utils": "workspace:*",
     "@types/node": "catalog:",

--- a/plugins/supabase/package.json
+++ b/plugins/supabase/package.json
@@ -53,7 +53,7 @@
     "@hot-updater/plugin-core": "workspace:*",
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/server": "workspace:*",
-    "@supabase/supabase-js": "catalog:db",
+    "@supabase/supabase-js": "catalog:supabase",
     "hono": "catalog:hono",
     "uuidv7": "^1.0.2"
   },

--- a/plugins/supabase/package.json
+++ b/plugins/supabase/package.json
@@ -53,12 +53,12 @@
     "@hot-updater/plugin-core": "workspace:*",
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/server": "workspace:*",
-    "@supabase/supabase-js": "^2.76.1",
+    "@supabase/supabase-js": "catalog:db",
     "hono": "catalog:hono",
     "uuidv7": "^1.0.2"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.2.15",
+    "@electric-sql/pglite": "catalog:db",
     "@hot-updater/js": "workspace:*",
     "@hot-updater/mock": "workspace:*",
     "@hot-updater/test-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
+        version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       elysia:
         specifier: ^1.2.17
         version: 1.4.13(@sinclair/typebox@0.34.41)(exact-mirror@0.2.2(@sinclair/typebox@0.34.41))(file-type@21.0.0)(openapi-types@12.1.3)(typescript@6.0.2)
@@ -306,7 +306,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
+        version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       hono:
         specifier: catalog:hono
         version: 4.12.9
@@ -1273,8 +1273,8 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       fast-xml-parser:
-        specifier: 5.4.1
-        version: 5.4.1
+        specifier: 5.7.2
+        version: 5.7.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1453,7 +1453,7 @@ importers:
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nitro:
         specifier: latest
-        version: 3.0.260415-beta(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(chokidar@4.0.3)(dotenv@17.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@25.5.0))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.83.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.6.1))(xml2js@0.6.2)
+        version: 3.0.260415-beta(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(chokidar@4.0.3)(dotenv@17.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@25.5.0))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.83.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.6.1))(xml2js@0.6.2)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1542,8 +1542,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       kysely:
-        specifier: 0.28.9
-        version: 0.28.9
+        specifier: 0.28.16
+        version: 0.28.16
       sql-formatter:
         specifier: 15.6.10
         version: 15.6.10
@@ -1594,8 +1594,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       fast-xml-parser:
-        specifier: 5.4.1
-        version: 5.4.1
+        specifier: 5.7.2
+        version: 5.7.2
       is-port-reachable:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1680,7 +1680,7 @@ importers:
         version: link:../../plugins/plugin-core
       fumadb:
         specifier: 0.2.2
-        version: 0.2.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(prisma@6.18.0(typescript@6.0.2))(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2)))
+        version: 0.2.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(prisma@6.18.0(typescript@6.0.2))(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2)))
       rou3:
         specifier: 0.7.9
         version: 0.7.9
@@ -1707,11 +1707,11 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       kysely:
-        specifier: ^0.28.9
-        version: 0.28.9
+        specifier: 0.28.16
+        version: 0.28.16
       kysely-pglite-dialect:
         specifier: ^1.2.0
-        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.9)
+        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.16)
       msw:
         specifier: ^2.7.0
         version: 2.7.0(@types/node@20.19.11)(typescript@6.0.2)
@@ -6220,6 +6220,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -12966,11 +12969,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
-
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
   fast-xml-parser@4.5.3:
     resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
@@ -12986,6 +12989,10 @@ packages:
 
   fast-xml-parser@5.5.9:
     resolution: {integrity: sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==}
+    hasBin: true
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastify-favicon@4.3.0:
@@ -14855,6 +14862,10 @@ packages:
     peerDependencies:
       kysely: '>= 0.24.0 < 1'
       typeorm: '>= 0.3.0 < 0.4.0'
+
+  kysely@0.28.16:
+    resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
+    engines: {node: '>=20.0.0'}
 
   kysely@0.28.8:
     resolution: {integrity: sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA==}
@@ -16895,6 +16906,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -18787,9 +18802,6 @@ packages:
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
-
-  strnum@2.2.0:
-    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -26738,6 +26750,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -34360,12 +34374,12 @@ snapshots:
 
   dayjs@1.11.20: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)):
+  db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.17
       '@libsql/client': 0.15.15
       better-sqlite3: 11.10.0
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       mysql2: 3.19.1(@types/node@25.5.0)
 
   debug@2.6.9:
@@ -34619,7 +34633,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
       '@electric-sql/pglite': 0.2.17
@@ -34629,12 +34643,12 @@ snapshots:
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.11.10
       better-sqlite3: 11.10.0
-      kysely: 0.28.9
+      kysely: 0.28.16
       mysql2: 3.19.1(@types/node@20.19.11)
       pg: 8.13.1
       prisma: 6.18.0(typescript@6.0.2)
 
-  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
       '@electric-sql/pglite': 0.2.17
@@ -34644,7 +34658,7 @@ snapshots:
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.11.10
       better-sqlite3: 11.10.0
-      kysely: 0.28.9
+      kysely: 0.28.16
       mysql2: 3.19.1(@types/node@25.5.0)
       pg: 8.13.1
       prisma: 6.18.0(typescript@6.0.2)
@@ -35907,13 +35921,13 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.3:
-    dependencies:
-      path-expression-matcher: 1.2.0
-
   fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.2.0
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
 
   fast-xml-parser@4.5.3:
     dependencies:
@@ -35921,19 +35935,26 @@ snapshots:
 
   fast-xml-parser@5.4.1:
     dependencies:
-      fast-xml-builder: 1.1.3
-      strnum: 2.2.0
+      fast-xml-builder: 1.1.4
+      strnum: 2.2.3
 
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
-      strnum: 2.2.0
+      strnum: 2.2.3
 
   fast-xml-parser@5.5.9:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
   fastify-favicon@4.3.0:
@@ -36445,17 +36466,17 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadb@0.2.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(prisma@6.18.0(typescript@6.0.2))(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))):
+  fumadb@0.2.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(prisma@6.18.0(typescript@6.0.2))(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))):
     dependencies:
       '@clack/prompts': 0.11.0
       '@paralleldrive/cuid2': 2.3.1
       commander: 14.0.3
-      kysely: 0.28.9
-      kysely-typeorm: 0.3.0(kysely@0.28.9)(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2)))
+      kysely: 0.28.16
+      kysely-typeorm: 0.3.0(kysely@0.28.16)(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2)))
       semver: 7.7.4
       zod: 4.3.6
     optionalDependencies:
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       mongodb: 6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4)
       prisma: 6.18.0(typescript@6.0.2)
       typeorm: 0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))
@@ -38469,15 +38490,22 @@ snapshots:
 
   kuler@2.0.0: {}
 
+  kysely-pglite-dialect@1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.16):
+    dependencies:
+      '@electric-sql/pglite': 0.2.17
+      kysely: 0.28.16
+
   kysely-pglite-dialect@1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.9):
     dependencies:
       '@electric-sql/pglite': 0.2.17
       kysely: 0.28.9
 
-  kysely-typeorm@0.3.0(kysely@0.28.9)(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))):
+  kysely-typeorm@0.3.0(kysely@0.28.16)(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))):
     dependencies:
-      kysely: 0.28.9
+      kysely: 0.28.16
       typeorm: 0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))
+
+  kysely@0.28.16: {}
 
   kysely@0.28.8: {}
 
@@ -40783,11 +40811,11 @@ snapshots:
       just-extend: 6.2.0
       path-to-regexp: 8.3.0
 
-  nitro@3.0.260415-beta(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(chokidar@4.0.3)(dotenv@17.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@25.5.0))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.83.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.6.1))(xml2js@0.6.2):
+  nitro@3.0.260415-beta(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(chokidar@4.0.3)(dotenv@17.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@25.5.0))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.83.0)(terser@5.31.0)(tsx@4.21.0)(yaml@2.6.1))(xml2js@0.6.2):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
-      db0: 0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0))
+      db0: 0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0))
       env-runner: 0.1.7
       h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
@@ -40798,7 +40826,7 @@ snapshots:
       rolldown: 1.0.0-rc.15
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)))(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)))(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.3.1
       giget: 2.0.0
@@ -41507,6 +41535,8 @@ snapshots:
   path-exists@5.0.0: {}
 
   path-expression-matcher@1.2.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -44081,8 +44111,6 @@ snapshots:
 
   strnum@1.1.2: {}
 
-  strnum@2.2.0: {}
-
   strnum@2.2.3: {}
 
   strtok3@10.3.5:
@@ -44924,10 +44952,10 @@ snapshots:
     optionalDependencies:
       synckit: 0.11.11
 
-  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)))(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0)))(lru-cache@11.2.7)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 4.0.3
-      db0: 0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.9)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0))
+      db0: 0.3.4(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@25.5.0))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mysql2@3.19.1(@types/node@25.5.0))
       lru-cache: 11.2.7
       mongodb: 6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4)
       ofetch: 2.0.0-alpha.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,46 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  db:
+    '@electric-sql/pglite':
+      specifier: ^0.2.17
+      version: 0.2.17
+    '@libsql/client':
+      specifier: ^0.15.15
+      version: 0.15.15
+    '@prisma/client':
+      specifier: ^6.18.0
+      version: 6.18.0
+    '@supabase/supabase-js':
+      specifier: ^2.76.1
+      version: 2.76.1
+    drizzle-orm:
+      specifier: ^0.44.7
+      version: 0.44.7
+    firebase-admin:
+      specifier: 13.6.0
+      version: 13.6.0
+    fumadb:
+      specifier: 0.2.2
+      version: 0.2.2
+    kysely:
+      specifier: 0.28.16
+      version: 0.28.16
+    kysely-pglite-dialect:
+      specifier: ^1.2.0
+      version: 1.2.0
+    mongodb:
+      specifier: ^6.20.0
+      version: 6.20.0
+    mysql2:
+      specifier: ^3.19.1
+      version: 3.19.1
+    pg:
+      specifier: ^8.13.1
+      version: 8.13.1
+    prisma:
+      specifier: ^6.18.0
+      version: 6.18.0
   default:
     '@types/node':
       specifier: ^20
@@ -186,13 +226,13 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@libsql/client':
-        specifier: ^0.15.15
+        specifier: catalog:db
         version: 0.15.15
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
       drizzle-orm:
-        specifier: ^0.44.7
+        specifier: catalog:db
         version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       elysia:
         specifier: ^1.2.17
@@ -217,7 +257,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/hot-updater
       prisma:
-        specifier: ^6.4.1
+        specifier: catalog:db
         version: 6.18.0(typescript@6.0.2)
       tsx:
         specifier: ^4.20.6
@@ -241,7 +281,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@prisma/client':
-        specifier: ^6.18.0
+        specifier: catalog:db
         version: 6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2)
       cors:
         specifier: ^2.8.5
@@ -272,7 +312,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/hot-updater
       prisma:
-        specifier: ^6.4.1
+        specifier: catalog:db
         version: 6.18.0(typescript@6.0.2)
       tsx:
         specifier: ^4.20.6
@@ -284,7 +324,7 @@ importers:
   examples-server/hono-drizzle-pglite:
     dependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.17
+        specifier: catalog:db
         version: 0.2.17
       '@hono/node-server':
         specifier: catalog:hono
@@ -305,7 +345,7 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
       drizzle-orm:
-        specifier: ^0.44.7
+        specifier: catalog:db
         version: 0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2))
       hono:
         specifier: catalog:hono
@@ -336,7 +376,7 @@ importers:
   examples-server/hono-e2e-local:
     dependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.17
+        specifier: catalog:db
         version: 0.2.17
       '@hono/node-server':
         specifier: catalog:hono
@@ -351,11 +391,11 @@ importers:
         specifier: catalog:hono
         version: 4.12.9
       kysely:
-        specifier: 0.28.9
-        version: 0.28.9
+        specifier: catalog:db
+        version: 0.28.16
       kysely-pglite-dialect:
-        specifier: ^1.2.0
-        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.9)
+        specifier: catalog:db
+        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.16)
     devDependencies:
       '@types/node':
         specifier: ^20.11.17
@@ -394,10 +434,10 @@ importers:
         specifier: catalog:hono
         version: 4.12.9
       kysely:
-        specifier: 0.28.9
-        version: 0.28.9
+        specifier: catalog:db
+        version: 0.28.16
       mysql2:
-        specifier: ^3.11.5
+        specifier: catalog:db
         version: 3.19.1(@types/node@20.19.11)
     devDependencies:
       '@hot-updater/test-utils':
@@ -422,7 +462,7 @@ importers:
   examples-server/hono-kysely-pglite:
     dependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.17
+        specifier: catalog:db
         version: 0.2.17
       '@hono/node-server':
         specifier: catalog:hono
@@ -446,11 +486,11 @@ importers:
         specifier: catalog:hono
         version: 4.12.9
       kysely:
-        specifier: 0.28.9
-        version: 0.28.9
+        specifier: catalog:db
+        version: 0.28.16
       kysely-pglite-dialect:
-        specifier: ^1.2.0
-        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.9)
+        specifier: catalog:db
+        version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.16)
     devDependencies:
       '@hot-updater/test-utils':
         specifier: workspace:*
@@ -501,13 +541,13 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
       firebase-admin:
-        specifier: 13.6.0
+        specifier: catalog:db
         version: 13.6.0(encoding@0.1.13)
       hono:
         specifier: catalog:hono
         version: 4.12.9
       mongodb:
-        specifier: ^6.12.0
+        specifier: catalog:db
         version: 6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4)
     devDependencies:
       '@hot-updater/test-utils':
@@ -547,7 +587,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@prisma/client':
-        specifier: ^6.18.0
+        specifier: catalog:db
         version: 6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2)
       dotenv:
         specifier: ^16.6.1
@@ -569,7 +609,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/hot-updater
       prisma:
-        specifier: ^6.4.1
+        specifier: catalog:db
         version: 6.18.0(typescript@6.0.2)
       tsx:
         specifier: ^4.20.6
@@ -1212,7 +1252,7 @@ importers:
         specifier: ^8.19.0
         version: 8.57.0
       firebase-admin:
-        specifier: 13.6.0
+        specifier: catalog:db
         version: 13.6.0(encoding@0.1.13)
       firebase-tools:
         specifier: ^13.35.1
@@ -1542,7 +1582,7 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       kysely:
-        specifier: 0.28.16
+        specifier: catalog:db
         version: 0.28.16
       sql-formatter:
         specifier: 15.6.10
@@ -1679,7 +1719,7 @@ importers:
         specifier: workspace:*
         version: link:../../plugins/plugin-core
       fumadb:
-        specifier: 0.2.2
+        specifier: catalog:db
         version: 0.2.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260313.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.18.0(prisma@6.18.0(typescript@6.0.2))(typescript@6.0.2))(@types/better-sqlite3@7.6.13)(@types/pg@8.11.10)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(prisma@6.18.0(typescript@6.0.2)))(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(prisma@6.18.0(typescript@6.0.2))(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2)))
       rou3:
         specifier: 0.7.9
@@ -1689,7 +1729,7 @@ importers:
         version: 7.7.2
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.17
+        specifier: catalog:db
         version: 0.2.17
       '@hot-updater/standalone':
         specifier: workspace:*
@@ -1707,10 +1747,10 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       kysely:
-        specifier: 0.28.16
+        specifier: catalog:db
         version: 0.28.16
       kysely-pglite-dialect:
-        specifier: ^1.2.0
+        specifier: catalog:db
         version: 1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.16)
       msw:
         specifier: ^2.7.0
@@ -2002,7 +2042,7 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       firebase-admin:
-        specifier: ^13.2.0
+        specifier: catalog:db
         version: 13.6.0(encoding@0.1.13)
       firebase-functions:
         specifier: ^6.3.2
@@ -2098,14 +2138,14 @@ importers:
         specifier: workspace:*
         version: link:../plugin-core
       kysely:
-        specifier: ^0.28.5
-        version: 0.28.8
+        specifier: catalog:db
+        version: 0.28.16
       pg:
-        specifier: ^8.13.1
+        specifier: catalog:db
         version: 8.13.1
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.15
+        specifier: catalog:db
         version: 0.2.17
       '@hot-updater/js':
         specifier: workspace:*
@@ -2210,7 +2250,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@supabase/supabase-js':
-        specifier: ^2.76.1
+        specifier: catalog:db
         version: 2.76.1
       hono:
         specifier: catalog:hono
@@ -2220,7 +2260,7 @@ importers:
         version: 1.0.2
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.2.15
+        specifier: catalog:db
         version: 0.2.17
       '@hot-updater/js':
         specifier: workspace:*
@@ -11549,9 +11589,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
-
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
@@ -14867,14 +14904,6 @@ packages:
     resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
     engines: {node: '>=20.0.0'}
 
-  kysely@0.28.8:
-    resolution: {integrity: sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA==}
-    engines: {node: '>=20.0.0'}
-
-  kysely@0.28.9:
-    resolution: {integrity: sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==}
-    engines: {node: '>=20.0.0'}
-
   launch-editor@2.12.0:
     resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
 
@@ -15366,9 +15395,6 @@ packages:
   logkitty@0.7.1:
     resolution: {integrity: sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==}
     hasBin: true
-
-  long@5.3.1:
-    resolution: {integrity: sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -25881,7 +25907,7 @@ snapshots:
   '@grpc/proto-loader@0.7.13':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.4.0
       yargs: 17.7.2
 
@@ -33664,7 +33690,7 @@ snapshots:
   c12@3.1.0:
     dependencies:
       chokidar: 4.0.3
-      confbox: 0.2.2
+      confbox: 0.2.4
       defu: 6.1.4
       dotenv: 16.6.1
       exsolve: 1.0.8
@@ -34121,8 +34147,6 @@ snapshots:
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
-
-  confbox@0.2.2: {}
 
   confbox@0.2.4: {}
 
@@ -38495,21 +38519,12 @@ snapshots:
       '@electric-sql/pglite': 0.2.17
       kysely: 0.28.16
 
-  kysely-pglite-dialect@1.2.0(@electric-sql/pglite@0.2.17)(kysely@0.28.9):
-    dependencies:
-      '@electric-sql/pglite': 0.2.17
-      kysely: 0.28.9
-
   kysely-typeorm@0.3.0(kysely@0.28.16)(typeorm@0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))):
     dependencies:
       kysely: 0.28.16
       typeorm: 0.3.27(babel-plugin-macros@3.1.0)(better-sqlite3@11.10.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1008.0)(socks@2.8.4))(mysql2@3.19.1(@types/node@20.19.11))(pg@8.13.1)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@20.19.11)(typescript@6.0.2))
 
   kysely@0.28.16: {}
-
-  kysely@0.28.8: {}
-
-  kysely@0.28.9: {}
 
   launch-editor@2.12.0:
     dependencies:
@@ -38889,8 +38904,6 @@ snapshots:
       ansi-fragments: 0.2.1
       dayjs: 1.11.20
       yargs: 15.4.1
-
-  long@5.3.1: {}
 
   long@5.3.2: {}
 
@@ -41921,7 +41934,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/node': 25.5.0
-      long: 5.3.1
+      long: 5.3.2
 
   protocols@1.4.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,17 @@ settings:
 catalogs:
   db:
     '@electric-sql/pglite':
-      specifier: ^0.2.17
+      specifier: 0.2.17
       version: 0.2.17
     '@libsql/client':
-      specifier: ^0.15.15
+      specifier: 0.15.15
       version: 0.15.15
     '@prisma/client':
-      specifier: ^6.18.0
+      specifier: 6.18.0
       version: 6.18.0
-    '@supabase/supabase-js':
-      specifier: ^2.76.1
-      version: 2.76.1
     drizzle-orm:
-      specifier: ^0.44.7
+      specifier: 0.44.7
       version: 0.44.7
-    firebase-admin:
-      specifier: 13.6.0
-      version: 13.6.0
     fumadb:
       specifier: 0.2.2
       version: 0.2.2
@@ -31,19 +25,19 @@ catalogs:
       specifier: 0.28.16
       version: 0.28.16
     kysely-pglite-dialect:
-      specifier: ^1.2.0
+      specifier: 1.2.0
       version: 1.2.0
     mongodb:
-      specifier: ^6.20.0
+      specifier: 6.20.0
       version: 6.20.0
     mysql2:
-      specifier: ^3.19.1
+      specifier: 3.19.1
       version: 3.19.1
     pg:
-      specifier: ^8.13.1
+      specifier: 8.13.1
       version: 8.13.1
     prisma:
-      specifier: ^6.18.0
+      specifier: 6.18.0
       version: 6.18.0
   default:
     '@types/node':
@@ -52,6 +46,10 @@ catalogs:
     vitest:
       specifier: 4.1.4
       version: 4.1.4
+  firebase:
+    firebase-admin:
+      specifier: 13.6.0
+      version: 13.6.0
   hono:
     '@hono/node-server':
       specifier: 1.19.11
@@ -59,6 +57,10 @@ catalogs:
     hono:
       specifier: 4.12.9
       version: 4.12.9
+  supabase:
+    '@supabase/supabase-js':
+      specifier: 2.76.1
+      version: 2.76.1
   tools:
     '@clack/prompts':
       specifier: 1.0.1
@@ -541,7 +543,7 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
       firebase-admin:
-        specifier: catalog:db
+        specifier: catalog:firebase
         version: 13.6.0(encoding@0.1.13)
       hono:
         specifier: catalog:hono
@@ -1252,7 +1254,7 @@ importers:
         specifier: ^8.19.0
         version: 8.57.0
       firebase-admin:
-        specifier: catalog:db
+        specifier: catalog:firebase
         version: 13.6.0(encoding@0.1.13)
       firebase-tools:
         specifier: ^13.35.1
@@ -2042,7 +2044,7 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       firebase-admin:
-        specifier: catalog:db
+        specifier: catalog:firebase
         version: 13.6.0(encoding@0.1.13)
       firebase-functions:
         specifier: ^6.3.2
@@ -2250,7 +2252,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@supabase/supabase-js':
-        specifier: catalog:db
+        specifier: catalog:supabase
         version: 2.76.1
       hono:
         specifier: catalog:hono
@@ -12336,9 +12338,6 @@ packages:
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
-  end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -34698,7 +34697,7 @@ snapshots:
 
   duplexify@4.1.3:
     dependencies:
-      end-of-stream: 1.4.4
+      end-of-stream: 1.4.5
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
@@ -34772,10 +34771,6 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
     optional: true
-
-  end-of-stream@1.4.4:
-    dependencies:
-      once: 1.4.0
 
   end-of-stream@1.4.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,20 @@ catalogs:
   hono:
     hono: 4.12.9
     "@hono/node-server": 1.19.11
+  db:
+    "@electric-sql/pglite": ^0.2.17
+    "@libsql/client": ^0.15.15
+    "@prisma/client": ^6.18.0
+    "@supabase/supabase-js": ^2.76.1
+    drizzle-orm: ^0.44.7
+    firebase-admin: 13.6.0
+    fumadb: 0.2.2
+    kysely: 0.28.16
+    kysely-pglite-dialect: ^1.2.0
+    mongodb: ^6.20.0
+    mysql2: ^3.19.1
+    pg: ^8.13.1
+    prisma: ^6.18.0
 
 onlyBuiltDependencies:
   - "@prisma/client"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,19 +17,21 @@ catalogs:
     hono: 4.12.9
     "@hono/node-server": 1.19.11
   db:
-    "@electric-sql/pglite": ^0.2.17
-    "@libsql/client": ^0.15.15
-    "@prisma/client": ^6.18.0
-    "@supabase/supabase-js": ^2.76.1
-    drizzle-orm: ^0.44.7
-    firebase-admin: 13.6.0
+    "@electric-sql/pglite": 0.2.17
+    "@libsql/client": 0.15.15
+    "@prisma/client": 6.18.0
+    drizzle-orm: 0.44.7
     fumadb: 0.2.2
     kysely: 0.28.16
-    kysely-pglite-dialect: ^1.2.0
-    mongodb: ^6.20.0
-    mysql2: ^3.19.1
-    pg: ^8.13.1
-    prisma: ^6.18.0
+    kysely-pglite-dialect: 1.2.0
+    mongodb: 6.20.0
+    mysql2: 3.19.1
+    pg: 8.13.1
+    prisma: 6.18.0
+  firebase:
+    firebase-admin: 13.6.0
+  supabase:
+    "@supabase/supabase-js": 2.76.1
 
 onlyBuiltDependencies:
   - "@prisma/client"


### PR DESCRIPTION
## Summary

- Run the published `hot-updater` CLI bin through `dist/index.mjs` and emit the CLI entry as native ESM only.
- Emit the package-root `hot-updater` config export as native ESM only as well; the `require` condition now points at `dist/config.mjs` instead of a CJS artifact.
- Convert `@hot-updater/cli-tools` to an ESM-only package surface, with `require` pointing at `dist/index.mjs` for Node `>=20.19.0` `require(esm)` support.
- Keep the React Native/Expo plugin CJS-compatible by loading `hot-updater` and `@hot-updater/cli-tools` through dynamic `import()`.
- Update integration tests that execute the built CLI to use `dist/index.mjs`.
- Bump the `hot-updater` CLI package's vulnerable `kysely` and `fast-xml-parser` entries, plus the CLI runtime `@hot-updater/apple-helper` `fast-xml-parser` entry, without pnpm overrides.
- Align the server test/dev Kysely peer graph on `0.28.16` so fresh CI installs do not load a second Kysely copy through `fumadb`.

## Root Cause

Issue 965 came from the CLI/package-root path still being able to enter CJS artifacts. Node would run the CLI from the package bin, then config loading and `require("hot-updater")` could resolve through CJS output and hit ESM-only dependencies from the wrong side.

The root fix here is to remove the CJS artifacts from the `hot-updater` CLI/config path and from `@hot-updater/cli-tools`, then require Node.js `>=20.19.0`, where Node 20 supports `require(esm)`. CJS callers can still call `require("hot-updater")`, but the package now resolves that to native ESM instead of a separate CJS build.

The GitHub Actions type failure was a separate lockfile/peer graph issue: `packages/server` still allowed `kysely@0.28.9`, so a fresh install could type `fumadb` against a different Kysely instance than the test code. Pinning the server dev dependency to `0.28.16` makes `pnpm --filter @hot-updater/server why kysely` report one Kysely version.

## Issue 965 Repro Check

Using built PR artifacts on Node `20.19.0`:

- `node packages/hot-updater/dist/index.mjs --help` starts the CLI successfully.
- `require("./packages/hot-updater").defineConfig` is a function.
- `require("./packages/cli-tools").loadConfig` is a function.
- A fixture `hot-updater.config.ts` using `import { defineConfig } from "hot-updater"` loads through `@hot-updater/cli-tools.loadConfig(null)` successfully.
- `packages/hot-updater/dist` and `packages/cli-tools/dist` have no root `.cjs` artifacts for the CLI/config path.

So this PR resolves Issue 965 for the supported Node range, `>=20.19.0`.

## Security Scope

This PR fixes the security items for the published `hot-updater` CLI package surface:

- `kysely`: `0.28.9` -> `0.28.16`
- `fast-xml-parser` in `hot-updater`: `5.4.1` -> `5.7.2`
- `fast-xml-parser` in `@hot-updater/apple-helper`: `5.4.1` -> `5.7.2`

No root `pnpm.overrides` are used.

Workspace-wide audit can still report unrelated dev/example paths such as Rock's React Native CLI path or Datadog's devDependency path; those are outside the published `hot-updater` CLI package fix in this PR.

## Validation

- `.agents/skills/fix-ci/scripts/run_fixci.sh all` green (`.codex/fix-ci/20260502-153953`)
  - `pnpm -w build`
  - `pnpm -w test:type`
  - `pnpm -w lint`
  - `pnpm -w test`
  - `pnpm -w test:integration`
- `pnpm --filter @hot-updater/server why kysely` reports one version: `kysely@0.28.16`.
- `pnpm --filter @hot-updater/server test:type` passes.
- Node 20.19.0 #965 smoke checks listed above pass.
