### PR TITLE
fix(hot-updater): load Expo fingerprint as optional peer

### DIFF
--- a/.changeset/optional-expo-fingerprint-peer.md
+++ b/.changeset/optional-expo-fingerprint-peer.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+fix(fingerprint): load `@expo/fingerprint` as an optional peer dependency for fingerprint commands

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -86,12 +86,16 @@
     "typescript": "6.0.2"
   },
   "peerDependencies": {
+    "@expo/fingerprint": "^0.15.4",
     "@hot-updater/aws": "*",
     "@hot-updater/cloudflare": "*",
     "@hot-updater/firebase": "*",
     "@hot-updater/supabase": "*"
   },
   "peerDependenciesMeta": {
+    "@expo/fingerprint": {
+      "optional": true
+    },
     "@hot-updater/supabase": {
       "optional": true
     },
@@ -111,9 +115,7 @@
   "inlinedDependencies": {
     "@bacons/xcode": "1.0.0-alpha.24",
     "@commander-js/extra-typings": "14.0.0",
-    "@expo/fingerprint": "0.15.4",
     "@expo/plist": "0.0.18",
-    "@expo/spawn-async": "1.7.2",
     "@nodable/entities": "2.1.0",
     "@nodelib/fs.scandir": "2.1.5",
     "@nodelib/fs.stat": "2.0.5",
@@ -124,21 +126,12 @@
       "0.7.13",
       "0.8.10"
     ],
-    "ansi-styles": "4.3.0",
-    "balanced-match": "1.0.2",
     "base64-js": "1.5.1",
-    "brace-expansion": "2.0.2",
     "braces": "3.0.3",
     "bundle-name": "4.1.0",
-    "chalk": "4.1.2",
-    "color-convert": "2.0.1",
-    "color-name": "1.1.4",
     "commander": "14.0.0",
     "cross-spawn": "7.0.6",
-    "debug": [
-      "4.4.1",
-      "4.4.3"
-    ],
+    "debug": "4.4.1",
     "default-browser": "5.2.1",
     "default-browser-id": "5.0.0",
     "define-lazy-prop": "3.0.0",
@@ -151,11 +144,9 @@
     "figures": "6.1.0",
     "fill-range": "7.1.1",
     "get-stream": "9.0.1",
-    "glob": "13.0.6",
     "glob-parent": "5.1.2",
     "has-flag": "4.0.0",
     "human-signals": "8.0.1",
-    "ignore": "5.3.2",
     "is-docker": "3.0.0",
     "is-extglob": "2.1.1",
     "is-glob": "4.0.3",
@@ -170,12 +161,10 @@
     "kysely": "0.28.16",
     "merge2": "1.4.1",
     "micromatch": "4.0.8",
-    "minimatch": "9.0.9",
     "ms": "2.1.3",
     "nearley": "2.20.1",
     "npm-run-path": "6.0.0",
     "open": "10.1.0",
-    "p-limit": "3.1.0",
     "parse-ms": "4.0.0",
     "path-expression-matcher": "1.5.0",
     "path-key": [
@@ -186,24 +175,17 @@
     "plist": "3.1.0",
     "pretty-ms": "9.2.0",
     "queue-microtask": "1.2.3",
-    "resolve-from": "5.0.0",
     "reusify": "1.0.4",
     "run-applescript": "7.0.0",
     "run-parallel": "1.2.0",
-    "semver": [
-      "7.7.2",
-      "7.7.4"
-    ],
+    "semver": "7.7.2",
     "shebang-command": "2.0.0",
     "shebang-regex": "3.0.0",
     "signal-exit": "4.1.0",
     "sql-formatter": "15.6.10",
     "strip-final-newline": "4.0.0",
     "strnum": "2.2.3",
-    "supports-color": [
-      "7.2.0",
-      "8.1.1"
-    ],
+    "supports-color": "8.1.1",
     "to-regex-range": "5.0.1",
     "unicorn-magic": "0.3.0",
     "which": "2.0.2",
@@ -211,7 +193,6 @@
       "14.0.0",
       "15.1.1"
     ],
-    "yocto-queue": "0.1.0",
     "yoctocolors": "2.1.1"
   }
 }

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -86,7 +86,7 @@
     "typescript": "6.0.2"
   },
   "peerDependencies": {
-    "@expo/fingerprint": "^0.15.4",
+    "@expo/fingerprint": "*",
     "@hot-updater/aws": "*",
     "@hot-updater/cloudflare": "*",
     "@hot-updater/firebase": "*",

--- a/packages/hot-updater/src/commands/fingerprint.ts
+++ b/packages/hot-updater/src/commands/fingerprint.ts
@@ -11,6 +11,7 @@ import {
   isFingerprintEquals,
   readLocalFingerprint,
 } from "@/utils/fingerprint";
+import { isMissingFingerprintDependencyError } from "@/utils/fingerprint/dependency";
 import {
   getFingerprintDiff,
   showFingerprintDiff,
@@ -18,11 +19,30 @@ import {
 
 import { ui } from "../utils/cli-ui";
 
+const exitWithFingerprintError = (error: unknown): never => {
+  if (error instanceof Error) {
+    p.log.error(error.message);
+  } else {
+    p.log.error(String(error));
+  }
+
+  if (!isMissingFingerprintDependencyError(error)) {
+    console.error(error);
+  }
+  process.exit(1);
+};
+
 export const handleFingerprint = async () => {
   const s = p.spinner();
   s.start("Generating fingerprints");
 
-  const fingerPrintRef = await generateFingerprints();
+  let fingerPrintRef: Awaited<ReturnType<typeof generateFingerprints>>;
+  try {
+    fingerPrintRef = await generateFingerprints();
+  } catch (error) {
+    s.error("Fingerprint generation failed");
+    return exitWithFingerprintError(error);
+  }
 
   s.stop("Fingerprint generated");
   p.log.message(
@@ -113,11 +133,8 @@ export const handleCreateFingerprint = async () => {
     }
     s.stop("Created fingerprint.json");
   } catch (error) {
-    if (error instanceof Error) {
-      p.log.error(error.message);
-    }
-    console.error(error);
-    process.exit(1);
+    s.error("Creating fingerprint.json failed");
+    exitWithFingerprintError(error);
   }
 
   if (diffChanged && result) {

--- a/packages/hot-updater/src/utils/fingerprint/common.ts
+++ b/packages/hot-updater/src/utils/fingerprint/common.ts
@@ -1,7 +1,7 @@
-import { SourceSkips } from "@expo/fingerprint";
 import { loadConfig, p } from "@hot-updater/cli-tools";
 
 import { isExpo } from "../expoDetection";
+import { loadExpoFingerprint } from "./dependency";
 import { processExtraSources } from "./processExtraSources";
 
 export const ensureFingerprintConfig = async () => {
@@ -32,11 +32,13 @@ function getDefaultIgnorePaths(): string[] {
   return ["**/*", "**/.build/**/*", "**/build/", "**/build*/**/*"];
 }
 
-export function getOtaFingerprintOptions(
+export async function getOtaFingerprintOptions(
   platform: "ios" | "android",
   path: string,
   options: FingerprintOptions,
-): OtaFingerprintOptions {
+): Promise<OtaFingerprintOptions> {
+  const { SourceSkips } = await loadExpoFingerprint();
+
   return {
     useRNCoreAutolinkingFromExpo: isExpo(),
     platforms: [platform],

--- a/packages/hot-updater/src/utils/fingerprint/dependency.spec.ts
+++ b/packages/hot-updater/src/utils/fingerprint/dependency.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createMissingFingerprintDependencyError,
+  isMissingExpoFingerprintError,
+} from "./dependency";
+
+describe("loadExpoFingerprint", () => {
+  afterEach(() => {
+    delete process.env["npm_config_user_agent"];
+  });
+
+  it("creates install guidance for the missing optional peer", () => {
+    process.env["npm_config_user_agent"] = "pnpm/10.33.0";
+
+    const error = createMissingFingerprintDependencyError();
+
+    expect(error.message).toContain(
+      "@expo/fingerprint is required for fingerprint commands but is not installed.",
+    );
+    expect(error.message).toContain("pnpm add -D @expo/fingerprint@^0.15.4");
+  });
+
+  it("detects missing @expo/fingerprint module errors", () => {
+    const error = Object.assign(
+      new Error("Cannot find package '@expo/fingerprint'"),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+
+    expect(isMissingExpoFingerprintError(error)).toBe(true);
+    expect(isMissingExpoFingerprintError(new Error("boom"))).toBe(false);
+  });
+});

--- a/packages/hot-updater/src/utils/fingerprint/dependency.spec.ts
+++ b/packages/hot-updater/src/utils/fingerprint/dependency.spec.ts
@@ -18,7 +18,7 @@ describe("loadExpoFingerprint", () => {
     expect(error.message).toContain(
       "@expo/fingerprint is required for fingerprint commands but is not installed.",
     );
-    expect(error.message).toContain("pnpm add -D @expo/fingerprint@^0.15.4");
+    expect(error.message).toContain("pnpm add -D @expo/fingerprint");
   });
 
   it("detects missing @expo/fingerprint module errors", () => {

--- a/packages/hot-updater/src/utils/fingerprint/dependency.ts
+++ b/packages/hot-updater/src/utils/fingerprint/dependency.ts
@@ -3,20 +3,18 @@ import { getPackageManager } from "../getPackageManager";
 export type ExpoFingerprint = typeof import("@expo/fingerprint");
 
 const PACKAGE_NAME = "@expo/fingerprint";
-const PACKAGE_RANGE = "^0.15.4";
 const MISSING_DEPENDENCY_ERROR_NAME = "MissingFingerprintDependencyError";
 
 const getInstallCommand = () => {
-  const pkg = `${PACKAGE_NAME}@${PACKAGE_RANGE}`;
   switch (getPackageManager()) {
     case "pnpm":
-      return `pnpm add -D ${pkg}`;
+      return `pnpm add -D ${PACKAGE_NAME}`;
     case "yarn":
-      return `yarn add -D ${pkg}`;
+      return `yarn add -D ${PACKAGE_NAME}`;
     case "bun":
-      return `bun add -d ${pkg}`;
+      return `bun add -d ${PACKAGE_NAME}`;
     default:
-      return `npm install -D ${pkg}`;
+      return `npm install -D ${PACKAGE_NAME}`;
   }
 };
 

--- a/packages/hot-updater/src/utils/fingerprint/dependency.ts
+++ b/packages/hot-updater/src/utils/fingerprint/dependency.ts
@@ -1,0 +1,69 @@
+import { getPackageManager } from "../getPackageManager";
+
+export type ExpoFingerprint = typeof import("@expo/fingerprint");
+
+const PACKAGE_NAME = "@expo/fingerprint";
+const PACKAGE_RANGE = "^0.15.4";
+const MISSING_DEPENDENCY_ERROR_NAME = "MissingFingerprintDependencyError";
+
+const getInstallCommand = () => {
+  const pkg = `${PACKAGE_NAME}@${PACKAGE_RANGE}`;
+  switch (getPackageManager()) {
+    case "pnpm":
+      return `pnpm add -D ${pkg}`;
+    case "yarn":
+      return `yarn add -D ${pkg}`;
+    case "bun":
+      return `bun add -d ${pkg}`;
+    default:
+      return `npm install -D ${pkg}`;
+  }
+};
+
+export class MissingFingerprintDependencyError extends Error {
+  constructor() {
+    super(
+      [
+        `${PACKAGE_NAME} is required for fingerprint commands but is not installed.`,
+        "",
+        `Install it in your app project, then re-run this command:`,
+        `  ${getInstallCommand()}`,
+      ].join("\n"),
+    );
+    this.name = MISSING_DEPENDENCY_ERROR_NAME;
+  }
+}
+
+export const createMissingFingerprintDependencyError = () =>
+  new MissingFingerprintDependencyError();
+
+export const isMissingFingerprintDependencyError = (
+  error: unknown,
+): error is MissingFingerprintDependencyError =>
+  error instanceof Error && error.name === MISSING_DEPENDENCY_ERROR_NAME;
+
+export const isMissingExpoFingerprintError = (error: unknown) => {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? error.code
+      : undefined;
+
+  return (
+    code === "ERR_MODULE_NOT_FOUND" ||
+    (error instanceof Error &&
+      (error.message.includes("Cannot find package '@expo/fingerprint'") ||
+        error.message.includes("Cannot find module '@expo/fingerprint'")))
+  );
+};
+
+export const loadExpoFingerprint = async (): Promise<ExpoFingerprint> => {
+  try {
+    return await import("@expo/fingerprint");
+  } catch (error) {
+    if (isMissingExpoFingerprintError(error)) {
+      throw createMissingFingerprintDependencyError();
+    }
+
+    throw error;
+  }
+};

--- a/packages/hot-updater/src/utils/fingerprint/diff.ts
+++ b/packages/hot-updater/src/utils/fingerprint/diff.ts
@@ -1,4 +1,3 @@
-import { diffFingerprintChangesAsync } from "@expo/fingerprint";
 import { colors, getCwd, p } from "@hot-updater/cli-tools";
 
 import {
@@ -7,6 +6,7 @@ import {
   type FingerprintResult,
   getOtaFingerprintOptions,
 } from "./common";
+import { type ExpoFingerprint, loadExpoFingerprint } from "./dependency";
 
 export type FingerprintDiffItem =
   | {
@@ -28,10 +28,13 @@ export async function getFingerprintDiff(
   options: FingerprintOptions,
 ): Promise<FingerprintDiffItem[]> {
   const projectPath = getCwd();
+  const { diffFingerprintChangesAsync } = await loadExpoFingerprint();
   return await diffFingerprintChangesAsync(
-    oldFingerprint as Parameters<typeof diffFingerprintChangesAsync>[0],
+    oldFingerprint as Parameters<
+      ExpoFingerprint["diffFingerprintChangesAsync"]
+    >[0],
     projectPath,
-    getOtaFingerprintOptions(options.platform, projectPath, options),
+    await getOtaFingerprintOptions(options.platform, projectPath, options),
   );
 }
 

--- a/packages/hot-updater/src/utils/fingerprint/index.ts
+++ b/packages/hot-updater/src/utils/fingerprint/index.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 
-import { createFingerprintAsync } from "@expo/fingerprint";
 import { getCwd } from "@hot-updater/cli-tools";
 import type { Platform } from "@hot-updater/plugin-core";
 
@@ -12,6 +11,7 @@ import {
   type FingerprintResult,
   getOtaFingerprintOptions,
 } from "./common";
+import { loadExpoFingerprint } from "./dependency";
 
 export * from "./common";
 export * from "./diff";
@@ -24,9 +24,10 @@ export async function nativeFingerprint(
   options: FingerprintOptions,
 ): Promise<FingerprintResult> {
   const platform = options.platform;
+  const { createFingerprintAsync } = await loadExpoFingerprint();
   return createFingerprintAsync(
     path,
-    getOtaFingerprintOptions(platform, path, options),
+    await getOtaFingerprintOptions(platform, path, options),
   );
 }
 

--- a/packages/hot-updater/tsdown.config.ts
+++ b/packages/hot-updater/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     index: "./src/index.ts",
   },
   deps: {
+    neverBundle: ["@expo/fingerprint"],
     onlyBundle: false,
   },
   exports: {


### PR DESCRIPTION
## Summary

- Mark `@expo/fingerprint` as an optional peer dependency for `hot-updater`.
- Keep `@expo/fingerprint` external to the CLI bundle so its `ExpoConfigLoader.js` helper remains resolvable from the upstream package directory.
- Load `@expo/fingerprint` lazily from fingerprint code paths and show an install command when it is missing.
- Add regression coverage for the missing optional peer guidance.

## Root Cause

`@expo/fingerprint` resolves `ExpoConfigLoader.js` relative to its own package files and runs that helper in a child Node process. After `hot-updater` started inlining CLI-only dependencies, that helper path was evaluated from `node_modules/hot-updater/dist`, so Expo fingerprinting attempted to execute a non-existent `hot-updater/dist/ExpoConfigLoader.js`.

## Impact

Expo projects can keep `@expo/fingerprint` installed in the app project, avoiding the Expo doctor warning from forcing it through `hot-updater` dependencies, while fingerprint commands still fail with a direct next step when the optional peer is absent.


Related #1020