### PR TITLE
fix(cli): `deploy` defaults targetAppVersion from native files in non-interactive mode

### DIFF
--- a/.changeset/cli-deploy-default-target-version.md
+++ b/.changeset/cli-deploy-default-target-version.md
@@ -1,0 +1,15 @@
+---
+"hot-updater": patch
+---
+
+fix(cli): `deploy` falls back to the auto-detected target app version in non-interactive mode
+
+Previously, running `hot-updater deploy` without `-t` and without `-i` errored with
+"Target app version not found", even though `getDefaultTargetAppVersion` had already
+extracted the version from the binary's native files (Info.plist for iOS, build.gradle
+for Android) for use as the interactive prompt's placeholder. CI deploys had to
+either pass `-t` explicitly or scrape the version out of package.json.
+
+Now the resolution order is: explicit `-t` → interactive prompt (with the auto-detected
+value as placeholder) → auto-detected default → clear error if the native config is
+unreadable. Existing `-t` and `-i` invocations are unchanged.

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -177,8 +177,10 @@ import { getLatestGitCommit } from "@/utils/git";
 import { printBanner } from "@/utils/printBanner";
 import { signBundle } from "@/utils/signing/bundleSigning";
 import { validateSigningConfig } from "@/utils/signing/validateSigningConfig";
+import { getDefaultTargetAppVersion } from "@/utils/version/getDefaultTargetAppVersion";
 import { getNativeAppVersion } from "@/utils/version/getNativeAppVersion";
 
+import { getConsolePort } from "./console";
 import {
   deploy,
   getRolloutCohortCountFromPercentage,
@@ -270,6 +272,7 @@ describe("deploy rollout wiring", () => {
       id: () => "git-hash",
       summary: () => "git summary",
     } as Awaited<ReturnType<typeof getLatestGitCommit>>);
+    vi.mocked(getDefaultTargetAppVersion).mockResolvedValue(null);
     vi.mocked(getNativeAppVersion).mockResolvedValue("1.0");
     vi.mocked(writeBundleManifest).mockResolvedValue({
       manifest: {
@@ -484,5 +487,81 @@ describe("deploy rollout wiring", () => {
 
     expect(buildOutputOrder).toBeGreaterThanOrEqual(0);
     expect(signingOrder).toBeGreaterThanOrEqual(0);
+  });
+
+  it("falls back to the auto-detected target app version in non-interactive mode when -t is omitted", async () => {
+    vi.mocked(getDefaultTargetAppVersion).mockResolvedValue("1.5.0");
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+    });
+
+    expect(mockDatabasePlugin.appendBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetAppVersion: "1.5.0",
+      }),
+    );
+  });
+
+  it("errors out in non-interactive mode when -t is omitted and the native config is unreadable", async () => {
+    vi.mocked(getDefaultTargetAppVersion).mockResolvedValue(null);
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+    });
+
+    expect(mockCli.p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Target app version not found in native files"),
+    );
+    expect(mockDatabasePlugin.appendBundle).not.toHaveBeenCalled();
+  });
+
+  it("uses the explicit -t value over the auto-detected default", async () => {
+    vi.mocked(getDefaultTargetAppVersion).mockResolvedValue("1.5.0");
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+      targetAppVersion: "1.2.0",
+    });
+
+    expect(mockDatabasePlugin.appendBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetAppVersion: "1.2.0",
+      }),
+    );
+  });
+
+  it("uses the interactive prompt with the auto-detected value as placeholder/initialValue", async () => {
+    vi.mocked(getDefaultTargetAppVersion).mockResolvedValue("1.5.0");
+    vi.mocked(getConsolePort).mockResolvedValue(3000);
+    mockCli.p.text.mockResolvedValue("1.7.0");
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: true,
+      platform: "ios",
+    });
+
+    expect(mockCli.p.text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placeholder: "1.5.0",
+        initialValue: "1.5.0",
+      }),
+    );
+    expect(mockDatabasePlugin.appendBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetAppVersion: "1.7.0",
+      }),
+    );
   });
 });

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -280,16 +280,15 @@ const deployPlatform = async ({
     target.fingerprintHash = newFingerprint.hash;
     s.stop(`Fingerprint(${platform}): ${newFingerprint.hash}`);
   } else {
-    const defaultTargetAppVersion =
-      (await getDefaultTargetAppVersion(platform)) ?? "1.0.0";
+    const defaultTargetAppVersion = await getDefaultTargetAppVersion(platform);
 
     const targetAppVersion =
       options.targetAppVersion ??
       (options.interactive
         ? await p.text({
             message: "Target app version",
-            placeholder: defaultTargetAppVersion,
-            initialValue: defaultTargetAppVersion,
+            placeholder: defaultTargetAppVersion ?? "1.0.0",
+            initialValue: defaultTargetAppVersion ?? "1.0.0",
             validate: (value) => {
               if (!semverValid(value)) {
                 return "Invalid semver format (e.g. 1.0.0, 1.x.x)";
@@ -297,7 +296,7 @@ const deployPlatform = async ({
               return;
             },
           })
-        : null);
+        : defaultTargetAppVersion);
 
     if (p.isCancel(targetAppVersion)) {
       return null;
@@ -305,7 +304,7 @@ const deployPlatform = async ({
 
     if (!targetAppVersion) {
       p.log.error(
-        "Target app version not found. -t <targetAppVersion> semver format (e.g. 1.0.0, 1.x.x)",
+        "Target app version not found in native files (Info.plist for iOS, build.gradle for Android). Pass -t <targetAppVersion> explicitly, or check your native config.",
       );
       return null;
     }


### PR DESCRIPTION
## What

Wires `getDefaultTargetAppVersion`'s output into `deploy`'s non-interactive mode, so a CI invocation like `hot-updater deploy -c dev` no longer errors with "Target app version not found" when both `-t` and `-i` are omitted.

## Why

The default is already computed and used as the interactive prompt's placeholder/initialValue. Not threading it through to non-interactive mode meant every CI deploy had to either pass `-t` explicitly or scrape the version out of `package.json` — duplicating logic that `getDefaultTargetAppVersion` already centralizes.

## Resolution order

1. Explicit `-t <targetAppVersion>`
2. Interactive prompt (`-i`), with the auto-detected value as placeholder
3. Auto-detected default from native files (new)
4. Clear error if the native config is unreadable

The error path is now reachable only when the native files can't be parsed — pointing the operator at the actual problem (broken Info.plist / build.gradle) rather than asking them to retype the version they already shipped.

## Behavior change scope

- `hot-updater deploy -p ios -c dev -t 1.2.0` — unchanged (explicit `-t` still wins).
- `hot-updater deploy -p ios -c dev -i` — unchanged (interactive prompt still fires; placeholder still shows the auto-detected value).
- `hot-updater deploy -p ios -c dev` — was: error. Now: deploys at the binary's version.

## Tests

Added four scenarios to `packages/hot-updater/src/commands/deploy.spec.ts` covering the resolution order: non-interactive auto-fallback, non-interactive error-when-unreadable, explicit `-t` overriding the default, and interactive mode using the prompt with the auto-detected placeholder.

## Risk

Low. The change is an additional fallback rung; no existing successful invocation changes behavior. Operators who relied on the "no `-t`, no `-i`" path failing as a sanity check will instead get a successful deploy at the binary's version — which is what they would have typed anyway.