### PR TITLE
[codex] Limit manifest asset upload concurrency

### DIFF
--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -200,6 +200,7 @@ vi.mock("./console", () => ({
 }));
 
 import fs from "fs";
+import path from "path";
 
 import type { Bundle, DatabasePlugin } from "@hot-updater/plugin-core";
 
@@ -660,6 +661,46 @@ describe("deploy rollout wiring", () => {
         }),
       }),
     );
+  });
+
+  it("limits concurrent manifest asset uploads", async () => {
+    const assetFiles = Array.from({ length: 20 }, (_, index) => ({
+      name: `assets/file-${index}.png`,
+      path: `/mock/build/assets/file-${index}.png`,
+    }));
+    let activeAssetUploads = 0;
+    let maxActiveAssetUploads = 0;
+
+    vi.mocked(getBundleZipTargets).mockResolvedValue(assetFiles);
+    mockStoragePlugin.profiles.node.upload.mockImplementation(
+      async (key, filePath) => {
+        if (key === "bundle-123/files/assets") {
+          activeAssetUploads += 1;
+          maxActiveAssetUploads = Math.max(
+            maxActiveAssetUploads,
+            activeAssetUploads,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          activeAssetUploads -= 1;
+        }
+
+        return {
+          storageUri: `s3://bundles/${key}/${path.basename(filePath)}`,
+        };
+      },
+    );
+
+    await deploy({
+      channel: "production",
+      forceUpdate: false,
+      interactive: false,
+      platform: "ios",
+      targetAppVersion: "1.0.x",
+    });
+
+    expect(mockStoragePlugin.profiles.node.upload).toHaveBeenCalledTimes(22);
+    expect(maxActiveAssetUploads).toBeGreaterThan(1);
+    expect(maxActiveAssetUploads).toBeLessThanOrEqual(8);
   });
 
   it("uploads hermes bundle artifacts using the manifest filename", async () => {

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -50,6 +50,7 @@ import { PLATFORMS } from "../commandOptions";
 import { getConsolePort, openConsole } from "./console";
 
 const compressBrotli = promisify(brotliCompress);
+const MANIFEST_ASSET_UPLOAD_CONCURRENCY = 8;
 
 export interface DeployOptions {
   bundleOutputPath?: string;
@@ -101,6 +102,25 @@ export const normalizePatchMaxBaseBundles = (
   }
 
   return maxBaseBundles;
+};
+
+const runWithConcurrency = async <T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+) => {
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const itemIndex = nextIndex;
+        nextIndex += 1;
+        await task(items[itemIndex]!);
+      }
+    }),
+  );
 };
 
 const areTargetAppVersionsPatchCompatible = (a: string, b: string): boolean => {
@@ -825,8 +845,10 @@ const deployPlatform = async ({
               "files",
             );
 
-            await Promise.all(
-              taskRef.targetFiles.map(async (targetFile) => {
+            await runWithConcurrency(
+              taskRef.targetFiles,
+              MANIFEST_ASSET_UPLOAD_CONCURRENCY,
+              async (targetFile) => {
                 const uploadName = isBrotliManifestBundleAsset(targetFile.name)
                   ? `${targetFile.name}.br`
                   : targetFile.name;
@@ -840,11 +862,11 @@ const deployPlatform = async ({
                   targetFile,
                 });
 
-                return storagePlugin.profiles.node.upload(
+                await storagePlugin.profiles.node.upload(
                   uploadKey,
                   uploadSourcePath,
                 );
-              }),
+              },
             );
           } catch (e) {
             if (e instanceof Error) {


### PR DESCRIPTION
## Summary

- Limit deploy manifest asset uploads to 8 concurrent storage requests.
- Add a regression test that verifies concurrent asset uploads stay bounded.

## Root Cause

File-level manifests can produce hundreds of asset uploads during deploy. The deploy path previously sent all asset uploads through an unbounded `Promise.all`, which could fan out hundreds of Supabase Storage requests at once. Supabase Storage stores object metadata through its database layer, so that burst can exhaust the project connection limit and fail with `The database has reached its maximum number of connections`.

## Impact

Deploys with many manifest assets now keep storage upload concurrency bounded while preserving manifest-driven diff update behavior.

## Validation

- `pnpm -w exec vitest run packages/hot-updater/src/commands/deploy.spec.ts`
- `pnpm --filter hot-updater test:type`
- `pnpm lint`

## Not Tested

- Live Supabase deploy against a low-connection project.