### PR TITLE
feat(cli): `deploy` runs both platforms when -p is omitted

### DIFF
--- a/.changeset/cli-deploy-multi-platform.md
+++ b/.changeset/cli-deploy-multi-platform.md
@@ -1,0 +1,15 @@
+---
+"hot-updater": patch
+---
+
+feat(cli): `deploy` runs both platforms when `-p` is omitted
+
+`hot-updater deploy` (without `-p ios` or `-p android`) now deploys ios then android sequentially. If ios fails, android is not attempted — the channel is never left half-updated. This is the typical CI/CD invocation pattern.
+
+```
+hot-updater deploy -c dev               # ios + android, sequential, abort-on-first-failure
+hot-updater deploy -p ios -c dev        # unchanged: single platform
+hot-updater deploy -i -c dev            # unchanged: interactive prompt for one platform
+```
+
+Existing `-p ios` / `-p android` invocations are unchanged; `-i` (interactive) still prompts for a single platform. The change is purely in the no-`-p`-no-`-i` path, which previously errored with "Platform not found" — that error path is now the multi-platform deploy.

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -16,6 +16,7 @@ import {
   interactiveCommandOption,
   nativeBuildOutputCommandOption,
   nativeBuildSchemeCommandOption,
+  PLATFORMS,
   platformCommandOption,
   portCommandOption,
 } from "@/commandOptions";
@@ -226,7 +227,18 @@ program
     ),
   )
   .action(async (options: DeployOptions) => {
-    deploy(options);
+    // When neither -p nor -i is set, deploy both platforms sequentially.
+    // ios runs first; if it fails (deploy() exits the process on error),
+    // android is not attempted -- avoids leaving a channel partially
+    // updated. Existing -p ios / -p android invocations are unchanged;
+    // -i still prompts for a single platform.
+    if (options.platform || options.interactive) {
+      await deploy(options);
+      return;
+    }
+    for (const platform of PLATFORMS) {
+      await deploy({ ...options, platform });
+    }
   });
 
 program


### PR DESCRIPTION
`hot-updater deploy` without -p ios / -p android / -i now deploys ios then android sequentially. ios runs first; if it fails, android is not attempted -- the channel is never left half-updated. This is the typical CI/CD invocation pattern.

  hot-updater deploy -c dev          # ios + android sequential, abort-on-first-failure
  hot-updater deploy -p ios -c dev   # unchanged: single platform
  hot-updater deploy -i -c dev       # unchanged: interactive prompt for one platform

Existing single-platform and interactive paths are preserved. The change is in the no-p-no-i path, which previously errored with "Platform not found" -- that error path is now the multi-platform deploy.

Part of #973