### PR TITLE
Feature - CLI Bundle Commands

### DIFF
--- a/.changeset/cli-bundle-commands.md
+++ b/.changeset/cli-bundle-commands.md
@@ -6,8 +6,8 @@ feat(cli): add `bundle list/disable/enable` commands
 
 Adds three subcommands under a new top-level `bundle` namespace:
 
-- `hot-updater bundle list [-c <channel>] [-p <ios|android>] [--limit <n>]` — tabulated listing of bundles, most recent first.
-- `hot-updater bundle disable <bundle-id> [-y]` — disable a single bundle. Refuses to mutate without `-y` in a non-TTY shell. Re-reads the bundle after `commitBundle` and exits non-zero if the change did not take effect.
+- `hot-updater bundle list [-c <channel>] [-p <ios|android>] [--limit <n>]` — tabulated listing of bundles, most recent first. `--limit` validation uses commander's idiomatic `InvalidArgumentError` shape.
+- `hot-updater bundle disable <bundle-id> [-y]` — disable a single bundle. Refuses to mutate without `-y` in a non-TTY shell. Re-reads the bundle after `commitBundle` and exits non-zero if the change did not take effect; treats a mid-flight deletion as success.
 - `hot-updater bundle enable <bundle-id> [-y]` — re-enable a previously disabled bundle.
 
-All three commands load config via `loadConfig(null)` (matching the `console` command's idiom) since they are not platform-scoped operations. They use the existing `DatabasePlugin` interface (`getBundles`, `getBundleById`, `updateBundle`, `commitBundle`), so they work against every supported provider with no plugin-side changes.
+All three commands load config via `loadConfig(null)` (matching the `console` command's idiom) since they are not platform-scoped operations. They use the existing `DatabasePlugin` interface (`getBundles`, `getBundleById`, `updateBundle`, `commitBundle`), so they work against every supported provider with no plugin-side changes. The `--platform` option is the shared `platformCommandOption` already used by `deploy`. `onUnmount` is wrapped in its own try/catch so cleanup errors never mask the originating mutation error. Help text documents the read-mutate-verify contract and exit codes (0 = success, 1 = error, 2 = user-aborted).

--- a/.changeset/cli-bundle-commands.md
+++ b/.changeset/cli-bundle-commands.md
@@ -1,0 +1,13 @@
+---
+"hot-updater": patch
+---
+
+feat(cli): add `bundle list/disable/enable` commands
+
+Adds three subcommands under a new top-level `bundle` namespace:
+
+- `hot-updater bundle list [-c <channel>] [-p <ios|android>] [--limit <n>]` — tabulated listing of bundles, most recent first.
+- `hot-updater bundle disable <bundle-id> [-y]` — disable a single bundle. Refuses to mutate without `-y` in a non-TTY shell. Re-reads the bundle after `commitBundle` and exits non-zero if the change did not take effect.
+- `hot-updater bundle enable <bundle-id> [-y]` — re-enable a previously disabled bundle.
+
+All three commands load config via `loadConfig(null)` (matching the `console` command's idiom) since they are not platform-scoped operations. They use the existing `DatabasePlugin` interface (`getBundles`, `getBundleById`, `updateBundle`, `commitBundle`), so they work against every supported provider with no plugin-side changes.

--- a/packages/hot-updater/src/commands/bundle.spec.ts
+++ b/packages/hot-updater/src/commands/bundle.spec.ts
@@ -1,0 +1,285 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCli, mockDatabasePlugin, mockPrintBanner } = vi.hoisted(() => {
+  const mockDatabasePlugin = {
+    appendBundle: vi.fn(),
+    commitBundle: vi.fn(),
+    deleteBundle: vi.fn(),
+    getBundleById: vi.fn(),
+    getBundles: vi.fn(),
+    getChannels: vi.fn(),
+    name: "mock-database",
+    onUnmount: vi.fn(),
+    updateBundle: vi.fn(),
+  };
+  const mockCli = {
+    loadConfig: vi.fn(),
+    p: {
+      confirm: vi.fn(),
+      isCancel: vi.fn(() => false),
+      log: {
+        error: vi.fn(),
+        info: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  };
+  const mockPrintBanner = vi.fn();
+  return { mockCli, mockDatabasePlugin, mockPrintBanner };
+});
+
+vi.mock("@hot-updater/cli-tools", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@hot-updater/cli-tools")>();
+  return {
+    ...actual,
+    loadConfig: mockCli.loadConfig,
+    p: mockCli.p,
+  };
+});
+
+vi.mock("@/utils/printBanner", () => ({
+  printBanner: mockPrintBanner,
+}));
+
+const buildBundle = (overrides: Partial<Bundle> = {}): Bundle => ({
+  id: "0195a408-8f13-7d9b-8df4-123456789abc",
+  channel: "dev",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeefcafe",
+  message: "Initial bundle",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+  ...overrides,
+});
+
+const stubLoadedConfig = () => {
+  mockCli.loadConfig.mockResolvedValue({
+    database: vi.fn().mockResolvedValue(mockDatabasePlugin),
+  } as never);
+};
+
+const expectExit = (code: number) => {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((c) => {
+    throw new Error(`process.exit(${c})`);
+  });
+  return { exitSpy, code };
+};
+
+describe("handleBundleList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubLoadedConfig();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints a tabulated row per bundle from getBundles result data", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [buildBundle({ id: "B1" }), buildBundle({ id: "B2" })],
+      pagination: { total: 2 },
+    });
+
+    const { handleBundleList } = await import("./bundle");
+    await handleBundleList({});
+
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
+      where: { channel: undefined, platform: undefined },
+      limit: 20,
+    });
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("B1");
+    expect(output).toContain("B2");
+    expect(output).toMatch(/^id\s+channel\s+platform/);
+  });
+
+  it("prints empty-state marker when no bundles exist", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [],
+      pagination: { total: 0 },
+    });
+    const { handleBundleList } = await import("./bundle");
+    await handleBundleList({});
+    expect(logSpy).toHaveBeenCalledWith("(no bundles)");
+  });
+
+  it("forwards channel/platform/limit options to getBundles", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [],
+      pagination: { total: 0 },
+    });
+    const { handleBundleList } = await import("./bundle");
+    await handleBundleList({ channel: "beta", platform: "android", limit: 5 });
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
+      where: { channel: "beta", platform: "android" },
+      limit: 5,
+    });
+  });
+
+  it("calls onUnmount even when getBundles throws", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundles.mockRejectedValue(new Error("DB down"));
+    const { handleBundleList } = await import("./bundle");
+    await expect(handleBundleList({})).rejects.toThrow("DB down");
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalled();
+  });
+});
+
+describe("handleBundleSetEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubLoadedConfig();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("disables an enabled bundle when -y is passed and verifies the result", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: true }))
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: false }));
+
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await handleBundleSetEnabled("B1", false, { yes: true });
+
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("B1", {
+      enabled: false,
+    });
+    expect(mockDatabasePlugin.commitBundle).toHaveBeenCalled();
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("disabled B1"),
+    );
+  });
+
+  it("enables a disabled bundle when -y is passed", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: false }))
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: true }));
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await handleBundleSetEnabled("B1", true, { yes: true });
+    expect(mockDatabasePlugin.updateBundle).toHaveBeenCalledWith("B1", {
+      enabled: true,
+    });
+  });
+
+  it("short-circuits with info log when bundle is already in target state", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById.mockResolvedValueOnce(
+      buildBundle({ id: "B1", enabled: false }),
+    );
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await handleBundleSetEnabled("B1", false, { yes: true });
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalled();
+    expect(mockDatabasePlugin.commitBundle).not.toHaveBeenCalled();
+    expect(mockCli.p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("already disable"),
+    );
+  });
+
+  it("exits 1 when bundle id does not exist", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById.mockResolvedValueOnce(null);
+    const { exitSpy } = expectExit(1);
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await expect(
+      handleBundleSetEnabled("missing", true, { yes: true }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("refuses to mutate without -y in a non-TTY shell", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    mockDatabasePlugin.getBundleById.mockResolvedValueOnce(
+      buildBundle({ id: "B1", enabled: true }),
+    );
+    const { exitSpy } = expectExit(1);
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await expect(handleBundleSetEnabled("B1", false, {})).rejects.toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("aborts with exit code 2 when interactive confirmation declines", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+
+    mockDatabasePlugin.getBundleById.mockResolvedValueOnce(
+      buildBundle({ id: "B1", enabled: true }),
+    );
+    mockCli.p.confirm.mockResolvedValueOnce(false);
+
+    const { exitSpy } = expectExit(2);
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await expect(handleBundleSetEnabled("B1", false, {})).rejects.toThrow(
+      "process.exit(2)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    expect(mockDatabasePlugin.updateBundle).not.toHaveBeenCalled();
+
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("exits 1 when verification reads a state mismatch after commit", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: true }))
+      .mockResolvedValueOnce(buildBundle({ id: "B1", enabled: true }));
+
+    const { exitSpy } = expectExit(1);
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await expect(
+      handleBundleSetEnabled("B1", false, { yes: true }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Verification failed"),
+    );
+  });
+
+  it("calls onUnmount even when getBundleById throws", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.getBundleById.mockRejectedValue(new Error("DB error"));
+    const { handleBundleSetEnabled } = await import("./bundle");
+    await expect(
+      handleBundleSetEnabled("B1", false, { yes: true }),
+    ).rejects.toThrow("DB error");
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalled();
+  });
+});

--- a/packages/hot-updater/src/commands/bundle.spec.ts
+++ b/packages/hot-updater/src/commands/bundle.spec.ts
@@ -21,6 +21,7 @@ const { mockCli, mockDatabasePlugin, mockPrintBanner } = vi.hoisted(() => {
       log: {
         error: vi.fn(),
         info: vi.fn(),
+        message: vi.fn(),
         success: vi.fn(),
         warn: vi.fn(),
       },

--- a/packages/hot-updater/src/commands/bundle.ts
+++ b/packages/hot-updater/src/commands/bundle.ts
@@ -1,0 +1,161 @@
+import { loadConfig, p } from "@hot-updater/cli-tools";
+import type {
+  Bundle,
+  DatabasePlugin,
+  Platform,
+} from "@hot-updater/plugin-core";
+
+import { printBanner } from "@/utils/printBanner";
+
+const LIST_FIELDS = [
+  "id",
+  "channel",
+  "platform",
+  "enabled",
+  "targetAppVersion",
+  "shouldForceUpdate",
+  "gitCommitHash",
+  "message",
+] as const satisfies readonly (keyof Bundle)[];
+
+export interface BundleListOptions {
+  channel?: string;
+  platform?: Platform;
+  limit?: number;
+}
+
+export interface BundleMutationOptions {
+  yes?: boolean;
+}
+
+const DEFAULT_LIMIT = 20;
+
+const formatRow = (bundle: Bundle): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const field of LIST_FIELDS) {
+    const v = bundle[field];
+    if (field === "enabled" || field === "shouldForceUpdate") {
+      out[field] = v ? "yes" : "no";
+    } else if (field === "gitCommitHash" && typeof v === "string") {
+      out[field] = v.slice(0, 7);
+    } else if (field === "message" && typeof v === "string") {
+      out[field] = v.slice(0, 60);
+    } else if (v == null) {
+      out[field] = "";
+    } else {
+      out[field] = String(v);
+    }
+  }
+  return out;
+};
+
+const tabulate = (bundles: Bundle[]): string => {
+  if (bundles.length === 0) {
+    return "(no bundles)";
+  }
+  const rows = bundles.map(formatRow);
+  const widths: Record<string, number> = {};
+  for (const field of LIST_FIELDS) {
+    widths[field] = Math.max(field.length, ...rows.map((r) => r[field].length));
+  }
+  const header = LIST_FIELDS.map((f) => f.padEnd(widths[f])).join("  ");
+  const body = rows.map((r) =>
+    LIST_FIELDS.map((f) => r[f].padEnd(widths[f])).join("  "),
+  );
+  return [header, ...body].join("\n");
+};
+
+const refuseNonInteractiveMutation = (action: string): never => {
+  p.log.error(
+    `Cannot ${action} a bundle without confirmation in a non-interactive shell. Re-run with -y, or use a TTY.`,
+  );
+  process.exit(1);
+};
+
+export const handleBundleList = async (options: BundleListOptions = {}) => {
+  printBanner();
+
+  const config = await loadConfig(null);
+  if (!config) {
+    p.log.error("No config found. Please run `hot-updater init` first.");
+    process.exit(1);
+  }
+
+  const databasePlugin: DatabasePlugin = await config.database();
+  try {
+    const limit =
+      Number.isInteger(options.limit) && options.limit! > 0
+        ? options.limit!
+        : DEFAULT_LIMIT;
+    const result = await databasePlugin.getBundles({
+      where: {
+        channel: options.channel,
+        platform: options.platform,
+      },
+      limit,
+    });
+    console.log(tabulate(result.data));
+  } finally {
+    await databasePlugin.onUnmount?.();
+  }
+};
+
+export const handleBundleSetEnabled = async (
+  bundleId: string,
+  nextEnabled: boolean,
+  options: BundleMutationOptions = {},
+) => {
+  const action = nextEnabled ? "enable" : "disable";
+  printBanner();
+
+  const config = await loadConfig(null);
+  if (!config) {
+    p.log.error("No config found. Please run `hot-updater init` first.");
+    process.exit(1);
+  }
+
+  const databasePlugin: DatabasePlugin = await config.database();
+  try {
+    const bundle = await databasePlugin.getBundleById(bundleId);
+    if (!bundle) {
+      p.log.error(`No bundle with id ${bundleId}.`);
+      process.exit(1);
+    }
+
+    console.log(tabulate([bundle]));
+
+    if (bundle.enabled === nextEnabled) {
+      p.log.info(`Bundle is already ${action}d. No changes.`);
+      return;
+    }
+
+    if (!options.yes) {
+      if (!process.stdin.isTTY) {
+        refuseNonInteractiveMutation(action);
+      }
+      const confirmed = await p.confirm({
+        message: `${action} this bundle?`,
+        initialValue: false,
+      });
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.log.info("Aborted.");
+        process.exit(2);
+      }
+    }
+
+    await databasePlugin.updateBundle(bundleId, { enabled: nextEnabled });
+    await databasePlugin.commitBundle();
+
+    const refetched = await databasePlugin.getBundleById(bundleId);
+    if (!refetched || refetched.enabled !== nextEnabled) {
+      p.log.error(
+        `Verification failed: ${bundleId} is not ${action}d after update.`,
+      );
+      process.exit(1);
+    }
+
+    p.log.success(`${action}d ${bundleId}.`);
+  } finally {
+    await databasePlugin.onUnmount?.();
+  }
+};

--- a/packages/hot-updater/src/commands/bundle.ts
+++ b/packages/hot-updater/src/commands/bundle.ts
@@ -72,14 +72,22 @@ const refuseNonInteractiveMutation = (action: string): never => {
   process.exit(1);
 };
 
+const safeOnUnmount = async (databasePlugin: DatabasePlugin): Promise<void> => {
+  try {
+    await databasePlugin.onUnmount?.();
+  } catch (err) {
+    p.log.warn(
+      `Database plugin onUnmount failed (cleanup-only, original error preserved): ${
+        (err as Error)?.message ?? String(err)
+      }`,
+    );
+  }
+};
+
 export const handleBundleList = async (options: BundleListOptions = {}) => {
   printBanner();
 
   const config = await loadConfig(null);
-  if (!config) {
-    p.log.error("No config found. Please run `hot-updater init` first.");
-    process.exit(1);
-  }
 
   const databasePlugin: DatabasePlugin = await config.database();
   try {
@@ -96,7 +104,7 @@ export const handleBundleList = async (options: BundleListOptions = {}) => {
     });
     console.log(tabulate(result.data));
   } finally {
-    await databasePlugin.onUnmount?.();
+    await safeOnUnmount(databasePlugin);
   }
 };
 
@@ -109,10 +117,6 @@ export const handleBundleSetEnabled = async (
   printBanner();
 
   const config = await loadConfig(null);
-  if (!config) {
-    p.log.error("No config found. Please run `hot-updater init` first.");
-    process.exit(1);
-  }
 
   const databasePlugin: DatabasePlugin = await config.database();
   try {
@@ -147,15 +151,19 @@ export const handleBundleSetEnabled = async (
     await databasePlugin.commitBundle();
 
     const refetched = await databasePlugin.getBundleById(bundleId);
-    if (!refetched || refetched.enabled !== nextEnabled) {
+    if (!refetched) {
+      p.log.warn(
+        `${bundleId} was deleted between commit and verify; treating as ${action}d.`,
+      );
+    } else if (refetched.enabled !== nextEnabled) {
       p.log.error(
         `Verification failed: ${bundleId} is not ${action}d after update.`,
       );
       process.exit(1);
+    } else {
+      p.log.success(`${action}d ${bundleId}.`);
     }
-
-    p.log.success(`${action}d ${bundleId}.`);
   } finally {
-    await databasePlugin.onUnmount?.();
+    await safeOnUnmount(databasePlugin);
   }
 };

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-import { Command, Option } from "@commander-js/extra-typings";
+import {
+  Command,
+  InvalidArgumentError,
+  Option,
+} from "@commander-js/extra-typings";
 import type { AndroidNativeRunOptions } from "@hot-updater/android-helper";
 import type { IosNativeRunOptions } from "@hot-updater/apple-helper";
 import { banner, log, p } from "@hot-updater/cli-tools";
@@ -89,23 +93,22 @@ bundleCommand
   .command("list")
   .description("List bundles, most recent first")
   .option("-c, --channel <channel>", "filter by channel")
-  .addOption(
-    new Option("-p, --platform <platform>", "filter by platform").choices([
-      "ios",
-      "android",
-    ]),
-  )
+  .addOption(platformCommandOption)
   .option(
     "--limit <n>",
-    "limit the number of results (default: 20)",
+    "limit the number of results",
     (value) => {
       const n = Number.parseInt(value, 10);
       if (!Number.isInteger(n) || n <= 0) {
-        p.log.error("--limit must be a positive integer");
-        process.exit(1);
+        throw new InvalidArgumentError("must be a positive integer");
       }
       return n;
     },
+    20,
+  )
+  .addHelpText(
+    "after",
+    `\nExit codes:\n  0  success\n  1  configuration error or DB error\n`,
   )
   .action(handleBundleList);
 
@@ -114,6 +117,10 @@ bundleCommand
   .description("Disable a bundle by id")
   .argument("<bundle-id>", "the id of the bundle to disable")
   .option("-y, --yes", "skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `\nDisables a bundle and re-reads its state to confirm the change.\n\nExit codes:\n  0  bundle is disabled (or was already disabled)\n  1  bundle not found, DB error, or post-commit verification failed\n  2  user declined the interactive confirmation\n\nIdempotent: running disable on an already-disabled bundle is a no-op.\nNon-TTY shells require -y; otherwise the command refuses to mutate.\n`,
+  )
   .action((bundleId: string, options: { yes?: boolean }) =>
     handleBundleSetEnabled(bundleId, false, options),
   );
@@ -123,6 +130,10 @@ bundleCommand
   .description("Re-enable a previously disabled bundle by id")
   .argument("<bundle-id>", "the id of the bundle to enable")
   .option("-y, --yes", "skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `\nRe-enables a previously disabled bundle and re-reads its state to confirm.\n\nExit codes:\n  0  bundle is enabled (or was already enabled)\n  1  bundle not found, DB error, or post-commit verification failed\n  2  user declined the interactive confirmation\n\nIdempotent: running enable on an already-enabled bundle is a no-op.\nNon-TTY shells require -y; otherwise the command refuses to mutate.\n`,
+  )
   .action((bundleId: string, options: { yes?: boolean }) =>
     handleBundleSetEnabled(bundleId, true, options),
   );

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -29,6 +29,7 @@ import { ensureNoConflicts } from "@/utils/conflictDetection";
 import { printBanner } from "@/utils/printBanner";
 import { getNativeAppVersion } from "@/utils/version/getNativeAppVersion";
 
+import { handleBundleList, handleBundleSetEnabled } from "./commands/bundle";
 import { handleChannel, handleSetChannel } from "./commands/channel";
 import { handleDoctor } from "./commands/doctor";
 import {
@@ -81,6 +82,50 @@ channelCommand
   .description("Set the channel for Android (BuildConfig) and iOS (Info.plist)")
   .argument("<channel>", "the channel to set")
   .action(handleSetChannel);
+
+const bundleCommand = program.command("bundle").description("Manage bundles");
+
+bundleCommand
+  .command("list")
+  .description("List bundles, most recent first")
+  .option("-c, --channel <channel>", "filter by channel")
+  .addOption(
+    new Option("-p, --platform <platform>", "filter by platform").choices([
+      "ios",
+      "android",
+    ]),
+  )
+  .option(
+    "--limit <n>",
+    "limit the number of results (default: 20)",
+    (value) => {
+      const n = Number.parseInt(value, 10);
+      if (!Number.isInteger(n) || n <= 0) {
+        p.log.error("--limit must be a positive integer");
+        process.exit(1);
+      }
+      return n;
+    },
+  )
+  .action(handleBundleList);
+
+bundleCommand
+  .command("disable")
+  .description("Disable a bundle by id")
+  .argument("<bundle-id>", "the id of the bundle to disable")
+  .option("-y, --yes", "skip confirmation prompt")
+  .action((bundleId: string, options: { yes?: boolean }) =>
+    handleBundleSetEnabled(bundleId, false, options),
+  );
+
+bundleCommand
+  .command("enable")
+  .description("Re-enable a previously disabled bundle by id")
+  .argument("<bundle-id>", "the id of the bundle to enable")
+  .option("-y, --yes", "skip confirmation prompt")
+  .action((bundleId: string, options: { yes?: boolean }) =>
+    handleBundleSetEnabled(bundleId, true, options),
+  );
 
 const keysCommand = program
   .command("keys")


### PR DESCRIPTION
Implements `bundle` commands for #973 

---
"hot-updater": patch
---

feat(cli): add `bundle list/disable/enable` commands

Adds three subcommands under a new top-level `bundle` namespace:

- `hot-updater bundle list [-c <channel>] [-p <ios|android>] [--limit <n>]` — tabulated listing of bundles, most recent first. `--limit` validation uses commander's idiomatic `InvalidArgumentError` shape.
- `hot-updater bundle disable <bundle-id> [-y]` — disable a single bundle. Refuses to mutate without `-y` in a non-TTY shell. Re-reads the bundle after `commitBundle` and exits non-zero if the change did not take effect; treats a mid-flight deletion as success.
- `hot-updater bundle enable <bundle-id> [-y]` — re-enable a previously disabled bundle.

All three commands load config via `loadConfig(null)` (matching the `console` command's idiom) since they are not platform-scoped operations. They use the existing `DatabasePlugin` interface (`getBundles`, `getBundleById`, `updateBundle`, `commitBundle`), so they work against every supported provider with no plugin-side changes. The `--platform` option is the shared `platformCommandOption` already used by `deploy`. `onUnmount` is wrapped in its own try/catch so cleanup errors never mask the originating mutation error. Help text documents the read-mutate-verify contract and exit codes (0 = success, 1 = error, 2 = user-aborted).