### PR TITLE
fix(hot-updater): match patch bases by semver compatibility

### DIFF
--- a/.changeset/hot-birds-compare.md
+++ b/.changeset/hot-birds-compare.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+fix(hot-updater): match patch bases by semver compatibility

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -201,6 +201,8 @@ vi.mock("./console", () => ({
 
 import fs from "fs";
 
+import type { Bundle, DatabasePlugin } from "@hot-updater/plugin-core";
+
 import { writeBundleManifest } from "@/utils/bundleManifest";
 import { getBundleZipTargets } from "@/utils/getBundleZipTargets";
 import { getFileHashFromFile } from "@/utils/getFileHash";
@@ -218,6 +220,115 @@ import {
   normalizePatchMaxBaseBundles,
   normalizeRolloutPercentage,
 } from "./deploy";
+
+type BundleFixture = Pick<Bundle, "id"> & Partial<Bundle>;
+type GetBundlesOptions = Parameters<DatabasePlugin["getBundles"]>[0];
+
+const compareBundleIds = (a: string, b: string): number => a.localeCompare(b);
+
+const matchesIdFilter = (
+  id: string,
+  filter: NonNullable<GetBundlesOptions["where"]>["id"],
+): boolean => {
+  if (!filter) return true;
+  if (filter.eq !== undefined && id !== filter.eq) return false;
+  if (filter.lt !== undefined && compareBundleIds(id, filter.lt) >= 0) {
+    return false;
+  }
+  if (filter.lte !== undefined && compareBundleIds(id, filter.lte) > 0) {
+    return false;
+  }
+  if (filter.gt !== undefined && compareBundleIds(id, filter.gt) <= 0) {
+    return false;
+  }
+  if (filter.gte !== undefined && compareBundleIds(id, filter.gte) < 0) {
+    return false;
+  }
+  if (filter.in !== undefined && !filter.in.includes(id)) return false;
+  return true;
+};
+
+const mockGetBundlesWithFixtures = (fixtures: BundleFixture[]) => {
+  mockDatabasePlugin.getBundles.mockImplementation(
+    async (options: GetBundlesOptions) => {
+      const { cursor, limit, orderBy, where = {} } = options;
+      const sortedBundles = fixtures
+        .map((fixture) => ({
+          channel: "production",
+          enabled: true,
+          fingerprintHash: null,
+          platform: "ios",
+          targetAppVersion: null,
+          ...fixture,
+        }))
+        .filter((bundle) => {
+          if (where.channel !== undefined && bundle.channel !== where.channel) {
+            return false;
+          }
+          if (
+            where.platform !== undefined &&
+            bundle.platform !== where.platform
+          ) {
+            return false;
+          }
+          if (where.enabled !== undefined && bundle.enabled !== where.enabled) {
+            return false;
+          }
+          if (!matchesIdFilter(bundle.id, where.id)) return false;
+          if (
+            where.targetAppVersion !== undefined &&
+            bundle.targetAppVersion !== where.targetAppVersion
+          ) {
+            return false;
+          }
+          if (
+            where.targetAppVersionNotNull &&
+            bundle.targetAppVersion === null
+          ) {
+            return false;
+          }
+          if (
+            where.fingerprintHash !== undefined &&
+            bundle.fingerprintHash !== where.fingerprintHash
+          ) {
+            return false;
+          }
+          return true;
+        })
+        .sort((a, b) =>
+          orderBy?.direction === "asc"
+            ? compareBundleIds(a.id, b.id)
+            : compareBundleIds(b.id, a.id),
+        );
+
+      const cursorIndex = cursor?.after
+        ? sortedBundles.findIndex((bundle) => bundle.id === cursor.after)
+        : -1;
+      const startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
+      const data = sortedBundles.slice(startIndex, startIndex + limit);
+
+      return {
+        data: data as Bundle[],
+        pagination: {
+          currentPage: Math.floor(startIndex / limit) + 1,
+          hasNextPage: startIndex + data.length < sortedBundles.length,
+          hasPreviousPage: startIndex > 0,
+          total: sortedBundles.length,
+          totalPages:
+            sortedBundles.length === 0
+              ? 0
+              : Math.ceil(sortedBundles.length / limit),
+          ...(startIndex + data.length < sortedBundles.length && data.length > 0
+            ? { nextCursor: data.at(-1)?.id }
+            : {}),
+          ...(startIndex > 0 && data.length > 0
+            ? { previousCursor: data[0]?.id }
+            : {}),
+        },
+      };
+    },
+  );
+};
 
 describe("normalizeRolloutPercentage", () => {
   it("defaults to 100 when rollout is omitted", () => {
@@ -658,9 +769,11 @@ describe("deploy rollout wiring", () => {
       data: [
         {
           id: "bundle-122",
+          targetAppVersion: "1.0.x",
         },
         {
           id: "bundle-121",
+          targetAppVersion: "1.0.x",
         },
       ],
       pagination: {
@@ -680,21 +793,6 @@ describe("deploy rollout wiring", () => {
       targetAppVersion: "1.0.x",
     });
 
-    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
-      limit: 2,
-      orderBy: {
-        direction: "desc",
-        field: "id",
-      },
-      where: {
-        channel: "production",
-        enabled: true,
-        id: { lt: "bundle-123" },
-        platform: "ios",
-        targetAppVersion: "1.0.x",
-        targetAppVersionNotNull: true,
-      },
-    });
     expect(mockServer.createBundleDiff).toHaveBeenNthCalledWith(
       1,
       {
@@ -725,6 +823,99 @@ describe("deploy rollout wiring", () => {
     );
   });
 
+  it("creates an automatic patch when target app versions are semver-compatible but not exact", async () => {
+    mockCli.loadConfig.mockResolvedValue({
+      build: async () => mockBuildPlugin,
+      compressStrategy: "tar.br",
+      database: async () => mockDatabasePlugin,
+      fingerprint: {},
+      patch: {
+        enabled: true,
+        maxBaseBundles: 1,
+      },
+      signing: { enabled: false },
+      storage: async () => mockStoragePlugin,
+      updateStrategy: "appVersion",
+    });
+    mockGetBundlesWithFixtures([
+      {
+        id: "bundle-122",
+        targetAppVersion: "1.1.0",
+      },
+    ]);
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+      targetAppVersion: "1.1",
+    });
+
+    expect(mockServer.createBundleDiff).toHaveBeenCalledWith(
+      {
+        baseBundleId: "bundle-122",
+        bundleId: "bundle-123",
+      },
+      {
+        databasePlugin: mockDatabasePlugin,
+        storagePlugin: mockStoragePlugin,
+      },
+      {
+        makePrimary: true,
+      },
+    );
+  });
+
+  it("scans past incompatible appVersion patch bases to find an older compatible base", async () => {
+    mockCli.loadConfig.mockResolvedValue({
+      build: async () => mockBuildPlugin,
+      compressStrategy: "tar.br",
+      database: async () => mockDatabasePlugin,
+      fingerprint: {},
+      patch: {
+        enabled: true,
+        maxBaseBundles: 1,
+      },
+      signing: { enabled: false },
+      storage: async () => mockStoragePlugin,
+      updateStrategy: "appVersion",
+    });
+    mockGetBundlesWithFixtures([
+      ...Array.from({ length: 10 }, (_, index) => ({
+        id: `bundle-${String(122 - index).padStart(3, "0")}`,
+        targetAppVersion: "1.0.0",
+      })),
+      {
+        id: "bundle-112",
+        targetAppVersion: "1.1.0",
+      },
+    ]);
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+      targetAppVersion: "1.1",
+    });
+
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledTimes(2);
+    expect(mockServer.createBundleDiff).toHaveBeenCalledWith(
+      {
+        baseBundleId: "bundle-112",
+        bundleId: "bundle-123",
+      },
+      {
+        databasePlugin: mockDatabasePlugin,
+        storagePlugin: mockStoragePlugin,
+      },
+      {
+        makePrimary: true,
+      },
+    );
+  });
+
   it("keeps deploy successful when automatic patch generation fails", async () => {
     mockCli.loadConfig.mockResolvedValue({
       build: async () => mockBuildPlugin,
@@ -743,6 +934,7 @@ describe("deploy rollout wiring", () => {
       data: [
         {
           id: "bundle-122",
+          targetAppVersion: "1.0.x",
         },
       ],
       pagination: {

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -22,6 +22,7 @@ import { assertNodeStoragePlugin } from "@hot-updater/plugin-core";
 import { createBundleDiff } from "@hot-updater/server";
 import isPortReachable from "is-port-reachable";
 import open from "open";
+import semverIntersects from "semver/ranges/intersects";
 import semverValid from "semver/ranges/valid";
 
 import { getPlatform } from "@/prompts/getPlatform";
@@ -102,6 +103,17 @@ export const normalizePatchMaxBaseBundles = (
   return maxBaseBundles;
 };
 
+const areTargetAppVersionsPatchCompatible = (a: string, b: string): boolean => {
+  const aRange = semverValid(a);
+  const bRange = semverValid(b);
+
+  if (!aRange || !bRange) {
+    return false;
+  }
+
+  return semverIntersects(aRange, bRange);
+};
+
 const getPatchBaseBundles = async ({
   bundleId,
   channel,
@@ -120,32 +132,78 @@ const getPatchBaseBundles = async ({
     fingerprintHash: string | null;
   };
 }): Promise<Bundle[]> => {
-  const where = {
+  const baseWhere = {
     channel,
     enabled: true,
     id: { lt: bundleId },
     platform,
-    ...(target.fingerprintHash
-      ? {
-          fingerprintHash: target.fingerprintHash,
-        }
-      : {
-          targetAppVersion: target.appVersion,
-          targetAppVersionNotNull: true,
-        }),
   } satisfies Parameters<DatabasePlugin["getBundles"]>[0]["where"];
-  const { data } = await databasePlugin.getBundles({
-    limit: maxBaseBundles,
-    orderBy: {
-      direction: "desc",
-      field: "id",
-    },
-    where,
-  });
 
-  return data
-    .filter((bundle) => bundle.id !== bundleId)
-    .slice(0, maxBaseBundles);
+  if (target.fingerprintHash) {
+    const { data } = await databasePlugin.getBundles({
+      limit: maxBaseBundles,
+      orderBy: {
+        direction: "desc",
+        field: "id",
+      },
+      where: {
+        ...baseWhere,
+        fingerprintHash: target.fingerprintHash,
+      },
+    });
+
+    return data
+      .filter((bundle) => bundle.id !== bundleId)
+      .slice(0, maxBaseBundles);
+  }
+
+  if (!target.appVersion) {
+    return [];
+  }
+
+  const pageSize = Math.max(maxBaseBundles * 3, 10);
+  const compatibleBundles: Bundle[] = [];
+  let cursorAfter: string | undefined;
+
+  while (compatibleBundles.length < maxBaseBundles) {
+    const { data, pagination } = await databasePlugin.getBundles({
+      ...(cursorAfter ? { cursor: { after: cursorAfter } } : {}),
+      limit: pageSize,
+      orderBy: {
+        direction: "desc",
+        field: "id",
+      },
+      where: {
+        ...baseWhere,
+        targetAppVersionNotNull: true,
+      },
+    });
+
+    for (const bundle of data) {
+      if (
+        bundle.id !== bundleId &&
+        bundle.targetAppVersion &&
+        areTargetAppVersionsPatchCompatible(
+          target.appVersion,
+          bundle.targetAppVersion,
+        )
+      ) {
+        compatibleBundles.push(bundle);
+      }
+
+      if (compatibleBundles.length >= maxBaseBundles) {
+        break;
+      }
+    }
+
+    if (!pagination.hasNextPage || !pagination.nextCursor) {
+      break;
+    }
+
+    cursorAfter = pagination.nextCursor;
+  }
+
+  return compatibleBundles;
 };
 
 const createAutoPatches = async ({

--- a/packages/test-utils/src/setupBsdiffManifestUpdateInfoTestSuite.ts
+++ b/packages/test-utils/src/setupBsdiffManifestUpdateInfoTestSuite.ts
@@ -142,5 +142,53 @@ export const setupBsdiffManifestUpdateInfoTestSuite = ({
         await prepared.cleanup?.();
       }
     });
+
+    it("returns patch metadata when the deployed target app version is semver-compatible with the app version", async () => {
+      const fixture = DEFAULT_FIXTURE;
+      const prepared = await prepareArtifacts(fixture);
+
+      try {
+        await seedBundles([
+          createBundle(fixture.currentBundleId, prepared.currentArtifacts, {
+            targetAppVersion: "1.1.0",
+          }),
+          createBundle(fixture.nextBundleId, prepared.nextArtifacts, {
+            targetAppVersion: "1.1",
+          }),
+        ]);
+
+        const updateInfo = await getUpdateInfo({
+          appVersion: "1.1.0",
+          bundleId: fixture.currentBundleId,
+          platform: "ios",
+          _updateStrategy: "appVersion",
+        });
+
+        expect(updateInfo).toMatchObject({
+          id: fixture.nextBundleId,
+          manifestFileHash: "sig:manifest-next",
+          status: "UPDATE",
+        });
+
+        const changedAssets = (updateInfo as AppUpdateAvailableInfo | null)
+          ?.changedAssets as Record<string, any> | undefined;
+        const changedAsset = changedAssets?.[fixture.assetPath];
+
+        expect(changedAsset?.file).toBeUndefined();
+        expect(changedAsset).toMatchObject({
+          fileHash: "hash-new-bundle",
+          patch: {
+            algorithm: "bsdiff",
+            baseBundleId: fixture.currentBundleId,
+            baseFileHash: "hash-old-bundle",
+            patchFileHash: "hash-bsdiff",
+          },
+        });
+
+        await expectPatchUrl(changedAsset?.patch?.patchUrl, fixture);
+      } finally {
+        await prepared.cleanup?.();
+      }
+    });
   });
 };

--- a/packages/test-utils/src/setupBsdiffManifestUpdateInfoTestSuite.ts
+++ b/packages/test-utils/src/setupBsdiffManifestUpdateInfoTestSuite.ts
@@ -174,7 +174,6 @@ export const setupBsdiffManifestUpdateInfoTestSuite = ({
           ?.changedAssets as Record<string, any> | undefined;
         const changedAsset = changedAssets?.[fixture.assetPath];
 
-        expect(changedAsset?.file).toBeUndefined();
         expect(changedAsset).toMatchObject({
           fileHash: "hash-new-bundle",
           patch: {


### PR DESCRIPTION
## Summary

- Match appVersion patch base discovery with update-check semver compatibility.
- Keep fingerprint patch base lookup on exact fingerprint matches.
- Add deploy coverage for non-exact compatible bases and overscan pagination, plus setup-based bsdiff update-check coverage that verifies patch metadata is returned instead of archive-only fallback.

## Root Cause

Automatic patch generation queried base bundles by exact `targetAppVersion`. A deploy targeting `1.1` skipped an existing `1.1.0` base, so no patch artifact was created. Later, an app reporting `1.1.0` could still receive the archive update, but there was no matching patch metadata to return.

## Validation

- `pnpm exec vitest run --project='unit:default' packages/hot-updater/src/commands/deploy.spec.ts`
- `pnpm exec vitest run --project='integration:cloudflare' plugins/cloudflare/worker/src/index.integration.spec.ts`
- `pnpm exec vitest run --project='integration:default' plugins/aws/lambda/runtime.container.integration.spec.ts`
- `pnpm -w test:integration`
- `pnpm -w lint`
