### PR TITLE
fix(android): mark channel string non-translatable

### DIFF
--- a/.changeset/bright-pigs-fail.md
+++ b/.changeset/bright-pigs-fail.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+fix(android): mark channel string non-translatable

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -219,9 +219,11 @@ const withHotUpdaterConfigAsync =
         $: {
           name: "hot_updater_channel",
           moduleConfig: "true",
+          translatable: "false",
         } as {
           name: string;
           moduleConfig: string;
+          translatable: string;
         },
         _: channel,
       });


### PR DESCRIPTION
Fixes #1010.

The Android Expo config plugin writes `hot_updater_channel` into `strings.xml`.
This value is an update channel identifier, not user-facing text, so it should
not be translated by Android resource localization.

Without `translatable="false"`, a release build on a Turkish device can read
`production` as `üretim`, causing the client to check the wrong update channel
and return `UP_TO_DATE`.

This PR marks `hot_updater_channel` as non-translatable.