### PR TITLE
fix(react-native): retry update checks with fresh signals

### DIFF
--- a/.changeset/fresh-retry-signals.md
+++ b/.changeset/fresh-retry-signals.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Ensure retried update checks use a fresh abort signal for each fetch attempt.

--- a/packages/react-native/src/fetchUpdateInfo.spec.ts
+++ b/packages/react-native/src/fetchUpdateInfo.spec.ts
@@ -78,6 +78,29 @@ describe("fetchUpdateInfo", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("uses a fresh abort signal for a retried fetch", async () => {
+    const response = createResponse();
+    const signals: Array<AbortSignal | undefined> = [];
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      signals.push(init?.signal);
+      return Promise.resolve(
+        signals.length === 1 ? (undefined as unknown as Response) : response,
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchUpdateInfo({
+        url: "https://updates.example.com/check-update",
+      }),
+    ).resolves.toEqual(updateInfo);
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(signals[1]).toBeInstanceOf(AbortSignal);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
   it("throws when fetch still returns no response after retry", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/packages/react-native/src/fetchUpdateInfo.ts
+++ b/packages/react-native/src/fetchUpdateInfo.ts
@@ -41,8 +41,8 @@ export const fetchUpdateInfo = async ({
 
   const response = await getUpdateResponse
     .pipe(
-      withRetry(1, (response) => !response),
       withTimeout(requestTimeout),
+      withRetry(1, (response) => !response),
     )
     .run();
 

--- a/packages/react-native/src/utils/task.ts
+++ b/packages/react-native/src/utils/task.ts
@@ -35,14 +35,14 @@ export const withTimeout =
 export const withRetry =
   <TValue>(retryCount: number, shouldRetry: (value: TValue) => boolean) =>
   (effect: Task<TValue>): Task<TValue> =>
-    task(async (signal) => {
-      let result = await effect.run(signal);
+    task(async () => {
+      let result = await effect.run();
 
       for (let attempt = 0; attempt < retryCount; attempt++) {
         if (!shouldRetry(result)) {
           return result;
         }
-        result = await effect.run(signal);
+        result = await effect.run();
       }
 
       return result;


### PR DESCRIPTION
## Summary
- keep update fetch retry in the task pipe while running each retry attempt as a fresh effect
- apply timeout before retry so each retried fetch gets a new AbortController signal
- add regression coverage that retried update checks do not reuse the first abort signal
- add a patch changeset for @hot-updater/react-native

## Validation
- pnpm -w lint
- pnpm --filter @hot-updater/react-native test -- fetchUpdateInfo
- pnpm --filter @hot-updater/react-native test:type
- pnpm -w test