### PR TITLE
chore(cli): tree-shake sql-formatter dialects

### DIFF
--- a/.changeset/ten-pandas-wash.md
+++ b/.changeset/ten-pandas-wash.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+tree-shake sql-formatter dialects

--- a/packages/hot-updater/src/commands/generate.ts
+++ b/packages/hot-updater/src/commands/generate.ts
@@ -11,7 +11,12 @@ import {
   PostgresDialect,
   SqliteDialect,
 } from "kysely";
-import { format } from "sql-formatter";
+import {
+  formatDialect,
+  mysql as mysqlDialect,
+  postgresql as postgresqlDialect,
+  sqlite as sqliteDialect,
+} from "sql-formatter";
 
 import { ui } from "../utils/cli-ui";
 import {
@@ -147,12 +152,12 @@ async function generateWithMigrator(
   }
 
   let formattedSql = sql;
-  const formatLanguages = ["postgresql", "mysql"] as const;
+  const formatDialects = [postgresqlDialect, mysqlDialect] as const;
 
-  for (const language of formatLanguages) {
+  for (const dialect of formatDialects) {
     try {
-      formattedSql = format(sql, {
-        language,
+      formattedSql = formatDialect(sql, {
+        dialect,
         tabWidth: 2,
         keywordCase: "upper",
       });
@@ -519,8 +524,14 @@ async function generateStandaloneSQL(options: {
     }
 
     // Format SQL for better readability
-    const formattedSql = format(sql, {
-      language: dbType,
+    const formatterDialects = {
+      postgresql: postgresqlDialect,
+      mysql: mysqlDialect,
+      sqlite: sqliteDialect,
+    } as const satisfies Record<SupportedProvider, unknown>;
+
+    const formattedSql = formatDialect(sql, {
+      dialect: formatterDialects[dbType],
       tabWidth: 2,
       keywordCase: "upper",
     });


### PR DESCRIPTION
## Summary

Follow-up to #1005. This trims the bundled `sql-formatter` code used by `hot-updater db generate`.

- Replace `format(sql, { language })` with `formatDialect`.
- Import only the dialect formatters Hot Updater actually uses: PostgreSQL, MySQL, and SQLite.
- Keep the existing formatted SQL behavior for Kysely migration generation and standalone SQL generation.

## Why

The top-level `format(..., { language })` helper imports `sql-formatter`'s `allDialects` registry. In the bundled CLI that retained unused dialects such as BigQuery, Snowflake, Redshift, Spark, Trino, DB2, N1QL, PL/SQL, and T-SQL.

Using explicit dialect imports lets tsdown/rolldown drop those unused dialects while still keeping the three dialects supported by `db generate --sql`.

## Validation

- `pnpm --filter hot-updater build`
- `pnpm --filter hot-updater test:type`
- `pnpm -w lint`
- `node packages/hot-updater/dist/index.mjs db generate /tmp/hot-updater-db-sql-tree --sql postgresql --yes`
- Bundle scan after build:
  - unused dialect markers `bigquery`, `snowflake`, `redshift`, `spark`, `trino`, `db2`, `n1ql`, `plsql`, `transactsql`, `allDialects`: 0 occurrences
  - `dist/index.mjs`: about 1.78 MB after this change, down from about 1.97 MB before this follow-up

## Notes

Full integration was already run for #1005. This follow-up only changes formatter import shape and was validated with targeted build/type/lint plus SQL generation smoke.