### PR TITLE
feat: allow custom DownloadService injection via factory

### DIFF
--- a/.changeset/yellow-fireants-sing.md
+++ b/.changeset/yellow-fireants-sing.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+feat: allow custom DownloadService injection via factory

--- a/docs/content/docs/guides/custom-download-service.mdx
+++ b/docs/content/docs/guides/custom-download-service.mdx
@@ -1,0 +1,99 @@
+---
+title: Custom Download Service
+description: Replace the built-in download client with your own networking stack
+---
+
+# Custom Download Service
+
+By default, Hot Updater uses `URLSessionDownloadService` on iOS and `OkHttpDownloadService` on Android to download OTA bundles. You can replace these with your own implementation to route downloads through a custom networking stack.
+
+## Use Cases
+
+- **TLS Certificate Pinning** — enforce that downloads only connect to trusted servers
+- **Corporate Proxy / VPN** — route traffic through enterprise network infrastructure (e.g., Zscaler)
+- **Custom Interceptors** — add logging, metrics, retry policies, or authentication headers
+- **Background Download Management** — integrate with your app's existing download manager
+
+## iOS (Swift)
+
+### 1. Implement the `DownloadService` protocol
+
+```swift
+import HotUpdater
+
+class PinnedDownloadService: NSObject, DownloadService {
+    private let session: URLSession
+
+    override init() {
+        let config = URLSessionConfiguration.default
+        super.init()
+        // Use your own delegate with certificate pinning
+        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }
+
+    public func downloadFile(
+        from url: URL,
+        to destination: String,
+        fileSizeHandler: ((Int64) -> Void)?,
+        progressHandler: @escaping (Double) -> Void,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) -> URLSessionDownloadTask? {
+        let task = session.downloadTask(with: url)
+        // ... handle delegates, progress, completion
+        task.resume()
+        return task
+    }
+}
+```
+
+### 2. Set the factory before HotUpdater initializes
+
+```swift
+// In AppDelegate.swift — application(_:didFinishLaunchingWithOptions:)
+HotUpdaterImpl.downloadServiceFactory = {
+    PinnedDownloadService()
+}
+```
+
+When the factory is `nil` (default), the built-in `URLSessionDownloadService` is used.
+
+## Android (Kotlin)
+
+### 1. Implement the `DownloadService` interface
+
+```kotlin
+import com.hotupdater.DownloadService
+import com.hotupdater.DownloadResult
+
+class PinnedDownloadService : DownloadService {
+    private val client = OkHttpClient.Builder()
+        .sslSocketFactory(yourPinnedSSLSocketFactory, yourTrustManager)
+        .build()
+
+    override suspend fun downloadFile(
+        fileUrl: URL,
+        destination: File,
+        fileSizeCallback: ((Long) -> Unit)?,
+        progressCallback: (Double) -> Unit,
+    ): DownloadResult {
+        // ... download using your pinned client
+        return DownloadResult.Success(destination)
+    }
+}
+```
+
+### 2. Set the factory before HotUpdater initializes
+
+```kotlin
+// In Application.onCreate()
+HotUpdaterImpl.downloadServiceFactory = { PinnedDownloadService() }
+```
+
+When the factory is `null` (default), the built-in `OkHttpDownloadService` is used.
+
+## Important Notes
+
+- Set the factory **before** `HotUpdater.init()` is called (typically in your app's entry point)
+- The factory is called once per `HotUpdaterImpl` initialization
+- Your implementation receives the same callbacks (progress, file size, completion) as the default service
+- The return type `URLSessionDownloadTask?` on iOS can return `nil` for non-URLSession implementations

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -14,6 +14,7 @@
     "update-strategies",
     "compression",
     "doctor",
-    "bundle-signing"
+    "bundle-signing",
+    "custom-download-service"
   ]
 }

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -13,6 +13,12 @@
       "url": "https://github.com/LESANF"
     },
     {
+      "login": "kr-yeon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
+      "name": "kr-yeon",
+      "url": "https://github.com/kr-yeon"
+    },
+    {
       "login": "valeriobelli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
       "name": "Valerio Belli",
@@ -25,5 +31,5 @@
       "url": "https://github.com/victorsaisse"
     }
   ],
-  "updatedAt": "2026-05-14T00:49:57Z"
+  "updatedAt": "2026-04-30T00:44:57Z"
 }

--- a/packages/react-native/android/src/main/java/com/hotupdater/DownloadService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/DownloadService.kt
@@ -1,0 +1,57 @@
+package com.hotupdater
+
+import java.io.File
+import java.net.URL
+
+/**
+ * Interface for custom download service implementations.
+ *
+ * Implement this interface to provide a custom networking stack for OTA bundle downloads.
+ * This is useful for enterprise environments that require TLS pinning, corporate proxies,
+ * or custom network interceptors.
+ *
+ * Example:
+ * ```kotlin
+ * class PinnedDownloadService : DownloadService {
+ *     override suspend fun downloadFile(
+ *         fileUrl: URL, destination: File,
+ *         fileSizeCallback: ((Long) -> Unit)?,
+ *         progressCallback: (Double) -> Unit
+ *     ): DownloadResult {
+ *         // Use your custom OkHttpClient with certificate pinning
+ *     }
+ * }
+ *
+ * // Before HotUpdater initializes:
+ * HotUpdaterImpl.downloadServiceFactory = { PinnedDownloadService() }
+ * ```
+ */
+interface DownloadService {
+    /**
+     * Downloads a file from a URL
+     * @param fileUrl The URL to download from
+     * @param destination The local file to save to
+     * @param fileSizeCallback Optional callback called when file size is known
+     * @param progressCallback Callback for download progress updates (0.0 to 1.0)
+     * @return Result indicating success or failure
+     */
+    suspend fun downloadFile(
+        fileUrl: URL,
+        destination: File,
+        fileSizeCallback: ((Long) -> Unit)? = null,
+        progressCallback: (Double) -> Unit,
+    ): DownloadResult
+}
+
+/**
+ * Result wrapper for download operations
+ */
+sealed class DownloadResult {
+    data class Success(
+        val file: File,
+    ) : DownloadResult()
+
+    data class Error(
+        val exception: Exception,
+    ) : DownloadResult()
+}

--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
@@ -70,13 +70,31 @@ class HotUpdaterImpl {
         private const val CHANNEL_STORAGE_KEY = "HotUpdaterChannel"
 
         /**
+         * Optional factory for providing a custom DownloadService implementation.
+         *
+         * Set this before HotUpdater initializes (e.g., in Application.onCreate())
+         * to route OTA bundle downloads through your own networking stack.
+         *
+         * When set, the factory is called instead of creating the default OkHttpDownloadService.
+         * When null (default), the built-in OkHttpDownloadService is used.
+         *
+         * Example:
+         * ```kotlin
+         * // In Application.onCreate():
+         * HotUpdaterImpl.downloadServiceFactory = { PinnedDownloadService() }
+         * ```
+         */
+        @JvmStatic
+        var downloadServiceFactory: (() -> DownloadService)? = null
+
+        /**
          * Create BundleStorageService with all dependencies
          */
         private fun createBundleStorage(context: Context): BundleStorageService {
             val appContext = context.applicationContext
             val fileSystem = FileManagerService(appContext)
             val preferences = createPreferences(appContext)
-            val downloadService = OkHttpDownloadService()
+            val downloadService = downloadServiceFactory?.invoke() ?: OkHttpDownloadService()
             val decompressService = DecompressService()
             val isolationKey = getIsolationKey(appContext)
 

--- a/packages/react-native/android/src/main/java/com/hotupdater/OkHttpDownloadService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/OkHttpDownloadService.kt
@@ -29,39 +29,6 @@ class IncompleteDownloadException(
 ) : IOException("Download incomplete: received $actualSize bytes, expected $expectedSize bytes")
 
 /**
- * Result wrapper for download operations
- */
-sealed class DownloadResult {
-    data class Success(
-        val file: File,
-    ) : DownloadResult()
-
-    data class Error(
-        val exception: Exception,
-    ) : DownloadResult()
-}
-
-/**
- * Interface for download operations
- */
-interface DownloadService {
-    /**
-     * Downloads a file from a URL
-     * @param fileUrl The URL to download from
-     * @param destination The local file to save to
-     * @param fileSizeCallback Optional callback called when file size is known
-     * @param progressCallback Callback for download progress updates
-     * @return Result indicating success or failure
-     */
-    suspend fun downloadFile(
-        fileUrl: URL,
-        destination: File,
-        fileSizeCallback: ((Long) -> Unit)? = null,
-        progressCallback: (Double) -> Unit,
-    ): DownloadResult
-}
-
-/**
  * Progress tracking wrapper for OkHttp ResponseBody
  */
 private class ProgressResponseBody(

--- a/packages/react-native/android/src/test/java/com/hotupdater/DownloadServiceFactoryTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/DownloadServiceFactoryTest.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.net.URL
 
 class DownloadServiceFactoryTest {
-
     @After
     fun tearDown() {
         HotUpdaterImpl.downloadServiceFactory = null
@@ -27,9 +26,7 @@ class DownloadServiceFactoryTest {
                     destination: File,
                     fileSizeCallback: ((Long) -> Unit)?,
                     progressCallback: (Double) -> Unit,
-                ): DownloadResult {
-                    return DownloadResult.Success(destination)
-                }
+                ): DownloadResult = DownloadResult.Success(destination)
             }
         }
 

--- a/packages/react-native/android/src/test/java/com/hotupdater/DownloadServiceFactoryTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/DownloadServiceFactoryTest.kt
@@ -1,0 +1,52 @@
+package com.hotupdater
+
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.net.URL
+
+class DownloadServiceFactoryTest {
+
+    @After
+    fun tearDown() {
+        HotUpdaterImpl.downloadServiceFactory = null
+    }
+
+    @Test
+    fun `custom factory is used when set`() {
+        var factoryCalled = false
+
+        HotUpdaterImpl.downloadServiceFactory = {
+            factoryCalled = true
+            object : DownloadService {
+                override suspend fun downloadFile(
+                    fileUrl: URL,
+                    destination: File,
+                    fileSizeCallback: ((Long) -> Unit)?,
+                    progressCallback: (Double) -> Unit,
+                ): DownloadResult {
+                    return DownloadResult.Success(destination)
+                }
+            }
+        }
+
+        val service = HotUpdaterImpl.downloadServiceFactory?.invoke()
+        assertTrue("Factory should have been called", factoryCalled)
+        assertNotNull("Service should not be null", service)
+    }
+
+    @Test
+    fun `default factory is null`() {
+        HotUpdaterImpl.downloadServiceFactory = null
+        assertNull(HotUpdaterImpl.downloadServiceFactory)
+    }
+
+    @Test
+    fun `OkHttpDownloadService conforms to DownloadService interface`() {
+        val service: DownloadService = OkHttpDownloadService()
+        assertTrue(service is OkHttpDownloadService)
+    }
+}

--- a/packages/react-native/ios/HotUpdater/Internal/DownloadService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/DownloadService.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/**
+ * Protocol for custom download service implementations.
+ *
+ * Implement this protocol to provide a custom networking stack for OTA bundle downloads.
+ * This is useful for enterprise environments that require TLS pinning, corporate proxies,
+ * or custom network interceptors.
+ *
+ * Example:
+ * ```swift
+ * class PinnedDownloadService: NSObject, DownloadService {
+ *     func downloadFile(from url: URL, to destination: String, ...) -> URLSessionDownloadTask? {
+ *         // Use your custom URLSession with certificate pinning
+ *     }
+ * }
+ *
+ * // Before HotUpdater initializes:
+ * HotUpdaterImpl.downloadServiceFactory = { PinnedDownloadService() }
+ * ```
+ */
+public protocol DownloadService {
+    /**
+     * Downloads a file from a URL.
+     * @param url The URL to download from
+     * @param destination The local path to save to
+     * @param fileSizeHandler Optional callback called when file size is known
+     * @param progressHandler Callback for download progress updates (0.0 to 1.0)
+     * @param completion Callback with downloaded file URL or error
+     * @return The download task, if applicable (may return nil for non-URLSession implementations)
+     */
+    func downloadFile(from url: URL, to destination: String, fileSizeHandler: ((Int64) -> Void)?, progressHandler: @escaping (Double) -> Void, completion: @escaping (Result<URL, Error>) -> Void) -> URLSessionDownloadTask?
+}

--- a/packages/react-native/ios/HotUpdater/Internal/HotUpdaterImpl.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/HotUpdaterImpl.swift
@@ -39,6 +39,27 @@ private func hotUpdaterPerformRecoveryReload() -> Bool {
     private static let DEFAULT_CHANNEL = "production"
     private static let CHANNEL_STORAGE_KEY = "HotUpdaterChannel"
 
+    // MARK: - Custom Download Service
+
+    /**
+     * Optional factory for providing a custom DownloadService implementation.
+     *
+     * Set this before HotUpdater initializes (e.g., in `application(_:didFinishLaunchingWithOptions:)`)
+     * to route OTA bundle downloads through your own networking stack.
+     *
+     * When set, the factory is called instead of creating the default `URLSessionDownloadService`.
+     * When nil (default), the built-in `URLSessionDownloadService` is used.
+     *
+     * Example:
+     * ```swift
+     * // In AppDelegate:
+     * HotUpdaterImpl.downloadServiceFactory = {
+     *     MyPinnedDownloadService()
+     * }
+     * ```
+     */
+    public static var downloadServiceFactory: (() -> DownloadService)?
+
     // MARK: - Initialization
 
     /**
@@ -48,7 +69,7 @@ private func hotUpdaterPerformRecoveryReload() -> Bool {
         let fileSystem = FileManagerService()
         let isolationKey = HotUpdaterImpl.getIsolationKey()
         let preferences = VersionedPreferencesService()
-        let downloadService = URLSessionDownloadService()
+        let downloadService = Self.downloadServiceFactory?() ?? URLSessionDownloadService()
         let decompressService = DecompressService()
 
         let bundleStorage = BundleFileStorageService(

--- a/packages/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift
@@ -121,7 +121,7 @@ public class URLSessionDownloadService: NSObject, DownloadService {
 }
 
 extension URLSessionDownloadService: URLSessionDownloadDelegate {
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         let completion = completionHandlers[downloadTask]
         let destination = destinations[downloadTask]
 
@@ -177,7 +177,7 @@ extension URLSessionDownloadService: URLSessionDownloadDelegate {
         }
     }
     
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         let completion = completionHandlers[task]
         defer {
             progressHandlers.removeValue(forKey: task)
@@ -194,7 +194,7 @@ extension URLSessionDownloadService: URLSessionDownloadDelegate {
         }
     }
     
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         let progressHandler = progressHandlers[downloadTask]
 
         // Call file size handler on first callback when size is known

--- a/packages/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift
@@ -3,21 +3,8 @@ import Foundation
 import UIKit
 #endif
 
-protocol DownloadService {
-    /**
-     * Downloads a file from a URL.
-     * @param url The URL to download from
-     * @param destination The local path to save to
-     * @param fileSizeHandler Optional callback called when file size is known
-     * @param progressHandler Callback for download progress updates
-     * @param completion Callback with downloaded file URL or error
-     * @return The download task (optional)
-     */
-    func downloadFile(from url: URL, to destination: String, fileSizeHandler: ((Int64) -> Void)?, progressHandler: @escaping (Double) -> Void, completion: @escaping (Result<URL, Error>) -> Void) -> URLSessionDownloadTask?
-}
 
-
-enum DownloadError: Error {
+public enum DownloadError: Error {
     case incompleteDownload(expected: Int64, actual: Int64)
     case invalidContentLength
 }
@@ -30,7 +17,7 @@ struct TaskState: Codable {
     let startedAt: TimeInterval
 }
 
-class URLSessionDownloadService: NSObject, DownloadService {
+public class URLSessionDownloadService: NSObject, DownloadService {
     private var session: URLSession!
     private var backgroundSession: URLSession!
     private var progressHandlers: [URLSessionTask: (Double) -> Void] = [:]
@@ -91,7 +78,7 @@ class URLSessionDownloadService: NSObject, DownloadService {
         }
     }
 
-    func downloadFile(from url: URL, to destination: String, fileSizeHandler: ((Int64) -> Void)?, progressHandler: @escaping (Double) -> Void, completion: @escaping (Result<URL, Error>) -> Void) -> URLSessionDownloadTask? {
+    public func downloadFile(from url: URL, to destination: String, fileSizeHandler: ((Int64) -> Void)?, progressHandler: @escaping (Double) -> Void, completion: @escaping (Result<URL, Error>) -> Void) -> URLSessionDownloadTask? {
         // Determine if we should use background session
         #if !os(macOS)
         let appState = UIApplication.shared.applicationState

--- a/packages/react-native/ios/HotUpdater/Package.swift
+++ b/packages/react-native/ios/HotUpdater/Package.swift
@@ -7,6 +7,7 @@ let archiveSources = [
     "BundleMetadata.swift",
     "DecompressService.swift",
     "DecompressionStrategy.swift",
+    "DownloadService.swift",
     "FileManagerService.swift",
     "HashUtils.swift",
     "NotificationExtension.swift",

--- a/packages/react-native/ios/HotUpdater/Test/DownloadServiceFactoryTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/DownloadServiceFactoryTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import HotUpdater
+
+// MARK: - Mock Download Service
+
+private final class MockDownloadService: DownloadService {
+    var downloadFileCalled = false
+    var lastURL: URL?
+
+    func downloadFile(
+        from url: URL,
+        to destination: String,
+        fileSizeHandler: ((Int64) -> Void)?,
+        progressHandler: @escaping (Double) -> Void,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) -> URLSessionDownloadTask? {
+        downloadFileCalled = true
+        lastURL = url
+        completion(.success(URL(fileURLWithPath: destination)))
+        return nil
+    }
+}
+
+// MARK: - Tests
+
+@Suite("DownloadServiceFactory")
+struct DownloadServiceFactoryTests {
+
+    @Test("Custom factory is used when set")
+    func customFactoryIsUsed() {
+        let mock = MockDownloadService()
+        HotUpdaterImpl.downloadServiceFactory = { mock }
+        defer { HotUpdaterImpl.downloadServiceFactory = nil }
+
+        // The factory should return our mock
+        let service = HotUpdaterImpl.downloadServiceFactory?()
+        #expect(service != nil)
+        #expect(service is MockDownloadService)
+    }
+
+    @Test("Default factory returns nil when not set")
+    func defaultFactoryIsNil() {
+        HotUpdaterImpl.downloadServiceFactory = nil
+        #expect(HotUpdaterImpl.downloadServiceFactory == nil)
+    }
+
+    @Test("URLSessionDownloadService conforms to public DownloadService protocol")
+    func defaultServiceConformsToProtocol() {
+        let service: DownloadService = URLSessionDownloadService()
+        #expect(service is URLSessionDownloadService)
+    }
+}


### PR DESCRIPTION
## Summary

Add a static `downloadServiceFactory` property to `HotUpdaterImpl` on both iOS and Android, enabling host apps to inject their own download service implementation.

## Motivation

Enterprise apps often need to route all network traffic through a custom networking stack for security compliance:

- **TLS Certificate Pinning** — enforce connections only to trusted servers
- **Corporate Proxy / VPN** — route through infrastructure like Zscaler
- **Custom Interceptors** — logging, metrics, auth headers, retry policies

Currently, `URLSessionDownloadService` (iOS) and `OkHttpDownloadService` (Android) are hardcoded in `HotUpdaterImpl`. This means OTA bundle downloads bypass the host app's networking stack entirely.

## Changes

### iOS
- Extract `DownloadService` protocol to its own file (`DownloadService.swift`)
- Make `DownloadService` protocol **public** (was `internal`)
- Make `URLSessionDownloadService` class **public** (was `internal`)
- Add `public static var downloadServiceFactory: (() -> DownloadService)?` to `HotUpdaterImpl`
- Use factory with fallback in `convenience init()`: `Self.downloadServiceFactory?() ?? URLSessionDownloadService()`

### Android
- Extract `DownloadService` interface + `DownloadResult` to `DownloadService.kt`
- Add `@JvmStatic var downloadServiceFactory: (() -> DownloadService)? = null` to `HotUpdaterImpl.companion`
- Use factory with fallback in `createBundleStorage()`: `downloadServiceFactory?.invoke() ?: OkHttpDownloadService()`

### Tests
- iOS: `DownloadServiceFactoryTests.swift` (Swift Testing)
- Android: `DownloadServiceFactoryTest.kt` (JUnit)

### Docs
- New guide: `docs/guides/custom-download-service.mdx`

## Backward Compatibility

**Zero breaking changes.** When the factory is `nil`/`null` (default), behavior is identical to the current implementation. The factory is only called if explicitly set by the host app before `HotUpdater.init()`.

## Usage

```swift
// iOS — AppDelegate.swift
HotUpdaterImpl.downloadServiceFactory = {
    MyPinnedDownloadService()
}
```

```kotlin
// Android — Application.onCreate()
HotUpdaterImpl.downloadServiceFactory = { PinnedDownloadService() }
```