### PR TITLE
fix(android): avoid localized native config values

### DIFF
--- a/packages/cli-tools/src/loadConfig.spec.ts
+++ b/packages/cli-tools/src/loadConfig.spec.ts
@@ -43,6 +43,7 @@ describe("loadConfig", () => {
     expect(config.compressStrategy).toBe("zip");
     expect(config.patch.enabled).toBe(true);
     expect(config.patch.maxBaseBundles).toBe(3);
+    expect(config.platform.android.androidManifestPaths).toEqual([]);
     expect(config.platform.android.stringResourcePaths).toEqual([]);
     expect(config.platform.ios.infoPlistPaths).toEqual([]);
     expect(config.console.port).toBe(1422);
@@ -56,6 +57,11 @@ describe("loadConfig", () => {
     );
     await writeProjectFile(
       projectRoot,
+      "android/app/src/main/AndroidManifest.xml",
+      "<manifest />",
+    );
+    await writeProjectFile(
+      projectRoot,
       "android/app/src/main/res/values/strings.xml",
       "<resources />",
     );
@@ -65,6 +71,9 @@ describe("loadConfig", () => {
 
     expect(config.platform.ios.infoPlistPaths).toEqual([
       "ios/HotUpdaterExample/Info.plist",
+    ]);
+    expect(config.platform.android.androidManifestPaths).toEqual([
+      path.join("android", "app", "src", "main", "AndroidManifest.xml"),
     ]);
     expect(config.platform.android.stringResourcePaths).toEqual([
       path.join(

--- a/packages/cli-tools/src/loadConfig.ts
+++ b/packages/cli-tools/src/loadConfig.ts
@@ -41,6 +41,26 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
     // Keep fallback value if glob fails
   }
 
+  // Find actual AndroidManifest.xml files in the android directory
+  let androidManifestPaths: string[] = []; // fallback
+  try {
+    const manifestFiles = fg.sync(path.join("**", "AndroidManifest.xml"), {
+      cwd: path.join(getCwd(), "android"),
+      absolute: false,
+      onlyFiles: true,
+      ignore: ["**/build/**", "**/.gradle/**"],
+    });
+
+    if (manifestFiles.length > 0) {
+      // Convert to relative paths from project root
+      androidManifestPaths = manifestFiles.map((file: string) =>
+        path.join("android", file),
+      );
+    }
+  } catch {
+    // Keep fallback value if glob fails
+  }
+
   // Find actual strings.xml files in the android directory
   let stringResourcePaths: string[] = []; // fallback
   try {
@@ -62,6 +82,7 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
 
   return {
     android: {
+      androidManifestPaths,
       stringResourcePaths,
     },
     ios: {

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -491,7 +491,14 @@ const checkAndroidNativeStatus = async ({
   requireFingerprint: boolean;
   expectedFingerprintHash?: string;
 }): Promise<{ status?: NativePlatformStatus; issues: NativeCheckIssue[] }> => {
-  const configuredPaths = config.platform.android.stringResourcePaths;
+  const configuredManifestPaths =
+    config.platform.android.androidManifestPaths ?? [];
+  const configuredStringPaths =
+    config.platform.android.stringResourcePaths ?? [];
+  const configuredPaths = [
+    ...configuredManifestPaths,
+    ...configuredStringPaths,
+  ];
   const androidDetected =
     fs.existsSync(path.join(cwd, "android")) || configuredPaths.length > 0;
 
@@ -499,7 +506,10 @@ const checkAndroidNativeStatus = async ({
     return { issues: [] };
   }
 
-  const androidParser = new AndroidConfigParser(configuredPaths);
+  const androidParser = new AndroidConfigParser(
+    configuredStringPaths,
+    configuredManifestPaths,
+  );
   const files = configuredPaths.filter((filePath) =>
     fs.existsSync(resolveProjectPath(cwd, filePath)),
   );
@@ -510,9 +520,9 @@ const checkAndroidNativeStatus = async ({
       type: "error",
       platform: "android",
       code: "NATIVE_FILES_NOT_FOUND",
-      message: "Android strings.xml files were not found.",
+      message: "Android native config files were not found.",
       resolution:
-        "Check platform.android.stringResourcePaths in hot-updater.config.ts or run Android prebuild first.",
+        "Check platform.android.androidManifestPaths in hot-updater.config.ts or run Android prebuild first.",
       fixability: "auto",
       paths: configuredPaths,
     });
@@ -528,7 +538,8 @@ const checkAndroidNativeStatus = async ({
       type: "error",
       platform: "android",
       code: "MISSING_FINGERPRINT_HASH",
-      message: "hot_updater_fingerprint_hash is missing from strings.xml.",
+      message:
+        "com.hotupdater.FINGERPRINT_HASH is missing from AndroidManifest.xml.",
       resolution:
         "Run `npx hot-updater fingerprint create` or rebuild through the Expo config plugin.",
       fixability: "command",

--- a/packages/hot-updater/src/commands/keys.ts
+++ b/packages/hot-updater/src/commands/keys.ts
@@ -95,16 +95,20 @@ interface WriteResult {
 async function writePublicKeyToAndroid(
   publicKey: string,
   customPaths: string[],
+  androidManifestPaths: string[],
 ): Promise<WriteResult> {
   try {
-    const androidParser = new AndroidConfigParser(customPaths);
+    const androidParser = new AndroidConfigParser(
+      customPaths,
+      androidManifestPaths,
+    );
 
     if (!(await androidParser.exists())) {
       return {
         platform: "android",
         paths: [],
         success: false,
-        error: "No strings.xml files found",
+        error: "No Android native config files found",
       };
     }
 
@@ -159,9 +163,10 @@ function printPublicKeyInstructions(publicKeyPEM: string): void {
   console.log(`<string>${publicKeyPEM.trim().replace(/\n/g, "\\n")}</string>`);
   console.log("");
   console.log(ui.title("Android"));
-  console.log('<string name="hot_updater_public_key">');
-  console.log(publicKeyPEM.trim());
-  console.log("</string>");
+  console.log('<meta-data android:name="com.hotupdater.PUBLIC_KEY"');
+  console.log(
+    `  android:value="${publicKeyPEM.trim().replace(/\n/g, "\\n")}" />`,
+  );
 }
 
 const formatNativeTarget = (
@@ -175,7 +180,7 @@ const formatNativeTarget = (
 
 /**
  * Export public key for embedding in native configuration.
- * By default, writes the public key to iOS Info.plist and Android strings.xml.
+ * By default, writes the public key to iOS Info.plist and AndroidManifest.xml.
  * Use --print-only to only display the key without modifying files.
  *
  * The private key path is read from hot-updater.config.ts (signing.privateKeyPath)
@@ -217,9 +222,15 @@ export const keysExportPublic = async (
       return;
     }
 
+    const androidStringPaths =
+      config.platform.android.stringResourcePaths ?? [];
+    const androidManifestPaths =
+      config.platform.android.androidManifestPaths ?? [];
+
     // Check which files exist (config already loaded above)
     const androidParser = new AndroidConfigParser(
-      config.platform.android.stringResourcePaths,
+      androidStringPaths,
+      androidManifestPaths,
     );
     const iosParser = new IosConfigParser(config.platform.ios.infoPlistPaths);
 
@@ -236,12 +247,7 @@ export const keysExportPublic = async (
 
     p.log.message(ui.title("Native files"));
     if (androidExists) {
-      p.log.message(
-        formatNativeTarget(
-          "android",
-          config.platform.android.stringResourcePaths,
-        ),
-      );
+      p.log.message(formatNativeTarget("android", androidManifestPaths));
     }
     if (iosExists) {
       p.log.message(
@@ -269,7 +275,8 @@ export const keysExportPublic = async (
       results.push(
         await writePublicKeyToAndroid(
           publicKeyPEM.trim(),
-          config.platform.android.stringResourcePaths,
+          androidStringPaths,
+          androidManifestPaths,
         ),
       );
     }
@@ -325,9 +332,13 @@ interface RemoveResult {
 
 async function removePublicKeyFromAndroid(
   customPaths: string[],
+  androidManifestPaths: string[],
 ): Promise<RemoveResult> {
   try {
-    const androidParser = new AndroidConfigParser(customPaths);
+    const androidParser = new AndroidConfigParser(
+      customPaths,
+      androidManifestPaths,
+    );
 
     if (!(await androidParser.exists())) {
       return {
@@ -419,9 +430,13 @@ async function removePublicKeyFromIos(
  */
 export const keysRemove = async (options: KeysRemoveOptions = {}) => {
   const config = await loadConfig(null);
+  const androidStringPaths = config.platform.android.stringResourcePaths ?? [];
+  const androidManifestPaths =
+    config.platform.android.androidManifestPaths ?? [];
 
   const androidParser = new AndroidConfigParser(
-    config.platform.android.stringResourcePaths,
+    androidStringPaths,
+    androidManifestPaths,
   );
   const iosParser = new IosConfigParser(config.platform.ios.infoPlistPaths);
 
@@ -495,7 +510,8 @@ export const keysRemove = async (options: KeysRemoveOptions = {}) => {
   if (androidKey.value) {
     results.push(
       await removePublicKeyFromAndroid(
-        config.platform.android.stringResourcePaths,
+        androidStringPaths,
+        androidManifestPaths,
       ),
     );
   }

--- a/packages/hot-updater/src/utils/configParser/androidParser.spec.ts
+++ b/packages/hot-updater/src/utils/configParser/androidParser.spec.ts
@@ -60,6 +60,8 @@ describe("AndroidConfigParser", () => {
   let mockBuilder: any;
   const mockStringsXmlPath =
     "/mock/project/android/app/src/main/res/values/strings.xml";
+  const mockAndroidManifestPath =
+    "/mock/project/android/app/src/main/AndroidManifest.xml";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -166,6 +168,7 @@ describe("AndroidConfigParser", () => {
           string: {
             "@_name": "test_key",
             "@_moduleConfig": "true",
+            "@_translatable": "false",
             "#text": "test_value",
           },
         },
@@ -186,6 +189,71 @@ describe("AndroidConfigParser", () => {
         "utf-8",
       );
       expect(mockParser.parse).toHaveBeenCalledWith("xml content");
+    });
+
+    it("should prefer AndroidManifest metadata for Hot Updater keys", async () => {
+      const parser = new AndroidConfigParser(
+        [mockStringsXmlPath],
+        [mockAndroidManifestPath],
+      );
+      const mockManifestData = {
+        manifest: {
+          application: {
+            "meta-data": {
+              "@_android:name": "com.hotupdater.CHANNEL",
+              "@_android:value": "manifest-channel",
+            },
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile).mockResolvedValue("manifest content");
+      mockParser.parse.mockReturnValue(mockManifestData);
+
+      const result = await parser.get("hot_updater_channel");
+
+      expect(result).toEqual({
+        value: "manifest-channel",
+        paths: ["android/app/src/main/AndroidManifest.xml"],
+      });
+    });
+
+    it("should fall back to strings.xml when manifest metadata is missing", async () => {
+      const parser = new AndroidConfigParser(
+        [mockStringsXmlPath],
+        [mockAndroidManifestPath],
+      );
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile)
+        .mockResolvedValueOnce("manifest content")
+        .mockResolvedValueOnce("strings content");
+      mockParser.parse
+        .mockReturnValueOnce({
+          manifest: {
+            application: {},
+          },
+        })
+        .mockReturnValueOnce({
+          resources: {
+            string: {
+              "@_name": "hot_updater_channel",
+              "@_moduleConfig": "true",
+              "#text": "legacy-channel",
+            },
+          },
+        });
+
+      const result = await parser.get("hot_updater_channel");
+
+      expect(result).toEqual({
+        value: "legacy-channel",
+        paths: [
+          "android/app/src/main/AndroidManifest.xml",
+          "android/app/src/main/res/values/strings.xml",
+        ],
+      });
     });
 
     it("should return null when key exists but moduleConfig is not true", async () => {
@@ -295,6 +363,7 @@ describe("AndroidConfigParser", () => {
           string: {
             "@_name": "test_key",
             "@_moduleConfig": "true",
+            "@_translatable": "false",
             "#text": "test_value",
           },
         },
@@ -306,6 +375,58 @@ describe("AndroidConfigParser", () => {
       );
       expect(result).toEqual({
         paths: ["android/app/src/main/res/values/strings.xml"],
+      });
+    });
+
+    it("should set Hot Updater keys in AndroidManifest metadata", async () => {
+      const parser = new AndroidConfigParser(
+        [mockStringsXmlPath],
+        [mockAndroidManifestPath],
+      );
+      const mockManifestData = {
+        manifest: {
+          application: {
+            "meta-data": {
+              "@_android:name": "existing_key",
+              "@_android:value": "existing_value",
+            },
+          },
+        },
+      };
+      const mockStringsData = {
+        resources: {},
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile)
+        .mockResolvedValueOnce("manifest content")
+        .mockResolvedValueOnce("strings content");
+      mockParser.parse
+        .mockReturnValueOnce(mockManifestData)
+        .mockReturnValueOnce(mockStringsData);
+      mockBuilder.build.mockReturnValue("new xml content");
+      vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+
+      const result = await parser.set("hot_updater_channel", "production");
+
+      expect(mockBuilder.build).toHaveBeenCalledWith({
+        manifest: {
+          application: {
+            "meta-data": [
+              {
+                "@_android:name": "existing_key",
+                "@_android:value": "existing_value",
+              },
+              {
+                "@_android:name": "com.hotupdater.CHANNEL",
+                "@_android:value": "production",
+              },
+            ],
+          },
+        },
+      });
+      expect(result).toEqual({
+        paths: ["android/app/src/main/AndroidManifest.xml"],
       });
     });
 
@@ -334,6 +455,7 @@ describe("AndroidConfigParser", () => {
           string: {
             "@_name": "test_key",
             "@_moduleConfig": "true",
+            "@_translatable": "false",
             "#text": "new_value",
           },
         },
@@ -372,6 +494,7 @@ describe("AndroidConfigParser", () => {
             {
               "@_name": "test_key",
               "@_moduleConfig": "true",
+              "@_translatable": "false",
               "#text": "test_value",
             },
           ],

--- a/packages/hot-updater/src/utils/configParser/androidParser.ts
+++ b/packages/hot-updater/src/utils/configParser/androidParser.ts
@@ -9,6 +9,7 @@ import type { ConfigParser } from "./configParser";
 interface StringElement {
   "@_name": string;
   "@_moduleConfig"?: string;
+  "@_translatable"?: string;
   "#text"?: string;
 }
 
@@ -18,12 +19,38 @@ interface ResourcesXml {
   };
 }
 
+interface MetaDataElement {
+  "@_android:name": string;
+  "@_android:value"?: string;
+}
+
+interface ApplicationElement {
+  "meta-data"?: MetaDataElement | MetaDataElement[];
+}
+
+interface ManifestXml {
+  manifest: {
+    application?: ApplicationElement | ApplicationElement[];
+  };
+}
+
+const MANIFEST_KEYS: Record<string, string> = {
+  hot_updater_channel: "com.hotupdater.CHANNEL",
+  hot_updater_fingerprint_hash: "com.hotupdater.FINGERPRINT_HASH",
+  hot_updater_public_key: "com.hotupdater.PUBLIC_KEY",
+};
+
 export class AndroidConfigParser implements ConfigParser {
+  private androidManifestPaths: string[];
   private stringsXmlPaths: string[];
   private parser: XMLParser;
   private builder: XMLBuilder;
 
-  constructor(customPaths?: string[]) {
+  constructor(customPaths?: string[], androidManifestPaths?: string[]) {
+    this.androidManifestPaths = (androidManifestPaths || []).map((p) =>
+      path.isAbsolute(p) ? p : path.join(getCwd(), p),
+    );
+
     // Convert to absolute paths
     this.stringsXmlPaths = (customPaths || []).map((p) =>
       path.isAbsolute(p) ? p : path.join(getCwd(), p),
@@ -49,29 +76,91 @@ export class AndroidConfigParser implements ConfigParser {
   }
 
   async exists(): Promise<boolean> {
-    return this.stringsXmlPaths.some((path) => fs.existsSync(path));
+    return (
+      this.androidManifestPaths.some((path) => fs.existsSync(path)) ||
+      this.stringsXmlPaths.some((path) => fs.existsSync(path))
+    );
   }
 
-  private getExistingPaths(): string[] {
+  private getExistingManifestPaths(): string[] {
+    return this.androidManifestPaths.filter((path) => fs.existsSync(path));
+  }
+
+  private getExistingStringPaths(): string[] {
     return this.stringsXmlPaths.filter((path) => fs.existsSync(path));
+  }
+
+  private getManifestKey(key: string): string | undefined {
+    return MANIFEST_KEYS[key];
+  }
+
+  private getApplication(result: ManifestXml): ApplicationElement | null {
+    const application = result.manifest.application;
+    if (!application) {
+      return null;
+    }
+    return Array.isArray(application) ? (application[0] ?? null) : application;
   }
 
   async get(key: string): Promise<{
     value: string | null;
     paths: string[];
   }> {
-    const existingPaths = this.getExistingPaths();
+    const manifestKey = this.getManifestKey(key);
+    const existingManifestPaths = this.getExistingManifestPaths();
+    const existingStringPaths = this.getExistingStringPaths();
     const searchedPaths: string[] = [];
 
-    if (existingPaths.length === 0) {
+    if (
+      existingManifestPaths.length === 0 &&
+      existingStringPaths.length === 0
+    ) {
       return {
         value: null,
         paths: [],
       };
     }
 
+    if (manifestKey) {
+      for (const androidManifestPath of existingManifestPaths) {
+        const relativePath = path.relative(getCwd(), androidManifestPath);
+        searchedPaths.push(relativePath);
+
+        try {
+          const content = await fs.promises.readFile(
+            androidManifestPath,
+            "utf-8",
+          );
+          const result = this.parser.parse(content) as ManifestXml;
+          const application = this.getApplication(result);
+
+          if (!application?.["meta-data"]) {
+            continue;
+          }
+
+          const metaData = Array.isArray(application["meta-data"])
+            ? application["meta-data"]
+            : [application["meta-data"]];
+
+          const entry = metaData.find(
+            (item) => item["@_android:name"] === manifestKey,
+          );
+
+          const value = entry?.["@_android:value"];
+          if (value) {
+            return {
+              value: value.trim(),
+              paths: searchedPaths,
+            };
+          }
+        } catch (error) {
+          throw new Error(`Failed to get ${androidManifestPath}: ${error}`);
+        }
+      }
+    }
+
     // Check each existing path until we find the key
-    for (const stringsXmlPath of existingPaths) {
+    for (const stringsXmlPath of existingStringPaths) {
       const relativePath = path.relative(getCwd(), stringsXmlPath);
       searchedPaths.push(relativePath);
 
@@ -110,15 +199,72 @@ export class AndroidConfigParser implements ConfigParser {
   }
 
   async remove(key: string): Promise<{ paths: string[] }> {
-    const existingPaths = this.getExistingPaths();
+    const manifestKey = this.getManifestKey(key);
+    const existingManifestPaths = this.getExistingManifestPaths();
+    const existingStringPaths = this.getExistingStringPaths();
 
-    if (existingPaths.length === 0) {
+    if (
+      existingManifestPaths.length === 0 &&
+      existingStringPaths.length === 0
+    ) {
       return { paths: [] };
     }
 
     const updatedPaths: string[] = [];
 
-    for (const stringsXmlPath of existingPaths) {
+    if (manifestKey) {
+      for (const androidManifestPath of existingManifestPaths) {
+        try {
+          const content = await fs.promises.readFile(
+            androidManifestPath,
+            "utf-8",
+          );
+          const result = this.parser.parse(content) as ManifestXml;
+          const application = this.getApplication(result);
+
+          if (!application?.["meta-data"]) {
+            continue;
+          }
+
+          const metaData = Array.isArray(application["meta-data"])
+            ? application["meta-data"]
+            : [application["meta-data"]];
+
+          const filtered = metaData.filter(
+            (item) => item["@_android:name"] !== manifestKey,
+          );
+
+          if (filtered.length === metaData.length) {
+            continue;
+          }
+
+          if (filtered.length === 0) {
+            delete application["meta-data"];
+          } else {
+            application["meta-data"] =
+              filtered.length === 1 ? filtered[0] : filtered;
+          }
+
+          const newContent = this.builder.build(result);
+          await fs.promises.writeFile(androidManifestPath, newContent, "utf-8");
+          updatedPaths.push(path.relative(getCwd(), androidManifestPath));
+        } catch (error) {
+          throw new Error(
+            `Failed to remove key from AndroidManifest.xml: ${error}`,
+          );
+        }
+      }
+    }
+
+    updatedPaths.push(...(await this.removeStringValue(key)));
+
+    return { paths: updatedPaths };
+  }
+
+  private async removeStringValue(key: string): Promise<string[]> {
+    const updatedPaths: string[] = [];
+
+    for (const stringsXmlPath of this.getExistingStringPaths()) {
       try {
         const content = await fs.promises.readFile(stringsXmlPath, "utf-8");
         const result = this.parser.parse(content) as ResourcesXml;
@@ -157,11 +303,98 @@ export class AndroidConfigParser implements ConfigParser {
       }
     }
 
-    return { paths: updatedPaths };
+    return updatedPaths;
   }
 
   async set(key: string, value: string): Promise<{ paths: string[] }> {
-    const existingPaths = this.getExistingPaths();
+    const manifestKey = this.getManifestKey(key);
+
+    if (manifestKey) {
+      const result = await this.setManifestValue(manifestKey, value);
+      if (result.paths.length > 0) {
+        const removedPaths = await this.removeStringValue(key);
+        return { paths: [...result.paths, ...removedPaths] };
+      }
+      return this.setStringValue(key, value);
+    }
+
+    return this.setStringValue(key, value);
+  }
+
+  private async setManifestValue(
+    key: string,
+    value: string,
+  ): Promise<{ paths: string[] }> {
+    const existingPaths = this.getExistingManifestPaths();
+
+    if (existingPaths.length === 0) {
+      console.warn(
+        "hot-updater: No AndroidManifest.xml files found. Skipping Android-specific config modifications.",
+      );
+      return { paths: [] };
+    }
+
+    const updatedPaths: string[] = [];
+
+    for (const androidManifestPath of existingPaths) {
+      try {
+        const content = await fs.promises.readFile(
+          androidManifestPath,
+          "utf-8",
+        );
+        const result = this.parser.parse(content) as ManifestXml;
+        const application = this.getApplication(result);
+
+        if (!application) {
+          continue;
+        }
+
+        if (!application["meta-data"]) {
+          application["meta-data"] = [];
+        }
+
+        const metaData = Array.isArray(application["meta-data"])
+          ? application["meta-data"]
+          : [application["meta-data"]];
+
+        const existingIndex = metaData.findIndex(
+          (item) => item["@_android:name"] === key,
+        );
+
+        const metaDataElement: MetaDataElement = {
+          "@_android:name": key,
+          "@_android:value": value,
+        };
+
+        if (existingIndex !== -1) {
+          metaData[existingIndex] = metaDataElement;
+        } else {
+          metaData.push(metaDataElement);
+        }
+
+        application["meta-data"] =
+          metaData.length === 1 ? metaData[0] : metaData;
+
+        const newContent = this.builder.build(result);
+        await fs.promises.writeFile(androidManifestPath, newContent, "utf-8");
+        updatedPaths.push(path.relative(getCwd(), androidManifestPath));
+      } catch (error) {
+        throw new Error(
+          `Failed to parse or update AndroidManifest.xml: ${error}`,
+        );
+      }
+    }
+
+    return {
+      paths: updatedPaths,
+    };
+  }
+
+  private async setStringValue(
+    key: string,
+    value: string,
+  ): Promise<{ paths: string[] }> {
+    const existingPaths = this.getExistingStringPaths();
 
     if (existingPaths.length === 0) {
       console.warn(
@@ -196,6 +429,7 @@ export class AndroidConfigParser implements ConfigParser {
         const stringElement: StringElement = {
           "@_name": key,
           "@_moduleConfig": "true",
+          "@_translatable": "false",
           "#text": value,
         };
 

--- a/packages/hot-updater/src/utils/setChannel.ts
+++ b/packages/hot-updater/src/utils/setChannel.ts
@@ -10,8 +10,11 @@ const setAndroidChannel = async (
   channel: string,
 ): Promise<{ paths: string[] }> => {
   const config = await loadConfig(null);
-  const customPaths = config.platform.android.stringResourcePaths;
-  const androidParser = new AndroidConfigParser(customPaths);
+  const customPaths = config.platform.android.stringResourcePaths ?? [];
+  const androidParser = new AndroidConfigParser(
+    customPaths,
+    config.platform.android.androidManifestPaths ?? [],
+  );
   return await androidParser.set("hot_updater_channel", channel);
 };
 
@@ -20,10 +23,13 @@ const getAndroidChannel = async (): Promise<{
   paths: string[];
 }> => {
   const config = await loadConfig(null);
-  const customPaths = config.platform.android.stringResourcePaths;
-  const androidParser = new AndroidConfigParser(customPaths);
+  const customPaths = config.platform.android.stringResourcePaths ?? [];
+  const androidParser = new AndroidConfigParser(
+    customPaths,
+    config.platform.android.androidManifestPaths ?? [],
+  );
   if (!(await androidParser.exists())) {
-    throw new Error("No Android strings.xml files found");
+    throw new Error("No Android native config files found");
   }
   return merge(
     { value: DEFAULT_CHANNEL },

--- a/packages/hot-updater/src/utils/setFingerprintHash.ts
+++ b/packages/hot-updater/src/utils/setFingerprintHash.ts
@@ -7,8 +7,11 @@ const setAndroidFingerprintHash = async (
   hash: string,
 ): Promise<{ paths: string[] }> => {
   const config = await loadConfig(null);
-  const customPaths = config.platform.android.stringResourcePaths;
-  const androidParser = new AndroidConfigParser(customPaths);
+  const customPaths = config.platform.android.stringResourcePaths ?? [];
+  const androidParser = new AndroidConfigParser(
+    customPaths,
+    config.platform.android.androidManifestPaths ?? [],
+  );
   return await androidParser.set("hot_updater_fingerprint_hash", hash);
 };
 
@@ -17,10 +20,13 @@ const getAndroidFingerprintHash = async (): Promise<{
   paths: string[];
 }> => {
   const config = await loadConfig(null);
-  const customPaths = config.platform.android.stringResourcePaths;
-  const androidParser = new AndroidConfigParser(customPaths);
+  const customPaths = config.platform.android.stringResourcePaths ?? [];
+  const androidParser = new AndroidConfigParser(
+    customPaths,
+    config.platform.android.androidManifestPaths ?? [],
+  );
   if (!(await androidParser.exists())) {
-    throw new Error("No Android strings.xml files found");
+    throw new Error("No Android native config files found");
   }
   return androidParser.get("hot_updater_fingerprint_hash");
 };

--- a/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
+++ b/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
@@ -35,7 +35,8 @@ export async function validateSigningConfig(
 
   const iosParser = new IosConfigParser(config.platform.ios.infoPlistPaths);
   const androidParser = new AndroidConfigParser(
-    config.platform.android.stringResourcePaths,
+    config.platform.android.stringResourcePaths ?? [],
+    config.platform.android.androidManifestPaths ?? [],
   );
 
   const [iosExists, androidExists] = await Promise.all([
@@ -73,7 +74,7 @@ export async function validateSigningConfig(
         platform: "android",
         code: "MISSING_PUBLIC_KEY",
         message:
-          "Signing is enabled but hot_updater_public_key is missing from strings.xml",
+          "Signing is enabled but com.hotupdater.PUBLIC_KEY is missing from AndroidManifest.xml",
         resolution:
           "Run `npx hot-updater keys export-public` to add the public key, then rebuild your Android app.",
       });
@@ -97,7 +98,7 @@ export async function validateSigningConfig(
         platform: "android",
         code: "ORPHAN_PUBLIC_KEY",
         message:
-          "Signing is disabled but hot_updater_public_key exists in strings.xml. This will cause OTA updates to be rejected.",
+          "Signing is disabled but com.hotupdater.PUBLIC_KEY exists in AndroidManifest.xml or legacy strings.xml. This will cause OTA updates to be rejected.",
         resolution:
           "Run `npx hot-updater keys remove` to remove public keys, or enable signing in hot-updater.config.ts",
       });

--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
@@ -140,13 +140,12 @@ class HotUpdaterImpl {
                 null
             }
 
-        fun getChannel(context: Context): String {
-            return NativeConfigUtils.getString(
+        fun getChannel(context: Context): String =
+            NativeConfigUtils.getString(
                 context,
                 NativeConfigUtils.CHANNEL_META_DATA_KEY,
                 "hot_updater_channel",
             ) ?: DEFAULT_CHANNEL
-        }
 
         /**
          * Get minimum bundle ID string
@@ -213,26 +212,24 @@ class HotUpdaterImpl {
          * @param context Application context
          * @return The fingerprint hash or null if not set
          */
-        fun getFingerprintHash(context: Context): String? {
-            return NativeConfigUtils.getString(
+        fun getFingerprintHash(context: Context): String? =
+            NativeConfigUtils.getString(
                 context,
                 NativeConfigUtils.FINGERPRINT_HASH_META_DATA_KEY,
                 "hot_updater_fingerprint_hash",
             )
-        }
     }
 
     /**
      * Gets the current fingerprint hash
      * @return The fingerprint hash or null if not set
      */
-    fun getFingerprintHash(): String? {
-        return NativeConfigUtils.getString(
+    fun getFingerprintHash(): String? =
+        NativeConfigUtils.getString(
             context,
             NativeConfigUtils.FINGERPRINT_HASH_META_DATA_KEY,
             "hot_updater_fingerprint_hash",
         )
-    }
 
     /**
      * Gets the current update channel

--- a/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt
@@ -105,14 +105,7 @@ class HotUpdaterImpl {
          * @return The isolation key in format: HotUpdaterPrefs_{fingerprintOrVersion}_{channel}
          */
         private fun getIsolationKey(context: Context): String {
-            // Get fingerprint hash directly from resources
-            val fingerprintId = StringResourceUtils.getIdentifier(context, "hot_updater_fingerprint_hash")
-            val fingerprintHash =
-                if (fingerprintId != 0) {
-                    context.getString(fingerprintId).takeIf { it.isNotEmpty() }
-                } else {
-                    null
-                }
+            val fingerprintHash = getFingerprintHash(context)
 
             // Get app version and channel
             val appVersion = getAppVersion(context) ?: "unknown"
@@ -148,12 +141,11 @@ class HotUpdaterImpl {
             }
 
         fun getChannel(context: Context): String {
-            val id = StringResourceUtils.getIdentifier(context, "hot_updater_channel")
-            return if (id != 0) {
-                context.getString(id).takeIf { it.isNotEmpty() } ?: DEFAULT_CHANNEL
-            } else {
-                DEFAULT_CHANNEL
-            }
+            return NativeConfigUtils.getString(
+                context,
+                NativeConfigUtils.CHANNEL_META_DATA_KEY,
+                "hot_updater_channel",
+            ) ?: DEFAULT_CHANNEL
         }
 
         /**
@@ -222,12 +214,11 @@ class HotUpdaterImpl {
          * @return The fingerprint hash or null if not set
          */
         fun getFingerprintHash(context: Context): String? {
-            val id = StringResourceUtils.getIdentifier(context, "hot_updater_fingerprint_hash")
-            return if (id != 0) {
-                context.getString(id).takeIf { it.isNotEmpty() }
-            } else {
-                null
-            }
+            return NativeConfigUtils.getString(
+                context,
+                NativeConfigUtils.FINGERPRINT_HASH_META_DATA_KEY,
+                "hot_updater_fingerprint_hash",
+            )
         }
     }
 
@@ -236,12 +227,11 @@ class HotUpdaterImpl {
      * @return The fingerprint hash or null if not set
      */
     fun getFingerprintHash(): String? {
-        val id = StringResourceUtils.getIdentifier(context, "hot_updater_fingerprint_hash")
-        return if (id != 0) {
-            context.getString(id).takeIf { it.isNotEmpty() }
-        } else {
-            null
-        }
+        return NativeConfigUtils.getString(
+            context,
+            NativeConfigUtils.FINGERPRINT_HASH_META_DATA_KEY,
+            "hot_updater_fingerprint_hash",
+        )
     }
 
     /**
@@ -254,12 +244,11 @@ class HotUpdaterImpl {
             return overriddenChannel
         }
 
-        val id = StringResourceUtils.getIdentifier(context, "hot_updater_channel")
-        return if (id != 0) {
-            context.getString(id).takeIf { it.isNotEmpty() } ?: DEFAULT_CHANNEL
-        } else {
-            DEFAULT_CHANNEL
-        }
+        return NativeConfigUtils.getString(
+            context,
+            NativeConfigUtils.CHANNEL_META_DATA_KEY,
+            "hot_updater_channel",
+        ) ?: DEFAULT_CHANNEL
     }
 
     fun getDefaultChannel(): String = getChannel(context)

--- a/packages/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt
@@ -1,0 +1,58 @@
+package com.hotupdater
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+object NativeConfigUtils {
+    const val CHANNEL_META_DATA_KEY = "com.hotupdater.CHANNEL"
+    const val FINGERPRINT_HASH_META_DATA_KEY = "com.hotupdater.FINGERPRINT_HASH"
+    const val PUBLIC_KEY_META_DATA_KEY = "com.hotupdater.PUBLIC_KEY"
+
+    fun getString(
+        context: Context,
+        metaDataKey: String,
+        stringResourceName: String,
+    ): String? =
+        getManifestMetaDataString(context, metaDataKey)
+            ?: getStringResource(context, stringResourceName)
+
+    private fun getManifestMetaDataString(
+        context: Context,
+        key: String,
+    ): String? =
+        try {
+            val packageManager = context.packageManager
+            val applicationInfo =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    packageManager.getApplicationInfo(
+                        context.packageName,
+                        PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()),
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    packageManager.getApplicationInfo(
+                        context.packageName,
+                        PackageManager.GET_META_DATA,
+                    )
+                }
+
+            applicationInfo.metaData
+                ?.getString(key)
+                ?.takeIf { it.isNotEmpty() }
+        } catch (e: Exception) {
+            null
+        }
+
+    private fun getStringResource(
+        context: Context,
+        name: String,
+    ): String? {
+        val id = StringResourceUtils.getIdentifier(context, name)
+        return if (id != 0) {
+            context.getString(id).takeIf { it.isNotEmpty() }
+        } else {
+            null
+        }
+    }
+}

--- a/packages/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt
@@ -37,12 +37,16 @@ object NativeConfigUtils {
                     )
                 }
 
-            applicationInfo.metaData
-                ?.getString(key)
-                ?.takeIf { it.isNotEmpty() }
+            @Suppress("DEPRECATION")
+            coerceManifestMetaDataString(applicationInfo.metaData?.get(key))
         } catch (e: Exception) {
             null
         }
+
+    internal fun coerceManifestMetaDataString(value: Any?): String? =
+        value
+            ?.toString()
+            ?.takeIf { it.isNotEmpty() }
 
     private fun getStringResource(
         context: Context,

--- a/packages/react-native/android/src/main/java/com/hotupdater/SignatureVerifier.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/SignatureVerifier.kt
@@ -27,7 +27,7 @@ sealed class SignatureVerificationException(
     class PublicKeyNotConfigured :
         SignatureVerificationException(
             "Public key not configured for signature verification. " +
-                "Add 'hot_updater_public_key' to res/values/strings.xml",
+                "Add 'com.hotupdater.PUBLIC_KEY' to AndroidManifest.xml",
         )
 
     class InvalidPublicKeyFormat :
@@ -97,16 +97,15 @@ object SignatureVerifier {
      * @return Public key PEM string or null if not configured
      */
     private fun getPublicKeyFromConfig(context: Context): String? {
-        val resourceId = StringResourceUtils.getIdentifier(context, "hot_updater_public_key")
+        val publicKeyPEM =
+            NativeConfigUtils.getString(
+                context,
+                NativeConfigUtils.PUBLIC_KEY_META_DATA_KEY,
+                "hot_updater_public_key",
+            )
 
-        if (resourceId == 0) {
-            Log.d(TAG, "hot_updater_public_key not found in strings.xml")
-            return null
-        }
-
-        val publicKeyPEM = context.getString(resourceId)
-        if (publicKeyPEM.isEmpty()) {
-            Log.d(TAG, "hot_updater_public_key is empty")
+        if (publicKeyPEM.isNullOrEmpty()) {
+            Log.d(TAG, "com.hotupdater.PUBLIC_KEY is not configured")
             return null
         }
 
@@ -229,7 +228,7 @@ object SignatureVerifier {
         val publicKeyPEM =
             getPublicKeyFromConfig(context)
                 ?: run {
-                    Log.e(TAG, "Cannot verify signature: public key not configured in strings.xml")
+                    Log.e(TAG, "Cannot verify signature: public key not configured")
                     throw SignatureVerificationException.PublicKeyNotConfigured()
                 }
 
@@ -267,7 +266,7 @@ object SignatureVerifier {
         val publicKeyPEM =
             getPublicKeyFromConfig(context)
                 ?: run {
-                    Log.e(TAG, "Cannot verify signature: public key not configured in strings.xml")
+                    Log.e(TAG, "Cannot verify signature: public key not configured")
                     throw SignatureVerificationException.PublicKeyNotConfigured()
                 }
 

--- a/packages/react-native/android/src/test/java/com/hotupdater/NativeConfigUtilsTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/NativeConfigUtilsTest.kt
@@ -1,0 +1,20 @@
+package com.hotupdater
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NativeConfigUtilsTest {
+    @Test
+    fun `coerces typed manifest metadata to strings`() {
+        assertEquals("123", NativeConfigUtils.coerceManifestMetaDataString(123))
+        assertEquals("true", NativeConfigUtils.coerceManifestMetaDataString(true))
+        assertEquals("-16711936", NativeConfigUtils.coerceManifestMetaDataString(-16711936))
+    }
+
+    @Test
+    fun `ignores missing and empty manifest metadata`() {
+        assertNull(NativeConfigUtils.coerceManifestMetaDataString(null))
+        assertNull(NativeConfigUtils.coerceManifestMetaDataString(""))
+    }
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -45,9 +45,11 @@
     "!**/.*"
   ],
   "scripts": {
-    "build": "pnpm sync:sdk-version && bob build && tsc -p plugin/tsconfig.build.json",
+    "build": "node ./scripts/sync-sdk-version.mjs run -- bob build && tsc -p plugin/tsconfig.build.json",
     "build:plugin": "tsc -p plugin/tsconfig.build.json",
     "sync:sdk-version": "node ./scripts/sync-sdk-version.mjs",
+    "prepack": "node ./scripts/sync-sdk-version.mjs sync",
+    "postpack": "node ./scripts/sync-sdk-version.mjs restore",
     "test:type": "tsc --noEmit",
     "test": "vitest",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -4,6 +4,7 @@ import path from "path";
 import type { ExpoConfig } from "expo/config";
 import {
   createRunOncePlugin,
+  withAndroidManifest,
   withAppDelegate,
   withInfoPlist,
   withMainApplication,
@@ -16,6 +17,62 @@ import { transformAndroid, transformIOS } from "./transformers";
 
 const loadCliTools = () => import("@hot-updater/cli-tools");
 const loadHotUpdater = () => import("hot-updater");
+
+const ANDROID_META_DATA_KEYS = {
+  channel: "com.hotupdater.CHANNEL",
+  fingerprintHash: "com.hotupdater.FINGERPRINT_HASH",
+  publicKey: "com.hotupdater.PUBLIC_KEY",
+} as const;
+
+type AndroidMetaData = {
+  $?: Record<string, string>;
+};
+
+type AndroidApplication = {
+  "meta-data"?: AndroidMetaData | AndroidMetaData[];
+};
+
+const removeAndroidMetaData = (
+  application: AndroidApplication,
+  name: string,
+) => {
+  const metaData = application["meta-data"];
+  if (!metaData) {
+    return;
+  }
+
+  const filtered = (Array.isArray(metaData) ? metaData : [metaData]).filter(
+    (item) => item?.$?.["android:name"] !== name,
+  );
+
+  if (filtered.length === 0) {
+    delete application["meta-data"];
+  } else {
+    application["meta-data"] = filtered;
+  }
+};
+
+const upsertAndroidMetaData = (
+  application: AndroidApplication,
+  name: string,
+  value: string,
+) => {
+  removeAndroidMetaData(application, name);
+
+  const metaData = Array.isArray(application["meta-data"])
+    ? application["meta-data"]
+    : application["meta-data"]
+      ? [application["meta-data"]]
+      : [];
+
+  metaData.push({
+    $: {
+      "android:name": name,
+      "android:value": value,
+    },
+  });
+  application["meta-data"] = metaData;
+};
 
 type Fingerprints = Awaited<
   ReturnType<Awaited<ReturnType<typeof loadHotUpdater>>["generateFingerprints"]>
@@ -188,8 +245,8 @@ const withHotUpdaterConfigAsync =
       return cfg;
     });
 
-    // === Android: Add channel and fingerprint to strings.xml ===
-    modifiedConfig = withStringsXml(modifiedConfig, async (cfg) => {
+    // === Android: Add channel and fingerprint to AndroidManifest.xml ===
+    modifiedConfig = withAndroidManifest(modifiedConfig, async (cfg) => {
       let fingerprintHash = null;
       const { loadConfig } = await loadCliTools();
       const config = await loadConfig(null);
@@ -201,73 +258,51 @@ const withHotUpdaterConfigAsync =
       // Load public key if signing is enabled
       const publicKey = await getPublicKeyFromConfig(config.signing);
 
-      // Ensure resources object exists
-      if (!cfg.modResults.resources) {
-        cfg.modResults.resources = {};
-      }
-      if (!cfg.modResults.resources.string) {
-        cfg.modResults.resources.string = [];
+      const application = cfg.modResults.manifest.application?.[0];
+      if (!application) {
+        return cfg;
       }
 
-      // Remove existing hot_updater_channel entry if it exists
-      cfg.modResults.resources.string = cfg.modResults.resources.string.filter(
-        (item) => !(item.$ && item.$.name === "hot_updater_channel"),
+      upsertAndroidMetaData(
+        application,
+        ANDROID_META_DATA_KEYS.channel,
+        channel,
       );
 
-      // Add the new hot_updater_channel entry
-      cfg.modResults.resources.string.push({
-        $: {
-          name: "hot_updater_channel",
-          moduleConfig: "true",
-          translatable: "false",
-        } as {
-          name: string;
-          moduleConfig: string;
-          translatable: string;
-        },
-        _: channel,
-      });
-
       if (fingerprintHash) {
-        // Remove existing hot_updater_fingerprint_hash entry if it exists
-        cfg.modResults.resources.string =
-          cfg.modResults.resources.string.filter(
-            (item) =>
-              !(item.$ && item.$.name === "hot_updater_fingerprint_hash"),
-          );
-
-        // Add the new hot_updater_fingerprint_hash entry
-        cfg.modResults.resources.string.push({
-          $: {
-            name: "hot_updater_fingerprint_hash",
-            moduleConfig: "true",
-          } as {
-            name: string;
-            moduleConfig: string;
-          },
-          _: fingerprintHash,
-        });
+        upsertAndroidMetaData(
+          application,
+          ANDROID_META_DATA_KEYS.fingerprintHash,
+          fingerprintHash,
+        );
       }
 
       if (publicKey) {
-        // Remove existing hot_updater_public_key entry if it exists
-        cfg.modResults.resources.string =
-          cfg.modResults.resources.string.filter(
-            (item) => !(item.$ && item.$.name === "hot_updater_public_key"),
-          );
-
-        // Add the new hot_updater_public_key entry
-        cfg.modResults.resources.string.push({
-          $: {
-            name: "hot_updater_public_key",
-            moduleConfig: "true",
-          } as {
-            name: string;
-            moduleConfig: string;
-          },
-          _: publicKey,
-        });
+        upsertAndroidMetaData(
+          application,
+          ANDROID_META_DATA_KEYS.publicKey,
+          publicKey,
+        );
       }
+
+      return cfg;
+    });
+
+    // Remove legacy Hot Updater string resources when prebuild reuses a tree.
+    modifiedConfig = withStringsXml(modifiedConfig, (cfg) => {
+      const strings = cfg.modResults.resources?.string;
+      if (!strings) {
+        return cfg;
+      }
+
+      cfg.modResults.resources.string = (
+        Array.isArray(strings) ? strings : [strings]
+      ).filter(
+        (item) =>
+          item.$?.name !== "hot_updater_channel" &&
+          item.$?.name !== "hot_updater_fingerprint_hash" &&
+          item.$?.name !== "hot_updater_public_key",
+      );
 
       return cfg;
     });

--- a/packages/react-native/scripts/sync-sdk-version.mjs
+++ b/packages/react-native/scripts/sync-sdk-version.mjs
@@ -23,6 +23,10 @@ if (typeof version !== "string" || version.length === 0) {
 }
 
 const source = [
+  "declare const HotUpdater: {",
+  "  SDK_VERSION: string;",
+  "};",
+  "",
   "export const HOT_UPDATER_SDK_VERSION = HotUpdater.SDK_VERSION;",
   "",
 ].join("\n");

--- a/packages/react-native/scripts/sync-sdk-version.mjs
+++ b/packages/react-native/scripts/sync-sdk-version.mjs
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +8,12 @@ import { transformSync } from "oxc-transform";
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJsonPath = join(packageRoot, "package.json");
 const sdkVersionPath = join(packageRoot, "src", "sdkVersion.ts");
+const backupPath = join(
+  packageRoot,
+  "node_modules",
+  ".cache",
+  "hot-updater-sdk-version.json",
+);
 
 const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 const version = packageJson.version;
@@ -28,10 +35,88 @@ const code =
   })?.code ?? source;
 
 const nextContents = code.endsWith("\n") ? code : `${code}\n`;
-const currentContents = await readFile(sdkVersionPath, "utf-8").catch(
-  () => "",
-);
 
-if (currentContents !== nextContents) {
-  await writeFile(sdkVersionPath, nextContents);
+async function syncSdkVersion() {
+  const currentContents = await readFile(sdkVersionPath, "utf-8").catch(
+    () => "",
+  );
+  const existingBackup = await readFile(backupPath, "utf-8").catch(() => null);
+
+  if (existingBackup !== null) {
+    throw new Error(
+      `SDK version backup already exists at ${backupPath}. Run sync:sdk-version restore before syncing again.`,
+    );
+  }
+
+  await mkdir(dirname(backupPath), { recursive: true });
+  await writeFile(
+    backupPath,
+    JSON.stringify({ contents: currentContents }, null, 2),
+  );
+
+  if (currentContents !== nextContents) {
+    await writeFile(sdkVersionPath, nextContents);
+  }
+}
+
+async function restoreSdkVersion() {
+  const backup = await readFile(backupPath, "utf-8").catch(() => null);
+
+  if (backup === null) {
+    return;
+  }
+
+  const parsed = JSON.parse(backup);
+  await writeFile(sdkVersionPath, parsed.contents);
+  await rm(backupPath, { force: true });
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: packageRoot,
+      shell: process.platform === "win32",
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(
+        new Error(
+          signal
+            ? `${command} exited with signal ${signal}`
+            : `${command} exited with code ${code}`,
+        ),
+      );
+    });
+  });
+}
+
+const [command = "once", separator, ...args] = process.argv.slice(2);
+
+if (command === "sync") {
+  await syncSdkVersion();
+} else if (command === "restore") {
+  await restoreSdkVersion();
+} else if (command === "once") {
+  await syncSdkVersion();
+  await restoreSdkVersion();
+} else if (command === "run") {
+  if (separator !== "--" || args.length === 0) {
+    throw new Error("Usage: sync-sdk-version.mjs run -- <command> [...args]");
+  }
+
+  await syncSdkVersion();
+  try {
+    await runCommand(args[0], args.slice(1));
+  } finally {
+    await restoreSdkVersion();
+  }
+} else {
+  throw new Error(`Unknown sync-sdk-version command: ${command}`);
 }

--- a/packages/react-native/src/DefaultResolver.spec.ts
+++ b/packages/react-native/src/DefaultResolver.spec.ts
@@ -8,9 +8,17 @@ import { createDefaultResolver } from "./DefaultResolver";
 import { HOT_UPDATER_SDK_VERSION } from "./sdkVersion";
 import type { ResolverCheckUpdateParams } from "./types";
 
-const mocks = vi.hoisted(() => ({
-  fetchUpdateInfo: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  (
+    globalThis as typeof globalThis & {
+      HotUpdater: { SDK_VERSION: string };
+    }
+  ).HotUpdater = { SDK_VERSION: "test-sdk-version" };
+
+  return {
+    fetchUpdateInfo: vi.fn(),
+  };
+});
 
 vi.mock("./fetchUpdateInfo", () => ({
   fetchUpdateInfo: mocks.fetchUpdateInfo,

--- a/packages/react-native/src/DefaultResolver.spec.ts
+++ b/packages/react-native/src/DefaultResolver.spec.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -90,14 +91,20 @@ describe("createDefaultResolver", () => {
     });
   });
 
-  it("keeps the SDK version header aligned with package.json", async () => {
-    const [{ HOT_UPDATER_SDK_VERSION }, packageJson] = await Promise.all([
-      import("./sdkVersion"),
-      readFile(join(__dirname, "../package.json"), "utf-8"),
-    ]);
-    const pkg = JSON.parse(packageJson) as { version: string };
+  it("keeps SDK version sync from leaving source changes behind", async () => {
+    const sdkVersionPath = join(__dirname, "sdkVersion.ts");
+    const before = await readFile(sdkVersionPath, "utf-8");
+    const result = spawnSync(
+      process.execPath,
+      [join(__dirname, "../scripts/sync-sdk-version.mjs")],
+      {
+        cwd: join(__dirname, ".."),
+        encoding: "utf-8",
+      },
+    );
 
-    expect(HOT_UPDATER_SDK_VERSION).toBe(pkg.version);
+    expect(result.status, result.stderr).toBe(0);
+    await expect(readFile(sdkVersionPath, "utf-8")).resolves.toBe(before);
   });
 
   it("propagates fetchUpdateInfo errors", async () => {

--- a/packages/react-native/src/index.spec.ts
+++ b/packages/react-native/src/index.spec.ts
@@ -3,30 +3,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HotUpdater as HotUpdaterValue } from "./index";
 import type { HotUpdaterInitOptions, HotUpdaterOptions } from "./wrap";
 
-const mocks = vi.hoisted(() => ({
-  addListener: vi.fn(() => () => {}),
-  checkForUpdate: vi.fn(),
-  clearCrashHistory: vi.fn(() => true),
-  createDefaultResolver: vi.fn(),
-  getAppVersion: vi.fn(() => "1.0.0"),
-  getBaseURL: vi.fn(() => null),
-  getBundleId: vi.fn(() => "bundle-id"),
-  getChannel: vi.fn(() => "production"),
-  getCohort: vi.fn(() => "123"),
-  getCrashHistory: vi.fn(() => []),
-  getDefaultChannel: vi.fn(() => "production"),
-  getFingerprintHash: vi.fn(() => null),
-  getManifest: vi.fn(() => null),
-  getMinBundleId: vi.fn(() => "min-bundle-id"),
-  init: vi.fn(),
-  isChannelSwitched: vi.fn(() => false),
-  reload: vi.fn(),
-  resetChannel: vi.fn(),
-  setCohort: vi.fn(),
-  setReloadBehavior: vi.fn(),
-  updateBundle: vi.fn(),
-  wrap: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  (
+    globalThis as typeof globalThis & {
+      HotUpdater: { SDK_VERSION: string };
+    }
+  ).HotUpdater = { SDK_VERSION: "test-sdk-version" };
+
+  return {
+    addListener: vi.fn(() => () => {}),
+    checkForUpdate: vi.fn(),
+    clearCrashHistory: vi.fn(() => true),
+    createDefaultResolver: vi.fn(),
+    getAppVersion: vi.fn(() => "1.0.0"),
+    getBaseURL: vi.fn(() => null),
+    getBundleId: vi.fn(() => "bundle-id"),
+    getChannel: vi.fn(() => "production"),
+    getCohort: vi.fn(() => "123"),
+    getCrashHistory: vi.fn(() => []),
+    getDefaultChannel: vi.fn(() => "production"),
+    getFingerprintHash: vi.fn(() => null),
+    getManifest: vi.fn(() => null),
+    getMinBundleId: vi.fn(() => "min-bundle-id"),
+    init: vi.fn(),
+    isChannelSwitched: vi.fn(() => false),
+    reload: vi.fn(),
+    resetChannel: vi.fn(),
+    setCohort: vi.fn(),
+    setReloadBehavior: vi.fn(),
+    updateBundle: vi.fn(),
+    wrap: vi.fn(),
+  };
+});
 
 vi.mock("./DefaultResolver", () => ({
   createDefaultResolver: mocks.createDefaultResolver,

--- a/packages/react-native/src/sdkVersion.ts
+++ b/packages/react-native/src/sdkVersion.ts
@@ -1,1 +1,1 @@
-export const HOT_UPDATER_SDK_VERSION = "0.31.2";
+export const HOT_UPDATER_SDK_VERSION = "0.31.4";

--- a/packages/react-native/src/sdkVersion.ts
+++ b/packages/react-native/src/sdkVersion.ts
@@ -1,1 +1,1 @@
-export const HOT_UPDATER_SDK_VERSION = "0.31.4";
+export const HOT_UPDATER_SDK_VERSION = "0.31.2";

--- a/packages/react-native/src/sdkVersion.ts
+++ b/packages/react-native/src/sdkVersion.ts
@@ -1,1 +1,5 @@
-export const HOT_UPDATER_SDK_VERSION = "0.31.2";
+declare const HotUpdater: {
+  SDK_VERSION: string;
+};
+
+export const HOT_UPDATER_SDK_VERSION = HotUpdater.SDK_VERSION;

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -308,7 +308,18 @@ export interface PlatformConfig {
    */
   android?: {
     /**
+     * Android manifest paths.
+     *
+     * @default all AndroidManifest.xml files in the android directory
+     * @example ["android/app/src/main/AndroidManifest.xml"]
+     */
+    androidManifestPaths?: string[];
+
+    /**
      * Android string resource paths.
+     *
+     * @deprecated Android Hot Updater config is stored in AndroidManifest.xml.
+     * This remains supported as a legacy read fallback.
      *
      * @default all strings.xml files in the android directory
      * @example ["android/app/src/main/res/values/strings.xml"]


### PR DESCRIPTION
## Summary

- Move Android Hot Updater native config writes from `strings.xml` to `AndroidManifest.xml` `<meta-data>`.
- Read manifest metadata first and keep legacy `strings.xml` values as fallback.
- Update Expo plugin, CLI XML mutation commands, doctor/signing validation, and Android native runtime reads.

Reference: https://github.com/gronxb/hot-updater/issues/1010#issuecomment-4486898180
