### PR TITLE
feat(cli): check native OTA wiring in `hot-updater doctor`

### DIFF
--- a/.agents/skills/hot-updater/SKILL.md
+++ b/.agents/skills/hot-updater/SKILL.md
@@ -21,9 +21,18 @@ or diagnostics.
 - Do not run `npx hot-updater init` on behalf of the user. It is interactive
   and asks for provider, build, and project-specific choices. Guide the user to
   run it directly and follow the setup documentation.
-- Before running `npx hot-updater doctor`, make sure the server base URL is
-  available. If the user did not provide it and it is not obvious from local
-  config, ask for the update server URL first.
+- Before running `npx hot-updater doctor` for a server/infrastructure check,
+  make sure the server base URL is available. If the user did not provide it
+  and it is not obvious from local config, ask for the update server URL first.
+- For doctor repair loops, run `npx hot-updater doctor --json` first. Fix
+  issues marked `fixability: "auto"` by editing local project files, run the
+  listed `commands` for issues marked `fixability: "command"`, and rerun doctor
+  after each focused change. Stop when doctor passes or the remaining issues are
+  marked `fixability: "blocked"`.
+- Treat `fixability: "blocked"` as outside the autonomous local loop. Server
+  infrastructure remediation commonly needs provider credentials, environment
+  variables, and redeploy access; summarize the blocker instead of running
+  migrations or mutating provider setup.
 - Treat `deploy`, `patch`, `bundle enable`, `bundle disable`, `bundle update`,
   `bundle delete`, `bundle promote`, `rollback`, `channel set`, `keys
   export-public`, `keys remove`, and `db migrate` as state-changing operations.
@@ -59,6 +68,7 @@ $hot-updater promote bundle <bundle-id> to staging
 $hot-updater create a patch from bundle <old-id> to <new-id>
 $hot-updater export the code signing public key
 $hot-updater run doctor with server URL https://updates.example.com/api/check-update
+$hot-updater fix local doctor issues that do not require server credentials
 ```
 
 Translate the request into the safest CLI flow. If a state-changing request is
@@ -120,6 +130,8 @@ If `--json` is unavailable, rerun the same command without `--json`.
 ```sh
 npx hot-updater init
 npx hot-updater doctor --server-base-url <update-server-url>
+npx hot-updater doctor --json
+npx hot-updater doctor --server-base-url <update-server-url> --json
 npx hot-updater fingerprint
 npx hot-updater fingerprint create
 npx hot-updater app-version
@@ -132,6 +144,9 @@ npx hot-updater console
 - `doctor` checks local setup and server health. Provide `--server-base-url`;
   the command appends `/version` for the server check. If the user has not
   provided one, ask for it before running the command.
+- `doctor --json` is the preferred agent surface. It returns stable issue
+  codes, related paths, `fixability`, and command hints for local iterative
+  repair. Do not parse the human-readable doctor output when JSON is available.
 - `fingerprint` and `fingerprint create` generate the app fingerprint.
 - `app-version` reads native iOS and Android app versions. `--json` returns
   `{ "android": string | null, "ios": string | null }` on CLIs that support it.

--- a/.changeset/sweet-camels-deliver.md
+++ b/.changeset/sweet-camels-deliver.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Check native OTA wiring in doctor

--- a/docs/content/docs/guides/ai-agents.mdx
+++ b/docs/content/docs/guides/ai-agents.mdx
@@ -28,6 +28,7 @@ $hot-updater deploy the current iOS app version to production
 $hot-updater roll back the most recently deployed bundle
 $hot-updater list iOS bundles on the production channel
 $hot-updater run doctor with server URL https://updates.example.com/api/check-update
+$hot-updater fix local doctor issues that do not require server credentials
 ```
 
 The skill gives the agent enough CLI context to translate those requests into
@@ -38,12 +39,19 @@ safe `npx hot-updater ...` flows.
 - The agent should not run `npx hot-updater init` for you. `init` is
   interactive and asks for project-specific provider and build choices, so run
   it directly in your terminal.
-- The agent should ask for the update server URL before running
-  `npx hot-updater doctor` unless you already provided it or it is obvious from
-  local configuration.
+- The agent should ask for the update server URL before running a
+  server/infrastructure doctor check unless you already provided it or it is
+  obvious from local configuration.
+- When iterating on doctor failures, the agent should prefer
+  `npx hot-updater doctor --json`. It should repair issues marked
+  `fixability: "auto"`, run listed commands for `fixability: "command"`, and
+  stop on `fixability: "blocked"`.
 - The agent should not edit provider credentials unless you explicitly ask it
   to. Credentials are commonly stored in `.env.hotupdater`, but projects may
   use a different environment-loading setup.
+- Server infrastructure failures are usually blocked because migrations and
+  redeploys need provider environment variables or deployment access. The agent
+  should summarize those blockers instead of attempting to mutate server state.
 - If a deploy fails, the agent should not keep trying fixes or mutate project
   setup automatically. It should summarize the failed command, the likely
   cause, and the next checks for you to decide.

--- a/docs/content/docs/guides/doctor.mdx
+++ b/docs/content/docs/guides/doctor.mdx
@@ -24,6 +24,15 @@ npx hot-updater doctor
 In an interactive terminal, the command asks for your server base URL. Press
 Enter to skip the server check.
 
+For AI agents and other automation, use JSON output:
+
+```package-install
+npx hot-updater doctor --json
+```
+
+`--json` does not prompt for the server URL. Pass `--server-base-url` when you
+want the infrastructure check included.
+
 ## Check Native Setup
 
 When `@hot-updater/react-native` is installed and native iOS or Android
@@ -47,6 +56,32 @@ For fingerprint projects, fix missing or stale native fingerprint settings with:
 ```package-install
 npx hot-updater fingerprint create
 ```
+
+## AI Agent Iteration
+
+`doctor --json` returns structured issues that an agent can use without parsing
+human-readable terminal output.
+
+Each native issue includes:
+
+- `code`: stable issue code, such as `MISSING_ANDROID_BUNDLE_PROVIDER`
+- `platform`: `ios`, `android`, or `project`
+- `paths`: related local files when available
+- `fixability`: whether the issue is suitable for an agent loop
+- `commands`: safe local commands when the fix is command-driven
+
+Use `fixability` as the automation boundary:
+
+| Fixability | Meaning                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| `auto`     | The agent may inspect and edit local project files, then rerun doctor.                             |
+| `command`  | The agent may run the listed local command, then rerun doctor.                                     |
+| `blocked`  | The issue needs credentials, environment variables, server access, or a human deployment decision. |
+
+Native wiring, fingerprint creation, and native public key export/removal are
+intended to be iterated locally by an agent. Infrastructure failures are marked
+as blocked because applying migrations or redeploying a server usually depends
+on provider credentials and environment-specific access.
 
 ## Check Infrastructure
 
@@ -100,6 +135,7 @@ How to fix it depends on how you run Hot Updater:
 
 ## Options
 
-| Option                    | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| `--server-base-url <url>` | Check deployed infrastructure at `<url>/version`. |
+| Option                    | Description                                             |
+| ------------------------- | ------------------------------------------------------- |
+| `--server-base-url <url>` | Check deployed infrastructure at `<url>/version`.       |
+| `--json`                  | Print a machine-readable result for agents and scripts. |

--- a/docs/content/docs/guides/doctor.mdx
+++ b/docs/content/docs/guides/doctor.mdx
@@ -1,15 +1,17 @@
 ---
 title: "Doctor"
-description: "Check Hot Updater package versions and server infrastructure."
+description: "Check Hot Updater package versions, native setup, and server infrastructure."
 icon: Stethoscope
 version: "v0.30.0"
 ---
 
 ## Overview
 
-Use `hot-updater doctor` to check two things:
+Use `hot-updater doctor` to check the parts that must agree for OTA updates to
+work:
 
 - All Hot Updater packages use compatible versions
+- React Native native files are connected to Hot Updater
 - Your deployed infrastructure server is not outdated
 
 Run it after upgrading Hot Updater, or when OTA updates behave differently after
@@ -21,6 +23,30 @@ npx hot-updater doctor
 
 In an interactive terminal, the command asks for your server base URL. Press
 Enter to skip the server check.
+
+## Check Native Setup
+
+When `@hot-updater/react-native` is installed and native iOS or Android
+directories exist, `doctor` checks:
+
+- iOS `AppDelegate` uses `HotUpdater.bundleURL()`
+- Android `MainApplication` uses `HotUpdater.getJSBundleFile(...)`
+- If `updateStrategy` is `fingerprint`, `fingerprint.json` exists and native
+  fingerprint hashes match it
+- Signing settings match native public key entries
+
+If any required native setting is missing, rebuild-time OTA configuration is not
+healthy yet. Run the command shown by `doctor`, then rebuild the native app.
+
+`doctor` does not require a default channel in native files. If
+`HOT_UPDATER_CHANNEL` or `hot_updater_channel` exists, the command reports it as
+context only.
+
+For fingerprint projects, fix missing or stale native fingerprint settings with:
+
+```package-install
+npx hot-updater fingerprint create
+```
 
 ## Check Infrastructure
 

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -9,6 +9,7 @@ import {
   areVersionsCompatible,
   doctor,
   getRequiredInfrastructureVersion,
+  handleDoctor,
   isInfrastructureUpdateRequired,
   resolveVersionEndpoint,
 } from "./doctor";
@@ -228,6 +229,25 @@ describe("doctor", () => {
 
     const result = await doctor();
     expect(result).toBe(true);
+  });
+
+  it("prints machine-readable JSON without prompting", async () => {
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleDoctor({ json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ success: true }, null, 2),
+    );
+    logSpy.mockRestore();
   });
 
   it("should return true for a healthy setup", async () => {
@@ -553,6 +573,7 @@ describe("doctor", () => {
           requiredVersion: "0.30.0",
           needsUpdate: true,
           remediation: {
+            fixability: "blocked",
             commands: [
               "hot-updater init",
               "hot-updater db migrate",
@@ -591,6 +612,7 @@ describe("doctor", () => {
           needsUpdate: true,
           updateReason: "Version endpoint not found",
           remediation: {
+            fixability: "blocked",
             commands: [
               "hot-updater init",
               "hot-updater db migrate",
@@ -670,6 +692,9 @@ describe("doctor", () => {
           "MISSING_ANDROID_BUNDLE_PROVIDER",
         ]),
       );
+      expect(
+        result.details?.native?.issues.map((issue) => issue.fixability),
+      ).toEqual(expect.arrayContaining(["auto"]));
     }
   });
 
@@ -953,6 +978,12 @@ describe("doctor", () => {
       expect(
         result.details?.native?.issues.map((issue) => issue.resolution),
       ).toContain("Run `npx hot-updater fingerprint create`.");
+      expect(
+        result.details?.native?.issues.map((issue) => issue.fixability),
+      ).toEqual(["command", "command", "command"]);
+      expect(
+        result.details?.native?.issues.flatMap((issue) => issue.commands ?? []),
+      ).toEqual(expect.arrayContaining(["npx hot-updater fingerprint create"]));
     }
   });
 

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -1,5 +1,9 @@
-import { readPackageUp } from "@hot-updater/cli-tools";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { getCwd, loadConfig, readPackageUp } from "@hot-updater/cli-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   areVersionsCompatible,
@@ -11,11 +15,70 @@ import {
 
 vi.mock("@hot-updater/cli-tools", () => ({
   getCwd: vi.fn(() => "/mock/cwd"),
+  loadConfig: vi.fn(),
   p: {},
   readPackageUp: vi.fn(),
 }));
 
+const mockGetCwd = getCwd as ReturnType<typeof vi.fn>;
+const mockLoadConfig = loadConfig as ReturnType<typeof vi.fn>;
 const mockReadPackageUp = readPackageUp as ReturnType<typeof vi.fn>;
+
+const createConfig = (overrides: Record<string, unknown> = {}) => ({
+  updateStrategy: "appVersion",
+  platform: {
+    ios: {
+      infoPlistPaths: [],
+    },
+    android: {
+      stringResourcePaths: [],
+    },
+  },
+  signing: {
+    enabled: false,
+  },
+  ...overrides,
+});
+
+const createTempProject = async () =>
+  await fs.mkdtemp(path.join(os.tmpdir(), "hot-updater-doctor-"));
+
+const writeFile = async (filePath: string, content: string) => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+};
+
+const writeInfoPlist = async (
+  cwd: string,
+  body: string,
+  filePath = "ios/App/Info.plist",
+) => {
+  await writeFile(
+    path.join(cwd, filePath),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+${body}
+</dict>
+</plist>
+`,
+  );
+};
+
+const writeStringsXml = async (
+  cwd: string,
+  body: string,
+  filePath = "android/app/src/main/res/values/strings.xml",
+) => {
+  await writeFile(
+    path.join(cwd, filePath),
+    `<resources>
+${body}
+</resources>
+`,
+  );
+};
 
 describe("areVersionsCompatible", () => {
   // Test cases for exact matches
@@ -131,8 +194,21 @@ describe("infrastructure version helpers", () => {
 });
 
 describe("doctor", () => {
+  const tempProjects: string[] = [];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCwd.mockReturnValue("/mock/cwd");
+    mockLoadConfig.mockResolvedValue(createConfig());
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempProjects.map((project) =>
+        fs.rm(project, { recursive: true, force: true }),
+      ),
+    );
+    tempProjects.length = 0;
   });
 
   it("should return true for a healthy setup", async () => {
@@ -524,5 +600,278 @@ describe("doctor", () => {
         },
       },
     });
+  });
+
+  it("detects missing native integration in existing React Native projects", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeInfoPlist(cwd, "");
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      'import UIKit\nfunc bundleURL() { Bundle.main.url(forResource: "main", withExtension: "jsbundle") }\n',
+    );
+    await writeStringsXml(cwd, "");
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.kt",
+      ),
+      "class MainApplication",
+    );
+
+    const result = await doctor();
+
+    expect(result).toMatchObject({
+      success: false,
+      details: {
+        native: {
+          updateStrategy: "appVersion",
+          ios: {
+            detected: true,
+            bundleProviderConfigured: false,
+          },
+          android: {
+            detected: true,
+            bundleProviderConfigured: false,
+          },
+        },
+      },
+    });
+    expect(result).not.toBe(true);
+    if (result !== true) {
+      expect(result.details?.native?.issues.map((issue) => issue.code)).toEqual(
+        expect.arrayContaining([
+          "MISSING_IOS_BUNDLE_PROVIDER",
+          "MISSING_ANDROID_BUNDLE_PROVIDER",
+        ]),
+      );
+    }
+  });
+
+  it("passes native integration checks when iOS and Android are configured", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeInfoPlist(
+      cwd,
+      "<key>HOT_UPDATER_CHANNEL</key>\n<string>production</string>",
+    );
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      "import HotUpdater\nfunc bundleURL() -> URL? { HotUpdater.bundleURL() }\n",
+    );
+    await writeStringsXml(
+      cwd,
+      '<string name="hot_updater_channel" moduleConfig="true">production</string>',
+    );
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.kt",
+      ),
+      "import com.hotupdater.HotUpdater\nval bundle = HotUpdater.getJSBundleFile(applicationContext)\n",
+    );
+
+    const result = await doctor();
+
+    expect(result).toMatchObject({
+      success: true,
+      details: {
+        native: {
+          ios: {
+            channel: "production",
+            bundleProviderConfigured: true,
+          },
+          android: {
+            channel: "production",
+            bundleProviderConfigured: true,
+          },
+          issues: [],
+        },
+      },
+    });
+  });
+
+  it("requires fingerprint.json and native hashes for fingerprint strategy", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        updateStrategy: "fingerprint",
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeInfoPlist(
+      cwd,
+      "<key>HOT_UPDATER_CHANNEL</key>\n<string>production</string>",
+    );
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      "import HotUpdater\nfunc bundleURL() -> URL? { HotUpdater.bundleURL() }\n",
+    );
+    await writeStringsXml(
+      cwd,
+      '<string name="hot_updater_channel" moduleConfig="true">production</string>',
+    );
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.kt",
+      ),
+      "import com.hotupdater.HotUpdater\nval bundle = HotUpdater.getJSBundleFile(applicationContext)\n",
+    );
+
+    const result = await doctor();
+
+    expect(result).not.toBe(true);
+    if (result !== true) {
+      expect(result.success).toBe(false);
+      expect(result.details?.native?.issues.map((issue) => issue.code)).toEqual(
+        [
+          "MISSING_FINGERPRINT_HASH",
+          "MISSING_FINGERPRINT_HASH",
+          "MISSING_FINGERPRINT_JSON",
+        ],
+      );
+      expect(
+        result.details?.native?.issues.map((issue) => issue.resolution),
+      ).toContain("Run `npx hot-updater fingerprint create`.");
+    }
+  });
+
+  it("requires fingerprint hashes in native files when fingerprint.json exists", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        updateStrategy: "fingerprint",
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeFile(
+      path.join(cwd, "fingerprint.json"),
+      JSON.stringify({
+        ios: { hash: "ios-fingerprint" },
+        android: { hash: "android-fingerprint" },
+      }),
+    );
+    await writeInfoPlist(
+      cwd,
+      "<key>HOT_UPDATER_CHANNEL</key>\n<string>production</string>",
+    );
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      "import HotUpdater\nfunc bundleURL() -> URL? { HotUpdater.bundleURL() }\n",
+    );
+    await writeStringsXml(
+      cwd,
+      '<string name="hot_updater_channel" moduleConfig="true">production</string>',
+    );
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.kt",
+      ),
+      "import com.hotupdater.HotUpdater\nval bundle = HotUpdater.getJSBundleFile(applicationContext)\n",
+    );
+
+    const result = await doctor();
+
+    expect(result).not.toBe(true);
+    if (result !== true) {
+      expect(result.success).toBe(false);
+      expect(result.details?.native?.issues.map((issue) => issue.code)).toEqual(
+        ["MISSING_FINGERPRINT_HASH", "MISSING_FINGERPRINT_HASH"],
+      );
+    }
   });
 });

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -741,6 +741,77 @@ describe("doctor", () => {
     });
   });
 
+  it("accepts Java Companion Android bundle provider calls", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeInfoPlist(
+      cwd,
+      "<key>HOT_UPDATER_CHANNEL</key>\n<string>production</string>",
+    );
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      "import HotUpdater\nfunc bundleURL() -> URL? { HotUpdater.bundleURL() }\n",
+    );
+    await writeStringsXml(
+      cwd,
+      '<string name="hot_updater_channel" moduleConfig="true">production</string>',
+    );
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.java",
+      ),
+      [
+        "import com.hotupdater.HotUpdater;",
+        "public class MainApplication {",
+        "  protected String getJSBundleFile() {",
+        "    return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+
+    const result = await doctor();
+
+    expect(result).toMatchObject({
+      success: true,
+      details: {
+        native: {
+          android: {
+            channel: "production",
+            bundleProviderConfigured: true,
+          },
+          issues: [],
+        },
+      },
+    });
+  });
+
   it("ignores fingerprint.json when update strategy is appVersion", async () => {
     const cwd = await createTempProject();
     tempProjects.push(cwd);

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -741,6 +741,83 @@ describe("doctor", () => {
     });
   });
 
+  it("ignores fingerprint.json when update strategy is appVersion", async () => {
+    const cwd = await createTempProject();
+    tempProjects.push(cwd);
+    mockGetCwd.mockReturnValue(cwd);
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "0.31.0",
+          "@hot-updater/react-native": "0.31.0",
+        },
+      },
+      path: path.join(cwd, "package.json"),
+    });
+    mockLoadConfig.mockResolvedValue(
+      createConfig({
+        updateStrategy: "appVersion",
+        platform: {
+          ios: {
+            infoPlistPaths: ["ios/App/Info.plist"],
+          },
+          android: {
+            stringResourcePaths: [
+              "android/app/src/main/res/values/strings.xml",
+            ],
+          },
+        },
+      }),
+    );
+
+    await writeFile(
+      path.join(cwd, "fingerprint.json"),
+      JSON.stringify({
+        ios: { hash: "ios-fingerprint" },
+        android: { hash: "android-fingerprint" },
+      }),
+    );
+    await writeInfoPlist(
+      cwd,
+      [
+        "<key>HOT_UPDATER_CHANNEL</key>",
+        "<string>production</string>",
+        "<key>HOT_UPDATER_FINGERPRINT_HASH</key>",
+        "<string>stale-ios-fingerprint</string>",
+      ].join("\n"),
+    );
+    await writeFile(
+      path.join(cwd, "ios/App/AppDelegate.swift"),
+      "import HotUpdater\nfunc bundleURL() -> URL? { HotUpdater.bundleURL() }\n",
+    );
+    await writeStringsXml(
+      cwd,
+      [
+        '<string name="hot_updater_channel" moduleConfig="true">production</string>',
+        '<string name="hot_updater_fingerprint_hash" moduleConfig="true">stale-android-fingerprint</string>',
+      ].join("\n"),
+    );
+    await writeFile(
+      path.join(
+        cwd,
+        "android/app/src/main/java/com/example/MainApplication.kt",
+      ),
+      "import com.hotupdater.HotUpdater\nval bundle = HotUpdater.getJSBundleFile(applicationContext)\n",
+    );
+
+    const result = await doctor();
+
+    expect(result).toMatchObject({
+      success: true,
+      details: {
+        native: {
+          updateStrategy: "appVersion",
+          issues: [],
+        },
+      },
+    });
+  });
+
   it("requires fingerprint.json and native hashes for fingerprint strategy", async () => {
     const cwd = await createTempProject();
     tempProjects.push(cwd);

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -42,6 +42,7 @@ interface InfrastructureStatus {
   remediation?: InfrastructureRemediation;
 }
 
+type DoctorFixability = "auto" | "command" | "blocked";
 type NativePlatform = "ios" | "android";
 type NativeIssueType = "error" | "warning";
 
@@ -60,6 +61,8 @@ interface NativeCheckIssue {
     | SigningConfigIssue["code"];
   message: string;
   resolution: string;
+  fixability: DoctorFixability;
+  commands?: string[];
   paths?: string[];
 }
 
@@ -112,6 +115,11 @@ interface DoctorOptions {
   fetch?: typeof fetch;
 }
 
+interface HandleDoctorOptions {
+  serverBaseUrl?: string;
+  json?: boolean;
+}
+
 interface ServerVersionResponse {
   version?: unknown;
 }
@@ -122,6 +130,8 @@ interface InfrastructureUpdateTarget {
 }
 
 interface InfrastructureRemediation {
+  fixability: DoctorFixability;
+  reason: string;
   commands: string[];
 }
 
@@ -130,6 +140,16 @@ const INFRASTRUCTURE_RECOVERY_COMMANDS = [
   "hot-updater db migrate",
   "hot-updater db generate",
 ] as const;
+
+const FINGERPRINT_RECOVERY_COMMANDS = [
+  "npx hot-updater fingerprint create",
+] as const;
+
+const EXPORT_PUBLIC_KEY_COMMANDS = [
+  "npx hot-updater keys export-public",
+] as const;
+
+const REMOVE_PUBLIC_KEY_COMMANDS = ["npx hot-updater keys remove"] as const;
 
 // Only versions that require deployed server/infrastructure changes belong here.
 // Regular package releases must not be added unless existing infrastructure needs
@@ -257,6 +277,9 @@ export function resolveVersionEndpoint(serverBaseUrl: string): string {
 }
 
 const createInfrastructureRemediation = (): InfrastructureRemediation => ({
+  fixability: "blocked",
+  reason:
+    "Server infrastructure changes usually need provider credentials, environment variables, and redeploy access.",
   commands: [...INFRASTRUCTURE_RECOVERY_COMMANDS],
 });
 
@@ -363,6 +386,7 @@ const checkIosNativeStatus = async ({
       message: "iOS Info.plist files were not found.",
       resolution:
         "Check platform.ios.infoPlistPaths in hot-updater.config.ts or run iOS prebuild first.",
+      fixability: "auto",
       paths: configuredPaths,
     });
   }
@@ -380,6 +404,8 @@ const checkIosNativeStatus = async ({
       message: "HOT_UPDATER_FINGERPRINT_HASH is missing from Info.plist.",
       resolution:
         "Run `npx hot-updater fingerprint create` or rebuild through the Expo config plugin.",
+      fixability: "command",
+      commands: [...FINGERPRINT_RECOVERY_COMMANDS],
       paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
     });
   } else if (
@@ -394,6 +420,8 @@ const checkIosNativeStatus = async ({
       message: "HOT_UPDATER_FINGERPRINT_HASH does not match fingerprint.json.",
       resolution:
         "Run `npx hot-updater fingerprint create` and rebuild your iOS app.",
+      fixability: "command",
+      commands: [...FINGERPRINT_RECOVERY_COMMANDS],
       paths: fingerprintHash?.paths ?? files,
     });
   }
@@ -413,6 +441,7 @@ const checkIosNativeStatus = async ({
       message: "iOS AppDelegate file was not found.",
       resolution:
         "Add HotUpdater.bundleURL() to the app's iOS bundleURL provider.",
+      fixability: "auto",
     });
   } else {
     const matchedFile = await findFirstMatchingFile({
@@ -433,6 +462,7 @@ const checkIosNativeStatus = async ({
         message: "iOS AppDelegate does not use HotUpdater.bundleURL().",
         resolution:
           "Replace the release JS bundle URL provider with HotUpdater.bundleURL().",
+        fixability: "auto",
         paths: appDelegateFiles,
       });
     }
@@ -483,6 +513,7 @@ const checkAndroidNativeStatus = async ({
       message: "Android strings.xml files were not found.",
       resolution:
         "Check platform.android.stringResourcePaths in hot-updater.config.ts or run Android prebuild first.",
+      fixability: "auto",
       paths: configuredPaths,
     });
   }
@@ -500,6 +531,8 @@ const checkAndroidNativeStatus = async ({
       message: "hot_updater_fingerprint_hash is missing from strings.xml.",
       resolution:
         "Run `npx hot-updater fingerprint create` or rebuild through the Expo config plugin.",
+      fixability: "command",
+      commands: [...FINGERPRINT_RECOVERY_COMMANDS],
       paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
     });
   } else if (
@@ -514,6 +547,8 @@ const checkAndroidNativeStatus = async ({
       message: "hot_updater_fingerprint_hash does not match fingerprint.json.",
       resolution:
         "Run `npx hot-updater fingerprint create` and rebuild your Android app.",
+      fixability: "command",
+      commands: [...FINGERPRINT_RECOVERY_COMMANDS],
       paths: fingerprintHash?.paths ?? files,
     });
   }
@@ -533,6 +568,7 @@ const checkAndroidNativeStatus = async ({
       message: "Android MainApplication file was not found.",
       resolution:
         "Add HotUpdater.getJSBundleFile(applicationContext) to the Android host configuration.",
+      fixability: "auto",
     });
   } else {
     const matchedFile = await findFirstMatchingFile({
@@ -553,6 +589,7 @@ const checkAndroidNativeStatus = async ({
           "Android MainApplication does not use HotUpdater.getJSBundleFile().",
         resolution:
           "Pass HotUpdater.getJSBundleFile(applicationContext) to React Native's JS bundle provider.",
+        fixability: "auto",
         paths: mainApplicationFiles,
       });
     }
@@ -570,13 +607,31 @@ const checkAndroidNativeStatus = async ({
   };
 };
 
-const toNativeIssue = (issue: SigningConfigIssue): NativeCheckIssue => ({
-  type: issue.type,
-  platform: issue.platform,
-  code: issue.code,
-  message: issue.message,
-  resolution: issue.resolution,
-});
+const toNativeIssue = (issue: SigningConfigIssue): NativeCheckIssue => {
+  if (issue.code === "NATIVE_FILES_NOT_FOUND") {
+    return {
+      type: issue.type,
+      platform: issue.platform,
+      code: issue.code,
+      message: issue.message,
+      resolution: issue.resolution,
+      fixability: "auto",
+    };
+  }
+
+  return {
+    type: issue.type,
+    platform: issue.platform,
+    code: issue.code,
+    message: issue.message,
+    resolution: issue.resolution,
+    fixability: "command",
+    commands:
+      issue.code === "ORPHAN_PUBLIC_KEY"
+        ? [...REMOVE_PUBLIC_KEY_COMMANDS]
+        : [...EXPORT_PUBLIC_KEY_COMMANDS],
+  };
+};
 
 async function checkNativeStatus({
   cwd,
@@ -624,6 +679,8 @@ async function checkNativeStatus({
       code: "MISSING_FINGERPRINT_JSON",
       message: "fingerprint.json is missing for fingerprint update strategy.",
       resolution: "Run `npx hot-updater fingerprint create`.",
+      fixability: "command",
+      commands: [...FINGERPRINT_RECOVERY_COMMANDS],
       paths: ["fingerprint.json"],
     });
   }
@@ -844,6 +901,14 @@ export async function doctor(
   }
 }
 
+const normalizeDoctorResult = (result: true | DoctorResult): DoctorResult => {
+  if (result === true) {
+    return { success: true };
+  }
+
+  return result;
+};
+
 const promptServerBaseUrl = async () => {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return undefined;
@@ -877,9 +942,17 @@ const promptServerBaseUrl = async () => {
 
 export const handleDoctor = async ({
   serverBaseUrl,
-}: {
-  serverBaseUrl?: string;
-} = {}) => {
+  json = false,
+}: HandleDoctorOptions = {}) => {
+  if (json) {
+    const result = normalizeDoctorResult(await doctor({ serverBaseUrl }));
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.success) {
+      process.exit(1);
+    }
+    return;
+  }
+
   p.intro("Hot Updater doctor");
 
   const resolvedServerBaseUrl = serverBaseUrl ?? (await promptServerBaseUrl());

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -538,7 +538,9 @@ const checkAndroidNativeStatus = async ({
     const matchedFile = await findFirstMatchingFile({
       cwd,
       files: mainApplicationFiles,
-      patterns: [/HotUpdater\.getJSBundleFile\s*\(/],
+      patterns: [
+        /HotUpdater\s*(?:\.\s*Companion\s*)?\.\s*getJSBundleFile\s*\(/,
+      ],
     });
     bundleProviderConfigured = matchedFile !== null;
 

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -1,8 +1,24 @@
-import { getCwd, p, readPackageUp } from "@hot-updater/cli-tools";
+import fs from "fs";
+import path from "path";
+
+import {
+  type ConfigResponse,
+  getCwd,
+  loadConfig,
+  p,
+  readPackageUp,
+} from "@hot-updater/cli-tools";
 import { merge } from "es-toolkit";
+import fg from "fast-glob";
 import * as semver from "semver";
 
 import { ui } from "../utils/cli-ui";
+import { AndroidConfigParser } from "../utils/configParser/androidParser";
+import { IosConfigParser } from "../utils/configParser/iosParser";
+import {
+  type SigningConfigIssue,
+  validateSigningConfig,
+} from "../utils/signing/validateSigningConfig";
 
 interface PackageJson {
   dependencies?: Record<string, string>;
@@ -26,11 +42,54 @@ interface InfrastructureStatus {
   remediation?: InfrastructureRemediation;
 }
 
+type NativePlatform = "ios" | "android";
+type NativeIssueType = "error" | "warning";
+
+interface NativeCheckIssue {
+  type: NativeIssueType;
+  platform: NativePlatform | "project";
+  code:
+    | "NATIVE_FILES_NOT_FOUND"
+    | "APP_DELEGATE_NOT_FOUND"
+    | "MAIN_APPLICATION_NOT_FOUND"
+    | "MISSING_IOS_BUNDLE_PROVIDER"
+    | "MISSING_ANDROID_BUNDLE_PROVIDER"
+    | "MISSING_FINGERPRINT_JSON"
+    | "MISSING_FINGERPRINT_HASH"
+    | "FINGERPRINT_HASH_MISMATCH"
+    | SigningConfigIssue["code"];
+  message: string;
+  resolution: string;
+  paths?: string[];
+}
+
+interface NativePlatformStatus {
+  detected: boolean;
+  files: string[];
+  channel?: string;
+  fingerprintHash?: string;
+  bundleProviderConfigured?: boolean;
+}
+
+interface NativeStatus {
+  updateStrategy: ConfigResponse["updateStrategy"];
+  fingerprintJsonPath?: string;
+  ios?: NativePlatformStatus;
+  android?: NativePlatformStatus;
+  issues: NativeCheckIssue[];
+}
+
+interface LocalFingerprint {
+  ios?: { hash?: string } | null;
+  android?: { hash?: string } | null;
+}
+
 interface DoctorDetails {
   // Version related
   hotUpdaterVersion?: string;
   versionMismatches?: VersionMismatch[];
   infrastructure?: InfrastructureStatus;
+  native?: NativeStatus;
 
   // Package info
   packageJsonPath?: string;
@@ -201,6 +260,379 @@ const createInfrastructureRemediation = (): InfrastructureRemediation => ({
   commands: [...INFRASTRUCTURE_RECOVERY_COMMANDS],
 });
 
+const toRelativePath = (cwd: string, filePath: string) =>
+  path.relative(cwd, filePath);
+
+const resolveProjectPath = (cwd: string, filePath: string) =>
+  path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+
+const findNativeFiles = ({
+  cwd,
+  platform,
+  pattern,
+}: {
+  cwd: string;
+  platform: NativePlatform;
+  pattern: string | string[];
+}) => {
+  const platformRoot = path.join(cwd, platform);
+  if (!fs.existsSync(platformRoot)) {
+    return [];
+  }
+
+  return fg
+    .sync(pattern, {
+      cwd: platformRoot,
+      absolute: true,
+      onlyFiles: true,
+      ignore: [
+        "**/Pods/**",
+        "**/build/**",
+        "**/Build/**",
+        "**/*.app/**",
+        "**/*.xcarchive/**",
+      ],
+    })
+    .map((filePath) => toRelativePath(cwd, filePath))
+    .sort();
+};
+
+const findFirstMatchingFile = async ({
+  cwd,
+  files,
+  patterns,
+}: {
+  cwd: string;
+  files: string[];
+  patterns: RegExp[];
+}) => {
+  for (const filePath of files) {
+    const absolutePath = resolveProjectPath(cwd, filePath);
+    const content = await fs.promises.readFile(absolutePath, "utf-8");
+    if (patterns.some((pattern) => pattern.test(content))) {
+      return filePath;
+    }
+  }
+
+  return null;
+};
+
+const readLocalFingerprintFile = async (cwd: string) => {
+  const fingerprintJsonPath = path.join(cwd, "fingerprint.json");
+  try {
+    const content = await fs.promises.readFile(fingerprintJsonPath, "utf-8");
+    return {
+      path: "fingerprint.json",
+      value: JSON.parse(content) as LocalFingerprint,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const checkIosNativeStatus = async ({
+  cwd,
+  config,
+  requireFingerprint,
+  expectedFingerprintHash,
+}: {
+  cwd: string;
+  config: ConfigResponse;
+  requireFingerprint: boolean;
+  expectedFingerprintHash?: string;
+}): Promise<{ status?: NativePlatformStatus; issues: NativeCheckIssue[] }> => {
+  const configuredPaths = config.platform.ios.infoPlistPaths;
+  const iosDetected =
+    fs.existsSync(path.join(cwd, "ios")) || configuredPaths.length > 0;
+
+  if (!iosDetected) {
+    return { issues: [] };
+  }
+
+  const iosParser = new IosConfigParser(configuredPaths);
+  const files = configuredPaths.filter((filePath) =>
+    fs.existsSync(resolveProjectPath(cwd, filePath)),
+  );
+  const issues: NativeCheckIssue[] = [];
+
+  if (!(await iosParser.exists())) {
+    issues.push({
+      type: "error",
+      platform: "ios",
+      code: "NATIVE_FILES_NOT_FOUND",
+      message: "iOS Info.plist files were not found.",
+      resolution:
+        "Check platform.ios.infoPlistPaths in hot-updater.config.ts or run iOS prebuild first.",
+      paths: configuredPaths,
+    });
+  }
+
+  const channel = await iosParser.get("HOT_UPDATER_CHANNEL");
+  const fingerprintHash = requireFingerprint
+    ? await iosParser.get("HOT_UPDATER_FINGERPRINT_HASH")
+    : undefined;
+
+  if (requireFingerprint && !fingerprintHash?.value) {
+    issues.push({
+      type: "error",
+      platform: "ios",
+      code: "MISSING_FINGERPRINT_HASH",
+      message: "HOT_UPDATER_FINGERPRINT_HASH is missing from Info.plist.",
+      resolution:
+        "Run `npx hot-updater fingerprint create` or rebuild through the Expo config plugin.",
+      paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
+    });
+  } else if (
+    expectedFingerprintHash &&
+    fingerprintHash?.value !== expectedFingerprintHash
+  ) {
+    issues.push({
+      type: "error",
+      platform: "ios",
+      code: "FINGERPRINT_HASH_MISMATCH",
+      message: "HOT_UPDATER_FINGERPRINT_HASH does not match fingerprint.json.",
+      resolution:
+        "Run `npx hot-updater fingerprint create` and rebuild your iOS app.",
+      paths: fingerprintHash?.paths ?? files,
+    });
+  }
+
+  const appDelegateFiles = findNativeFiles({
+    cwd,
+    platform: "ios",
+    pattern: "**/AppDelegate.{swift,mm,m}",
+  });
+
+  let bundleProviderConfigured = false;
+  if (appDelegateFiles.length === 0) {
+    issues.push({
+      type: "error",
+      platform: "ios",
+      code: "APP_DELEGATE_NOT_FOUND",
+      message: "iOS AppDelegate file was not found.",
+      resolution:
+        "Add HotUpdater.bundleURL() to the app's iOS bundleURL provider.",
+    });
+  } else {
+    const matchedFile = await findFirstMatchingFile({
+      cwd,
+      files: appDelegateFiles,
+      patterns: [
+        /HotUpdater\.bundleURL\s*\(/,
+        /\[HotUpdater\s+bundleURL(?:WithBundle)?:?/,
+      ],
+    });
+    bundleProviderConfigured = matchedFile !== null;
+
+    if (!bundleProviderConfigured) {
+      issues.push({
+        type: "error",
+        platform: "ios",
+        code: "MISSING_IOS_BUNDLE_PROVIDER",
+        message: "iOS AppDelegate does not use HotUpdater.bundleURL().",
+        resolution:
+          "Replace the release JS bundle URL provider with HotUpdater.bundleURL().",
+        paths: appDelegateFiles,
+      });
+    }
+  }
+
+  return {
+    status: {
+      detected: true,
+      files: [...files, ...appDelegateFiles],
+      channel: channel.value ?? undefined,
+      fingerprintHash: fingerprintHash?.value ?? undefined,
+      bundleProviderConfigured,
+    },
+    issues,
+  };
+};
+
+const checkAndroidNativeStatus = async ({
+  cwd,
+  config,
+  requireFingerprint,
+  expectedFingerprintHash,
+}: {
+  cwd: string;
+  config: ConfigResponse;
+  requireFingerprint: boolean;
+  expectedFingerprintHash?: string;
+}): Promise<{ status?: NativePlatformStatus; issues: NativeCheckIssue[] }> => {
+  const configuredPaths = config.platform.android.stringResourcePaths;
+  const androidDetected =
+    fs.existsSync(path.join(cwd, "android")) || configuredPaths.length > 0;
+
+  if (!androidDetected) {
+    return { issues: [] };
+  }
+
+  const androidParser = new AndroidConfigParser(configuredPaths);
+  const files = configuredPaths.filter((filePath) =>
+    fs.existsSync(resolveProjectPath(cwd, filePath)),
+  );
+  const issues: NativeCheckIssue[] = [];
+
+  if (!(await androidParser.exists())) {
+    issues.push({
+      type: "error",
+      platform: "android",
+      code: "NATIVE_FILES_NOT_FOUND",
+      message: "Android strings.xml files were not found.",
+      resolution:
+        "Check platform.android.stringResourcePaths in hot-updater.config.ts or run Android prebuild first.",
+      paths: configuredPaths,
+    });
+  }
+
+  const channel = await androidParser.get("hot_updater_channel");
+  const fingerprintHash = requireFingerprint
+    ? await androidParser.get("hot_updater_fingerprint_hash")
+    : undefined;
+
+  if (requireFingerprint && !fingerprintHash?.value) {
+    issues.push({
+      type: "error",
+      platform: "android",
+      code: "MISSING_FINGERPRINT_HASH",
+      message: "hot_updater_fingerprint_hash is missing from strings.xml.",
+      resolution:
+        "Run `npx hot-updater fingerprint create` or rebuild through the Expo config plugin.",
+      paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
+    });
+  } else if (
+    expectedFingerprintHash &&
+    fingerprintHash?.value !== expectedFingerprintHash
+  ) {
+    issues.push({
+      type: "error",
+      platform: "android",
+      code: "FINGERPRINT_HASH_MISMATCH",
+      message: "hot_updater_fingerprint_hash does not match fingerprint.json.",
+      resolution:
+        "Run `npx hot-updater fingerprint create` and rebuild your Android app.",
+      paths: fingerprintHash?.paths ?? files,
+    });
+  }
+
+  const mainApplicationFiles = findNativeFiles({
+    cwd,
+    platform: "android",
+    pattern: "**/MainApplication.{kt,java}",
+  });
+
+  let bundleProviderConfigured = false;
+  if (mainApplicationFiles.length === 0) {
+    issues.push({
+      type: "error",
+      platform: "android",
+      code: "MAIN_APPLICATION_NOT_FOUND",
+      message: "Android MainApplication file was not found.",
+      resolution:
+        "Add HotUpdater.getJSBundleFile(applicationContext) to the Android host configuration.",
+    });
+  } else {
+    const matchedFile = await findFirstMatchingFile({
+      cwd,
+      files: mainApplicationFiles,
+      patterns: [/HotUpdater\.getJSBundleFile\s*\(/],
+    });
+    bundleProviderConfigured = matchedFile !== null;
+
+    if (!bundleProviderConfigured) {
+      issues.push({
+        type: "error",
+        platform: "android",
+        code: "MISSING_ANDROID_BUNDLE_PROVIDER",
+        message:
+          "Android MainApplication does not use HotUpdater.getJSBundleFile().",
+        resolution:
+          "Pass HotUpdater.getJSBundleFile(applicationContext) to React Native's JS bundle provider.",
+        paths: mainApplicationFiles,
+      });
+    }
+  }
+
+  return {
+    status: {
+      detected: true,
+      files: [...files, ...mainApplicationFiles],
+      channel: channel.value ?? undefined,
+      fingerprintHash: fingerprintHash?.value ?? undefined,
+      bundleProviderConfigured,
+    },
+    issues,
+  };
+};
+
+const toNativeIssue = (issue: SigningConfigIssue): NativeCheckIssue => ({
+  type: issue.type,
+  platform: issue.platform,
+  code: issue.code,
+  message: issue.message,
+  resolution: issue.resolution,
+});
+
+async function checkNativeStatus({
+  cwd,
+}: {
+  cwd: string;
+}): Promise<NativeStatus | undefined> {
+  const hasNativeDirectories =
+    fs.existsSync(path.join(cwd, "ios")) ||
+    fs.existsSync(path.join(cwd, "android"));
+
+  if (!hasNativeDirectories) {
+    return undefined;
+  }
+
+  const config = await loadConfig(null);
+  const localFingerprint = await readLocalFingerprintFile(cwd);
+  const requireFingerprint = config.updateStrategy === "fingerprint";
+
+  const [ios, android, signing] = await Promise.all([
+    checkIosNativeStatus({
+      cwd,
+      config,
+      requireFingerprint,
+      expectedFingerprintHash: localFingerprint?.value.ios?.hash,
+    }),
+    checkAndroidNativeStatus({
+      cwd,
+      config,
+      requireFingerprint,
+      expectedFingerprintHash: localFingerprint?.value.android?.hash,
+    }),
+    validateSigningConfig(config),
+  ]);
+
+  const issues = [
+    ...ios.issues,
+    ...android.issues,
+    ...signing.issues.map(toNativeIssue),
+  ];
+
+  if (requireFingerprint && !localFingerprint) {
+    issues.push({
+      type: "error",
+      platform: "project",
+      code: "MISSING_FINGERPRINT_JSON",
+      message: "fingerprint.json is missing for fingerprint update strategy.",
+      resolution: "Run `npx hot-updater fingerprint create`.",
+      paths: ["fingerprint.json"],
+    });
+  }
+
+  return {
+    updateStrategy: config.updateStrategy,
+    fingerprintJsonPath: localFingerprint?.path,
+    ios: ios.status,
+    android: android.status,
+    issues,
+  };
+}
+
 async function checkInfrastructureStatus({
   serverBaseUrl,
   fetchImpl = fetch,
@@ -315,6 +747,8 @@ export async function doctor(
     const hotUpdaterPackages = Object.keys(allDependencies).filter((key) =>
       key.startsWith("@hot-updater/"),
     );
+    const hasReactNativePackage =
+      allDependencies["@hot-updater/react-native"] !== undefined;
 
     // Check for version mismatches
     const versionMismatches: VersionMismatch[] = [];
@@ -356,6 +790,10 @@ export async function doctor(
       }
     }
 
+    if (hasReactNativePackage) {
+      details.native = await checkNativeStatus({ cwd });
+    }
+
     // Add version mismatches if any
     if (versionMismatches.length > 0) {
       details.versionMismatches = versionMismatches;
@@ -365,7 +803,10 @@ export async function doctor(
     const hasInfrastructureIssue =
       details.infrastructure?.error !== undefined ||
       details.infrastructure?.needsUpdate === true;
-    const hasIssues = versionMismatches.length > 0 || hasInfrastructureIssue;
+    const hasNativeIssue =
+      details.native?.issues.some((issue) => issue.type === "error") === true;
+    const hasIssues =
+      versionMismatches.length > 0 || hasInfrastructureIssue || hasNativeIssue;
     // Future: || configurationIssues.length > 0 || etc.
 
     if (hasIssues) {
@@ -376,6 +817,13 @@ export async function doctor(
     }
 
     if (details.infrastructure) {
+      return {
+        success: true,
+        details,
+      };
+    }
+
+    if (details.native) {
       return {
         success: true,
         details,
@@ -496,6 +944,53 @@ export const handleDoctor = async ({
           ),
         ]),
       );
+    }
+  }
+
+  if (details?.native) {
+    const native = details.native;
+    const lines = [ui.kv("Strategy", native.updateStrategy)];
+
+    if (native.ios?.detected) {
+      lines.push(
+        ui.kv(
+          "iOS",
+          native.ios.bundleProviderConfigured
+            ? ui.status(true)
+            : ui.status(false),
+        ),
+      );
+      if (native.ios.channel) {
+        lines.push(ui.kv("iOS channel", ui.channel(native.ios.channel)));
+      }
+    }
+
+    if (native.android?.detected) {
+      lines.push(
+        ui.kv(
+          "Android",
+          native.android.bundleProviderConfigured
+            ? ui.status(true)
+            : ui.status(false),
+        ),
+      );
+      if (native.android.channel) {
+        lines.push(
+          ui.kv("Android channel", ui.channel(native.android.channel)),
+        );
+      }
+    }
+
+    p.log.message(ui.block("Native", lines));
+
+    for (const issue of native.issues) {
+      const message = `${issue.platform}: ${issue.message}`;
+      if (issue.type === "error") {
+        p.log.error(message);
+      } else {
+        p.log.warn(message);
+      }
+      p.log.info(issue.resolution);
     }
   }
 

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -383,6 +383,7 @@ const checkIosNativeStatus = async ({
       paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
     });
   } else if (
+    requireFingerprint &&
     expectedFingerprintHash &&
     fingerprintHash?.value !== expectedFingerprintHash
   ) {
@@ -502,6 +503,7 @@ const checkAndroidNativeStatus = async ({
       paths: fingerprintHash?.paths.length ? fingerprintHash.paths : files,
     });
   } else if (
+    requireFingerprint &&
     expectedFingerprintHash &&
     fingerprintHash?.value !== expectedFingerprintHash
   ) {

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -88,6 +88,7 @@ program
     "--server-base-url <url>",
     "server base URL used by update checks (doctor appends /version)",
   )
+  .option("--json", "output machine-readable doctor result")
   .action(handleDoctor);
 
 const fingerprintCommand = program

--- a/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
+++ b/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
@@ -1,7 +1,7 @@
 import type { ConfigResponse } from "@hot-updater/cli-tools";
 
-import { AndroidConfigParser } from "@/utils/configParser/androidParser";
-import { IosConfigParser } from "@/utils/configParser/iosParser";
+import { AndroidConfigParser } from "../configParser/androidParser";
+import { IosConfigParser } from "../configParser/iosParser";
 
 const ANDROID_KEY = "hot_updater_public_key";
 const IOS_KEY = "HOT_UPDATER_PUBLIC_KEY";


### PR DESCRIPTION
## What changed

- Extend `hot-updater doctor` to inspect React Native native wiring when `@hot-updater/react-native` and native project directories are present.
- Validate iOS `AppDelegate` uses `HotUpdater.bundleURL()` and Android `MainApplication` uses `HotUpdater.getJSBundleFile(...)`.
- For `updateStrategy: "fingerprint"`, require `fingerprint.json` and matching native fingerprint hash values, with `npx hot-updater fingerprint create` as the recovery command.
- Surface signing/native public-key mismatches through doctor and document the expanded checks.

## Why

`doctor` should diagnose the setup required for OTA updates to actually launch from Hot Updater, not only package and infrastructure version drift. Missing native bundle-provider wiring or stale fingerprint values can make deployments look healthy while the app still loads the wrong bundle.

## Notes

- Native channel values are reported as context only. They are not required by doctor.
- Native checks are skipped when no native iOS/Android directories are present.

## Validation

- `pnpm -w vitest packages/hot-updater/src/commands/doctor.spec.ts --run`
- `pnpm --filter hot-updater test:type`
- `pnpm -w lint`
