### PR TITLE
fix(cli): clarify multi-platform deploy output and remove startup deprecation warning

### DIFF
--- a/.changeset/deploy-multi-platform-support.md
+++ b/.changeset/deploy-multi-platform-support.md
@@ -1,0 +1,11 @@
+---
+"hot-updater": patch
+---
+
+fix(cli): make multi-platform deploy a first-class flow
+
+`hot-updater deploy` now handles the no-`-p` path inside the deploy command
+itself instead of looping from the CLI entrypoint. This keeps the banner and
+success output consistent, makes it explicit that iOS and Android are deployed
+sequentially, and writes local bundle archives to platform-specific output
+directories so one platform no longer overwrites the other.

--- a/docs/content/docs/get-started/basic-usage.mdx
+++ b/docs/content/docs/get-started/basic-usage.mdx
@@ -507,6 +507,9 @@ Build and publish an update to your users:
 npx hot-updater deploy
 ```
 
+This default command deploys iOS first and Android second. Use `-p ios` or
+`-p android` when you want to target only one platform.
+
 Use the interactive mode for guided deployment:
 
 ```package-install

--- a/docs/content/docs/guides/deploy.mdx
+++ b/docs/content/docs/guides/deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deploy"
-description: "This command is used to deploy the update to the specified platform."
+description: "Deploy an update to one platform or both platforms sequentially."
 icon: Upload
 ---
 
@@ -20,7 +20,7 @@ Options:
   -p, --platform <platform>                    specify the platform (choices: "ios", "android")
   -t, --target-app-version <targetAppVersion>  specify the target app version (semver format e.g. 1.0.0, 1.x.x)
   -f, --force-update                           force update the app (default: false)
-  -o, --bundle-output-path <bundleOutputPath>  the path where the bundle.zip will be generated
+  -o, --bundle-output-path <bundleOutputPath>  the directory where bundle archives will be generated
   -r, --rollout <percentage>                   specify the rollout percentage for the deployed bundle (0-100) (default: 100)
   -i, --interactive                            interactive mode (default: false)
   -c, --channel <channel>                      specify the channel to deploy (default: "production")
@@ -29,6 +29,22 @@ Options:
 ```
 
 ## Usage
+
+### Default Mode
+
+When you omit `-p` and `-i`, Hot Updater deploys **iOS first, then Android**
+sequentially. If the iOS deploy fails, Android is not attempted.
+
+Run the following command:
+
+```package-install
+npx hot-updater deploy
+```
+
+- This is the default mode for CI/CD pipelines when both platforms should move
+  together.
+- Local bundle archives are written under platform-specific directories such as
+  `<bundle-output-path>/ios/bundle/` and `<bundle-output-path>/android/bundle/`.
 
 ### Interactive Mode
 
@@ -45,7 +61,7 @@ The `-i` (or `--interactive`) flag enables interactive keyboard input.
 
 ### For Continuous Deployment (CD) Pipelines
 
-Use this mode for automating deployment in CI/CD pipelines.
+Use this mode when a pipeline should deploy only one platform.
 
 Run the following command:
 
@@ -53,7 +69,7 @@ Run the following command:
 npx hot-updater deploy -p <"ios" | "android">
 ```
 
-- This mode is suitable for Continuous Deployment (CD) pipelines.
+- Use `-p` to scope the deploy to exactly one platform.
 
 ### Force Update
 
@@ -116,6 +132,9 @@ Run the following command:
 ```package-install
 npx hot-updater deploy -p <"ios" | "android"> -m "<message>"
 ```
+
+If you omit `-p`, the same message is applied to both sequential platform
+deploys.
 
 ## Force Update Flag Difference
 

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -63,7 +63,6 @@
     "fast-glob": "3.3.3",
     "jszip": "^3.10.1",
     "picocolors": "1.1.1",
-    "read-package-up": "^11.0.0",
     "semver": "^7.6.3",
     "tar": "^7.5.1",
     "workspace-tools": "^0.36.4"
@@ -152,7 +151,6 @@
     "process-nextick-args": "2.0.1",
     "protocols": "2.0.2",
     "queue-microtask": "1.2.3",
-    "read-package-up": "11.0.0",
     "read-pkg": "9.0.1",
     "readable-stream": "2.3.8",
     "reusify": "1.0.4",

--- a/packages/cli-tools/src/ensureInstallPackages.ts
+++ b/packages/cli-tools/src/ensureInstallPackages.ts
@@ -1,9 +1,14 @@
 import { ExecaError, execa } from "execa";
-import { readPackageUp } from "read-package-up";
 
 import { getCwd } from "./cwd.js";
 import { getPackageManager } from "./getPackageManager.js";
 import { p } from "./prompts.js";
+import { readPackageUp } from "./readPackageUp.js";
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
 
 export const ensureInstallPackages = async (
   packages: {
@@ -16,7 +21,7 @@ export const ensureInstallPackages = async (
 ) => {
   const { versionResolver = (pkg: string) => pkg } = options ?? {};
 
-  const pkgJson = await readPackageUp({ cwd: getCwd() });
+  const pkgJson = await readPackageUp<PackageJson>(getCwd());
 
   const dependenciesToInstall = (packages.dependencies ?? []).filter((pkg) => {
     return !pkgJson?.packageJson?.dependencies?.[pkg];

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -20,6 +20,7 @@ export * from "./log";
 export * from "./makeEnv";
 export * from "./promoteBundle";
 export * from "./prompts";
+export * from "./readPackageUp";
 export * from "./resolvePackageVersion";
 export * from "./transformEnv";
 export * from "./transformTemplate";

--- a/packages/cli-tools/src/readPackageUp.spec.ts
+++ b/packages/cli-tools/src/readPackageUp.spec.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readPackageUp } from "./readPackageUp";
+
+let tempDir = "";
+
+describe("readPackageUp", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-read-closest-package-json-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("finds the nearest package.json from a nested directory", async () => {
+    const packageJsonPath = path.join(tempDir, "package.json");
+    const nestedDir = path.join(tempDir, "apps", "example", "src");
+
+    await fs.mkdir(nestedDir, { recursive: true });
+    await fs.writeFile(
+      packageJsonPath,
+      `${JSON.stringify(
+        {
+          name: "example-app",
+          dependencies: {
+            react: "19.0.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    await expect(readPackageUp(nestedDir)).resolves.toEqual({
+      packageJson: {
+        name: "example-app",
+        dependencies: {
+          react: "19.0.0",
+        },
+      },
+      path: packageJsonPath,
+    });
+  });
+
+  it("returns undefined when no package.json exists up to the filesystem root", async () => {
+    const nestedDir = path.join(tempDir, "apps", "example", "src");
+
+    await fs.mkdir(nestedDir, { recursive: true });
+
+    await expect(readPackageUp(nestedDir)).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli-tools/src/readPackageUp.ts
+++ b/packages/cli-tools/src/readPackageUp.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface ReadPackageUpResult<T = unknown> {
+  packageJson: T;
+  path: string;
+}
+
+const isMissingPackageJsonError = (error: unknown) => {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+};
+
+export const readPackageUp = async <T = unknown>(
+  cwd: string,
+): Promise<ReadPackageUpResult<T> | undefined> => {
+  let currentDir = path.resolve(cwd);
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+
+    try {
+      const packageJson = JSON.parse(
+        await fs.readFile(packageJsonPath, "utf-8"),
+      ) as T;
+
+      return {
+        packageJson,
+        path: packageJsonPath,
+      };
+    } catch (error) {
+      if (!isMissingPackageJsonError(error)) {
+        throw error;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+
+    currentDir = parentDir;
+  }
+};

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -82,7 +82,6 @@
     "is-port-reachable": "^4.0.0",
     "open": "^10.1.0",
     "plist": "^3.1.0",
-    "read-package-up": "^11.0.0",
     "semver": "^7.6.3",
     "typescript": "6.0.2"
   },

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -174,6 +174,7 @@ import { writeBundleManifest } from "@/utils/bundleManifest";
 import { getBundleZipTargets } from "@/utils/getBundleZipTargets";
 import { getFileHashFromFile } from "@/utils/getFileHash";
 import { getLatestGitCommit } from "@/utils/git";
+import { printBanner } from "@/utils/printBanner";
 import { signBundle } from "@/utils/signing/bundleSigning";
 import { validateSigningConfig } from "@/utils/signing/validateSigningConfig";
 import { getNativeAppVersion } from "@/utils/version/getNativeAppVersion";
@@ -356,11 +357,66 @@ describe("deploy rollout wiring", () => {
     });
 
     expect(mockCli.p.note).toHaveBeenCalledWith(
-      "Channel: production\nRollout: 100%\nTarget app version: >=1.0.0 <1.1.0-0",
+      "Platform: iOS\nChannel: production\nRollout: 100%\nTarget app version: >=1.0.0 <1.1.0-0",
       "Deployment",
     );
     expect(mockCli.p.outro).toHaveBeenCalledWith(
       "🚀 Deployment Successful (bundle-123)",
+    );
+  });
+
+  it("deploys both platforms sequentially when platform is omitted", async () => {
+    mockBuildPlugin.build.mockImplementation(async ({ platform }) => ({
+      buildPath: "/mock/build",
+      bundleId: platform === "ios" ? "bundle-ios" : "bundle-android",
+      stdout: null,
+    }));
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      targetAppVersion: "1.0.x",
+    });
+
+    expect(printBanner).toHaveBeenCalledTimes(1);
+    expect(mockBuildPlugin.build.mock.calls).toEqual([
+      [{ platform: "ios" }],
+      [{ platform: "android" }],
+    ]);
+    expect(mockCli.p.note).toHaveBeenNthCalledWith(
+      1,
+      "Platform: Both (iOS, Android)\nChannel: production\nRollout: 100%\nTarget app version: >=1.0.0 <1.1.0-0",
+      "Deployment",
+    );
+    expect(mockCli.p.log.step).toHaveBeenNthCalledWith(
+      1,
+      "Deployment (iOS 1/2) • production",
+    );
+    expect(mockCli.p.log.step).toHaveBeenNthCalledWith(
+      2,
+      "Deployment (Android 2/2) • production",
+    );
+    expect(mockCli.createTarBrTargetFiles).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outfile: "/mock/cwd/.hot-updater/output/ios/bundle/bundle.tar.br",
+      }),
+    );
+    expect(mockCli.createTarBrTargetFiles).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outfile: "/mock/cwd/.hot-updater/output/android/bundle/bundle.tar.br",
+      }),
+    );
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      "✅ iOS Deployment Successful (bundle-ios)",
+    );
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      "✅ Android Deployment Successful (bundle-android)",
+    );
+    expect(mockCli.p.outro).toHaveBeenCalledWith(
+      "🚀 Deployment Successful (iOS, Android)",
     );
   });
 
@@ -414,7 +470,7 @@ describe("deploy rollout wiring", () => {
       "✅ Bundle Signing Complete",
     );
     expect(mockCli.p.note).toHaveBeenCalledWith(
-      "Channel: production\nRollout: 100%\nTarget app version: >=1.0.0 <1.1.0-0",
+      "Platform: iOS\nChannel: production\nRollout: 100%\nTarget app version: >=1.0.0 <1.1.0-0",
       "Deployment",
     );
 

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -36,6 +36,7 @@ import { validateSigningConfig } from "@/utils/signing/validateSigningConfig";
 import { getDefaultTargetAppVersion } from "@/utils/version/getDefaultTargetAppVersion";
 import { getNativeAppVersion } from "@/utils/version/getNativeAppVersion";
 
+import { PLATFORMS } from "../commandOptions";
 import { getConsolePort, openConsole } from "./console";
 
 export interface DeployOptions {
@@ -89,13 +90,102 @@ const getExtensionFromCompressStrategy = (compressStrategy: string) => {
   }
 };
 
-export const deploy = async (options: DeployOptions) => {
-  printBanner();
+const getPlatformName = (platform: Platform) =>
+  platform === "ios" ? "iOS" : "Android";
 
+const getDeployPlatforms = async (
+  options: DeployOptions,
+): Promise<Platform[] | null> => {
+  if (options.platform) {
+    return [options.platform];
+  }
+
+  if (!options.interactive) {
+    return [...PLATFORMS];
+  }
+
+  const platform = await getPlatform("Which platform do you want to deploy?");
+  if (p.isCancel(platform)) {
+    return null;
+  }
+
+  if (!platform) {
+    p.log.error(
+      "Platform not found. -p <ios | android> or --platform <ios | android>",
+    );
+    return null;
+  }
+
+  return [platform];
+};
+
+const getBundleOutputRoot = ({
+  cwd,
+  outputPath,
+  platform,
+  multiPlatform,
+}: {
+  cwd: string;
+  outputPath: string;
+  platform: Platform;
+  multiPlatform: boolean;
+}) => {
+  const normalizedOutputPath = path.isAbsolute(outputPath)
+    ? outputPath
+    : path.join(cwd, outputPath);
+
+  return multiPlatform
+    ? path.join(normalizedOutputPath, platform)
+    : normalizedOutputPath;
+};
+
+const getMultiPlatformDeploymentContext = async ({
+  channel,
+  options,
+  platforms,
+  rolloutPercentage,
+}: {
+  channel: string;
+  options: DeployOptions;
+  platforms: Platform[];
+  rolloutPercentage: number;
+}) => {
+  const config = await loadConfig({ platform: platforms[0]!, channel });
+  if (!config) {
+    return null;
+  }
+
+  const lines = [
+    `Platform: Both (${platforms.map(getPlatformName).join(", ")})`,
+    `Channel: ${channel}`,
+    `Rollout: ${rolloutPercentage}%`,
+  ];
+
+  if (config.updateStrategy === "fingerprint") {
+    lines.push("Fingerprint: per-platform");
+  } else if (options.targetAppVersion) {
+    lines.push(`Target app version: ${semverValid(options.targetAppVersion)}`);
+  }
+
+  return lines.join("\n");
+};
+
+const deployPlatform = async ({
+  options,
+  platform,
+  platformIndex,
+  platformCount,
+}: {
+  options: DeployOptions;
+  platform: Platform;
+  platformIndex: number;
+  platformCount: number;
+}): Promise<{ bundleId: string; platform: Platform } | null> => {
   const cwd = getCwd();
   const rolloutPercentage = normalizeRolloutPercentage(options.rollout);
   const rolloutCohortCount =
     getRolloutCohortCountFromPercentage(rolloutPercentage);
+  const multiPlatform = platformCount > 1;
 
   const gitCommit = await getLatestGitCommit();
   const [gitCommitHash, gitMessage] = [
@@ -103,25 +193,7 @@ export const deploy = async (options: DeployOptions) => {
     gitCommit?.summary() ?? null,
   ];
 
-  const platform =
-    options.platform ??
-    (options.interactive
-      ? await getPlatform("Which platform do you want to deploy?")
-      : null);
-
-  if (p.isCancel(platform)) {
-    return;
-  }
-
-  if (!platform) {
-    p.log.error(
-      "Platform not found. -p <ios | android> or --platform <ios | android>",
-    );
-    return;
-  }
-
   const channel = options.channel;
-
   const config = await loadConfig({ platform, channel });
   if (!config) {
     console.error("No config found. Please run `hot-updater init` first.");
@@ -228,14 +300,14 @@ export const deploy = async (options: DeployOptions) => {
         : null);
 
     if (p.isCancel(targetAppVersion)) {
-      return;
+      return null;
     }
 
     if (!targetAppVersion) {
       p.log.error(
         "Target app version not found. -t <targetAppVersion> semver format (e.g. 1.0.0, 1.x.x)",
       );
-      return;
+      return null;
     }
     target.appVersion = targetAppVersion;
   }
@@ -253,16 +325,6 @@ export const deploy = async (options: DeployOptions) => {
     process.exit(1);
   }
 
-  const deploymentContext = [
-    `Channel: ${channel}`,
-    `Rollout: ${rolloutPercentage}%`,
-    config.updateStrategy === "fingerprint"
-      ? `Fingerprint: ${target.fingerprintHash}`
-      : `Target app version: ${semverValid(target.appVersion)}`,
-  ].join("\n");
-
-  p.note(deploymentContext, "Deployment");
-
   if (
     appendToProjectRootGitignore({
       globLines: [HotUpdateDirUtil.outputGitignorePath],
@@ -276,18 +338,40 @@ export const deploy = async (options: DeployOptions) => {
 
   let bundleId: string | null = null;
   let fileHash: string;
-
-  const normalizeOutputPath = path.isAbsolute(outputPath)
-    ? outputPath
-    : path.join(cwd, outputPath);
+  const platformName = getPlatformName(platform);
+  const outputRoot = getBundleOutputRoot({
+    cwd,
+    outputPath,
+    platform,
+    multiPlatform,
+  });
 
   const compressStrategy = config.compressStrategy;
   const bundleExtension = getExtensionFromCompressStrategy(compressStrategy);
   const bundlePath = path.join(
-    normalizeOutputPath,
+    outputRoot,
     "bundle",
     `bundle${bundleExtension}`,
   );
+
+  const deploymentContext = [
+    `Platform: ${platformName}`,
+    `Channel: ${channel}`,
+    `Rollout: ${rolloutPercentage}%`,
+    config.updateStrategy === "fingerprint"
+      ? `Fingerprint: ${target.fingerprintHash}`
+      : `Target app version: ${semverValid(target.appVersion)}`,
+  ].join("\n");
+
+  const deploymentTitle = multiPlatform
+    ? `Deployment (${platformName} ${platformIndex + 1}/${platformCount})`
+    : "Deployment";
+
+  if (multiPlatform) {
+    p.log.step(`${deploymentTitle} • ${channel}`);
+  } else {
+    p.note(deploymentContext, deploymentTitle);
+  }
 
   const [buildPlugin, storagePlugin, databasePlugin] = await Promise.all([
     config.build({
@@ -312,13 +396,13 @@ export const deploy = async (options: DeployOptions) => {
 
     await p.tasks([
       {
-        title: `📦 Building Bundle (${buildPlugin.name})`,
+        title: `📦 Building Bundle (${platformName} • ${buildPlugin.name})`,
         task: async () => {
           taskRef.buildResult = await buildPlugin.build({
             platform: platform,
           });
 
-          await fs.promises.mkdir(normalizeOutputPath, { recursive: true });
+          await fs.promises.mkdir(outputRoot, { recursive: true });
 
           const buildPath = taskRef.buildResult?.buildPath;
           if (!buildPath) {
@@ -413,7 +497,10 @@ export const deploy = async (options: DeployOptions) => {
     ]);
 
     if (taskRef.buildResult?.stdout) {
-      p.note(taskRef.buildResult.stdout.trim(), "Build Output");
+      p.note(
+        taskRef.buildResult.stdout.trim(),
+        multiPlatform ? `Build Output (${platformName})` : "Build Output",
+      );
     }
 
     if (config.signing?.enabled) {
@@ -422,7 +509,7 @@ export const deploy = async (options: DeployOptions) => {
 
     await p.tasks([
       {
-        title: `📦 Uploading to Storage (${storagePlugin.name})`,
+        title: `📦 Uploading to Storage (${platformName} • ${storagePlugin.name})`,
         task: async () => {
           if (!bundleId) {
             throw new Error("Bundle ID not found");
@@ -444,7 +531,7 @@ export const deploy = async (options: DeployOptions) => {
         },
       },
       {
-        title: `📦 Updating Database (${databasePlugin.name})`,
+        title: `📦 Updating Database (${platformName} • ${databasePlugin.name})`,
         task: async () => {
           if (!bundleId) {
             throw new Error("Bundle ID not found");
@@ -519,7 +606,13 @@ export const deploy = async (options: DeployOptions) => {
 
       p.note(note);
     }
+    if (multiPlatform) {
+      p.log.success(`✅ ${platformName} Deployment Successful (${bundleId})`);
+      return { bundleId, platform };
+    }
+
     p.outro(`🚀 Deployment Successful (${bundleId})`);
+    return { bundleId, platform };
   } catch (e) {
     await databasePlugin.onUnmount?.();
     await fs.promises.rm(bundlePath, { force: true });
@@ -527,5 +620,51 @@ export const deploy = async (options: DeployOptions) => {
     process.exit(1);
   } finally {
     await databasePlugin.onUnmount?.();
+  }
+};
+
+export const deploy = async (options: DeployOptions) => {
+  printBanner();
+
+  const platforms = await getDeployPlatforms(options);
+  if (!platforms || platforms.length === 0) {
+    return;
+  }
+
+  const rolloutPercentage = normalizeRolloutPercentage(options.rollout);
+
+  if (platforms.length > 1) {
+    const deploymentContext = await getMultiPlatformDeploymentContext({
+      channel: options.channel,
+      options,
+      platforms,
+      rolloutPercentage,
+    });
+
+    if (deploymentContext) {
+      p.note(deploymentContext, "Deployment");
+    }
+  }
+
+  const results: Array<{ bundleId: string; platform: Platform }> = [];
+  for (const [platformIndex, platform] of platforms.entries()) {
+    const result = await deployPlatform({
+      options,
+      platform,
+      platformCount: platforms.length,
+      platformIndex,
+    });
+
+    if (!result) {
+      return;
+    }
+
+    results.push(result);
+  }
+
+  if (platforms.length > 1) {
+    p.outro(
+      `🚀 Deployment Successful (${results.map(({ platform }) => getPlatformName(platform)).join(", ")})`,
+    );
   }
 };

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -1,4 +1,4 @@
-import { readPackageUp } from "read-package-up";
+import { readPackageUp } from "@hot-updater/cli-tools";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -9,13 +9,13 @@ import {
   resolveVersionEndpoint,
 } from "./doctor";
 
-vi.mock("read-package-up", () => ({
+vi.mock("@hot-updater/cli-tools", () => ({
+  getCwd: vi.fn(() => "/mock/cwd"),
+  p: {},
   readPackageUp: vi.fn(),
 }));
 
-vi.mock("@hot-updater/plugin-core", () => ({
-  getCwd: vi.fn(() => "/mock/cwd"),
-}));
+const mockReadPackageUp = readPackageUp as ReturnType<typeof vi.fn>;
 
 describe("areVersionsCompatible", () => {
   // Test cases for exact matches
@@ -129,7 +129,7 @@ describe("doctor", () => {
   });
 
   it("should return true for a healthy setup", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^0.18.2",
@@ -148,7 +148,7 @@ describe("doctor", () => {
   });
 
   it("should return true for a healthy setup", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "0.18.2",
@@ -167,7 +167,7 @@ describe("doctor", () => {
   });
 
   it("should return true for a healthy setup", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^0.18.2",
@@ -186,7 +186,7 @@ describe("doctor", () => {
   });
 
   it("should return true for a healthy setup", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^0.18.2",
@@ -227,7 +227,7 @@ describe("doctor", () => {
   });
 
   it("should return true for a healthy setup", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^1.0.0",
@@ -246,7 +246,7 @@ describe("doctor", () => {
   });
 
   it("should return an error if package.json is not found", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    mockReadPackageUp.mockResolvedValue(undefined);
 
     const result = await doctor();
     expect(result).toEqual({
@@ -256,7 +256,7 @@ describe("doctor", () => {
   });
 
   it("should return an error if hot-updater CLI is not found", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "@hot-updater/core": "1.0.0",
@@ -273,7 +273,7 @@ describe("doctor", () => {
   });
 
   it("should detect version mismatches", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^1.0.0",
@@ -315,7 +315,7 @@ describe("doctor", () => {
   });
 
   it("should return true if only hot-updater CLI is present and no other @hot-updater packages", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "^1.0.0",
@@ -329,7 +329,7 @@ describe("doctor", () => {
   });
 
   it("should handle empty dependencies and devDependencies", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "1.0.0",
@@ -340,7 +340,7 @@ describe("doctor", () => {
     const result = await doctor();
     expect(result).toBe(true);
 
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         devDependencies: {
           "hot-updater": "1.0.0",
@@ -351,7 +351,7 @@ describe("doctor", () => {
     const result2 = await doctor();
     expect(result2).toBe(true);
 
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {},
       path: "/mock/cwd/package.json",
     });
@@ -363,7 +363,7 @@ describe("doctor", () => {
   });
 
   it("should pass when server infrastructure is on the required target", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "0.30.0",
@@ -409,7 +409,7 @@ describe("doctor", () => {
   });
 
   it("should pass when server version is newer than the required infrastructure target", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "0.30.0",
@@ -442,7 +442,7 @@ describe("doctor", () => {
   });
 
   it("should fail when server infrastructure is below the required target", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "0.30.0",
@@ -475,7 +475,7 @@ describe("doctor", () => {
   });
 
   it("should require an update when server version endpoint is unavailable", async () => {
-    (readPackageUp as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
           "hot-updater": "0.30.0",

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -1,6 +1,5 @@
-import { getCwd, p } from "@hot-updater/cli-tools";
+import { getCwd, p, readPackageUp } from "@hot-updater/cli-tools";
 import { merge } from "es-toolkit";
-import { readPackageUp } from "read-package-up";
 import * as semver from "semver";
 
 import { ui } from "../utils/cli-ui";
@@ -265,7 +264,7 @@ export async function doctor(
     const { cwd = getCwd(), serverBaseUrl, fetch: fetchImpl } = options;
 
     // Read package.json
-    const packageResult = await readPackageUp({ cwd });
+    const packageResult = await readPackageUp<PackageJson>(cwd);
 
     if (!packageResult) {
       return {

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -16,7 +16,6 @@ import {
   interactiveCommandOption,
   nativeBuildOutputCommandOption,
   nativeBuildSchemeCommandOption,
-  PLATFORMS,
   platformCommandOption,
   portCommandOption,
 } from "@/commandOptions";
@@ -221,7 +220,7 @@ program
   .addOption(
     new Option(
       "-o, --bundle-output-path <bundleOutputPath>",
-      "the path where the bundle.zip will be generated",
+      "the directory where bundle archives will be generated",
     ),
   )
   .addOption(
@@ -252,20 +251,7 @@ program
       "Specify a custom message for this deployment. If not provided, the latest git commit message will be used as the deployment message",
     ),
   )
-  .action(async (options: DeployOptions) => {
-    // When neither -p nor -i is set, deploy both platforms sequentially.
-    // ios runs first; if it fails (deploy() exits the process on error),
-    // android is not attempted -- avoids leaving a channel partially
-    // updated. Existing -p ios / -p android invocations are unchanged;
-    // -i still prompts for a single platform.
-    if (options.platform || options.interactive) {
-      await deploy(options);
-      return;
-    }
-    for (const platform of PLATFORMS) {
-      await deploy({ ...options, platform });
-    }
-  });
+  .action(async (options: DeployOptions) => deploy(options));
 
 program
   .command("rollback")

--- a/packages/hot-updater/src/packageJson.ts
+++ b/packages/hot-updater/src/packageJson.ts
@@ -1,7 +1,9 @@
-import { readPackageUpSync } from "read-package-up";
+import { createRequire } from "node:module";
 
-export const packageJsonData = readPackageUpSync({
-  cwd: __dirname,
-});
+const require = createRequire(import.meta.url);
 
-export const version = packageJsonData?.packageJson.version;
+export const packageJsonData = require("../package.json") as {
+  version?: string;
+};
+
+export const version = packageJsonData.version;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,13 +889,13 @@ importers:
         version: 0.74.83
       '@react-native/metro-config':
         specifier: 0.74.83
-        version: 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
+        version: 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)
       '@react-native/typescript-config':
         specifier: 0.74.83
         version: 0.74.83
       '@rnx-kit/metro-config':
         specifier: ^2.0.1
-        version: 2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@rnx-kit/metro-resolver-symlinks':
         specifier: ^0.2.1
         version: 0.2.1
@@ -1385,9 +1385,6 @@ importers:
       picocolors:
         specifier: 1.1.1
         version: 1.1.1
-      read-package-up:
-        specifier: ^11.0.0
-        version: 11.0.0
       semver:
         specifier: ^7.6.3
         version: 7.7.3
@@ -1647,9 +1644,6 @@ importers:
       plist:
         specifier: ^3.1.0
         version: 3.1.0
-      read-package-up:
-        specifier: ^11.0.0
-        version: 11.0.0
       semver:
         specifier: ^7.6.3
         version: 7.7.2
@@ -1704,7 +1698,7 @@ importers:
         version: 0.79.1(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@types/react@19.1.3)(react@19.1.3)
       react-native-builder-bob:
         specifier: ^0.40.10
-        version: 0.40.10(encoding@0.1.13)
+        version: 0.40.10
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -10020,9 +10014,6 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
-  '@types/normalize-package-data@2.4.4':
-    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -13152,10 +13143,6 @@ packages:
     resolution: {integrity: sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==}
     engines: {node: '>=14'}
 
-  find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
-
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -14086,10 +14073,6 @@ packages:
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
-
-  index-to-position@0.1.2:
-    resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
-    engines: {node: '>=18'}
 
   infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
@@ -16494,10 +16477,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
 
-  normalize-package-data@6.0.2:
-    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -16867,10 +16846,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  parse-json@8.1.0:
-    resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
-    engines: {node: '>=18'}
 
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
@@ -17757,14 +17732,6 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  read-package-up@11.0.0:
-    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
-    engines: {node: '>=18'}
-
-  read-pkg@9.0.1:
-    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
-    engines: {node: '>=18'}
-
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
@@ -18597,18 +18564,6 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
-  spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
-
-  spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-
-  spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
-
-  spdx-license-ids@3.0.18:
-    resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
 
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
@@ -19855,9 +19810,6 @@ packages:
 
   valid-url@1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
-
-  validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   validate-npm-package-name@3.0.0:
     resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==}
@@ -24352,7 +24304,7 @@ snapshots:
   '@datadog/datadog-ci-plugin-deployment@5.12.1(@datadog/datadog-ci-base@5.12.1)':
     dependencies:
       '@datadog/datadog-ci-base': 5.12.1(@datadog/datadog-ci-plugin-coverage@5.12.1)(@datadog/datadog-ci-plugin-deployment@5.12.1)(@datadog/datadog-ci-plugin-dora@5.12.1)(@datadog/datadog-ci-plugin-gate@5.12.1)(@datadog/datadog-ci-plugin-junit@5.12.1)(@datadog/datadog-ci-plugin-sarif@5.12.1)(@datadog/datadog-ci-plugin-sbom@5.12.1)(@types/node@20.19.11)
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.1)
       chalk: 3.0.0
       simple-git: 3.33.0
     transitivePeerDependencies:
@@ -24398,7 +24350,7 @@ snapshots:
       '@datadog/datadog-ci-base': 5.12.1(@datadog/datadog-ci-plugin-coverage@5.12.1)(@datadog/datadog-ci-plugin-deployment@5.12.1)(@datadog/datadog-ci-plugin-dora@5.12.1)(@datadog/datadog-ci-plugin-gate@5.12.1)(@datadog/datadog-ci-plugin-junit@5.12.1)(@datadog/datadog-ci-plugin-sarif@5.12.1)(@datadog/datadog-ci-plugin-sbom@5.12.1)(@types/node@20.19.11)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.1)
       chalk: 3.0.0
       packageurl-js: 2.0.1
     transitivePeerDependencies:
@@ -30167,7 +30119,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))':
+  '@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)':
     dependencies:
       '@react-native/js-polyfills': 0.74.83
       '@react-native/metro-babel-transformer': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
@@ -30176,7 +30128,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
+      - encoding
       - supports-color
+      - utf-8-validate
 
   '@react-native/metro-config@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))':
     dependencies:
@@ -30325,7 +30280,7 @@ snapshots:
 
   '@rnx-kit/console@2.0.0': {}
 
-  '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@rnx-kit/tools-node': 3.0.0
       '@rnx-kit/tools-react-native': 2.0.0
@@ -30333,7 +30288,7 @@ snapshots:
       react: 18.2.0
       react-native: 0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.20)(encoding@0.1.13)(react@18.2.0)
     optionalDependencies:
-      '@react-native/metro-config': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
+      '@react-native/metro-config': 0.74.83(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(encoding@0.1.13)
 
   '@rnx-kit/metro-config@2.0.1(@react-native/metro-config@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))(react-native@0.76.1(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@20.0.0)(@types/react@18.3.20)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -32173,8 +32128,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/normalize-package-data@2.4.4': {}
-
   '@types/parse-json@4.0.2': {}
 
   '@types/pg@8.11.10':
@@ -33142,14 +33095,6 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
@@ -33160,7 +33105,7 @@ snapshots:
 
   axios@1.14.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -36160,8 +36105,6 @@ snapshots:
       fast-querystring: 1.1.2
       safe-regex2: 3.1.0
 
-  find-up-simple@1.0.1: {}
-
   find-up@3.0.0:
     dependencies:
       locate-path: 3.0.0
@@ -37367,8 +37310,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
-
-  index-to-position@0.1.2: {}
 
   infer-owner@1.0.4: {}
 
@@ -40988,12 +40929,6 @@ snapshots:
       abbrev: 2.0.0
     optional: true
 
-  normalize-package-data@6.0.2:
-    dependencies:
-      hosted-git-info: 7.0.2
-      semver: 7.7.4
-      validate-npm-package-license: 3.0.4
-
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
@@ -41512,12 +41447,6 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  parse-json@8.1.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      index-to-position: 0.1.2
-      type-fest: 4.37.0
 
   parse-ms@4.0.0: {}
 
@@ -42281,7 +42210,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-builder-bob@0.40.10(encoding@0.1.13):
+  react-native-builder-bob@0.40.10:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.26.0)
@@ -42307,10 +42236,7 @@ snapshots:
       which: 2.0.2
       yargs: 17.7.2
     transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
 
   react-native-dotenv@3.4.11(@babel/runtime@7.26.0):
     dependencies:
@@ -42835,20 +42761,6 @@ snapshots:
   react@19.2.3: {}
 
   react@19.2.4: {}
-
-  read-package-up@11.0.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      read-pkg: 9.0.1
-      type-fest: 4.37.0
-
-  read-pkg@9.0.1:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 6.0.2
-      parse-json: 8.1.0
-      type-fest: 4.37.0
-      unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -43941,20 +43853,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  spdx-correct@3.2.0:
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.18
-
-  spdx-exceptions@2.5.0: {}
-
-  spdx-expression-parse@3.0.1:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.18
-
-  spdx-license-ids@3.0.18: {}
 
   split-on-first@1.1.0: {}
 
@@ -45177,11 +45075,6 @@ snapshots:
       convert-source-map: 2.0.0
 
   valid-url@1.0.9: {}
-
-  validate-npm-package-license@3.0.4:
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@3.0.0:
     dependencies:


### PR DESCRIPTION
## What changed

- moved the no-`-p` deploy flow into `deploy()` so multi-platform deploy is handled as a first-class path
- changed the default multi-platform note to render once as `Platform: Both (iOS, Android)` while keeping per-platform progress readable
- wrote local bundle archives into platform-specific output directories to avoid one platform overwriting the other
- updated deploy docs and changeset text to match the new default behavior
- removed `read-package-up` from CLI startup version loading so example CLI runs no longer emit the Node `DEP0169` warning

## Why

The recent multi-platform deploy support worked, but orchestration still lived in the CLI entrypoint, which made output handling and artifact paths feel bolted on. The startup warning was separate but user-visible in the same flow, so this bundles both fixes into one pass.

## User impact

- `hot-updater deploy` without `-p` now presents a single deployment note that explicitly says both iOS and Android are being handled
- local output artifacts for iOS and Android no longer collide under the same bundle archive path
- `examples/v0.81.0` CLI commands no longer print the `url.parse()` deprecation warning during startup on newer Node versions

## Root cause

- multi-platform deploy was implemented by looping in `index.ts`, so deploy-specific UX and file layout decisions were split across layers
- CLI startup read package metadata through `read-package-up`, whose dependency chain still pulls deprecated URL parsing on current Node runtimes

## Validation

- `pnpm exec vitest run packages/hot-updater/src/commands/deploy.spec.ts`
- `pnpm --filter hot-updater test:type`
- `pnpm --filter hot-updater build`
- `NODE_OPTIONS=--trace-deprecation pnpm exec hot-updater app-version` in `examples/v0.81.0`
- `pnpm lint`
