### PR TITLE
feat(cli): `hot-updater rollback <channel>`

### DIFF
--- a/.changeset/cli-rollback-command.md
+++ b/.changeset/cli-rollback-command.md
@@ -4,17 +4,17 @@
 
 feat(cli): add `rollback <channel>` command
 
-Disables the most recent enabled bundle on a channel for each requested platform. Operationally equivalent to revealing the second-most-recent bundle as the channel's active update.
+Disables the most recent enabled bundle on a channel for each requested platform.
 
 ```
-hot-updater rollback <channel> [-p ios|android] [-y] [--confirm-revert-to-binary]
+hot-updater rollback <channel> [-p ios|android] [-y] [--confirm-revert-to-binary] [--target <bundle-id>]
 ```
 
 Behavior:
 
 - **Read phase** loads up to two most-recent enabled bundles per (channel, platform) so the operator can see what would become active after rollback.
-- **Validate phase** refuses with non-zero exit if any (channel, platform) would have **no** enabled bundles after the rollback unless `--confirm-revert-to-binary` is passed. This prevents an accidental fall-back to the binary-shipped JS.
-- **Mutate phase** queues `updateBundle({ enabled: false })` for each target and commits once. Note: `DatabasePlugin.commitBundle` runs ops sequentially, so atomicity across platforms is **not** guaranteed at the underlying provider.
-- **Verify phase** re-reads each target. Surfaces partial-failure state explicitly with non-zero exit and per-platform `FAILED` lines so the operator knows exactly what to retry.
+- **Validate phase** refuses with non-zero exit if any (channel, platform) would have **no** enabled bundles after the rollback unless `--confirm-revert-to-binary` is passed. The error message names both safe escape hatches in priority order: `-p <unaffected>` first, then `--confirm-revert-to-binary`.
+- **Mutate phase** queues `updateBundle({ enabled: false })` for each target and commits once. Note: `DatabasePlugin.commitBundle` runs ops sequentially in the underlying provider, so atomicity across platforms is **not** guaranteed. The mutate is wrapped in a try/catch so a mid-commit throw still falls through to the verify phase.
+- **Verify phase** re-reads each target. Distinguishes three states — disabled (success), still-enabled (failure), and gone (success: a deleted bundle satisfies the rollback intent). Surfaces partial-failure state explicitly with non-zero exit and per-platform `FAILED` lines naming the exact retry command, including a `--target <bundle-id>` flag for scoped retry.
 
-Refuses to mutate without `-y` in a non-TTY shell.
+Refuses to mutate without `-y` in a non-TTY shell. `onUnmount` is wrapped in its own try/catch so cleanup errors never mask the originating mutation error. Help text documents the four-phase contract and exit codes (0 = success, 1 = error, 2 = user-aborted).

--- a/.changeset/cli-rollback-command.md
+++ b/.changeset/cli-rollback-command.md
@@ -1,0 +1,20 @@
+---
+"hot-updater": patch
+---
+
+feat(cli): add `rollback <channel>` command
+
+Disables the most recent enabled bundle on a channel for each requested platform. Operationally equivalent to revealing the second-most-recent bundle as the channel's active update.
+
+```
+hot-updater rollback <channel> [-p ios|android] [-y] [--confirm-revert-to-binary]
+```
+
+Behavior:
+
+- **Read phase** loads up to two most-recent enabled bundles per (channel, platform) so the operator can see what would become active after rollback.
+- **Validate phase** refuses with non-zero exit if any (channel, platform) would have **no** enabled bundles after the rollback unless `--confirm-revert-to-binary` is passed. This prevents an accidental fall-back to the binary-shipped JS.
+- **Mutate phase** queues `updateBundle({ enabled: false })` for each target and commits once. Note: `DatabasePlugin.commitBundle` runs ops sequentially, so atomicity across platforms is **not** guaranteed at the underlying provider.
+- **Verify phase** re-reads each target. Surfaces partial-failure state explicitly with non-zero exit and per-platform `FAILED` lines so the operator knows exactly what to retry.
+
+Refuses to mutate without `-y` in a non-TTY shell.

--- a/.changeset/late-rats-explode.md
+++ b/.changeset/late-rats-explode.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Feature - CLI Rollback

--- a/packages/hot-updater/src/commandOptions/index.ts
+++ b/packages/hot-updater/src/commandOptions/index.ts
@@ -1,4 +1,7 @@
 import { Option } from "@commander-js/extra-typings";
+import type { Platform } from "@hot-updater/plugin-core";
+
+export const PLATFORMS: readonly Platform[] = ["ios", "android"];
 
 export const platformCommandOption = new Option(
   "-p, --platform <platform>",

--- a/packages/hot-updater/src/commands/rollback.spec.ts
+++ b/packages/hot-updater/src/commands/rollback.spec.ts
@@ -1,0 +1,334 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCli, mockDatabasePlugin, mockPrintBanner } = vi.hoisted(() => {
+  const mockDatabasePlugin = {
+    appendBundle: vi.fn(),
+    commitBundle: vi.fn(),
+    deleteBundle: vi.fn(),
+    getBundleById: vi.fn(),
+    getBundles: vi.fn(),
+    getChannels: vi.fn(),
+    name: "mock-database",
+    onUnmount: vi.fn(),
+    updateBundle: vi.fn(),
+  };
+  const mockCli = {
+    loadConfig: vi.fn(),
+    p: {
+      confirm: vi.fn(),
+      isCancel: vi.fn(() => false),
+      log: {
+        error: vi.fn(),
+        info: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  };
+  const mockPrintBanner = vi.fn();
+  return { mockCli, mockDatabasePlugin, mockPrintBanner };
+});
+
+vi.mock("@hot-updater/cli-tools", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@hot-updater/cli-tools")>();
+  return {
+    ...actual,
+    loadConfig: mockCli.loadConfig,
+    p: mockCli.p,
+  };
+});
+
+vi.mock("@/utils/printBanner", () => ({
+  printBanner: mockPrintBanner,
+}));
+
+const buildBundle = (overrides: Partial<Bundle> = {}): Bundle => ({
+  id: "0195a408-8f13-7d9b-8df4-123456789abc",
+  channel: "dev",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeefcafe",
+  message: "msg",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+  ...overrides,
+});
+
+const stubLoadedConfig = () => {
+  mockCli.loadConfig.mockResolvedValue({
+    database: vi.fn().mockResolvedValue(mockDatabasePlugin),
+  } as never);
+};
+
+const expectExit = (code: number) => {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((c) => {
+    throw new Error(`process.exit(${c})`);
+  });
+  return { exitSpy, code };
+};
+
+const setupConsoleSpies = () => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+};
+
+const stubGetBundlesByPlatform = (
+  byPlatform: Partial<Record<"ios" | "android", Bundle[]>>,
+) => {
+  mockDatabasePlugin.getBundles.mockImplementation((options) => {
+    const platform = options.where?.platform;
+    const bundles = (platform && byPlatform[platform]) ?? [];
+    return Promise.resolve({
+      data: bundles.slice(0, options.limit ?? bundles.length),
+      pagination: { total: bundles.length },
+    });
+  });
+};
+
+describe("handleRollback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubLoadedConfig();
+    setupConsoleSpies();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rolls back both platforms when each has >=2 enabled bundles", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+      android: [
+        buildBundle({ id: "and-2", platform: "android" }),
+        buildBundle({ id: "and-1", platform: "android" }),
+      ],
+    });
+    mockDatabasePlugin.getBundleById.mockImplementation((id: string) =>
+      Promise.resolve(buildBundle({ id, enabled: false })),
+    );
+
+    const { handleRollback } = await import("./rollback");
+    await handleRollback("dev", { yes: true });
+
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("ios-2", {
+      enabled: false,
+    });
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("and-2", {
+      enabled: false,
+    });
+    expect(mockDatabasePlugin.commitBundle).toHaveBeenCalledTimes(1);
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("ios-2"),
+    );
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("and-2"),
+    );
+  });
+
+  it("only mutates the specified platform when -p is passed", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+    });
+    mockDatabasePlugin.getBundleById.mockImplementation((id: string) =>
+      Promise.resolve(buildBundle({ id, enabled: false })),
+    );
+
+    const { handleRollback } = await import("./rollback");
+    await handleRollback("dev", { platform: "ios", yes: true });
+
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("ios-2", {
+      enabled: false,
+    });
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^and-/),
+      expect.anything(),
+    );
+  });
+
+  it("refuses without --confirm-revert-to-binary when a platform has only one enabled bundle", async () => {
+    stubGetBundlesByPlatform({
+      ios: [buildBundle({ id: "ios-1", platform: "ios" })],
+      android: [
+        buildBundle({ id: "and-2", platform: "android" }),
+        buildBundle({ id: "and-1", platform: "android" }),
+      ],
+    });
+    const { exitSpy } = expectExit(1);
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", { yes: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalled();
+    expect(mockDatabasePlugin.commitBundle).not.toHaveBeenCalled();
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("would leave channel"),
+    );
+  });
+
+  it("proceeds with --confirm-revert-to-binary when the only-enabled-bundle case is acknowledged", async () => {
+    stubGetBundlesByPlatform({
+      ios: [buildBundle({ id: "ios-1", platform: "ios" })],
+    });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "ios-1", enabled: false }),
+    );
+    const { handleRollback } = await import("./rollback");
+    await handleRollback("dev", {
+      platform: "ios",
+      yes: true,
+      confirmRevertToBinary: true,
+    });
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("ios-1", {
+      enabled: false,
+    });
+    expect(mockCli.p.log.success).toHaveBeenCalled();
+  });
+
+  it("skips a platform with no enabled bundle and proceeds on the rest", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+      android: [],
+    });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "ios-2", enabled: false }),
+    );
+    const { handleRollback } = await import("./rollback");
+    await handleRollback("dev", { yes: true });
+
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledTimes(1);
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("ios-2", {
+      enabled: false,
+    });
+    expect(mockCli.p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("No enabled bundle on dev/android"),
+    );
+  });
+
+  it("exits 1 when no platform has any enabled bundle on the channel", async () => {
+    stubGetBundlesByPlatform({ ios: [], android: [] });
+    const { exitSpy } = expectExit(1);
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", { yes: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Nothing to roll back"),
+    );
+  });
+
+  it("aborts with exit code 2 when interactive confirmation declines", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+      android: [
+        buildBundle({ id: "and-2", platform: "android" }),
+        buildBundle({ id: "and-1", platform: "android" }),
+      ],
+    });
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    mockCli.p.confirm.mockResolvedValueOnce(false);
+    const { exitSpy } = expectExit(2);
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", {})).rejects.toThrow("process.exit(2)");
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalled();
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("refuses to mutate without -y in a non-TTY shell", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+      android: [
+        buildBundle({ id: "and-2", platform: "android" }),
+        buildBundle({ id: "and-1", platform: "android" }),
+      ],
+    });
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    const { exitSpy } = expectExit(1);
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", {})).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalled();
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("verify phase: exits 1 when a target is still enabled after commit", async () => {
+    stubGetBundlesByPlatform({
+      ios: [
+        buildBundle({ id: "ios-2", platform: "ios" }),
+        buildBundle({ id: "ios-1", platform: "ios" }),
+      ],
+      android: [
+        buildBundle({ id: "and-2", platform: "android" }),
+        buildBundle({ id: "and-1", platform: "android" }),
+      ],
+    });
+    // ios commit "succeeds" (returns disabled), android commit appears to
+    // have not taken effect (still enabled).
+    mockDatabasePlugin.getBundleById.mockImplementation((id: string) => {
+      if (id === "ios-2")
+        return Promise.resolve(buildBundle({ id, enabled: false }));
+      if (id === "and-2")
+        return Promise.resolve(buildBundle({ id, enabled: true }));
+      return Promise.resolve(null);
+    });
+    const { exitSpy } = expectExit(1);
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", { yes: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("FAILED: android and-2 is still enabled"),
+    );
+  });
+
+  it("calls onUnmount even when getBundles throws", async () => {
+    mockDatabasePlugin.getBundles.mockRejectedValue(new Error("DB down"));
+    const { handleRollback } = await import("./rollback");
+    await expect(handleRollback("dev", { yes: true })).rejects.toThrow(
+      "DB down",
+    );
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalled();
+  });
+});

--- a/packages/hot-updater/src/commands/rollback.spec.ts
+++ b/packages/hot-updater/src/commands/rollback.spec.ts
@@ -21,6 +21,7 @@ const { mockCli, mockDatabasePlugin, mockPrintBanner } = vi.hoisted(() => {
       log: {
         error: vi.fn(),
         info: vi.fn(),
+        message: vi.fn(),
         success: vi.fn(),
         warn: vi.fn(),
       },

--- a/packages/hot-updater/src/commands/rollback.ts
+++ b/packages/hot-updater/src/commands/rollback.ts
@@ -1,0 +1,156 @@
+import { loadConfig, p } from "@hot-updater/cli-tools";
+import type {
+  Bundle,
+  DatabasePlugin,
+  Platform,
+} from "@hot-updater/plugin-core";
+
+import { printBanner } from "@/utils/printBanner";
+
+export interface RollbackOptions {
+  platform?: Platform;
+  yes?: boolean;
+  confirmRevertToBinary?: boolean;
+}
+
+interface RollbackTarget {
+  platform: Platform;
+  bundle: Bundle;
+  fallbackId: string | null;
+}
+
+const PLATFORMS: readonly Platform[] = ["ios", "android"];
+
+const summarizeTarget = (target: RollbackTarget): string => {
+  const fallback = target.fallbackId
+    ? `next: ${target.fallbackId}`
+    : "next: (would revert to binary-shipped JS)";
+  return `  - ${target.platform}: disable ${target.bundle.id} (${fallback})`;
+};
+
+export const handleRollback = async (
+  channel: string,
+  options: RollbackOptions = {},
+) => {
+  printBanner();
+
+  if (!channel) {
+    p.log.error("rollback requires a channel argument: `rollback <channel>`");
+    process.exit(1);
+  }
+
+  const config = await loadConfig(null);
+  if (!config) {
+    p.log.error("No config found. Please run `hot-updater init` first.");
+    process.exit(1);
+  }
+
+  const platforms = options.platform ? [options.platform] : PLATFORMS;
+
+  const databasePlugin: DatabasePlugin = await config.database();
+  try {
+    const targets: RollbackTarget[] = [];
+    const skippedPlatforms: Platform[] = [];
+    const wouldRevertToBinary: Platform[] = [];
+
+    for (const platform of platforms) {
+      const result = await databasePlugin.getBundles({
+        where: { channel, platform, enabled: true },
+        limit: 2,
+      });
+      const [target, fallback] = result.data;
+      if (!target) {
+        p.log.info(`No enabled bundle on ${channel}/${platform}; skipping.`);
+        skippedPlatforms.push(platform);
+        continue;
+      }
+      if (!fallback) {
+        wouldRevertToBinary.push(platform);
+      }
+      targets.push({
+        platform,
+        bundle: target,
+        fallbackId: fallback?.id ?? null,
+      });
+    }
+
+    if (targets.length === 0) {
+      p.log.error(
+        `Nothing to roll back: no enabled bundles for ${channel} on ${platforms.join(", ")}.`,
+      );
+      process.exit(1);
+    }
+
+    p.log.info(`Rollback plan for channel "${channel}":`);
+    for (const t of targets) {
+      console.log(summarizeTarget(t));
+    }
+
+    if (wouldRevertToBinary.length > 0 && !options.confirmRevertToBinary) {
+      p.log.error(
+        `Rollback would leave channel "${channel}" with NO enabled bundles for: ${wouldRevertToBinary.join(", ")}.`,
+      );
+      p.log.info(
+        "Affected platforms would fall back to the binary-shipped JS.",
+      );
+      p.log.info("Re-run with --confirm-revert-to-binary to proceed.");
+      process.exit(1);
+    }
+
+    if (skippedPlatforms.length > 0 && !options.yes) {
+      p.log.warn(
+        `Some requested platforms had no enabled bundle on ${channel}; only the platforms above will be touched.`,
+      );
+    }
+
+    if (!options.yes) {
+      if (!process.stdin.isTTY) {
+        p.log.error(
+          "Cannot prompt for confirmation in a non-interactive shell. Re-run with -y, or use a TTY.",
+        );
+        process.exit(1);
+      }
+      const ids = targets.map((t) => t.bundle.id).join(", ");
+      const confirmed = await p.confirm({
+        message: `Disable ${ids} on ${channel}?`,
+        initialValue: false,
+      });
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.log.info("Aborted.");
+        process.exit(2);
+      }
+    }
+
+    // Mutate phase: queue updates, then flush via a single commitBundle.
+    // Note: DatabasePlugin.commitBundle runs ops sequentially in the
+    // underlying provider, so atomicity across platforms is not guaranteed.
+    // The verify phase below catches partial-failure state explicitly.
+    for (const t of targets) {
+      await databasePlugin.updateBundle(t.bundle.id, { enabled: false });
+    }
+    await databasePlugin.commitBundle();
+
+    // Verify phase: re-read each target. Surface failures per-platform.
+    const failures: RollbackTarget[] = [];
+    for (const t of targets) {
+      const refetched = await databasePlugin.getBundleById(t.bundle.id);
+      if (!refetched || refetched.enabled) {
+        failures.push(t);
+        p.log.error(
+          `FAILED: ${t.platform} ${t.bundle.id} is still enabled after rollback.`,
+        );
+      } else {
+        p.log.success(`rolled back ${t.platform} ${t.bundle.id}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      p.log.error(
+        `Rollback completed with ${failures.length} failed platform(s) out of ${targets.length}.`,
+      );
+      process.exit(1);
+    }
+  } finally {
+    await databasePlugin.onUnmount?.();
+  }
+};

--- a/packages/hot-updater/src/commands/rollback.ts
+++ b/packages/hot-updater/src/commands/rollback.ts
@@ -7,10 +7,13 @@ import type {
 
 import { printBanner } from "@/utils/printBanner";
 
+import { PLATFORMS } from "../commandOptions";
+
 export interface RollbackOptions {
   platform?: Platform;
   yes?: boolean;
   confirmRevertToBinary?: boolean;
+  target?: string;
 }
 
 interface RollbackTarget {
@@ -19,13 +22,29 @@ interface RollbackTarget {
   fallbackId: string | null;
 }
 
-const PLATFORMS: readonly Platform[] = ["ios", "android"];
-
 const summarizeTarget = (target: RollbackTarget): string => {
   const fallback = target.fallbackId
-    ? `next: ${target.fallbackId}`
+    ? `next-most-recent enabled bundle: ${target.fallbackId}` +
+      ` (actual active bundle per app version may differ — depends on` +
+      ` targetAppVersion / fingerprint match)`
     : "next: (would revert to binary-shipped JS)";
   return `  - ${target.platform}: disable ${target.bundle.id} (${fallback})`;
+};
+
+const formatRetryHint = (channel: string, target: RollbackTarget): string =>
+  `Re-run with: hot-updater rollback ${channel} -p ${target.platform} --target ${target.bundle.id}`;
+
+const safeOnUnmount = async (databasePlugin: DatabasePlugin): Promise<void> => {
+  try {
+    await databasePlugin.onUnmount?.();
+  } catch (err) {
+    // Cleanup errors must never mask the originating mutation error.
+    p.log.warn(
+      `Database plugin onUnmount failed (cleanup-only, original error preserved): ${
+        (err as Error)?.message ?? String(err)
+      }`,
+    );
+  }
 };
 
 export const handleRollback = async (
@@ -40,10 +59,6 @@ export const handleRollback = async (
   }
 
   const config = await loadConfig(null);
-  if (!config) {
-    p.log.error("No config found. Please run `hot-updater init` first.");
-    process.exit(1);
-  }
 
   const platforms = options.platform ? [options.platform] : PLATFORMS;
 
@@ -53,25 +68,69 @@ export const handleRollback = async (
     const skippedPlatforms: Platform[] = [];
     const wouldRevertToBinary: Platform[] = [];
 
-    for (const platform of platforms) {
-      const result = await databasePlugin.getBundles({
-        where: { channel, platform, enabled: true },
+    if (options.target) {
+      // Scoped retry path: roll back exactly the named bundle.
+      const targetBundle = await databasePlugin.getBundleById(options.target);
+      if (!targetBundle) {
+        p.log.error(`No bundle with id ${options.target}.`);
+        process.exit(1);
+      }
+      if (targetBundle.channel !== channel) {
+        p.log.error(
+          `Bundle ${options.target} is on channel "${targetBundle.channel}", not "${channel}".`,
+        );
+        process.exit(1);
+      }
+      if (options.platform && targetBundle.platform !== options.platform) {
+        p.log.error(
+          `Bundle ${options.target} is on platform "${targetBundle.platform}", not "${options.platform}".`,
+        );
+        process.exit(1);
+      }
+      if (!targetBundle.enabled) {
+        p.log.info(`Bundle ${options.target} is already disabled. No changes.`);
+        return;
+      }
+      const fallbackResult = await databasePlugin.getBundles({
+        where: {
+          channel,
+          platform: targetBundle.platform,
+          enabled: true,
+        },
         limit: 2,
       });
-      const [target, fallback] = result.data;
-      if (!target) {
-        p.log.info(`No enabled bundle on ${channel}/${platform}; skipping.`);
-        skippedPlatforms.push(platform);
-        continue;
-      }
+      const fallback = fallbackResult.data.find(
+        (b) => b.id !== targetBundle.id,
+      );
       if (!fallback) {
-        wouldRevertToBinary.push(platform);
+        wouldRevertToBinary.push(targetBundle.platform);
       }
       targets.push({
-        platform,
-        bundle: target,
+        platform: targetBundle.platform,
+        bundle: targetBundle,
         fallbackId: fallback?.id ?? null,
       });
+    } else {
+      for (const platform of platforms) {
+        const result = await databasePlugin.getBundles({
+          where: { channel, platform, enabled: true },
+          limit: 2,
+        });
+        const [target, fallback] = result.data;
+        if (!target) {
+          p.log.info(`No enabled bundle on ${channel}/${platform}; skipping.`);
+          skippedPlatforms.push(platform);
+          continue;
+        }
+        if (!fallback) {
+          wouldRevertToBinary.push(platform);
+        }
+        targets.push({
+          platform,
+          bundle: target,
+          fallbackId: fallback?.id ?? null,
+        });
+      }
     }
 
     if (targets.length === 0) {
@@ -81,19 +140,27 @@ export const handleRollback = async (
       process.exit(1);
     }
 
-    p.log.info(`Rollback plan for channel "${channel}":`);
+    p.log.message(`Rollback plan for channel "${channel}":`);
     for (const t of targets) {
-      console.log(summarizeTarget(t));
+      p.log.message(summarizeTarget(t));
     }
 
     if (wouldRevertToBinary.length > 0 && !options.confirmRevertToBinary) {
+      const safePlatforms = targets
+        .map((t) => t.platform)
+        .filter((pl) => !wouldRevertToBinary.includes(pl));
+      const safePlatformsHint = safePlatforms.length
+        ? ` Re-run with -p ${safePlatforms.join("/")} to skip the platforms above,`
+        : "";
       p.log.error(
         `Rollback would leave channel "${channel}" with NO enabled bundles for: ${wouldRevertToBinary.join(", ")}.`,
       );
       p.log.info(
         "Affected platforms would fall back to the binary-shipped JS.",
       );
-      p.log.info("Re-run with --confirm-revert-to-binary to proceed.");
+      p.log.info(
+        `${safePlatformsHint} or --confirm-revert-to-binary to also revert ${wouldRevertToBinary.join(", ")} to binary-shipped JS.`,
+      );
       process.exit(1);
     }
 
@@ -122,35 +189,50 @@ export const handleRollback = async (
     }
 
     // Mutate phase: queue updates, then flush via a single commitBundle.
-    // Note: DatabasePlugin.commitBundle runs ops sequentially in the
-    // underlying provider, so atomicity across platforms is not guaranteed.
-    // The verify phase below catches partial-failure state explicitly.
-    for (const t of targets) {
-      await databasePlugin.updateBundle(t.bundle.id, { enabled: false });
+    // commitBundle is sequential in the underlying provider; if it throws
+    // partway, we still run the verify phase below to surface per-platform
+    // state rather than hiding it behind the raw error.
+    let commitError: unknown = null;
+    try {
+      for (const t of targets) {
+        await databasePlugin.updateBundle(t.bundle.id, { enabled: false });
+      }
+      await databasePlugin.commitBundle();
+    } catch (err) {
+      commitError = err;
+      p.log.error(
+        `commitBundle threw: ${(err as Error)?.message ?? String(err)}`,
+      );
+      p.log.info("Running verify phase to surface per-platform state...");
     }
-    await databasePlugin.commitBundle();
 
-    // Verify phase: re-read each target. Surface failures per-platform.
+    // Verify phase: re-read each target. Distinguish three states —
+    // disabled (success), still-enabled (failure), and gone (success: a
+    // deleted bundle satisfies the rollback intent).
     const failures: RollbackTarget[] = [];
     for (const t of targets) {
       const refetched = await databasePlugin.getBundleById(t.bundle.id);
-      if (!refetched || refetched.enabled) {
+      if (!refetched) {
+        p.log.warn(
+          `${t.platform} ${t.bundle.id} was deleted between commit and verify; treating as rolled back.`,
+        );
+      } else if (refetched.enabled) {
         failures.push(t);
         p.log.error(
-          `FAILED: ${t.platform} ${t.bundle.id} is still enabled after rollback.`,
+          `FAILED: ${t.platform} ${t.bundle.id} is still enabled after rollback. ${formatRetryHint(channel, t)}`,
         );
       } else {
         p.log.success(`rolled back ${t.platform} ${t.bundle.id}`);
       }
     }
 
-    if (failures.length > 0) {
+    if (commitError || failures.length > 0) {
       p.log.error(
         `Rollback completed with ${failures.length} failed platform(s) out of ${targets.length}.`,
       );
       process.exit(1);
     }
   } finally {
-    await databasePlugin.onUnmount?.();
+    await safeOnUnmount(databasePlugin);
   }
 };

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -38,6 +38,7 @@ import {
 import { generate } from "./commands/generate";
 import { keysExportPublic, keysGenerate, keysRemove } from "./commands/keys";
 import { migrate } from "./commands/migrate";
+import { handleRollback } from "./commands/rollback";
 
 const DEFAULT_CHANNEL = "production";
 
@@ -182,6 +183,32 @@ program
   .action(async (options: DeployOptions) => {
     deploy(options);
   });
+
+program
+  .command("rollback")
+  .description("Disable the most recent enabled bundle on a channel")
+  .argument("<channel>", "the channel to roll back")
+  .addOption(
+    new Option(
+      "-p, --platform <platform>",
+      "limit to a single platform (default: both)",
+    ).choices(["ios", "android"]),
+  )
+  .option("-y, --yes", "skip confirmation prompt")
+  .option(
+    "--confirm-revert-to-binary",
+    "allow rollback even when no other enabled bundle exists for that platform",
+  )
+  .action(
+    (
+      channel: string,
+      options: {
+        platform?: "ios" | "android";
+        yes?: boolean;
+        confirmRevertToBinary?: boolean;
+      },
+    ) => handleRollback(channel, options),
+  );
 
 program
   .command("console")

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -188,16 +188,19 @@ program
   .command("rollback")
   .description("Disable the most recent enabled bundle on a channel")
   .argument("<channel>", "the channel to roll back")
-  .addOption(
-    new Option(
-      "-p, --platform <platform>",
-      "limit to a single platform (default: both)",
-    ).choices(["ios", "android"]),
-  )
+  .addOption(platformCommandOption)
   .option("-y, --yes", "skip confirmation prompt")
   .option(
     "--confirm-revert-to-binary",
     "allow rollback even when no other enabled bundle exists for that platform",
+  )
+  .option(
+    "--target <bundle-id>",
+    "scope rollback to exactly this bundle id (use to retry a failed rollback)",
+  )
+  .addHelpText(
+    "after",
+    `\nFour phases: read (pull up to two most-recent enabled bundles per platform),\nvalidate (refuse if a platform would have no enabled bundle, unless\n--confirm-revert-to-binary), mutate (one commitBundle for all platforms\n— note: commit is sequential, not atomic across platforms), verify\n(re-read each target).\n\nExit codes:\n  0  rollback succeeded and verified\n  1  validation, mutation, or post-mutate verification failed\n  2  user declined the interactive confirmation\n\nWhen rollback partially fails, the FAILED line names the exact bundle id;\nretry the failed platform with: hot-updater rollback <channel> -p <platform> --target <bundle-id>\n\nExamples:\n  hot-updater rollback production -y\n  hot-updater rollback production -p ios --confirm-revert-to-binary -y\n  hot-updater rollback production -p android --target 0195a408-... -y\n`,
   )
   .action(
     (
@@ -206,6 +209,7 @@ program
         platform?: "ios" | "android";
         yes?: boolean;
         confirmRevertToBinary?: boolean;
+        target?: string;
       },
     ) => handleRollback(channel, options),
   );


### PR DESCRIPTION
Implements `rollback` command for #973 

---
"hot-updater": patch
---

feat(cli): add `rollback <channel>` command

Disables the most recent enabled bundle on a channel for each requested platform.

```
hot-updater rollback <channel> [-p ios|android] [-y] [--confirm-revert-to-binary] [--target <bundle-id>]
```

Behavior:

- **Read phase** loads up to two most-recent enabled bundles per (channel, platform) so the operator can see what would become active after rollback.
- **Validate phase** refuses with non-zero exit if any (channel, platform) would have **no** enabled bundles after the rollback unless `--confirm-revert-to-binary` is passed. The error message names both safe escape hatches in priority order: `-p <unaffected>` first, then `--confirm-revert-to-binary`.
- **Mutate phase** queues `updateBundle({ enabled: false })` for each target and commits once. Note: `DatabasePlugin.commitBundle` runs ops sequentially in the underlying provider, so atomicity across platforms is **not** guaranteed. The mutate is wrapped in a try/catch so a mid-commit throw still falls through to the verify phase.
- **Verify phase** re-reads each target. Distinguishes three states — disabled (success), still-enabled (failure), and gone (success: a deleted bundle satisfies the rollback intent). Surfaces partial-failure state explicitly with non-zero exit and per-platform `FAILED` lines naming the exact retry command, including a `--target <bundle-id>` flag for scoped retry.

Refuses to mutate without `-y` in a non-TTY shell. `onUnmount` is wrapped in its own try/catch so cleanup errors never mask the originating mutation error. Help text documents the four-phase contract and exit codes (0 = success, 1 = error, 2 = user-aborted).