### PR TITLE
fix: repair stale blob bundle indexes from doctor

### DIFF
--- a/docs/content/docs/guides/doctor.mdx
+++ b/docs/content/docs/guides/doctor.mdx
@@ -33,6 +33,18 @@ npx hot-updater doctor --json
 `--json` does not prompt for the server URL. Pass `--server-base-url` when you
 want the infrastructure check included.
 
+To repair safe local metadata issues, run:
+
+```package-install
+npx hot-updater doctor --fix
+```
+
+`--fix` loads your Hot Updater config and runs maintenance hooks exposed by the
+active database adapter. For blob-style adapters, this can rebuild the
+management bundle index from canonical `update.json` manifests. The command
+checks the index again after repair and reports a failure if the index is still
+out of sync.
+
 ## Check Native Setup
 
 When `@hot-updater/react-native` is installed and native iOS or Android
@@ -82,6 +94,9 @@ Native wiring, fingerprint creation, and native public key export/removal are
 intended to be iterated locally by an agent. Infrastructure failures are marked
 as blocked because applying migrations or redeploying a server usually depends
 on provider credentials and environment-specific access.
+
+Bundle index repair is only available when the active database adapter exposes
+maintenance hooks. Adapters without those hooks report `not-applicable`.
 
 ## Check Infrastructure
 
@@ -138,4 +153,5 @@ How to fix it depends on how you run Hot Updater:
 | Option                    | Description                                             |
 | ------------------------- | ------------------------------------------------------- |
 | `--server-base-url <url>` | Check deployed infrastructure at `<url>/version`.       |
+| `--fix`                   | Run safe adapter maintenance repairs, then recheck.     |
 | `--json`                  | Print a machine-readable result for agents and scripts. |

--- a/packages/console/src/hooks/useFilterParams.spec.tsx
+++ b/packages/console/src/hooks/useFilterParams.spec.tsx
@@ -100,7 +100,9 @@ describe("useFilterParams", () => {
         after: undefined,
         before: undefined,
         bundleId: "bundle-123",
+        expandedBundleId: undefined,
       },
+      resetScroll: false,
     });
   });
 

--- a/packages/console/src/lib/api.spec.tsx
+++ b/packages/console/src/lib/api.spec.tsx
@@ -1,0 +1,119 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { queryKeys, useUpdateBundleMutation } from "./api";
+import { updateBundle as updateBundleApi } from "./api-rpc";
+
+vi.mock("./api-rpc", () => ({
+  createBundle: vi.fn(),
+  deleteBundle: vi.fn(),
+  getBundle: vi.fn(),
+  getBundleChildCounts: vi.fn(),
+  getBundleChildren: vi.fn(),
+  getBundleDownloadUrl: vi.fn(),
+  getBundles: vi.fn(),
+  getChannels: vi.fn(),
+  getConfig: vi.fn(),
+  getConfigLoaded: vi.fn(),
+  promoteBundle: vi.fn(),
+  updateBundle: vi.fn(),
+}));
+
+const bundle: Bundle = {
+  id: "bundle-001",
+  channel: "production",
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "hash",
+  gitCommitHash: null,
+  message: null,
+  storageUri: "s3://bucket/bundle.zip",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+};
+
+const timeout = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve("timeout"), ms);
+  });
+
+describe("useUpdateBundleMutation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("does not wait for background invalidations after updating cached bundle data", async () => {
+    const updatedBundle = {
+      ...bundle,
+      enabled: false,
+    };
+    vi.mocked(updateBundleApi).mockResolvedValue({
+      success: true,
+      bundle: updatedBundle,
+    });
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockImplementation(() => new Promise<never>(() => {}));
+
+    queryClient.setQueryData(queryKeys.bundle(bundle.id), bundle);
+    queryClient.setQueryData(queryKeys.bundles.list({}), {
+      data: [bundle],
+      pagination: {
+        total: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        currentPage: 1,
+        totalPages: 1,
+      },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useUpdateBundleMutation(), {
+      wrapper,
+    });
+
+    let mutation: Promise<unknown> | undefined;
+    act(() => {
+      mutation = result.current.mutateAsync({
+        bundleId: bundle.id,
+        bundle: {
+          enabled: false,
+        },
+      });
+    });
+
+    await expect(
+      Promise.race([mutation!.then(() => "resolved"), timeout(20)]),
+    ).resolves.toBe("resolved");
+
+    expect(queryClient.getQueryData(queryKeys.bundle(bundle.id))).toEqual(
+      updatedBundle,
+    );
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.bundles.all,
+    });
+  });
+});

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -1,5 +1,11 @@
 import type { Bundle } from "@hot-updater/plugin-core";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  type QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   createBundle as createBundleApi,
@@ -65,6 +71,13 @@ function replaceBundleInQueryData(
 
 const hasOwn = (value: object, key: PropertyKey) =>
   Object.prototype.hasOwnProperty.call(value, key);
+
+const invalidateInBackground = (
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+) => {
+  void queryClient.invalidateQueries({ queryKey }).catch(() => undefined);
+};
 
 // Query Hooks
 export function useConfigQuery() {
@@ -154,20 +167,18 @@ export function useUpdateBundleMutation() {
           replaceBundleInQueryData(data, updatedBundle),
       );
 
-      void queryClient.invalidateQueries({ queryKey: queryKeys.bundles.all });
+      invalidateInBackground(queryClient, queryKeys.bundles.all);
 
       if (
         hasOwn(vars.bundle, "patches") ||
         hasOwn(vars.bundle, "channel") ||
         hasOwn(vars.bundle, "platform")
       ) {
-        void queryClient.invalidateQueries({
-          queryKey: queryKeys.bundleChildren.all,
-        });
+        invalidateInBackground(queryClient, queryKeys.bundleChildren.all);
       }
 
       if (hasOwn(vars.bundle, "channel")) {
-        void queryClient.invalidateQueries({ queryKey: queryKeys.channels });
+        invalidateInBackground(queryClient, queryKeys.channels);
       }
     },
   });

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -63,6 +63,9 @@ function replaceBundleInQueryData(
   };
 }
 
+const hasOwn = (value: object, key: PropertyKey) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
 // Query Hooks
 export function useConfigQuery() {
   return useQuery({
@@ -143,7 +146,7 @@ export function useUpdateBundleMutation() {
   return useMutation({
     mutationFn: (params: { bundleId: string; bundle: Partial<Bundle> }) =>
       updateBundleApi({ data: params }),
-    onSuccess: async ({ bundle: updatedBundle }, vars) => {
+    onSuccess: ({ bundle: updatedBundle }, vars) => {
       queryClient.setQueryData(queryKeys.bundle(vars.bundleId), updatedBundle);
       queryClient.setQueriesData(
         { queryKey: queryKeys.bundles.all },
@@ -151,16 +154,21 @@ export function useUpdateBundleMutation() {
           replaceBundleInQueryData(data, updatedBundle),
       );
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.bundles.all }),
-        queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({ queryKey: queryKeys.bundles.all });
+
+      if (
+        hasOwn(vars.bundle, "patches") ||
+        hasOwn(vars.bundle, "channel") ||
+        hasOwn(vars.bundle, "platform")
+      ) {
+        void queryClient.invalidateQueries({
           queryKey: queryKeys.bundleChildren.all,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.bundle(vars.bundleId),
-        }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.channels }),
-      ]);
+        });
+      }
+
+      if (hasOwn(vars.bundle, "channel")) {
+        void queryClient.invalidateQueries({ queryKey: queryKeys.channels });
+      }
     },
   });
 }

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -13,6 +13,7 @@ import {
   isInfrastructureUpdateRequired,
   resolveVersionEndpoint,
 } from "./doctor";
+import { loadHotUpdater } from "./utils/load-hot-updater";
 
 vi.mock("@hot-updater/cli-tools", () => ({
   getCwd: vi.fn(() => "/mock/cwd"),
@@ -21,9 +22,14 @@ vi.mock("@hot-updater/cli-tools", () => ({
   readPackageUp: vi.fn(),
 }));
 
+vi.mock("./utils/load-hot-updater", () => ({
+  loadHotUpdater: vi.fn(),
+}));
+
 const mockGetCwd = getCwd as ReturnType<typeof vi.fn>;
 const mockLoadConfig = loadConfig as ReturnType<typeof vi.fn>;
 const mockReadPackageUp = readPackageUp as ReturnType<typeof vi.fn>;
+const mockLoadHotUpdater = loadHotUpdater as ReturnType<typeof vi.fn>;
 
 const createConfig = (overrides: Record<string, unknown> = {}) => ({
   updateStrategy: "appVersion",
@@ -212,6 +218,12 @@ describe("doctor", () => {
     vi.clearAllMocks();
     mockGetCwd.mockReturnValue("/mock/cwd");
     mockLoadConfig.mockResolvedValue(createConfig());
+    mockLoadHotUpdater.mockResolvedValue({
+      adapterName: "memory",
+      hotUpdater: {
+        adapterName: "memory",
+      },
+    });
   });
 
   afterEach(async () => {
@@ -242,6 +254,98 @@ describe("doctor", () => {
     expect(result).toBe(true);
   });
 
+  it("does not load the hot-updater config unless fix is enabled", async () => {
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+
+    await expect(doctor()).resolves.toBe(true);
+
+    expect(mockLoadHotUpdater).not.toHaveBeenCalled();
+  });
+
+  it("reports bundle index repair as not applicable for adapters without maintenance hooks", async () => {
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+
+    await expect(doctor({ fix: true })).resolves.toEqual({
+      success: true,
+      details: expect.objectContaining({
+        bundleIndex: {
+          adapterName: "memory",
+          status: "not-applicable",
+        },
+      }),
+    });
+  });
+
+  it("repairs stale bundle indexes when fix is enabled", async () => {
+    const checkBundleIndex = vi.fn().mockResolvedValue({
+      status: "stale",
+      canonicalBundles: 2,
+      indexedBundles: 1,
+      missingBundles: 1,
+      extraBundles: 0,
+      missingBundleIds: ["bundle-B"],
+      extraBundleIds: [],
+    });
+    const repairBundleIndex = vi.fn().mockResolvedValue({
+      scannedBundles: 2,
+      indexedBundles: 2,
+      pagesWritten: 1,
+      scopesWritten: 4,
+    });
+    mockLoadHotUpdater.mockResolvedValue({
+      adapterName: "s3",
+      hotUpdater: {
+        adapterName: "s3",
+        checkBundleIndex,
+        repairBundleIndex,
+      },
+    });
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+
+    await expect(doctor({ fix: true })).resolves.toEqual({
+      success: true,
+      details: expect.objectContaining({
+        bundleIndex: {
+          adapterName: "s3",
+          status: "repaired",
+          health: expect.objectContaining({
+            status: "stale",
+            missingBundles: 1,
+          }),
+          repair: {
+            scannedBundles: 2,
+            indexedBundles: 2,
+            pagesWritten: 1,
+            scopesWritten: 4,
+          },
+        },
+      }),
+    });
+    expect(checkBundleIndex).toHaveBeenCalledTimes(1);
+    expect(repairBundleIndex).toHaveBeenCalledTimes(1);
+  });
+
   it("prints machine-readable JSON without prompting", async () => {
     mockReadPackageUp.mockResolvedValue({
       packageJson: {
@@ -257,6 +361,41 @@ describe("doctor", () => {
 
     expect(logSpy).toHaveBeenCalledWith(
       JSON.stringify({ success: true }, null, 2),
+    );
+    logSpy.mockRestore();
+  });
+
+  it("passes fix through machine-readable doctor output", async () => {
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleDoctor({ json: true, fix: true });
+
+    expect(mockLoadHotUpdater).toHaveBeenCalledWith("");
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          success: true,
+          details: {
+            hotUpdaterVersion: "^0.18.2",
+            packageJsonPath: "/mock/cwd/package.json",
+            installedHotUpdaterPackages: [],
+            bundleIndex: {
+              adapterName: "memory",
+              status: "not-applicable",
+            },
+          },
+        },
+        null,
+        2,
+      ),
     );
     logSpy.mockRestore();
   });

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -291,7 +291,7 @@ describe("doctor", () => {
   });
 
   it("repairs stale bundle indexes when fix is enabled", async () => {
-    const checkBundleIndex = vi.fn().mockResolvedValue({
+    const staleHealth = {
       status: "stale",
       canonicalBundles: 2,
       indexedBundles: 1,
@@ -299,7 +299,20 @@ describe("doctor", () => {
       extraBundles: 0,
       missingBundleIds: ["bundle-B"],
       extraBundleIds: [],
-    });
+    };
+    const repairedHealth = {
+      status: "ok",
+      canonicalBundles: 2,
+      indexedBundles: 2,
+      missingBundles: 0,
+      extraBundles: 0,
+      missingBundleIds: [],
+      extraBundleIds: [],
+    };
+    const checkBundleIndex = vi
+      .fn()
+      .mockResolvedValueOnce(staleHealth)
+      .mockResolvedValueOnce(repairedHealth);
     const repairBundleIndex = vi.fn().mockResolvedValue({
       scannedBundles: 2,
       indexedBundles: 2,
@@ -333,6 +346,7 @@ describe("doctor", () => {
             status: "stale",
             missingBundles: 1,
           }),
+          postRepairHealth: repairedHealth,
           repair: {
             scannedBundles: 2,
             indexedBundles: 2,
@@ -342,7 +356,63 @@ describe("doctor", () => {
         },
       }),
     });
-    expect(checkBundleIndex).toHaveBeenCalledTimes(1);
+    expect(mockLoadHotUpdater).toHaveBeenCalledWith("", { cwd: "/mock/cwd" });
+    expect(checkBundleIndex).toHaveBeenCalledTimes(2);
+    expect(repairBundleIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails doctor when bundle index repair does not restore index health", async () => {
+    const staleHealth = {
+      status: "stale",
+      canonicalBundles: 2,
+      indexedBundles: 1,
+      missingBundles: 1,
+      extraBundles: 0,
+      missingBundleIds: ["bundle-B"],
+      extraBundleIds: [],
+    };
+    const checkBundleIndex = vi.fn().mockResolvedValue(staleHealth);
+    const repairBundleIndex = vi.fn().mockResolvedValue({
+      scannedBundles: 2,
+      indexedBundles: 2,
+      pagesWritten: 1,
+      scopesWritten: 4,
+    });
+    mockLoadHotUpdater.mockResolvedValue({
+      adapterName: "s3",
+      hotUpdater: {
+        adapterName: "s3",
+        checkBundleIndex,
+        repairBundleIndex,
+      },
+    });
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "^0.18.2",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+
+    await expect(doctor({ fix: true })).resolves.toEqual({
+      success: false,
+      details: expect.objectContaining({
+        bundleIndex: {
+          adapterName: "s3",
+          status: "stale",
+          health: staleHealth,
+          postRepairHealth: staleHealth,
+          repair: {
+            scannedBundles: 2,
+            indexedBundles: 2,
+            pagesWritten: 1,
+            scopesWritten: 4,
+          },
+        },
+      }),
+    });
+    expect(checkBundleIndex).toHaveBeenCalledTimes(2);
     expect(repairBundleIndex).toHaveBeenCalledTimes(1);
   });
 
@@ -378,7 +448,7 @@ describe("doctor", () => {
 
     await handleDoctor({ json: true, fix: true });
 
-    expect(mockLoadHotUpdater).toHaveBeenCalledWith("");
+    expect(mockLoadHotUpdater).toHaveBeenCalledWith("", { cwd: "/mock/cwd" });
     expect(logSpy).toHaveBeenCalledWith(
       JSON.stringify(
         {

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -91,6 +91,7 @@ interface BundleIndexDoctorStatus {
   adapterName?: string;
   status: "not-applicable" | "ok" | "missing" | "stale" | "repaired" | "error";
   health?: BundleIndexHealth;
+  postRepairHealth?: BundleIndexHealth;
   repair?: BundleIndexRepairResult;
   error?: string;
 }
@@ -814,8 +815,10 @@ async function checkInfrastructureStatus({
 }
 
 async function checkBundleIndexStatus({
+  cwd,
   fix,
 }: {
+  cwd: string;
   fix: boolean;
 }): Promise<BundleIndexDoctorStatus | undefined> {
   if (!fix) {
@@ -823,7 +826,7 @@ async function checkBundleIndexStatus({
   }
 
   try {
-    const { hotUpdater, adapterName } = await loadHotUpdater("");
+    const { hotUpdater, adapterName } = await loadHotUpdater("", { cwd });
     const checkBundleIndex = hotUpdater.checkBundleIndex;
     const repairBundleIndex = hotUpdater.repairBundleIndex;
 
@@ -852,10 +855,24 @@ async function checkBundleIndexStatus({
     }
 
     const repair = await repairBundleIndex();
+    const postRepairHealth = checkBundleIndex
+      ? await checkBundleIndex()
+      : undefined;
+    if (postRepairHealth && postRepairHealth.status !== "ok") {
+      return {
+        adapterName,
+        status: postRepairHealth.status,
+        health,
+        postRepairHealth,
+        repair,
+      };
+    }
+
     return {
       adapterName,
       status: "repaired",
       health,
+      postRepairHealth,
       repair,
     };
   } catch (error) {
@@ -962,7 +979,7 @@ export async function doctor(
       details.native = await checkNativeStatus({ cwd });
     }
 
-    details.bundleIndex = await checkBundleIndexStatus({ fix });
+    details.bundleIndex = await checkBundleIndexStatus({ cwd, fix });
 
     // Add version mismatches if any
     if (versionMismatches.length > 0) {
@@ -1213,6 +1230,14 @@ export const handleDoctor = async ({
       );
     }
 
+    if (bundleIndex.postRepairHealth) {
+      lines.push(
+        ui.kv("Post-repair", bundleIndex.postRepairHealth.status),
+        ui.kv("Post missing", bundleIndex.postRepairHealth.missingBundles),
+        ui.kv("Post extra", bundleIndex.postRepairHealth.extraBundles),
+      );
+    }
+
     if (bundleIndex.repair) {
       lines.push(
         ui.kv("Written", bundleIndex.repair.indexedBundles),
@@ -1231,6 +1256,10 @@ export const handleDoctor = async ({
       p.log.success("Bundle index is healthy.");
     } else if (bundleIndex.status === "not-applicable") {
       p.log.info("Bundle index repair is not supported by this adapter.");
+    } else if (bundleIndex.repair) {
+      p.log.error(
+        "Bundle index repair completed, but the index is still out of sync.",
+      );
     } else {
       p.log.error("Bundle index is out of sync and repair is not available.");
     }

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -8,6 +8,10 @@ import {
   p,
   readPackageUp,
 } from "@hot-updater/cli-tools";
+import type {
+  BundleIndexHealth,
+  BundleIndexRepairResult,
+} from "@hot-updater/plugin-core";
 import { merge } from "es-toolkit";
 import fg from "fast-glob";
 import * as semver from "semver";
@@ -19,6 +23,7 @@ import {
   type SigningConfigIssue,
   validateSigningConfig,
 } from "../utils/signing/validateSigningConfig";
+import { loadHotUpdater } from "./utils/load-hot-updater";
 
 interface PackageJson {
   dependencies?: Record<string, string>;
@@ -82,6 +87,14 @@ interface NativeStatus {
   issues: NativeCheckIssue[];
 }
 
+interface BundleIndexDoctorStatus {
+  adapterName?: string;
+  status: "not-applicable" | "ok" | "missing" | "stale" | "repaired" | "error";
+  health?: BundleIndexHealth;
+  repair?: BundleIndexRepairResult;
+  error?: string;
+}
+
 interface LocalFingerprint {
   ios?: { hash?: string } | null;
   android?: { hash?: string } | null;
@@ -93,6 +106,7 @@ interface DoctorDetails {
   versionMismatches?: VersionMismatch[];
   infrastructure?: InfrastructureStatus;
   native?: NativeStatus;
+  bundleIndex?: BundleIndexDoctorStatus;
 
   // Package info
   packageJsonPath?: string;
@@ -113,11 +127,13 @@ interface DoctorOptions {
   cwd?: string;
   serverBaseUrl?: string;
   fetch?: typeof fetch;
+  fix?: boolean;
 }
 
 interface HandleDoctorOptions {
   serverBaseUrl?: string;
   json?: boolean;
+  fix?: boolean;
 }
 
 interface ServerVersionResponse {
@@ -797,6 +813,59 @@ async function checkInfrastructureStatus({
   }
 }
 
+async function checkBundleIndexStatus({
+  fix,
+}: {
+  fix: boolean;
+}): Promise<BundleIndexDoctorStatus | undefined> {
+  if (!fix) {
+    return undefined;
+  }
+
+  try {
+    const { hotUpdater, adapterName } = await loadHotUpdater("");
+    const checkBundleIndex = hotUpdater.checkBundleIndex;
+    const repairBundleIndex = hotUpdater.repairBundleIndex;
+
+    if (!checkBundleIndex && !repairBundleIndex) {
+      return {
+        adapterName,
+        status: "not-applicable",
+      };
+    }
+
+    const health = checkBundleIndex ? await checkBundleIndex() : undefined;
+    if (health?.status === "ok") {
+      return {
+        adapterName,
+        status: "ok",
+        health,
+      };
+    }
+
+    if (!repairBundleIndex) {
+      return {
+        adapterName,
+        status: health?.status ?? "not-applicable",
+        health,
+      };
+    }
+
+    const repair = await repairBundleIndex();
+    return {
+      adapterName,
+      status: "repaired",
+      health,
+      repair,
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      error: (error as Error).message,
+    };
+  }
+}
+
 /**
  * Performs health check on Hot Updater installation
  * @param options - Doctor check options
@@ -806,7 +875,12 @@ export async function doctor(
   options: DoctorOptions = {},
 ): Promise<true | DoctorResult> {
   try {
-    const { cwd = getCwd(), serverBaseUrl, fetch: fetchImpl } = options;
+    const {
+      cwd = getCwd(),
+      serverBaseUrl,
+      fetch: fetchImpl,
+      fix = false,
+    } = options;
 
     // Read package.json
     const packageResult = await readPackageUp<PackageJson>(cwd);
@@ -888,6 +962,8 @@ export async function doctor(
       details.native = await checkNativeStatus({ cwd });
     }
 
+    details.bundleIndex = await checkBundleIndexStatus({ fix });
+
     // Add version mismatches if any
     if (versionMismatches.length > 0) {
       details.versionMismatches = versionMismatches;
@@ -899,8 +975,15 @@ export async function doctor(
       details.infrastructure?.needsUpdate === true;
     const hasNativeIssue =
       details.native?.issues.some((issue) => issue.type === "error") === true;
+    const hasBundleIndexIssue =
+      details.bundleIndex?.status === "error" ||
+      details.bundleIndex?.status === "missing" ||
+      details.bundleIndex?.status === "stale";
     const hasIssues =
-      versionMismatches.length > 0 || hasInfrastructureIssue || hasNativeIssue;
+      versionMismatches.length > 0 ||
+      hasInfrastructureIssue ||
+      hasNativeIssue ||
+      hasBundleIndexIssue;
     // Future: || configurationIssues.length > 0 || etc.
 
     if (hasIssues) {
@@ -918,6 +1001,13 @@ export async function doctor(
     }
 
     if (details.native) {
+      return {
+        success: true,
+        details,
+      };
+    }
+
+    if (details.bundleIndex) {
       return {
         success: true,
         details,
@@ -976,9 +1066,10 @@ const promptServerBaseUrl = async () => {
 export const handleDoctor = async ({
   serverBaseUrl,
   json = false,
+  fix = false,
 }: HandleDoctorOptions = {}) => {
   if (json) {
-    const result = normalizeDoctorResult(await doctor({ serverBaseUrl }));
+    const result = normalizeDoctorResult(await doctor({ serverBaseUrl, fix }));
     console.log(JSON.stringify(result, null, 2));
     if (!result.success) {
       process.exit(1);
@@ -989,7 +1080,7 @@ export const handleDoctor = async ({
   p.intro("Hot Updater doctor");
 
   const resolvedServerBaseUrl = serverBaseUrl ?? (await promptServerBaseUrl());
-  const result = await doctor({ serverBaseUrl: resolvedServerBaseUrl });
+  const result = await doctor({ serverBaseUrl: resolvedServerBaseUrl, fix });
 
   if (result === true) {
     p.log.success("All checks passed.");
@@ -1101,6 +1192,47 @@ export const handleDoctor = async ({
         p.log.warn(message);
       }
       p.log.info(issue.resolution);
+    }
+  }
+
+  if (details?.bundleIndex) {
+    const bundleIndex = details.bundleIndex;
+    const lines = [
+      ui.kv("Status", bundleIndex.status),
+      ...(bundleIndex.adapterName
+        ? [ui.kv("Adapter", bundleIndex.adapterName)]
+        : []),
+    ];
+
+    if (bundleIndex.health) {
+      lines.push(
+        ui.kv("Canonical", bundleIndex.health.canonicalBundles),
+        ui.kv("Indexed", bundleIndex.health.indexedBundles),
+        ui.kv("Missing", bundleIndex.health.missingBundles),
+        ui.kv("Extra", bundleIndex.health.extraBundles),
+      );
+    }
+
+    if (bundleIndex.repair) {
+      lines.push(
+        ui.kv("Written", bundleIndex.repair.indexedBundles),
+        ui.kv("Pages", bundleIndex.repair.pagesWritten),
+        ui.kv("Scopes", bundleIndex.repair.scopesWritten),
+      );
+    }
+
+    p.log.message(ui.block("Bundle index", lines));
+
+    if (bundleIndex.status === "error") {
+      p.log.error(`Bundle index check failed: ${bundleIndex.error}`);
+    } else if (bundleIndex.status === "repaired") {
+      p.log.success("Bundle index repaired.");
+    } else if (bundleIndex.status === "ok") {
+      p.log.success("Bundle index is healthy.");
+    } else if (bundleIndex.status === "not-applicable") {
+      p.log.info("Bundle index repair is not supported by this adapter.");
+    } else {
+      p.log.error("Bundle index is out of sync and repair is not available.");
     }
   }
 

--- a/packages/hot-updater/src/commands/utils/load-hot-updater.ts
+++ b/packages/hot-updater/src/commands/utils/load-hot-updater.ts
@@ -2,6 +2,10 @@ import { existsSync, statSync } from "fs";
 import path from "path";
 
 import { p } from "@hot-updater/cli-tools";
+import type {
+  BundleIndexHealth,
+  BundleIndexRepairResult,
+} from "@hot-updater/plugin-core";
 import type { Migrator } from "@hot-updater/server";
 import { createJiti } from "jiti";
 
@@ -13,6 +17,8 @@ export interface HotUpdaterInstance {
     version: string | "latest",
     name?: string,
   ) => { code: string; path: string };
+  checkBundleIndex?: () => Promise<BundleIndexHealth>;
+  repairBundleIndex?: () => Promise<BundleIndexRepairResult>;
   adapterName: string;
 }
 

--- a/packages/hot-updater/src/commands/utils/load-hot-updater.ts
+++ b/packages/hot-updater/src/commands/utils/load-hot-updater.ts
@@ -43,10 +43,14 @@ const DEFAULT_CONFIG_BASENAMES = [
   path.join("src", "db"),
 ] as const;
 
-const findDefaultConfigPath = () => {
+interface LoadHotUpdaterOptions {
+  cwd?: string;
+}
+
+const findDefaultConfigPath = (cwd: string) => {
   for (const basename of DEFAULT_CONFIG_BASENAMES) {
     for (const ext of SUPPORTED_CONFIG_EXTENSIONS) {
-      const candidate = path.resolve(process.cwd(), `${basename}.${ext}`);
+      const candidate = path.resolve(cwd, `${basename}.${ext}`);
       if (existsSync(candidate)) {
         return candidate;
       }
@@ -56,13 +60,13 @@ const findDefaultConfigPath = () => {
   return null;
 };
 
-const resolveConfigPath = (configPath: string) => {
+const resolveConfigPath = (configPath: string, cwd: string) => {
   const trimmedConfigPath = configPath.trim();
   if (trimmedConfigPath) {
-    return path.resolve(process.cwd(), trimmedConfigPath);
+    return path.resolve(cwd, trimmedConfigPath);
   }
 
-  const defaultConfigPath = findDefaultConfigPath();
+  const defaultConfigPath = findDefaultConfigPath(cwd);
   if (defaultConfigPath) {
     return defaultConfigPath;
   }
@@ -83,8 +87,12 @@ const resolveConfigPath = (configPath: string) => {
  */
 export async function loadHotUpdater(
   configPath: string,
+  options: LoadHotUpdaterOptions = {},
 ): Promise<LoadHotUpdaterResult> {
-  const absoluteConfigPath = resolveConfigPath(configPath);
+  const absoluteConfigPath = resolveConfigPath(
+    configPath,
+    options.cwd ?? process.cwd(),
+  );
 
   // Verify config file exists
   if (!existsSync(absoluteConfigPath)) {

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -88,6 +88,7 @@ program
     "--server-base-url <url>",
     "server base URL used by update checks (doctor appends /version)",
   )
+  .option("--fix", "automatically fix safe issues")
   .option("--json", "output machine-readable doctor result")
   .action(handleDoctor);
 

--- a/packages/server/src/db/index.spec.ts
+++ b/packages/server/src/db/index.spec.ts
@@ -866,6 +866,42 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
   });
 
   describe("database plugin factories", () => {
+    it("keeps optional maintenance capabilities lazy", () => {
+      const factory = vi.fn(() => ({
+        async getBundleById() {
+          return null;
+        },
+        async getBundles() {
+          return {
+            data: [],
+            pagination: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              currentPage: 1,
+              totalPages: 1,
+              total: 0,
+            },
+          };
+        },
+        async getChannels() {
+          return [];
+        },
+        async commitBundle() {},
+      }));
+      const hotUpdater = createHotUpdater({
+        database: createDatabasePlugin({
+          name: "lazyPlugin",
+          factory,
+        })({}),
+      });
+
+      expect(factory).not.toHaveBeenCalled();
+      expect(hotUpdater.checkBundleIndex).toBeUndefined();
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(hotUpdater.checkBundleIndex).toBeUndefined();
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
+
     it("isolates pending mutation state between overlapping writes", async () => {
       const committedBundleIds: string[][] = [];
       const onUnmount = vi.fn(async () => undefined);

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -104,19 +104,15 @@ export function createHotUpdater<TContext = unknown>(
         });
 
   const api = {
-    ...core.api,
+    basePath,
+    adapterName: core.adapterName,
+    createMigrator: core.createMigrator,
+    generateSchema: core.generateSchema,
     handler: createHandler(core.api, {
       basePath,
       routes: options.routes,
     }),
-    adapterName: core.adapterName,
-    createMigrator: core.createMigrator,
-    generateSchema: core.generateSchema,
   };
-
-  return {
-    ...api,
-    basePath,
-    handler: api.handler,
-  };
+  Object.defineProperties(api, Object.getOwnPropertyDescriptors(core.api));
+  return api as HotUpdaterAPI<TContext>;
 }

--- a/packages/server/src/db/pluginCore.ts
+++ b/packages/server/src/db/pluginCore.ts
@@ -435,6 +435,16 @@ export function createPluginDatabaseCore<TContext = unknown>(
     },
   };
 
+  if (getPlugin().checkBundleIndex) {
+    api.checkBundleIndex = (context?: HotUpdaterContext<TContext>) =>
+      getPlugin().checkBundleIndex!(context);
+  }
+
+  if (getPlugin().repairBundleIndex) {
+    api.repairBundleIndex = (context?: HotUpdaterContext<TContext>) =>
+      getPlugin().repairBundleIndex!(context);
+  }
+
   return {
     api,
     adapterName: getPlugin().name,

--- a/packages/server/src/db/pluginCore.ts
+++ b/packages/server/src/db/pluginCore.ts
@@ -435,15 +435,57 @@ export function createPluginDatabaseCore<TContext = unknown>(
     },
   };
 
-  if (getPlugin().checkBundleIndex) {
-    api.checkBundleIndex = (context?: HotUpdaterContext<TContext>) =>
-      getPlugin().checkBundleIndex!(context);
-  }
+  Object.defineProperty(api, "checkBundleIndex", {
+    configurable: true,
+    enumerable: true,
+    get(this: DatabaseAPI<TContext>) {
+      const checkBundleIndex = getPlugin().checkBundleIndex;
+      if (!checkBundleIndex) {
+        Object.defineProperty(this, "checkBundleIndex", {
+          configurable: true,
+          enumerable: true,
+          value: undefined,
+        });
+        return undefined;
+      }
 
-  if (getPlugin().repairBundleIndex) {
-    api.repairBundleIndex = (context?: HotUpdaterContext<TContext>) =>
-      getPlugin().repairBundleIndex!(context);
-  }
+      const wrapped: NonNullable<DatabaseAPI<TContext>["checkBundleIndex"]> = (
+        context?: HotUpdaterContext<TContext>,
+      ) => getPlugin().checkBundleIndex!(context);
+      Object.defineProperty(this, "checkBundleIndex", {
+        configurable: true,
+        enumerable: true,
+        value: wrapped,
+      });
+      return wrapped;
+    },
+  });
+
+  Object.defineProperty(api, "repairBundleIndex", {
+    configurable: true,
+    enumerable: true,
+    get(this: DatabaseAPI<TContext>) {
+      const repairBundleIndex = getPlugin().repairBundleIndex;
+      if (!repairBundleIndex) {
+        Object.defineProperty(this, "repairBundleIndex", {
+          configurable: true,
+          enumerable: true,
+          value: undefined,
+        });
+        return undefined;
+      }
+
+      const wrapped: NonNullable<DatabaseAPI<TContext>["repairBundleIndex"]> = (
+        context?: HotUpdaterContext<TContext>,
+      ) => getPlugin().repairBundleIndex!(context);
+      Object.defineProperty(this, "repairBundleIndex", {
+        configurable: true,
+        enumerable: true,
+        value: wrapped,
+      });
+      return wrapped;
+    },
+  });
 
   return {
     api,

--- a/packages/server/src/db/types.ts
+++ b/packages/server/src/db/types.ts
@@ -5,6 +5,8 @@ import type {
   UpdateInfo,
 } from "@hot-updater/core";
 import type {
+  BundleIndexHealth,
+  BundleIndexRepairResult,
   DatabaseBundleQueryOptions,
   DatabasePlugin,
   HotUpdaterContext,
@@ -108,6 +110,12 @@ export interface DatabaseAPI<TContext = unknown> {
     bundleId: string,
     context?: HotUpdaterContext<TContext>,
   ): Promise<void>;
+  checkBundleIndex?(
+    context?: HotUpdaterContext<TContext>,
+  ): Promise<BundleIndexHealth>;
+  repairBundleIndex?(
+    context?: HotUpdaterContext<TContext>,
+  ): Promise<BundleIndexRepairResult>;
 }
 
 export type StoragePluginFactory<TContext = unknown> =

--- a/packages/server/src/runtime.spec.ts
+++ b/packages/server/src/runtime.spec.ts
@@ -706,6 +706,45 @@ describe("runtime createHotUpdater", () => {
     });
   });
 
+  it("keeps optional maintenance capabilities lazy", () => {
+    const factory = vi.fn(() => ({
+      async getBundleById() {
+        return null;
+      },
+      async getBundles() {
+        return {
+          data: [],
+          pagination: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            currentPage: 1,
+            totalPages: 1,
+            total: 0,
+          },
+        };
+      },
+      async getChannels() {
+        return [];
+      },
+      async commitBundle() {},
+    }));
+    const database = createDatabasePlugin({
+      name: "lazyRuntimePlugin",
+      factory,
+    })({});
+
+    const hotUpdater = createHotUpdater({
+      database,
+      basePath: "/api/check-update",
+    });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(hotUpdater.repairBundleIndex).toBeUndefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(hotUpdater.repairBundleIndex).toBeUndefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
   it("clears pending plugin changes after a failed mutation commit", async () => {
     const committedBundles = new Map<string, Bundle>();
     let commitAttempt = 0;

--- a/packages/server/src/runtime.ts
+++ b/packages/server/src/runtime.ts
@@ -73,14 +73,10 @@ export function createHotUpdater<TContext = unknown>(
       : { readStorageText },
   );
 
-  const api = {
-    ...core.api,
-    handler: createHandler(core.api, {
-      basePath,
-      routes: options.routes,
-    }),
-    adapterName: core.adapterName,
-  };
+  const internalHandler = createHandler(core.api, {
+    basePath,
+    routes: options.routes,
+  });
 
   // Some framework adapters strip the mounted base path or pass extra
   // bindings/execution context arguments. Ignore those extras here so the
@@ -91,17 +87,19 @@ export function createHotUpdater<TContext = unknown>(
     ...extraArgs: unknown[]
   ) => {
     if (extraArgs.length > 0) {
-      return api.handler(request);
+      return internalHandler(request);
     }
 
-    return api.handler(request, context);
+    return internalHandler(request, context);
   };
 
-  return {
-    ...api,
+  const api = {
     basePath,
+    adapterName: core.adapterName,
     handler,
   };
+  Object.defineProperties(api, Object.getOwnPropertyDescriptors(core.api));
+  return api as HotUpdaterAPI<TContext>;
 }
 
 export { createHandler };

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -1051,6 +1051,70 @@ describe("blobDatabase plugin", () => {
     expect(fakeStore[getManagementPageKey({}, 2)]).toBeUndefined();
   });
 
+  it("detects a stale management index missing canonical bundles", async () => {
+    const indexedBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "index-health-A",
+    );
+    const missingBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "index-health-B",
+    );
+    seedUpdateManifests([indexedBundle, missingBundle]);
+    seedPagedBundlesIndex([indexedBundle]);
+
+    await expect(plugin.checkBundleIndex?.()).resolves.toEqual({
+      status: "stale",
+      canonicalBundles: 2,
+      indexedBundles: 1,
+      missingBundles: 1,
+      extraBundles: 0,
+      missingBundleIds: [missingBundle.id],
+      extraBundleIds: [],
+    });
+  });
+
+  it("repairs a stale management index from canonical update manifests", async () => {
+    const indexedBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "index-repair-A",
+    );
+    const missingBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "index-repair-B",
+    );
+    seedUpdateManifests([indexedBundle, missingBundle]);
+    seedPagedBundlesIndex([indexedBundle]);
+
+    await expect(plugin.repairBundleIndex?.()).resolves.toMatchObject({
+      scannedBundles: 2,
+      indexedBundles: 2,
+    });
+
+    listObjectCalls = [];
+    loadObjectCalls = [];
+
+    const result = await plugin.getBundles({ limit: 20 });
+
+    expect(result.data.map((bundle) => bundle.id)).toEqual([
+      missingBundle.id,
+      indexedBundle.id,
+    ]);
+    expect(listObjectCalls).toEqual([]);
+    expect(loadObjectCalls).toEqual([
+      getManagementRootKey({}),
+      getManagementPageKey({}, 0),
+    ]);
+  });
+
   it("reads the first all-bundles page from one root and one leaf page", async () => {
     const bundles = createScopedBundles({ count: 70 });
     seedPagedBundlesIndex(bundles);

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -163,6 +163,15 @@ interface ManagementIndexArtifacts {
   scopes: ManagementIndexScopeArtifact[];
 }
 
+function summarizeManagementIndexArtifacts(
+  artifacts: ManagementIndexArtifacts,
+) {
+  return {
+    pagesWritten: artifacts.pages.size,
+    scopesWritten: artifacts.scopes.length,
+  };
+}
+
 function resolveManagementIndexPageSize(
   config: BlobDatabasePluginConfig,
 ): number {
@@ -620,6 +629,53 @@ export const createBlobDatabasePlugin = <TConfig>({
 
     const loadCurrentBundlesForIndexRebuild = async (): Promise<Bundle[]> => {
       return loadAllBundlesForManagementFallback();
+    };
+
+    const loadCanonicalBundlesForIndexRepair = async (): Promise<Bundle[]> => {
+      return sortManagedBundles(
+        (await reloadBundles()).map((bundle) =>
+          removeBundleInternalKeys(bundle),
+        ),
+      );
+    };
+
+    const compareBundleIndex = ({
+      canonicalBundles,
+      indexedBundles,
+      rootMissing,
+    }: {
+      canonicalBundles: Bundle[];
+      indexedBundles: Bundle[] | null;
+      rootMissing: boolean;
+    }) => {
+      const canonicalIds = new Set(canonicalBundles.map((bundle) => bundle.id));
+      const indexedIds = new Set(
+        indexedBundles?.map((bundle) => bundle.id) ?? [],
+      );
+      const missingBundleIds = Array.from(canonicalIds)
+        .filter((id) => !indexedIds.has(id))
+        .sort((left, right) => right.localeCompare(left));
+      const extraBundleIds = Array.from(indexedIds)
+        .filter((id) => !canonicalIds.has(id))
+        .sort((left, right) => right.localeCompare(left));
+      const status =
+        missingBundleIds.length === 0 &&
+        extraBundleIds.length === 0 &&
+        !rootMissing
+          ? "ok"
+          : rootMissing
+            ? "missing"
+            : "stale";
+
+      return {
+        status,
+        canonicalBundles: canonicalBundles.length,
+        indexedBundles: indexedBundles?.length ?? 0,
+        missingBundles: missingBundleIds.length,
+        extraBundles: extraBundleIds.length,
+        missingBundleIds: missingBundleIds.slice(0, 20),
+        extraBundleIds: extraBundleIds.slice(0, 20),
+      } as const;
     };
 
     const findPageIndexContainingId = (
@@ -1253,6 +1309,63 @@ export const createBlobDatabasePlugin = <TConfig>({
         async getChannels() {
           const allRoot = await loadManagementScopeRoot({});
           return allRoot?.channels ?? [];
+        },
+
+        async checkBundleIndex() {
+          const canonicalBundles = await loadCanonicalBundlesForIndexRepair();
+          const allRoot = await loadStoredManagementRoot({});
+          const indexedBundles = allRoot
+            ? await loadAllBundlesFromRoot(allRoot)
+            : null;
+
+          return compareBundleIndex({
+            canonicalBundles,
+            indexedBundles,
+            rootMissing: !allRoot,
+          });
+        },
+
+        async repairBundleIndex() {
+          const canonicalBundles = await loadCanonicalBundlesForIndexRepair();
+          const previousRoot = await loadStoredManagementRoot({});
+          const previousBundles = previousRoot
+            ? await loadAllBundlesFromRoot(previousRoot)
+            : null;
+          const previousArtifacts =
+            previousRoot && previousBundles
+              ? buildManagementIndexArtifacts(
+                  previousBundles,
+                  previousRoot.pageSize,
+                )
+              : undefined;
+          const nextArtifacts = buildManagementIndexArtifacts(
+            canonicalBundles,
+            managementIndexPageSize,
+          );
+          const indexedObjectKeys = await listObjects(
+            `${MANAGEMENT_INDEX_PREFIX}/`,
+          );
+          const nextObjectKeys = new Set([
+            ...nextArtifacts.pages.keys(),
+            ...nextArtifacts.scopes.map((scope) => scope.rootKey),
+          ]);
+
+          await persistManagementIndexArtifacts(
+            nextArtifacts,
+            previousArtifacts,
+          );
+          await Promise.all(
+            indexedObjectKeys
+              .filter((key) => !nextObjectKeys.has(key))
+              .map((key) => deleteObject(key).catch(() => {})),
+          );
+          replaceManagementRootCache(nextArtifacts);
+
+          return {
+            scannedBundles: canonicalBundles.length,
+            indexedBundles: canonicalBundles.length,
+            ...summarizeManagementIndexArtifacts(nextArtifacts),
+          };
         },
 
         async commitBundle({ changedSets }) {

--- a/plugins/plugin-core/src/createDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createDatabasePlugin.ts
@@ -39,6 +39,12 @@ export interface AbstractDatabasePlugin<TContext = unknown> {
     },
     context?: HotUpdaterContext<TContext>,
   ) => Promise<void>;
+  checkBundleIndex?: (
+    context?: HotUpdaterContext<TContext>,
+  ) => ReturnType<NonNullable<DatabasePlugin<TContext>["checkBundleIndex"]>>;
+  repairBundleIndex?: (
+    context?: HotUpdaterContext<TContext>,
+  ) => ReturnType<NonNullable<DatabasePlugin<TContext>["repairBundleIndex"]>>;
 }
 
 /**
@@ -532,6 +538,72 @@ export function createDatabasePlugin<TConfig, TContext = unknown>(
             value: wrappedGetUpdateInfo,
           });
           return wrappedGetUpdateInfo;
+        },
+      });
+
+      Object.defineProperty(plugin, "checkBundleIndex", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          const directCheckBundleIndex = getMethods().checkBundleIndex;
+          if (!directCheckBundleIndex) {
+            Object.defineProperty(plugin, "checkBundleIndex", {
+              configurable: true,
+              enumerable: true,
+              value: undefined,
+            });
+            return undefined;
+          }
+
+          const wrappedCheckBundleIndex: NonNullable<
+            DatabasePlugin<TContext>["checkBundleIndex"]
+          > = async (context) => {
+            if (context === undefined) {
+              return directCheckBundleIndex();
+            }
+
+            return directCheckBundleIndex(context);
+          };
+
+          Object.defineProperty(plugin, "checkBundleIndex", {
+            configurable: true,
+            enumerable: true,
+            value: wrappedCheckBundleIndex,
+          });
+          return wrappedCheckBundleIndex;
+        },
+      });
+
+      Object.defineProperty(plugin, "repairBundleIndex", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          const directRepairBundleIndex = getMethods().repairBundleIndex;
+          if (!directRepairBundleIndex) {
+            Object.defineProperty(plugin, "repairBundleIndex", {
+              configurable: true,
+              enumerable: true,
+              value: undefined,
+            });
+            return undefined;
+          }
+
+          const wrappedRepairBundleIndex: NonNullable<
+            DatabasePlugin<TContext>["repairBundleIndex"]
+          > = async (context) => {
+            if (context === undefined) {
+              return directRepairBundleIndex();
+            }
+
+            return directRepairBundleIndex(context);
+          };
+
+          Object.defineProperty(plugin, "repairBundleIndex", {
+            configurable: true,
+            enumerable: true,
+            value: wrappedRepairBundleIndex,
+          });
+          return wrappedRepairBundleIndex;
         },
       });
 

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -94,6 +94,23 @@ export interface DatabaseBundleQueryOptions {
   orderBy?: DatabaseBundleQueryOrder;
 }
 
+export interface BundleIndexHealth {
+  status: "ok" | "missing" | "stale";
+  canonicalBundles: number;
+  indexedBundles: number;
+  missingBundles: number;
+  extraBundles: number;
+  missingBundleIds: string[];
+  extraBundleIds: string[];
+}
+
+export interface BundleIndexRepairResult {
+  scannedBundles: number;
+  indexedBundles: number;
+  pagesWritten: number;
+  scopesWritten: number;
+}
+
 export interface BuildPluginConfig {
   outDir?: string;
 }
@@ -122,6 +139,12 @@ export interface DatabasePlugin<TContext = unknown> {
     context?: HotUpdaterContext<TContext>,
   ) => Promise<void>;
   commitBundle: (context?: HotUpdaterContext<TContext>) => Promise<void>;
+  checkBundleIndex?: (
+    context?: HotUpdaterContext<TContext>,
+  ) => Promise<BundleIndexHealth>;
+  repairBundleIndex?: (
+    context?: HotUpdaterContext<TContext>,
+  ) => Promise<BundleIndexRepairResult>;
   onUnmount?: () => Promise<void>;
   name: string;
   deleteBundle: (


### PR DESCRIPTION
## Summary
- add provider-agnostic bundle index maintenance hooks and implement blob index health/repair from canonical update manifests
- expose explicit repair through `hot-updater doctor --fix` instead of an S3-only command or deploy-time implicit behavior
- re-check bundle index health after repair before reporting success, and respect the requested `cwd` when loading the Hot Updater config
- document `doctor --fix` for users and keep unsupported adapters explicitly `not-applicable`
- make console bundle edits update local query cache immediately and move expensive refetches to background invalidation
- preserve lazy plugin capability discovery when exposing optional maintenance hooks through server APIs

## Close Readiness
- Closes #1023: stale/missing blob management indexes can now be detected and rebuilt with `doctor --fix`, which covers the old-vs-new console bundle listing mismatch.
- Addresses the linked #828 comment: the bundle edit delay is covered by local cache updates plus non-blocking background invalidation, so editing no longer waits on broad bundle/channel refetches.
- Issue #828 is intentionally kept as a linked reference rather than a closing reference: the original issue body also asks about bulk deletion and Glacier Deep Archive failures. This PR does not implement bulk deletion, so that issue should only be manually resolved if the original scope is considered superseded by the newer console/index behavior.

## Validation
- `.agents/skills/fix-ci/scripts/run_fixci.sh all`
- `pnpm vitest run --project="unit:*" plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts packages/hot-updater/src/commands/doctor.spec.ts`
- `pnpm --filter @hot-updater/console test src/lib/api.spec.tsx`
- `pnpm --filter @hot-updater/plugin-core test:type`
- `pnpm --filter @hot-updater/server test:type`
- `pnpm --filter hot-updater test:type`
- `pnpm --filter @hot-updater/console test:type`
- `pnpm exec oxlint plugins/plugin-core/src/createBlobDatabasePlugin.ts plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts plugins/plugin-core/src/createDatabasePlugin.ts plugins/plugin-core/src/types/index.ts packages/server/src/db/pluginCore.ts packages/server/src/db/types.ts packages/hot-updater/src/commands/doctor.ts packages/hot-updater/src/commands/doctor.spec.ts packages/hot-updater/src/commands/utils/load-hot-updater.ts packages/hot-updater/src/index.ts packages/console/src/lib/api.ts packages/console/src/lib/api.spec.tsx`
- `pnpm exec vitest run --project unit:default packages/server/src/db/index.spec.ts packages/server/src/runtime.spec.ts`
- `pnpm --dir packages/console exec vitest run src/lib/api.spec.tsx`
- `pnpm exec oxlint packages/server/src/db/pluginCore.ts packages/server/src/db/index.ts packages/server/src/runtime.ts packages/server/src/db/index.spec.ts packages/server/src/runtime.spec.ts packages/console/src/lib/api.ts`
- `pnpm exec oxlint packages/hot-updater/src/commands/doctor.ts packages/hot-updater/src/commands/doctor.spec.ts packages/hot-updater/src/commands/utils/load-hot-updater.ts packages/console/src/hooks/useFilterParams.spec.tsx`
- `pnpm exec vitest run --project unit:default packages/hot-updater/src/commands/doctor.spec.ts`
- `pnpm exec vitest run --project unit:default packages/hot-updater/src/commands/doctor.spec.ts plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts packages/server/src/db/index.spec.ts packages/server/src/runtime.spec.ts packages/console/src/lib/api.spec.tsx`
- `pnpm --filter @hot-updater/console test -- src/lib/api.spec.tsx`
- `pnpm --filter @hot-updater/console test:type`
- `pnpm -w test:type`
- `pnpm --filter hot-updater build`

## Notes
- `doctor --fix` performs the full canonical scan only when explicitly requested.
- `doctor --fix` reports failure if an adapter repair completes but the post-repair health check is still `missing` or `stale`.
- live S3/R2 bucket repair was not run locally.
