### PR TITLE
feat(react-native): add `HotUpdater.init` for manual flows

### DIFF
--- a/docs/content/docs/concepts/automatic-rollback.mdx
+++ b/docs/content/docs/concepts/automatic-rollback.mdx
@@ -11,7 +11,9 @@ Automatic rollback is the safety mechanism that prevents a bad OTA bundle from t
 
 When a new bundle is installed, Hot Updater does not trust it immediately. It launches that bundle in a temporary state first, keeps the last known-good bundle as a fallback, and only treats the new bundle as safe after startup succeeds.
 
-This happens automatically when you use `HotUpdater.wrap()`.
+This happens automatically when you use `HotUpdater.wrap()`. For custom manual
+flows without a root wrapper, call [`HotUpdater.init()`](/docs/react-native-api/init)
+when your runtime considers the app ready.
 
 ## Core Mechanism
 
@@ -46,7 +48,9 @@ Typical examples include:
 - a native crash while the new bundle is loading
 - a fatal error before the first screen appears
 
-This is why `HotUpdater.wrap()` is required for rollback support. It connects bundle verification to the app lifecycle automatically.
+This is why Hot Updater must be configured with `HotUpdater.wrap()` or
+`HotUpdater.init()` for rollback support. These APIs connect bundle verification
+to the app lifecycle.
 
 ## What Happens During Rollback?
 

--- a/docs/content/docs/guides/custom-update-logic.mdx
+++ b/docs/content/docs/guides/custom-update-logic.mdx
@@ -1,0 +1,224 @@
+---
+title: "Custom Update Logic"
+description: "Build a custom Hot Updater client flow with init, checkForUpdate, updateBundle, reload, and custom resolvers."
+icon: Settings2
+---
+
+## Overview
+
+Hot Updater can manage updates automatically with `HotUpdater.wrap`, but you can
+also build the client flow yourself. A custom flow is useful when you want to
+check only after login, gate updates by app state, use your own network layer,
+or let another runtime own the root component.
+
+The custom flow has four parts:
+
+1. Initialize Hot Updater with `HotUpdater.init` or manual `HotUpdater.wrap`.
+2. Decide when to call `HotUpdater.checkForUpdate`.
+3. Download the bundle with `updateInfo.updateBundle()` or
+   `HotUpdater.updateBundle`.
+4. Reload immediately, later, or with your own reload behavior.
+
+## Initialize
+
+Use `HotUpdater.init` when you do not want to wrap the root component.
+
+```tsx
+import { HotUpdater } from "@hot-updater/react-native";
+
+void HotUpdater.init({
+  baseURL: "<your-update-server-url>",
+  updateMode: "manual",
+  requestHeaders: {
+    Authorization: "Bearer <your-access-token>",
+  },
+});
+```
+
+<Callout>
+`HotUpdater.init` has the same initialization effect as manual `wrap`.
+
+```tsx
+export default HotUpdater.wrap({
+  baseURL: "<your-update-server-url>",
+  updateMode: "manual",
+})(App);
+```
+
+Both options configure the shared resolver and notify the update server that the
+current app launch is ready, which keeps crash recovery and rollback tracking
+working.
+</Callout>
+
+## Check on Your Schedule
+
+Call `checkForUpdate` only when your app is ready for the decision.
+
+```tsx
+async function checkForAppUpdate() {
+  const updateInfo = await HotUpdater.checkForUpdate({
+    updateStrategy: "appVersion",
+  });
+
+  if (!updateInfo) {
+    return { status: "UP_TO_DATE" as const };
+  }
+
+  return updateInfo;
+}
+```
+
+Common places to check:
+
+- After authentication finishes
+- After the first screen becomes interactive
+- When the app returns to foreground
+- Behind a remote-config or staged rollout gate
+- From a user-facing "Check for updates" action
+
+## Download and Apply
+
+The return value includes an `updateBundle` helper with all required update
+metadata pre-filled.
+
+```tsx
+const updateInfo = await HotUpdater.checkForUpdate({
+  updateStrategy: "appVersion",
+});
+
+if (updateInfo) {
+  const downloaded = await updateInfo.updateBundle();
+
+  if (downloaded && updateInfo.shouldForceUpdate) {
+    await HotUpdater.reload();
+  }
+}
+```
+
+For non-force updates, you can download in the background and reload later.
+
+```tsx
+if (updateInfo && !updateInfo.shouldForceUpdate) {
+  await updateInfo.updateBundle();
+
+  // Later, after navigation is idle or the user accepts a prompt:
+  await HotUpdater.reload();
+}
+```
+
+## Customize Reload Behavior
+
+By default, `HotUpdater.reload()` uses a process restart on Android and a normal
+React Native reload on iOS. Configure it once if your app needs different
+behavior.
+
+```tsx
+HotUpdater.setReloadBehavior("custom", async () => {
+  await flushAnalytics();
+  await restartAppShell();
+});
+```
+
+See [`HotUpdater.setReloadBehavior`](/docs/react-native-api/setReloadBehavior)
+for all reload modes.
+
+## Use a Custom Resolver
+
+Use a resolver when your backend is not using the default Hot Updater endpoint
+shape, or when you want to use GraphQL, RPC, signed requests, or a shared API
+client.
+
+```tsx
+void HotUpdater.init({
+  updateMode: "manual",
+  resolver: {
+    async checkUpdate(params) {
+      const response = await apiClient.post("/updates/check", params);
+
+      if (response.status === 204) {
+        return null;
+      }
+
+      return response.data;
+    },
+    async notifyAppReady(params) {
+      await apiClient.post("/updates/ready", params);
+      return undefined;
+    },
+  },
+});
+```
+
+The resolver receives the native runtime context Hot Updater needs for update
+decisions: platform, app version, current bundle ID, minimum bundle ID, channel,
+cohort, fingerprint hash, request headers, and request timeout.
+
+## Runtime Channel Checks
+
+Custom flows can switch channels at check time. The switch is persisted only
+after the returned update is applied.
+
+```tsx
+const updateInfo = await HotUpdater.checkForUpdate({
+  channel: "beta",
+  updateStrategy: "appVersion",
+});
+
+if (updateInfo) {
+  await updateInfo.updateBundle();
+  await HotUpdater.reload();
+}
+```
+
+To return to the build-time channel, call `HotUpdater.resetChannel()`.
+
+```tsx
+const reset = await HotUpdater.resetChannel();
+
+if (reset) {
+  await HotUpdater.reload();
+}
+```
+
+## Error Handling
+
+Wrap your custom flow in one boundary and keep the app usable when an update
+check fails.
+
+```tsx
+async function runUpdateFlow() {
+  try {
+    const updateInfo = await HotUpdater.checkForUpdate({
+      updateStrategy: "appVersion",
+    });
+
+    if (!updateInfo) {
+      return;
+    }
+
+    const downloaded = await updateInfo.updateBundle();
+
+    if (downloaded && updateInfo.shouldForceUpdate) {
+      await HotUpdater.reload();
+    }
+  } catch (error) {
+    reportUpdateError(error);
+  }
+}
+```
+
+## Checklist
+
+- Call `HotUpdater.init` or manual `HotUpdater.wrap` before update APIs.
+- Keep `notifyAppReady` wired through `baseURL` or a custom resolver.
+- Choose the check timing based on your app state, not module import order.
+- Download with `updateInfo.updateBundle()` unless you need direct control.
+- Use `reload()` immediately only for force updates or explicit user consent.
+- Add error reporting around the full flow.
+
+## Related
+
+- [`HotUpdater.init()`](/docs/react-native-api/init)
+- [`HotUpdater.wrap()`](/docs/react-native-api/wrap)
+- [`HotUpdater.checkForUpdate()`](/docs/react-native-api/checkForUpdate)
+- [`HotUpdater.reload()`](/docs/react-native-api/reload)

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -4,6 +4,7 @@
   "icon": "BookOpenCheck",
   "pages": [
     "deploy",
+    "custom-update-logic",
     "rollout-cohorts",
     "console",
     "simulator-test",

--- a/docs/content/docs/react-native-api/checkForUpdate.mdx
+++ b/docs/content/docs/react-native-api/checkForUpdate.mdx
@@ -6,21 +6,22 @@ icon: Search
 
 ## Usage
 
-Use `checkForUpdate` to verify if an update bundle is available. The function reuses the `baseURL` configured in `HotUpdater.wrap()`, and optionally allows overriding the `updateStrategy`.
+Use `checkForUpdate` to verify if an update bundle is available. The function
+reuses the `baseURL` or `resolver` configured in `HotUpdater.wrap()` or
+`HotUpdater.init()`.
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
 
-// First, configure baseURL and updateStrategy in wrap
-export default HotUpdater.wrap({
+// First, configure baseURL in manual wrap or init
+void HotUpdater.init({
   baseURL: "<your-update-server-url>",
-  updateMode: "manual"
-})(App);
+  updateMode: "manual",
+});
 
-// Use checkForUpdate - it reuses wrap's baseURL
+// Use checkForUpdate - it reuses the configured baseURL
 async function checkForAppUpdate() {
   try {
-    // Option 1: Use wrap's updateStrategy
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion",
       requestHeaders: {
@@ -65,9 +66,11 @@ async function checkForAppUpdate() {
 
 ```
 
-## Important: HotUpdater.wrap Required
+## Important: HotUpdater.wrap or HotUpdater.init Required
 
-When using `checkForUpdate`, you must wrap your root component with `HotUpdater.wrap()` and configure `baseURL` and `updateStrategy`. This is required for proper crash detection and rollback functionality.
+When using `checkForUpdate`, configure Hot Updater first with
+`HotUpdater.wrap()` or `HotUpdater.init()`. This is required for proper crash
+detection and rollback functionality.
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
@@ -95,14 +98,24 @@ function App() {
   return <YourApp />;
 }
 
-// Configure baseURL and updateStrategy in wrap
+// Configure baseURL with manual wrap
 export default HotUpdater.wrap({
   baseURL: "<your-update-server-url>",
   updateMode: "manual"
 })(App);
 ```
 
-Without wrap, calling `checkForUpdate` will throw an error with instructions on how to fix it.
+If another runtime owns your root component, use `HotUpdater.init()` instead:
+
+```tsx
+void HotUpdater.init({
+  baseURL: "<your-update-server-url>",
+  updateMode: "manual",
+});
+```
+
+Without `wrap` or `init`, calling `checkForUpdate` will throw an error with
+instructions on how to fix it.
 
 ## Parameters
 
@@ -110,16 +123,18 @@ The `checkForUpdate` function accepts the following optional parameters:
 
 | Parameter         | Type                           | Required | Description                                                                      |
 |-------------------|--------------------------------|----------|----------------------------------------------------------------------------------|
-| `updateStrategy`  | `"appVersion"` \| `"fingerprint"` | ✅        | Override the update strategy set in wrap. If not provided, uses the strategy from `HotUpdater.wrap()`. |
+| `updateStrategy`  | `"appVersion"` \| `"fingerprint"` | ✅        | Update detection strategy for this check. |
 | `requestHeaders`  | `Record<string, string>`       | ❌        | Optional headers to include in the update request.                               |
 | `requestTimeout`  | `number`                       | ❌        | Request timeout in milliseconds (default: 5000).                                 |
 | `onError`         | `(error: Error) => void`       | ❌        | Error callback.                                                                  |
 
-The `baseURL` is always from `HotUpdater.wrap()` - it cannot be overridden in `checkForUpdate`.
+The `baseURL` or `resolver` is always from `HotUpdater.wrap()` or
+`HotUpdater.init()`; it cannot be overridden in `checkForUpdate`.
 
 ## How It Works
 
-When you call `checkForUpdate`, the function uses the `baseURL` and `updateStrategy` from `HotUpdater.wrap()` to construct the appropriate endpoint URL:
+When you call `checkForUpdate`, the function uses the configured `baseURL` and
+the provided `updateStrategy` to construct the appropriate endpoint URL:
 
 * For `updateStrategy: "appVersion"`: `GET {baseURL}/app-version/:platform/:appVersion/:channel/:minBundleId/:bundleId`
 * For `updateStrategy: "fingerprint"`: `GET {baseURL}/fingerprint/:platform/:fingerprintHash/:channel/:minBundleId/:bundleId`

--- a/docs/content/docs/react-native-api/init.mdx
+++ b/docs/content/docs/react-native-api/init.mdx
@@ -1,0 +1,118 @@
+---
+title: "init"
+description: "`HotUpdater.init` initializes HotUpdater for manual update flows without wrapping a React component."
+icon: Settings2
+---
+
+## Usage
+
+Use `HotUpdater.init` when you want a fully custom update flow and cannot, or do
+not want to, wrap your root component with `HotUpdater.wrap`. Call it once when
+your runtime considers the app ready.
+
+`HotUpdater.init` has the same initialization effect as
+`HotUpdater.wrap({ updateMode: "manual" })(App)`: it configures the resolver,
+stores shared request options, and runs the app-ready notification used by crash
+recovery and rollback tracking.
+
+```tsx
+import { HotUpdater } from "@hot-updater/react-native";
+
+void HotUpdater.init({
+  baseURL: "<your-update-server-url>",
+  updateMode: "manual",
+  requestHeaders: {
+    Authorization: "Bearer <your-access-token>",
+  },
+});
+```
+
+After initialization, call `HotUpdater.checkForUpdate()` wherever your runtime
+or app state says it is safe to check.
+
+```tsx
+const updateInfo = await HotUpdater.checkForUpdate({
+  updateStrategy: "appVersion",
+});
+
+if (!updateInfo) {
+  return;
+}
+
+await updateInfo.updateBundle();
+
+if (updateInfo.shouldForceUpdate) {
+  await HotUpdater.reload();
+}
+```
+
+## With a Custom Resolver
+
+Use `resolver` when your update check or app-ready notification does not use the
+default Hot Updater endpoint shape.
+
+```tsx
+import { HotUpdater } from "@hot-updater/react-native";
+
+void HotUpdater.init({
+  updateMode: "manual",
+  resolver: {
+    async checkUpdate(params) {
+      const response = await fetch("https://api.example.com/updates/check", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...params.requestHeaders,
+        },
+        body: JSON.stringify(params),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      return response.json();
+    },
+    async notifyAppReady(params) {
+      await fetch("https://api.example.com/updates/ready", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...params.requestHeaders,
+        },
+        body: JSON.stringify(params),
+      });
+
+      return undefined;
+    },
+  },
+});
+```
+
+## Configuration Reference
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `baseURL` | `string` | Yes* | Your update server URL |
+| `resolver` | `HotUpdaterResolver` | Yes* | Custom update-check and app-ready behavior |
+| `updateMode` | `"manual"` | Yes | `init` is only for manual flows |
+| `requestHeaders` | `Record<string, string>` | No | Shared headers used by update checks and app-ready notifications |
+| `requestTimeout` | `number` | No | Request timeout in milliseconds (default: 5000) |
+| `onNotifyAppReady` | `(result) => void` | No | Callback invoked after native app-ready state is read |
+
+\*Either `baseURL` or `resolver` must be provided.
+
+## When to Use init
+
+Use `HotUpdater.init` when another runtime owns the root component, when you
+need to initialize before rendering, or when your app has a custom shell that
+does not make a root HOC convenient.
+
+Use `HotUpdater.wrap` when you want Hot Updater to manage the root component
+lifecycle directly, especially for automatic update checks with a fallback UI.
+
+## Related
+
+- [`HotUpdater.wrap()`](/docs/react-native-api/wrap)
+- [`HotUpdater.checkForUpdate()`](/docs/react-native-api/checkForUpdate)
+- [Custom Update Logic](/docs/guides/custom-update-logic)

--- a/docs/content/docs/react-native-api/meta.json
+++ b/docs/content/docs/react-native-api/meta.json
@@ -4,6 +4,7 @@
   "icon": "Smartphone",
   "pages": [
     "wrap",
+    "init",
     "checkForUpdate",
     "reload",
     "setReloadBehavior",

--- a/docs/content/docs/react-native-api/wrap.mdx
+++ b/docs/content/docs/react-native-api/wrap.mdx
@@ -6,7 +6,10 @@ icon: Package
 
 ## Usage
 
-> **Important:** `HotUpdater.wrap` is **required** for all apps. It enables automatic crash detection and rollback. All HotUpdater methods will throw an error if wrap is not used.
+> **Important:** Configure Hot Updater with either `HotUpdater.wrap` or
+> [`HotUpdater.init`](/docs/react-native-api/init) before calling update APIs.
+> This enables automatic crash detection and rollback. Update methods will
+> throw an error if neither API is used.
 
 `HotUpdater.wrap` supports two usage patterns:
 
@@ -57,6 +60,19 @@ export default HotUpdater.wrap({ // [!code hl:3]
   baseURL: "<your-update-server-url>",
   updateMode: "manual",
 })(App);
+```
+
+If another runtime owns the root component, use
+[`HotUpdater.init`](/docs/react-native-api/init) instead. It has the same
+initialization effect as manual `wrap` without returning a React HOC.
+
+```tsx
+import { HotUpdater } from "@hot-updater/react-native";
+
+void HotUpdater.init({
+  baseURL: "<your-update-server-url>",
+  updateMode: "manual",
+});
 ```
 
 Then use `checkForUpdate` or `updateBundle` manually when needed:
@@ -115,6 +131,7 @@ Available in both automatic and manual modes:
 | `resolver` | `HotUpdaterResolver` | Yes* | Custom network operations (advanced) |
 | `requestHeaders` | `Record<string, string>` | No | Custom HTTP headers for update requests |
 | `requestTimeout` | `number` | No | Request timeout in milliseconds (default: 5000) |
+| `onNotifyAppReady` | `(result) => void` | No | Callback invoked after native app-ready state is read |
 
 \*Either `baseURL` or `resolver` must be provided (mutually exclusive)
 

--- a/packages/react-native/src/index.spec.ts
+++ b/packages/react-native/src/index.spec.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addListener: vi.fn(() => () => {}),
+  checkForUpdate: vi.fn(),
+  clearCrashHistory: vi.fn(() => true),
+  createDefaultResolver: vi.fn(),
+  getAppVersion: vi.fn(() => "1.0.0"),
+  getBaseURL: vi.fn(() => null),
+  getBundleId: vi.fn(() => "bundle-id"),
+  getChannel: vi.fn(() => "production"),
+  getCohort: vi.fn(() => "123"),
+  getCrashHistory: vi.fn(() => []),
+  getDefaultChannel: vi.fn(() => "production"),
+  getFingerprintHash: vi.fn(() => null),
+  getManifest: vi.fn(() => null),
+  getMinBundleId: vi.fn(() => "min-bundle-id"),
+  init: vi.fn(),
+  isChannelSwitched: vi.fn(() => false),
+  reload: vi.fn(),
+  resetChannel: vi.fn(),
+  setCohort: vi.fn(),
+  setReloadBehavior: vi.fn(),
+  updateBundle: vi.fn(),
+  wrap: vi.fn(),
+}));
+
+vi.mock("./DefaultResolver", () => ({
+  createDefaultResolver: mocks.createDefaultResolver,
+}));
+
+vi.mock("./checkForUpdate", () => ({
+  checkForUpdate: mocks.checkForUpdate,
+}));
+
+vi.mock("./native", () => ({
+  addListener: mocks.addListener,
+  clearCrashHistory: mocks.clearCrashHistory,
+  getAppVersion: mocks.getAppVersion,
+  getBaseURL: mocks.getBaseURL,
+  getBundleId: mocks.getBundleId,
+  getChannel: mocks.getChannel,
+  getCohort: mocks.getCohort,
+  getCrashHistory: mocks.getCrashHistory,
+  getDefaultChannel: mocks.getDefaultChannel,
+  getFingerprintHash: mocks.getFingerprintHash,
+  getManifest: mocks.getManifest,
+  getMinBundleId: mocks.getMinBundleId,
+  isChannelSwitched: mocks.isChannelSwitched,
+  reload: mocks.reload,
+  resetChannel: mocks.resetChannel,
+  setCohort: mocks.setCohort,
+  setReloadBehavior: mocks.setReloadBehavior,
+  updateBundle: mocks.updateBundle,
+}));
+
+vi.mock("./wrap", () => ({
+  init: mocks.init,
+  wrap: mocks.wrap,
+}));
+
+const importHotUpdater = async () => {
+  const { HotUpdater } = await import("./index");
+  return HotUpdater;
+};
+
+describe("HotUpdater client initialization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    for (const mock of Object.values(mocks)) {
+      mock.mockReset();
+    }
+
+    mocks.addListener.mockReturnValue(() => {});
+    mocks.checkForUpdate.mockResolvedValue(null);
+    mocks.createDefaultResolver.mockImplementation((baseURL: string) => ({
+      baseURL,
+      checkUpdate: vi.fn(),
+      notifyAppReady: vi.fn(),
+    }));
+    mocks.getBaseURL.mockReturnValue(null);
+    mocks.init.mockReturnValue(undefined);
+    mocks.wrap.mockReturnValue((Component: unknown) => Component);
+  });
+
+  it("initializes manual update flows without wrapping a component", async () => {
+    const resolver = {
+      checkUpdate: vi.fn(),
+      notifyAppReady: vi.fn(),
+    };
+    mocks.createDefaultResolver.mockReturnValue(resolver);
+
+    const HotUpdater = await importHotUpdater();
+
+    const result = HotUpdater.init({
+      baseURL: "https://updates.example.com",
+      requestHeaders: {
+        Authorization: "Bearer token",
+      },
+      requestTimeout: 1000,
+      updateMode: "manual",
+    });
+
+    expect(result).toBeUndefined();
+    expect(mocks.createDefaultResolver).toHaveBeenCalledWith(
+      "https://updates.example.com",
+    );
+    expect(mocks.init).toHaveBeenCalledWith({
+      requestHeaders: {
+        Authorization: "Bearer token",
+      },
+      requestTimeout: 1000,
+      resolver,
+      updateMode: "manual",
+    });
+  });
+
+  it("uses init configuration for later manual update checks", async () => {
+    const resolver = {
+      checkUpdate: vi.fn(),
+      notifyAppReady: vi.fn(),
+    };
+    mocks.createDefaultResolver.mockReturnValue(resolver);
+
+    const HotUpdater = await importHotUpdater();
+
+    HotUpdater.init({
+      baseURL: "https://updates.example.com",
+      requestHeaders: {
+        Authorization: "Bearer token",
+      },
+      requestTimeout: 1000,
+      updateMode: "manual",
+    });
+
+    await HotUpdater.checkForUpdate({
+      requestHeaders: {
+        "X-Runtime": "secondary",
+      },
+      updateStrategy: "appVersion",
+    });
+
+    expect(mocks.checkForUpdate).toHaveBeenCalledWith({
+      requestHeaders: {
+        Authorization: "Bearer token",
+        "X-Runtime": "secondary",
+      },
+      requestTimeout: 1000,
+      resolver,
+      updateStrategy: "appVersion",
+    });
+  });
+
+  it("points users to wrap or init when methods are called too early", async () => {
+    const HotUpdater = await importHotUpdater();
+
+    expect(() =>
+      HotUpdater.checkForUpdate({
+        updateStrategy: "appVersion",
+      }),
+    ).toThrow("requires HotUpdater.wrap() or HotUpdater.init() to be used");
+  });
+
+  it("rejects automatic update mode for init at runtime", async () => {
+    const HotUpdater = await importHotUpdater();
+
+    expect(() =>
+      HotUpdater.init({
+        baseURL: "https://updates.example.com",
+        updateMode: "auto",
+        updateStrategy: "appVersion",
+      } as never),
+    ).toThrow('HotUpdater.init() only supports updateMode: "manual"');
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -27,7 +27,13 @@ import {
 } from "./native";
 import { hotUpdaterStore } from "./store";
 import type { HotUpdaterResolver } from "./types";
-import { type HotUpdaterOptions, type InternalWrapOptions, wrap } from "./wrap";
+import {
+  type HotUpdaterOptions,
+  init,
+  type InternalWrapOptions,
+  type ManualUpdateOptions,
+  wrap,
+} from "./wrap";
 
 export type {
   CustomReloadHandler,
@@ -48,6 +54,7 @@ export {
   type SignatureVerificationFailure,
 } from "./types";
 export type { HotUpdaterOptions, RunUpdateProcessResponse } from "./wrap";
+export type { ManualUpdateOptions as HotUpdaterInitOptions } from "./wrap";
 
 /**
  * Register getBaseURL to global objects for use without imports.
@@ -81,23 +88,88 @@ function createHotUpdaterClient() {
     resolver: null,
   };
 
+  const normalizeOptions = (
+    options: HotUpdaterOptions,
+    apiName: "init" | "wrap",
+  ): InternalWrapOptions => {
+    if ("baseURL" in options && options.baseURL) {
+      const { baseURL, ...rest } = options;
+      return {
+        ...rest,
+        resolver: createDefaultResolver(baseURL),
+      };
+    }
+
+    if ("resolver" in options && options.resolver) {
+      return options;
+    }
+
+    const baseURLExample =
+      apiName === "wrap"
+        ? `  export default HotUpdater.wrap({\n` +
+          `    baseURL: "<your-update-server-url>",\n` +
+          `    updateStrategy: "appVersion",\n` +
+          `    updateMode: "auto"\n` +
+          `  })(App);\n\n`
+        : `  HotUpdater.init({\n` +
+          `    baseURL: "<your-update-server-url>",\n` +
+          `    updateMode: "manual"\n` +
+          `  });\n\n`;
+
+    const resolverExample =
+      apiName === "wrap"
+        ? `  export default HotUpdater.wrap({\n` +
+          `    resolver: {\n` +
+          `      checkUpdate: async (params) => { /* custom logic */ },\n` +
+          `      notifyAppReady: async (params) => { /* custom logic */ }\n` +
+          `    },\n` +
+          `    updateMode: "manual"\n` +
+          `  })(App);\n\n`
+        : `  HotUpdater.init({\n` +
+          `    resolver: {\n` +
+          `      checkUpdate: async (params) => { /* custom logic */ },\n` +
+          `      notifyAppReady: async (params) => { /* custom logic */ }\n` +
+          `    },\n` +
+          `    updateMode: "manual"\n` +
+          `  });\n\n`;
+
+    throw new Error(
+      `[HotUpdater] Either baseURL or resolver must be provided.\n\n` +
+        `Option 1: Using baseURL (recommended for most cases)\n` +
+        baseURLExample +
+        `Option 2: Using custom resolver (advanced)\n` +
+        resolverExample +
+        `For more information, visit: https://hot-updater.dev/docs/react-native-api/${apiName}`,
+    );
+  };
+
+  const configureGlobal = (
+    normalizedOptions: InternalWrapOptions,
+    options: HotUpdaterOptions,
+  ) => {
+    globalConfig.resolver = normalizedOptions.resolver;
+    globalConfig.requestHeaders = options.requestHeaders;
+    globalConfig.requestTimeout = options.requestTimeout;
+  };
+
   const ensureGlobalResolver = (methodName: string) => {
     if (!globalConfig.resolver) {
       throw new Error(
-        `[HotUpdater] ${methodName} requires HotUpdater.wrap() to be used.\n\n` +
-          `To fix this issue, wrap your root component with HotUpdater.wrap():\n\n` +
-          `Option 1: With automatic updates\n` +
+        `[HotUpdater] ${methodName} requires HotUpdater.wrap() or HotUpdater.init() to be used.\n\n` +
+          `To fix this issue, configure HotUpdater before calling ${methodName}:\n\n` +
+          `Option 1: With HotUpdater.wrap()\n` +
           `  export default HotUpdater.wrap({\n` +
           `    baseURL: "<your-update-server-url>",\n` +
           `    updateStrategy: "appVersion",\n` +
           `    updateMode: "auto"\n` +
           `  })(App);\n\n` +
-          `Option 2: Manual updates only (custom flow)\n` +
-          `  export default HotUpdater.wrap({\n` +
+          `Option 2: With HotUpdater.init() for custom runtimes\n` +
+          `  HotUpdater.init({\n` +
           `    baseURL: "<your-update-server-url>",\n` +
           `    updateMode: "manual"\n` +
-          `  })(App);\n\n` +
-          `For more information, visit: https://hot-updater.dev/docs/react-native-api/wrap`,
+          `  });\n\n` +
+          `For more information, visit: https://hot-updater.dev/docs/react-native-api/wrap ` +
+          `or https://hot-updater.dev/docs/react-native-api/init`,
       );
     }
     return globalConfig.resolver;
@@ -129,42 +201,31 @@ function createHotUpdaterClient() {
      * ```
      */
     wrap: (options: HotUpdaterOptions) => {
-      let normalizedOptions: InternalWrapOptions;
+      const normalizedOptions = normalizeOptions(options, "wrap");
+      configureGlobal(normalizedOptions, options);
 
-      if ("baseURL" in options && options.baseURL) {
-        const { baseURL, ...rest } = options;
-        normalizedOptions = {
-          ...rest,
-          resolver: createDefaultResolver(baseURL),
-        };
-      } else if ("resolver" in options && options.resolver) {
-        normalizedOptions = options;
-      } else {
+      return wrap(normalizedOptions);
+    },
+
+    /**
+     * Initializes HotUpdater without wrapping a React component.
+     *
+     * Use this for manual update flows in runtimes where a root component HOC
+     * is not convenient. It has the same initialization effect as
+     * `HotUpdater.wrap({ updateMode: "manual" })(App)`.
+     */
+    init: (options: ManualUpdateOptions): void => {
+      const normalizedOptions = normalizeOptions(options, "init");
+      if (normalizedOptions.updateMode !== "manual") {
         throw new Error(
-          `[HotUpdater] Either baseURL or resolver must be provided.\n\n` +
-            `Option 1: Using baseURL (recommended for most cases)\n` +
-            `  export default HotUpdater.wrap({\n` +
-            `    baseURL: "<your-update-server-url>",\n` +
-            `    updateStrategy: "appVersion",\n` +
-            `    updateMode: "auto"\n` +
-            `  })(App);\n\n` +
-            `Option 2: Using custom resolver (advanced)\n` +
-            `  export default HotUpdater.wrap({\n` +
-            `    resolver: {\n` +
-            `      checkUpdate: async (params) => { /* custom logic */ },\n` +
-            `      notifyAppReady: async (params) => { /* custom logic */ }\n` +
-            `    },\n` +
-            `    updateMode: "manual"\n` +
-            `  })(App);\n\n` +
-            `For more information, visit: https://hot-updater.dev/docs/react-native-api/wrap`,
+          `[HotUpdater] HotUpdater.init() only supports updateMode: "manual". ` +
+            `Use HotUpdater.wrap() for automatic updates.`,
         );
       }
 
-      globalConfig.resolver = normalizedOptions.resolver;
-      globalConfig.requestHeaders = options.requestHeaders;
-      globalConfig.requestTimeout = options.requestTimeout;
+      configureGlobal(normalizedOptions, options);
 
-      return wrap(normalizedOptions);
+      init(normalizedOptions);
     },
 
     /**

--- a/packages/react-native/src/wrap.spec.ts
+++ b/packages/react-native/src/wrap.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addListener: vi.fn(() => () => {}),
+  checkForUpdate: vi.fn(),
+  getBundleId: vi.fn(() => "bundle-id"),
+  notifyAppReady: vi.fn(() => ({ status: "STABLE" })),
+  reload: vi.fn(),
+}));
+
+vi.mock("./checkForUpdate", () => ({
+  checkForUpdate: mocks.checkForUpdate,
+}));
+
+vi.mock("./native", () => ({
+  addListener: mocks.addListener,
+  getBundleId: mocks.getBundleId,
+  notifyAppReady: mocks.notifyAppReady,
+  reload: mocks.reload,
+}));
+
+describe("HotUpdater wrap initialization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+
+    for (const mock of Object.values(mocks)) {
+      mock.mockReset();
+    }
+
+    mocks.checkForUpdate.mockResolvedValue(null);
+    mocks.addListener.mockReturnValue(() => {});
+    mocks.getBundleId.mockReturnValue("bundle-id");
+    mocks.notifyAppReady.mockReturnValue({ status: "STABLE" });
+  });
+
+  it("returns void from init and defers notifyAppReady to the next frame", async () => {
+    vi.useFakeTimers();
+
+    const requestAnimationFrame = vi.fn(
+      (callback: (timestamp: number) => void) => {
+        setTimeout(() => callback(0), 0);
+        return 1;
+      },
+    );
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrame);
+
+    const resolver = {
+      checkUpdate: vi.fn(),
+      notifyAppReady: vi.fn().mockResolvedValue(undefined),
+    };
+    const { init } = await import("./wrap");
+
+    const result = init({
+      resolver,
+      requestHeaders: {
+        Authorization: "Bearer token",
+      },
+      requestTimeout: 1000,
+      updateMode: "manual",
+    });
+
+    expect(result).toBeUndefined();
+    expect(mocks.notifyAppReady).not.toHaveBeenCalled();
+    expect(resolver.notifyAppReady).not.toHaveBeenCalled();
+
+    expect(requestAnimationFrame).toHaveBeenCalled();
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(mocks.notifyAppReady).toHaveBeenCalledWith();
+    expect(resolver.notifyAppReady).toHaveBeenCalledWith({
+      status: "STABLE",
+      crashedBundleId: undefined,
+      requestHeaders: {
+        Authorization: "Bearer token",
+      },
+      requestTimeout: 1000,
+    });
+  });
+});

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -204,9 +204,29 @@ type InternalManualUpdateOptions = InternalCommonOptions & {
   updateMode: "manual";
 };
 
+export type InternalInitOptions = InternalManualUpdateOptions;
+
 export type InternalWrapOptions =
   | InternalAutoUpdateOptions
   | InternalManualUpdateOptions;
+
+type RequestAnimationFrame = (callback: (timestamp: number) => void) => number;
+
+const waitForNextFrame = () =>
+  new Promise<void>((resolve) => {
+    const requestAnimationFrame = (
+      globalThis as typeof globalThis & {
+        requestAnimationFrame?: RequestAnimationFrame;
+      }
+    )?.requestAnimationFrame;
+
+    if (requestAnimationFrame) {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+
+    void Promise.resolve().then(resolve);
+  });
 
 /**
  * Helper function to handle notifyAppReady flow
@@ -217,6 +237,8 @@ const handleNotifyAppReady = async (options: {
   requestTimeout?: number;
   onNotifyAppReady?: (result: NotifyAppReadyResult) => void;
 }): Promise<void> => {
+  await waitForNextFrame();
+
   try {
     const nativeResult = nativeNotifyAppReady();
 
@@ -239,6 +261,10 @@ const handleNotifyAppReady = async (options: {
     console.warn("[HotUpdater] Failed to notify app ready:", e);
   }
 };
+
+export function init(options: InternalInitOptions): void {
+  void handleNotifyAppReady(options);
+}
 
 export function wrap<P extends React.JSX.IntrinsicAttributes = object>(
   options: InternalWrapOptions,


### PR DESCRIPTION
## Summary
- Add HotUpdater.init for manual/custom runtimes that cannot wrap their root component
- Share resolver configuration and notify-app-ready behavior with manual HotUpdater.wrap
- Update early-use errors and docs to point users to HotUpdater.wrap or HotUpdater.init

## Validation
- pnpm --filter @hot-updater/react-native test -- src/index.spec.ts
- pnpm --filter @hot-updater/react-native test:type
- pnpm exec oxfmt --check packages/react-native/src/index.ts packages/react-native/src/wrap.tsx packages/react-native/src/index.spec.ts
- pnpm exec oxlint packages/react-native/src/index.ts packages/react-native/src/wrap.tsx packages/react-native/src/index.spec.ts
- pnpm --filter @hot-updater/react-native build
- pnpm --filter hot-updater-docs test:type
- pnpm --filter hot-updater-docs build

## Not tested
- Native device OTA runtime smoke test