### PR TITLE
feat(cli): add `hot-updater bundle promote` command

### DIFF
--- a/.changeset/cli-promote-command.md
+++ b/.changeset/cli-promote-command.md
@@ -1,0 +1,18 @@
+---
+"hot-updater": patch
+---
+
+feat(cli): add `bundle promote` command
+
+Move or copy a bundle to a different channel from the CLI, mirroring the console's Promote-to-Channel UI.
+
+```
+hot-updater bundle promote <bundle-id> -t <target-channel> [-a copy|move] [-y]
+```
+
+- The bundle id is positional — the bundle carries its own source channel, so no `--source` flag is needed.
+- `--action copy` (default) creates a new bundle id on the target channel and leaves the original in place — CodePush-promote semantics.
+- `--action move` updates the bundle's `channel` column without creating a new bundle (D1-only mutation; no R2 work).
+- Wraps the `promoteBundle` function from `@hot-updater/cli-tools`, so the CLI and console use one implementation. Surfaces the underlying `LEGACY_BUNDLE_ERROR` and signing/storage configuration errors directly.
+
+Pre-flight: rejects bundle-already-on-target, missing bundle id, empty target. Refuses to mutate without `-y` in a non-TTY shell. Lives under the `bundle` namespace alongside `bundle list/disable/enable` since the noun being mutated is the bundle (its channel attribute, or a copy of it).

--- a/packages/hot-updater/src/commands/promote.spec.ts
+++ b/packages/hot-updater/src/commands/promote.spec.ts
@@ -1,0 +1,285 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCli,
+  mockDatabasePlugin,
+  mockStoragePlugin,
+  mockPrintBanner,
+  mockPromoteBundle,
+} = vi.hoisted(() => {
+  const mockDatabasePlugin = {
+    appendBundle: vi.fn(),
+    commitBundle: vi.fn(),
+    deleteBundle: vi.fn(),
+    getBundleById: vi.fn(),
+    getBundles: vi.fn(),
+    getChannels: vi.fn(),
+    name: "mock-database",
+    onUnmount: vi.fn(),
+    updateBundle: vi.fn(),
+  };
+  const mockStoragePlugin = {
+    name: "mock-storage",
+    upload: vi.fn(),
+    delete: vi.fn(),
+    supportedProtocol: "s3",
+    getDownloadUrl: vi.fn(),
+  };
+  const mockCli = {
+    loadConfig: vi.fn(),
+    p: {
+      confirm: vi.fn(),
+      isCancel: vi.fn(() => false),
+      log: {
+        error: vi.fn(),
+        info: vi.fn(),
+        message: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  };
+  const mockPrintBanner = vi.fn();
+  const mockPromoteBundle = vi.fn();
+  return {
+    mockCli,
+    mockDatabasePlugin,
+    mockStoragePlugin,
+    mockPrintBanner,
+    mockPromoteBundle,
+  };
+});
+
+vi.mock("@hot-updater/cli-tools", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@hot-updater/cli-tools")>();
+  return {
+    ...actual,
+    loadConfig: mockCli.loadConfig,
+    p: mockCli.p,
+    promoteBundle: mockPromoteBundle,
+  };
+});
+
+vi.mock("@/utils/printBanner", () => ({
+  printBanner: mockPrintBanner,
+}));
+
+const buildBundle = (overrides: Partial<Bundle> = {}): Bundle => ({
+  id: "0195a408-8f13-7d9b-8df4-123456789abc",
+  channel: "internal",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeefcafe",
+  message: "msg",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+  ...overrides,
+});
+
+const stubLoadedConfig = () => {
+  mockCli.loadConfig.mockResolvedValue({
+    database: vi.fn().mockResolvedValue(mockDatabasePlugin),
+    storage: vi.fn().mockResolvedValue(mockStoragePlugin),
+  } as never);
+};
+
+const expectExit = (code: number) => {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((c) => {
+    throw new Error(`process.exit(${c})`);
+  });
+  return { exitSpy, code };
+};
+
+const setupConsoleSpies = () => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+};
+
+describe("handlePromote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubLoadedConfig();
+    setupConsoleSpies();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("copies the named bundle to the target channel", async () => {
+    const bundle = buildBundle({ id: "src-1", channel: "internal" });
+    const promoted = buildBundle({ id: "new-1", channel: "beta" });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(bundle);
+    mockPromoteBundle.mockResolvedValue(promoted);
+
+    const { handlePromote } = await import("./promote");
+    await handlePromote("src-1", {
+      target: "beta",
+      action: "copy",
+      yes: true,
+    });
+
+    expect(mockDatabasePlugin.getBundleById).toHaveBeenCalledWith("src-1");
+    expect(mockPromoteBundle).toHaveBeenCalledWith(
+      {
+        action: "copy",
+        bundleId: "src-1",
+        targetChannel: "beta",
+      },
+      expect.objectContaining({
+        databasePlugin: mockDatabasePlugin,
+        storagePlugin: mockStoragePlugin,
+      }),
+    );
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Copied bundle to beta"),
+    );
+  });
+
+  it("moves the named bundle to the target channel", async () => {
+    const bundle = buildBundle({ id: "src-1", channel: "internal" });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(bundle);
+    mockPromoteBundle.mockResolvedValue({ ...bundle, channel: "beta" });
+
+    const { handlePromote } = await import("./promote");
+    await handlePromote("src-1", {
+      target: "beta",
+      action: "move",
+      yes: true,
+    });
+
+    expect(mockPromoteBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "move", bundleId: "src-1" }),
+      expect.anything(),
+    );
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Moved bundle to beta"),
+    );
+  });
+
+  it("defaults --action to copy when omitted", async () => {
+    const bundle = buildBundle({ id: "src-1" });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(bundle);
+    mockPromoteBundle.mockResolvedValue({
+      ...bundle,
+      id: "new-1",
+      channel: "beta",
+    });
+
+    const { handlePromote } = await import("./promote");
+    await handlePromote("src-1", { target: "beta", yes: true });
+
+    expect(mockPromoteBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "copy" }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects when the bundle's channel equals --target", async () => {
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "src-1", channel: "beta" }),
+    );
+    const { exitSpy } = expectExit(1);
+    const { handlePromote } = await import("./promote");
+    await expect(
+      handlePromote("src-1", { target: "beta", yes: true }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockPromoteBundle).not.toHaveBeenCalled();
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('already on channel "beta"'),
+    );
+  });
+
+  it("exits 1 when the bundle id does not exist", async () => {
+    mockDatabasePlugin.getBundleById.mockResolvedValue(null);
+    const { exitSpy } = expectExit(1);
+    const { handlePromote } = await import("./promote");
+    await expect(
+      handlePromote("missing", { target: "beta", yes: true }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockPromoteBundle).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 when --target is empty/whitespace", async () => {
+    const { exitSpy } = expectExit(1);
+    const { handlePromote } = await import("./promote");
+    await expect(
+      handlePromote("src-1", { target: "  ", yes: true }),
+    ).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockDatabasePlugin.getBundleById).not.toHaveBeenCalled();
+    expect(mockPromoteBundle).not.toHaveBeenCalled();
+  });
+
+  it("aborts with exit code 2 when interactive confirmation declines", async () => {
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "src-1" }),
+    );
+    mockCli.p.confirm.mockResolvedValueOnce(false);
+
+    const { exitSpy } = expectExit(2);
+    const { handlePromote } = await import("./promote");
+    await expect(handlePromote("src-1", { target: "beta" })).rejects.toThrow(
+      "process.exit(2)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    expect(mockPromoteBundle).not.toHaveBeenCalled();
+
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("refuses to mutate without -y in a non-TTY shell", async () => {
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "src-1" }),
+    );
+
+    const { exitSpy } = expectExit(1);
+    const { handlePromote } = await import("./promote");
+    await expect(handlePromote("src-1", { target: "beta" })).rejects.toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    if (isTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+    }
+  });
+
+  it("propagates promoteBundle errors and calls onUnmount", async () => {
+    mockDatabasePlugin.getBundleById.mockResolvedValue(
+      buildBundle({ id: "src-1" }),
+    );
+    mockPromoteBundle.mockRejectedValue(new Error("storage plugin failed"));
+
+    const { handlePromote } = await import("./promote");
+    await expect(
+      handlePromote("src-1", { target: "beta", yes: true }),
+    ).rejects.toThrow("storage plugin failed");
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalled();
+  });
+});

--- a/packages/hot-updater/src/commands/promote.ts
+++ b/packages/hot-updater/src/commands/promote.ts
@@ -1,0 +1,127 @@
+import { loadConfig, p, promoteBundle } from "@hot-updater/cli-tools";
+import type {
+  Bundle,
+  DatabasePlugin,
+  StoragePlugin,
+} from "@hot-updater/plugin-core";
+
+import { printBanner } from "@/utils/printBanner";
+
+import { ui } from "../utils/cli-ui";
+
+export type PromoteAction = "copy" | "move";
+
+export interface PromoteOptions {
+  target: string;
+  action?: PromoteAction;
+  yes?: boolean;
+}
+
+const safeOnUnmount = async (databasePlugin: DatabasePlugin): Promise<void> => {
+  try {
+    await databasePlugin.onUnmount?.();
+  } catch (err) {
+    p.log.warn(
+      `Database plugin onUnmount failed (cleanup-only, original error preserved): ${
+        (err as Error)?.message ?? String(err)
+      }`,
+    );
+  }
+};
+
+const summarizePlan = (params: {
+  target: string;
+  action: PromoteAction;
+  bundle: Bundle;
+}): string =>
+  ui.block(
+    `Promote (${params.action})`,
+    [
+      ui.kv("Bundle", ui.id(params.bundle.id)),
+      ui.kv("Platform", ui.platform(params.bundle.platform)),
+      ui.kv("From", ui.channel(params.bundle.channel)),
+      ui.kv("To", ui.channel(params.target)),
+      params.bundle.targetAppVersion
+        ? ui.kv("Version", ui.version(params.bundle.targetAppVersion))
+        : ui.kv("Version", ui.muted("-")),
+      params.bundle.message ? ui.kv("Message", params.bundle.message) : null,
+    ].filter((line): line is string => line !== null),
+  );
+
+export const handlePromote = async (
+  bundleId: string,
+  options: PromoteOptions,
+) => {
+  printBanner();
+
+  const action: PromoteAction = options.action ?? "copy";
+  const target = options.target.trim();
+
+  if (!target) {
+    p.log.error("--target is required.");
+    process.exit(1);
+  }
+
+  const config = await loadConfig(null);
+  const databasePlugin: DatabasePlugin = await config.database();
+  let storagePlugin: StoragePlugin | null = null;
+  try {
+    storagePlugin = await config.storage();
+  } catch {
+    storagePlugin = null;
+  }
+
+  try {
+    const bundle = await databasePlugin.getBundleById(bundleId);
+    if (!bundle) {
+      p.log.error(`No bundle with id ${bundleId}.`);
+      process.exit(1);
+    }
+    if (bundle.channel === target) {
+      p.log.error(`Bundle ${bundleId} is already on channel "${target}".`);
+      process.exit(1);
+    }
+
+    p.log.message(summarizePlan({ target, action, bundle }));
+
+    if (!options.yes) {
+      if (!process.stdin.isTTY) {
+        p.log.error(
+          "Cannot prompt for confirmation in a non-interactive shell. Re-run with -y, or use a TTY.",
+        );
+        process.exit(1);
+      }
+      const confirmed = await p.confirm({
+        message: `${action === "copy" ? "Copy" : "Move"} ${bundle.id} from ${bundle.channel} to ${target}?`,
+        initialValue: false,
+      });
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.log.info("Aborted.");
+        process.exit(2);
+      }
+    }
+
+    const promoted = await promoteBundle(
+      {
+        action,
+        bundleId: bundle.id,
+        targetChannel: target,
+      },
+      {
+        config,
+        databasePlugin,
+        storagePlugin,
+      },
+    );
+
+    if (action === "copy") {
+      p.log.success(`Copied bundle to ${target}.`);
+      p.log.info(`  ${ui.id(promoted.id)} (new bundle id)`);
+    } else {
+      p.log.success(`Moved bundle to ${target}.`);
+      p.log.info(`  ${ui.id(promoted.id)}`);
+    }
+  } finally {
+    await safeOnUnmount(databasePlugin);
+  }
+};

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -43,6 +43,7 @@ import {
 import { generate } from "./commands/generate";
 import { keysExportPublic, keysGenerate, keysRemove } from "./commands/keys";
 import { migrate } from "./commands/migrate";
+import { handlePromote } from "./commands/promote";
 import { handleRollback } from "./commands/rollback";
 
 const DEFAULT_CHANNEL = "production";
@@ -126,6 +127,31 @@ bundleCommand
   .option("-y, --yes", "skip confirmation prompt")
   .action((bundleId: string, options: { yes?: boolean }) =>
     handleBundleSetEnabled(bundleId, true, options),
+  );
+
+bundleCommand
+  .command("promote")
+  .description("Move or copy a bundle to a different channel")
+  .argument("<bundle-id>", "the id of the bundle to promote")
+  .requiredOption("-t, --target <channel>", "channel to promote the bundle to")
+  .addOption(
+    new Option(
+      "-a, --action <action>",
+      "promote action (copy creates a new bundle id; move keeps the id)",
+    )
+      .choices(["copy", "move"])
+      .default("copy"),
+  )
+  .option("-y, --yes", "skip confirmation prompt")
+  .action(
+    (
+      bundleId: string,
+      options: {
+        target: string;
+        action: "copy" | "move";
+        yes?: boolean;
+      },
+    ) => handlePromote(bundleId, options),
   );
 
 const keysCommand = program


### PR DESCRIPTION
Move or copy a bundle to a different channel from the CLI, mirroring the console's Promote-to-Channel UI.

  hot-updater bundle promote <bundle-id> -t <target> [-a copy|move] [-y]

Lives under the `bundle` namespace alongside list/disable/enable because the noun being mutated is the bundle (its channel attribute, or a copy of it). Bundle id is positional; the bundle carries its own source channel, so no --source flag is needed.

--action copy (default) creates a new bundle id on the target channel and leaves the original in place -- CodePush-promote semantics. 
--action move updates the bundle's channel column without creating a new bundle (D1-only mutation; no R2 work).

Wraps the promoteBundle function exported from @hot-updater/cli-tools so the CLI and console use one implementation. Surfaces the underlying LEGACY_BUNDLE_ERROR and signing/storage configuration errors directly.

Pre-flight: rejects bundle-already-on-target, missing bundle id, empty target. Refuses to mutate without -y in a non-TTY shell.

Part of #973 