### PR TITLE
fix(e2e): reduce reset pressure under OTA verification

### DIFF
--- a/e2e/maestro/flows/subflows/launch-app-home.yaml
+++ b/e2e/maestro/flows/subflows/launch-app-home.yaml
@@ -30,10 +30,15 @@ appId: ${APP_ID}
       - tapOn:
           text: Wait
           optional: true
+      - tapOn:
+          id: e2e-nav-top
+          optional: true
+      - waitForAnimationToEnd:
+          timeout: 1000
       - scrollUntilVisible:
           element:
             id: runtime-bundle-id
-          direction: UP
+          direction: DOWN
           timeout: 10000
       - extendedWaitUntil:
           visible:

--- a/e2e/maestro/flows/subflows/launch-app-home.yaml
+++ b/e2e/maestro/flows/subflows/launch-app-home.yaml
@@ -35,6 +35,12 @@ appId: ${APP_ID}
           optional: true
       - waitForAnimationToEnd:
           timeout: 1000
+      - tapOn:
+          id: android:id/aerr_wait
+          optional: true
+      - tapOn:
+          text: Wait
+          optional: true
       - scrollUntilVisible:
           element:
             id: runtime-bundle-id

--- a/e2e/maestro/flows/subflows/navigate-crash-history.yaml
+++ b/e2e/maestro/flows/subflows/navigate-crash-history.yaml
@@ -10,6 +10,13 @@ appId: ${APP_ID}
     waitToSettleTimeoutMs: 500
 - waitForAnimationToEnd:
     timeout: 500
+- runFlow:
+    file: navigate-top.yaml
+- scrollUntilVisible:
+    element:
+      id: section-crash-history
+    direction: DOWN
+    timeout: 10000
 - extendedWaitUntil:
     visible:
       id: section-crash-history

--- a/e2e/maestro/flows/subflows/navigate-top.yaml
+++ b/e2e/maestro/flows/subflows/navigate-top.yaml
@@ -1,15 +1,20 @@
 appId: ${APP_ID}
 ---
+- tapOn:
+    id: e2e-nav-top
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 1000
 - scrollUntilVisible:
     element:
-      id: runtime-bundle-id
+      id: section-runtime-snapshot
     direction: UP
     timeout: 10000
 - extendedWaitUntil:
     visible:
-      id: runtime-bundle-id
+      id: section-runtime-snapshot
     timeout: 10000
 - extendedWaitUntil:
     visible:
-      id: section-runtime-snapshot
+      id: runtime-bundle-id
     timeout: 10000

--- a/e2e/maestro/flows/subflows/navigate-top.yaml
+++ b/e2e/maestro/flows/subflows/navigate-top.yaml
@@ -7,12 +7,8 @@ appId: ${APP_ID}
     timeout: 1000
 - scrollUntilVisible:
     element:
-      id: section-runtime-snapshot
+      id: runtime-bundle-id
     direction: UP
-    timeout: 10000
-- extendedWaitUntil:
-    visible:
-      id: section-runtime-snapshot
     timeout: 10000
 - extendedWaitUntil:
     visible:

--- a/e2e/maestro/flows/subflows/navigate-top.yaml
+++ b/e2e/maestro/flows/subflows/navigate-top.yaml
@@ -5,6 +5,12 @@ appId: ${APP_ID}
     optional: true
 - waitForAnimationToEnd:
     timeout: 1000
+- tapOn:
+    id: android:id/aerr_wait
+    optional: true
+- tapOn:
+    text: Wait
+    optional: true
 - scrollUntilVisible:
     element:
       id: runtime-bundle-id

--- a/e2e/maestro/flows/subflows/navigate-top.yaml
+++ b/e2e/maestro/flows/subflows/navigate-top.yaml
@@ -8,7 +8,7 @@ appId: ${APP_ID}
 - scrollUntilVisible:
     element:
       id: runtime-bundle-id
-    direction: UP
+    direction: DOWN
     timeout: 10000
 - extendedWaitUntil:
     visible:

--- a/e2e/maestro/scripts/run-flow.ts
+++ b/e2e/maestro/scripts/run-flow.ts
@@ -51,6 +51,19 @@ function parsePortEnv(name: string, fallback: number) {
   return port;
 }
 
+function parsePositiveIntEnv(name: string, fallback: number) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: ${raw}`);
+  }
+  return value;
+}
+
 function safeFileToken(value: string) {
   return value.replace(/[^a-zA-Z0-9_.-]/g, "-");
 }
@@ -115,6 +128,14 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
 );
 const MAESTRO_TRANSPORT_ATTEMPTS = 3;
 const MAESTRO_TRANSPORT_RETRY_DELAY_MS = 2000;
+const ANDROID_DEVICE_READY_ATTEMPTS = parsePositiveIntEnv(
+  "HOT_UPDATER_E2E_ANDROID_DEVICE_READY_ATTEMPTS",
+  90,
+);
+const ANDROID_DEVICE_READY_DELAY_MS = parsePositiveIntEnv(
+  "HOT_UPDATER_E2E_ANDROID_DEVICE_READY_DELAY_MS",
+  1000,
+);
 const MAESTRO_DRIVER_STARTUP_TIMEOUT_MS =
   process.env.MAESTRO_DRIVER_STARTUP_TIMEOUT || "240000";
 const MAESTRO_DRIVER_HOST_PORT_PATTERN = String(
@@ -124,7 +145,9 @@ const MAESTRO_ANDROID_TRANSPORT_PATTERNS = [
   /Not able to reach the gRPC server while processing deviceInfo command/i,
   /StatusRuntimeException:\s*UNAVAILABLE/i,
   /Command failed \(tcp:\d+\): closed/i,
+  /Command failed \(host:transport:[^)]+\): device ['"][^'"]+['"] not found/i,
   /dadb\.forwarding\.TcpForwarder/i,
+  /device ['"][^'"]+['"] not found/i,
   /Failed to launch app/i,
   /Maestro Android transport failure before E2E mutation/i,
   /Maestro command idle timeout/i,
@@ -426,6 +449,75 @@ function runCapture(
   }
 
   return result.stdout.trim();
+}
+
+function readAndroidDeviceRows() {
+  return runCapture("adb", ["devices"], { allowFailure: true })
+    .split("\n")
+    .slice(1)
+    .map((line: string) => line.trim().split(/\s+/))
+    .filter((columns: string[]) => columns[0]);
+}
+
+function isAndroidDeviceOnline(deviceId: string) {
+  return readAndroidDeviceRows().some(
+    (columns: string[]) => columns[0] === deviceId && columns[1] === "device",
+  );
+}
+
+function formatAndroidDeviceRows() {
+  const rows = readAndroidDeviceRows();
+  if (rows.length === 0) {
+    return "no devices";
+  }
+  return rows
+    .map((columns: string[]) => columns.slice(0, 2).join(":"))
+    .join(", ");
+}
+
+function isAndroidDeviceBootCompleted(deviceId: string) {
+  return (
+    runCapture(
+      "adb",
+      ["-s", deviceId, "shell", "getprop", "sys.boot_completed"],
+      { allowFailure: true },
+    ).trim() === "1"
+  );
+}
+
+async function waitForAndroidDeviceReady(deviceId: string, reason: string) {
+  let lastState = "unknown";
+
+  for (
+    let attempt = 1;
+    attempt <= ANDROID_DEVICE_READY_ATTEMPTS;
+    attempt += 1
+  ) {
+    runCapture("adb", ["start-server"], { allowFailure: true });
+
+    if (isAndroidDeviceOnline(deviceId)) {
+      if (isAndroidDeviceBootCompleted(deviceId)) {
+        return;
+      }
+      lastState = "listed as device, boot not completed";
+    } else {
+      lastState = formatAndroidDeviceRows();
+    }
+
+    if (attempt === 1 || attempt % 15 === 0) {
+      p.log.info(
+        `Waiting for Android device ${deviceId} before ${reason}: ${lastState}`,
+      );
+    }
+
+    await sleep(ANDROID_DEVICE_READY_DELAY_MS);
+  }
+
+  throw new Error(
+    `Android device ${deviceId} was not ready before ${reason} after ${formatDuration(
+      ANDROID_DEVICE_READY_ATTEMPTS * ANDROID_DEVICE_READY_DELAY_MS,
+    )}: ${lastState}`,
+  );
 }
 
 async function fetchWithTimeout(
@@ -1124,8 +1216,10 @@ async function runMaestroWithTransportRetry({
     const releaseMaestroLock = await acquireMaestroDriverLock();
     try {
       if (platform === "android") {
+        await waitForAndroidDeviceReady(deviceId, "resetting Maestro driver");
         p.log.info("Reset Android Maestro driver host state");
         await resetAndroidMaestroDriverHostState(deviceId);
+        await waitForAndroidDeviceReady(deviceId, "starting Maestro driver");
         await ensureAndroidMaestroDriver(deviceId);
       } else {
         p.log.info("Reset iOS Maestro driver host state");
@@ -1835,6 +1929,7 @@ async function main() {
     appId = IOS_APP_ID;
   } else {
     deviceId = resolveAndroidSerial();
+    await waitForAndroidDeviceReady(deviceId, "preparing Android E2E flow");
     const reversedPort = ensureAndroidReverse(
       deviceId,
       developerSetup.appBaseUrl,

--- a/e2e/maestro/scripts/run-flow.ts
+++ b/e2e/maestro/scripts/run-flow.ts
@@ -307,6 +307,15 @@ function getUrlPort(url: URL) {
   return url.protocol === "https:" ? 443 : 80;
 }
 
+function parsePositivePort(value: string | undefined) {
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const port = Number.parseInt(value, 10);
+  return Number.isInteger(port) && port > 0 ? port : null;
+}
+
 function isLoopbackHost(hostname: string) {
   return hostname === "localhost" || hostname === "127.0.0.1";
 }
@@ -354,6 +363,15 @@ async function validateDeveloperE2ESetup(
     relativeEnvPath,
     DEFAULT_UPDATE_SERVER_BASE_URL,
   );
+  const scopedServicePort = parsePositivePort(process.env.PORT);
+  if (
+    platform === "ios" &&
+    scopedServicePort !== null &&
+    isLoopbackHost(appBaseUrl.hostname)
+  ) {
+    appBaseUrl.port = String(scopedServicePort);
+  }
+
   const controlPort = DEFAULT_SERVER_PORT;
   const appBaseUrlPort = getUrlPort(appBaseUrl);
 

--- a/e2e/maestro/server/controller.ts
+++ b/e2e/maestro/server/controller.ts
@@ -1864,10 +1864,44 @@ async function fetchBundlesPage(args: {
     cliArgs.push("-c", args.channel);
   }
 
-  const response = parseHotUpdaterCliJson<BundleListPage>(
-    "bundle list",
-    runHotUpdaterCliCapture(cliArgs),
-  );
+  let response: BundleListPage | null = null;
+  let lastError: unknown = null;
+
+  for (
+    let attempt = 1;
+    attempt <= PROVIDER_OPERATION_RETRY_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      response = parseHotUpdaterCliJson<BundleListPage>(
+        "bundle list",
+        runHotUpdaterCliCapture(cliArgs),
+      );
+      break;
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt >= PROVIDER_OPERATION_RETRY_ATTEMPTS ||
+        !isTransientProviderError(error)
+      ) {
+        throw error;
+      }
+
+      logE2e("hot-updater cli bundle list retry", {
+        attempt,
+        channel: args.channel ?? null,
+        error: formatErrorMessage(error),
+        platform: session.platform,
+        retryDelayMs: PROVIDER_OPERATION_RETRY_DELAY_MS,
+      });
+      await sleep(PROVIDER_OPERATION_RETRY_DELAY_MS);
+    }
+  }
+
+  if (!response) {
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
   const bundles = normalizeBundleListResponse(response);
   logE2e("hot-updater cli bundle list", {
     channel: args.channel ?? null,

--- a/e2e/maestro/server/controller.ts
+++ b/e2e/maestro/server/controller.ts
@@ -335,6 +335,15 @@ const PROVIDER_OPERATION_RETRY_ATTEMPTS = Number(
 const PROVIDER_OPERATION_RETRY_DELAY_MS = Number(
   process.env.HOT_UPDATER_E2E_PROVIDER_OPERATION_RETRY_DELAY_MS || 1000,
 );
+const PROVIDER_READY_WAIT_ATTEMPTS = Number(
+  process.env.HOT_UPDATER_E2E_PROVIDER_READY_WAIT_ATTEMPTS || 120,
+);
+const PROVIDER_READY_WAIT_DELAY_MS = Number(
+  process.env.HOT_UPDATER_E2E_PROVIDER_READY_WAIT_DELAY_MS || 1000,
+);
+const PROVIDER_READY_HTTP_TIMEOUT_MS = Number(
+  process.env.HOT_UPDATER_E2E_PROVIDER_READY_HTTP_TIMEOUT_MS || 2000,
+);
 const AUTO_PATCH_METADATA_WAIT_ATTEMPTS = Number(
   process.env.HOT_UPDATER_E2E_AUTO_PATCH_METADATA_WAIT_ATTEMPTS || 120,
 );
@@ -3695,6 +3704,60 @@ function getControllerReachableAppBaseUrl() {
   return url.toString().replace(/\/+$/, "");
 }
 
+function getControllerReachableProviderHealthUrl() {
+  const url = new URL(getControllerReachableAppBaseUrl());
+  if (!isLoopbackHost(url.hostname)) {
+    return null;
+  }
+
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+async function waitForLocalProviderReady() {
+  const url = getControllerReachableProviderHealthUrl();
+  if (!url) {
+    return;
+  }
+
+  let lastError: string | null = null;
+  for (let attempt = 1; attempt <= PROVIDER_READY_WAIT_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(PROVIDER_READY_HTTP_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        logE2e("local provider ready", {
+          attempt,
+          platform: session.platform,
+          url,
+        });
+        return;
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = formatErrorMessage(error);
+    }
+
+    if (attempt === 1 || attempt % 10 === 0) {
+      logE2e("local provider readiness pending", {
+        attempt,
+        lastError,
+        platform: session.platform,
+        retryDelayMs: PROVIDER_READY_WAIT_DELAY_MS,
+        url,
+      });
+    }
+    await sleep(PROVIDER_READY_WAIT_DELAY_MS);
+  }
+
+  throw new Error(
+    `Timed out waiting for local provider ${url}: ${lastError ?? "unknown error"}`,
+  );
+}
+
 function getUrlPort(url: URL) {
   if (url.port) {
     return Number.parseInt(url.port, 10);
@@ -4832,6 +4895,7 @@ async function bootstrap() {
   session.deployedBundles = [];
   session.storePath = null;
 
+  await waitForLocalProviderReady();
   await clearRemoteBundles({
     mode: session.reuseApp ? "disable" : "delete",
   });

--- a/e2e/maestro/server/controller.ts
+++ b/e2e/maestro/server/controller.ts
@@ -4282,11 +4282,7 @@ function parseAndroidFocusedPackage(output: string) {
 }
 
 function getAndroidFocusedPackage() {
-  const windowOutput = runCapture(
-    "adb",
-    ["-s", deviceId as string, "shell", "dumpsys", "window", "windows"],
-    { allowFailure: true },
-  );
+  const windowOutput = getAndroidWindowOutput();
   const focusedWindowPackage = parseAndroidFocusedPackage(windowOutput);
   if (focusedWindowPackage) {
     return focusedWindowPackage;
@@ -4298,6 +4294,39 @@ function getAndroidFocusedPackage() {
     { allowFailure: true },
   );
   return parseAndroidFocusedPackage(activityOutput);
+}
+
+function getAndroidWindowOutput() {
+  return runCapture(
+    "adb",
+    ["-s", deviceId as string, "shell", "dumpsys", "window", "windows"],
+    { allowFailure: true },
+  );
+}
+
+function getAndroidAnrPackage(windowOutput: string) {
+  const match = windowOutput.match(
+    /Window\{[^\n]*Application Not Responding:\s*([A-Za-z0-9._]+)/i,
+  );
+  return match?.[1] ?? null;
+}
+
+function dismissAndroidAnrWindow(reason: string) {
+  const anrPackage = getAndroidAnrPackage(getAndroidWindowOutput());
+  if (!anrPackage) {
+    return false;
+  }
+
+  logE2e("android dismiss anr window", {
+    anrPackage,
+    reason,
+  });
+  runCapture(
+    "adb",
+    ["-s", deviceId as string, "shell", "am", "force-stop", anrPackage],
+    { allowFailure: true },
+  );
+  return true;
 }
 
 function getAndroidHomePackage() {
@@ -4536,6 +4565,10 @@ async function ensureAppForeground() {
     return {};
   }
 
+  if (dismissAndroidAnrWindow("ensure-app-foreground")) {
+    await sleep(E2E_ANDROID_FOREGROUND_POLL_MS);
+  }
+
   let focusedPackage = getAndroidFocusedPackage();
   const homePackage = getAndroidHomePackage();
   if (focusedPackage === session.appId) {
@@ -4721,6 +4754,10 @@ async function prepareAppLaunch() {
     focusedPackage,
     targetAppId: session.appId,
   });
+
+  if (dismissAndroidAnrWindow("prepare-app-launch")) {
+    await sleep(E2E_ANDROID_FOREGROUND_POLL_MS);
+  }
 
   ensureAndroidReverse();
   writeAndroidE2ERuntimeConfig();

--- a/e2e/maestro/server/controller.ts
+++ b/e2e/maestro/server/controller.ts
@@ -116,6 +116,43 @@ type BundleListPage = {
   };
 };
 
+const REMOTE_RESET_DATABASE_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, TResult>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+
+        if (index >= items.length) {
+          break;
+        }
+
+        results[index] = await mapper(items[index]!, index);
+      }
+    }),
+  );
+
+  return results;
+}
+
+async function forEachWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  await mapWithConcurrency(items, concurrency, mapper);
+}
+
 type LaunchReportAssertion = {
   crashedBundleId?: string;
   optional: boolean;
@@ -2236,15 +2273,18 @@ async function clearRemoteBundles({
 
     if (mode === "disable") {
       await withDatabasePlugin(async (databasePlugin) => {
-        await Promise.all(
-          nextBatch.map((bundle) =>
+        await forEachWithConcurrency(
+          nextBatch,
+          REMOTE_RESET_DATABASE_CONCURRENCY,
+          (bundle) =>
             databasePlugin.updateBundle(bundle.id, { enabled: false }),
-          ),
         );
         await databasePlugin.commitBundle();
 
-        const refetched = await Promise.all(
-          nextBatch.map((bundle) => databasePlugin.getBundleById(bundle.id)),
+        const refetched = await mapWithConcurrency(
+          nextBatch,
+          REMOTE_RESET_DATABASE_CONCURRENCY,
+          (bundle) => databasePlugin.getBundleById(bundle.id),
         );
         const stillEnabled = refetched.find(
           (bundle) => bundle?.enabled !== false,
@@ -4313,7 +4353,11 @@ async function waitForIosMetadataState(
     E2E_METADATA_WAIT_RELAUNCH_LIMIT,
   );
 
-  for (let relaunchIndex = 0; relaunchIndex <= relaunchLimit; relaunchIndex += 1) {
+  for (
+    let relaunchIndex = 0;
+    relaunchIndex <= relaunchLimit;
+    relaunchIndex += 1
+  ) {
     for (let index = 0; index < attempts; index += 1) {
       totalAttempts += 1;
 
@@ -4378,7 +4422,11 @@ async function waitForAndroidMetadataState(
     E2E_METADATA_WAIT_RELAUNCH_LIMIT,
   );
 
-  for (let relaunchIndex = 0; relaunchIndex <= relaunchLimit; relaunchIndex += 1) {
+  for (
+    let relaunchIndex = 0;
+    relaunchIndex <= relaunchLimit;
+    relaunchIndex += 1
+  ) {
     for (let index = 0; index < attempts; index += 1) {
       totalAttempts += 1;
 
@@ -6025,7 +6073,9 @@ export function startWaitForMetadataJob(
   verificationPending: boolean,
   options: WaitForMetadataOptions = {},
 ) {
-  return createJob(() => waitForMetadata(bundleId, verificationPending, options));
+  return createJob(() =>
+    waitForMetadata(bundleId, verificationPending, options),
+  );
 }
 
 export function getJob(jobId: string) {

--- a/examples/v0.85.0/App.tsx
+++ b/examples/v0.85.0/App.tsx
@@ -19,7 +19,6 @@ import {
   findNodeHandle,
   Image,
   Keyboard,
-  NativeModules,
   type LayoutChangeEvent,
   Modal,
   Platform,
@@ -35,6 +34,8 @@ import {
 } from "react-native";
 import BootSplash from "react-native-bootsplash";
 import { proxy, useSnapshot } from "valtio";
+
+import E2ERuntimeConfig from "./src/specs/NativeE2ERuntimeConfig";
 
 const notify = proxy<{
   status?: string;
@@ -75,7 +76,7 @@ const getConfiguredBaseUrl = () => {
   const runtimeBaseUrl =
     Platform.OS === "ios"
       ? Settings.get(E2E_APP_BASE_URL_SETTING)
-      : NativeModules.E2ERuntimeConfig?.getAppBaseUrl?.();
+      : E2ERuntimeConfig?.getAppBaseUrl();
   return typeof runtimeBaseUrl === "string" && runtimeBaseUrl.trim()
     ? runtimeBaseUrl
     : HOT_UPDATER_BASE_URL;
@@ -84,7 +85,7 @@ const getE2EChannelNamespace = () => {
   const namespace =
     Platform.OS === "ios"
       ? Settings.get(E2E_CHANNEL_NAMESPACE_SETTING)
-      : NativeModules.E2ERuntimeConfig?.getChannelNamespace?.();
+      : E2ERuntimeConfig?.getChannelNamespace();
   return typeof namespace === "string" && namespace.trim()
     ? namespace.trim()
     : null;

--- a/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/E2ERuntimeConfigModule.kt
+++ b/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/E2ERuntimeConfigModule.kt
@@ -2,21 +2,17 @@ package com.hotupdaterexample
 
 import android.content.Context
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
 
 class E2ERuntimeConfigModule(
     reactContext: ReactApplicationContext,
-) : ReactContextBaseJavaModule(reactContext) {
-    override fun getName(): String = "E2ERuntimeConfig"
+) : NativeE2ERuntimeConfigSpec(reactContext) {
+    override fun getName(): String = NAME
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    fun getAppBaseUrl(): String? {
+    override fun getAppBaseUrl(): String? {
         return getString(APP_BASE_URL_KEY)
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    fun getChannelNamespace(): String? {
+    override fun getChannelNamespace(): String? {
         return getString(CHANNEL_NAMESPACE_KEY)
     }
 
@@ -31,6 +27,7 @@ class E2ERuntimeConfigModule(
     }
 
     companion object {
+        const val NAME = "E2ERuntimeConfig"
         private const val PREFERENCES_NAME = "HotUpdaterE2E"
         private const val APP_BASE_URL_KEY = "HOT_UPDATER_E2E_APP_BASE_URL"
         private const val CHANNEL_NAMESPACE_KEY = "HOT_UPDATER_E2E_CHANNEL_NAMESPACE"

--- a/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/ReloadCrashProbeModule.kt
+++ b/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/ReloadCrashProbeModule.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class ReloadCrashProbeModule(
     reactContext: ReactApplicationContext,
 ) : ReactContextBaseJavaModule(reactContext) {
-    override fun getName(): String = "ReloadCrashProbe"
+    override fun getName(): String = NAME
 
     init {
         val creationIndex = creationCount.incrementAndGet()
@@ -40,6 +40,7 @@ class ReloadCrashProbeModule(
     }
 
     companion object {
+        const val NAME = "ReloadCrashProbe"
         private const val TAG = "ReloadCrashProbe"
         private val creationCount = AtomicInteger(0)
     }

--- a/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/ReloadCrashProbePackage.kt
+++ b/examples/v0.85.0/android/app/src/main/java/com/hotupdaterexample/ReloadCrashProbePackage.kt
@@ -1,18 +1,47 @@
 package com.hotupdaterexample
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
+import java.util.HashMap
 
-class ReloadCrashProbePackage : ReactPackage {
-    override fun createNativeModules(
+class ReloadCrashProbePackage : BaseReactPackage() {
+    override fun getModule(
+        name: String,
         reactContext: ReactApplicationContext,
-    ): List<NativeModule> =
-        listOf(
-            ReloadCrashProbeModule(reactContext),
-            E2ERuntimeConfigModule(reactContext),
-        )
+    ): NativeModule? =
+        when (name) {
+            ReloadCrashProbeModule.NAME -> ReloadCrashProbeModule(reactContext)
+            E2ERuntimeConfigModule.NAME -> E2ERuntimeConfigModule(reactContext)
+            else -> null
+        }
+
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
+        ReactModuleInfoProvider {
+            val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
+            moduleInfos[ReloadCrashProbeModule.NAME] =
+                ReactModuleInfo(
+                    ReloadCrashProbeModule.NAME,
+                    ReloadCrashProbeModule.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    false, // isTurboModule
+                )
+            moduleInfos[E2ERuntimeConfigModule.NAME] =
+                ReactModuleInfo(
+                    E2ERuntimeConfigModule.NAME,
+                    E2ERuntimeConfigModule.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    true, // isTurboModule
+                )
+            moduleInfos
+        }
 
     override fun createViewManagers(
         reactContext: ReactApplicationContext,

--- a/examples/v0.85.0/package.json
+++ b/examples/v0.85.0/package.json
@@ -66,5 +66,13 @@
   },
   "engines": {
     "node": ">=22.11.0"
+  },
+  "codegenConfig": {
+    "name": "HotUpdaterExampleSpec",
+    "type": "modules",
+    "jsSrcsDir": "./src",
+    "android": {
+      "javaPackageName": "com.hotupdaterexample"
+    }
   }
 }

--- a/examples/v0.85.0/src/specs/NativeE2ERuntimeConfig.ts
+++ b/examples/v0.85.0/src/specs/NativeE2ERuntimeConfig.ts
@@ -1,0 +1,9 @@
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+export interface Spec extends TurboModule {
+  getAppBaseUrl: () => string | null;
+  getChannelNamespace: () => string | null;
+}
+
+export default TurboModuleRegistry.get<Spec>("E2ERuntimeConfig");

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -87,12 +87,18 @@ let fakeStore: Record<string, string> = {};
 let cloudfrontInvalidations: { paths: string[] }[] = [];
 let listObjectCalls: string[] = [];
 let loadObjectCalls: string[] = [];
+let uploadObjectDelayMs = 0;
+let activeUploadObjectCount = 0;
+let maxActiveUploadObjectCount = 0;
 
 beforeEach(() => {
   fakeStore = {};
   cloudfrontInvalidations = [];
   listObjectCalls = [];
   loadObjectCalls = [];
+  uploadObjectDelayMs = 0;
+  activeUploadObjectCount = 0;
+  maxActiveUploadObjectCount = 0;
 });
 
 afterEach(() => {
@@ -129,7 +135,22 @@ describe("blobDatabase plugin", () => {
   }
 
   async function uploadObject<T>(path: string, data: T): Promise<void> {
-    fakeStore[path] = JSON.stringify(data);
+    activeUploadObjectCount += 1;
+    maxActiveUploadObjectCount = Math.max(
+      maxActiveUploadObjectCount,
+      activeUploadObjectCount,
+    );
+
+    try {
+      if (uploadObjectDelayMs > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, uploadObjectDelayMs),
+        );
+      }
+      fakeStore[path] = JSON.stringify(data);
+    } finally {
+      activeUploadObjectCount -= 1;
+    }
   }
 
   async function deleteObject(path: string): Promise<void> {
@@ -2949,6 +2970,26 @@ describe("blobDatabase plugin", () => {
         ),
       ).toBe(false);
       expect(invalidatedPaths).toContain("/api/check-update/app-version/ios/*");
+    });
+
+    it("limits concurrent storage writes while committing many index artifacts", async () => {
+      plugin = createPlugin({ managementIndexPageSize: 1 });
+      uploadObjectDelayMs = 5;
+
+      for (let index = 0; index < 20; index++) {
+        await plugin.appendBundle(
+          createBundleJson(
+            "production",
+            "ios",
+            `1.0.${index}`,
+            `concurrency-test-${String(index).padStart(2, "0")}`,
+          ),
+        );
+      }
+
+      await plugin.commitBundle();
+
+      expect(maxActiveUploadObjectCount).toBeLessThanOrEqual(8);
     });
   });
 

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -24,6 +24,63 @@ interface BundleWithUpdateJsonKey extends Bundle {
   _oldUpdateJsonKey?: string;
 }
 
+const STORAGE_OPERATION_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, TResult>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+
+        if (index >= items.length) {
+          break;
+        }
+
+        results[index] = await mapper(items[index]!, index);
+      }
+    }),
+  );
+
+  return results;
+}
+
+async function forEachWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  await mapWithConcurrency(items, concurrency, mapper);
+}
+
+async function allSettledWithConcurrency<T, TResult>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<TResult>,
+): Promise<PromiseSettledResult<TResult>[]> {
+  return mapWithConcurrency(items, concurrency, async (item, index) => {
+    try {
+      return {
+        status: "fulfilled",
+        value: await mapper(item, index),
+      } satisfies PromiseFulfilledResult<TResult>;
+    } catch (reason) {
+      return {
+        reason,
+        status: "rejected",
+      } satisfies PromiseRejectedResult;
+    }
+  });
+}
+
 // Helper function to remove internal management keys
 function removeBundleInternalKeys(bundle: BundleWithUpdateJsonKey): Bundle {
   const { _updateJsonKey, _oldUpdateJsonKey, ...pureBundle } = bundle;
@@ -523,16 +580,16 @@ export const createBlobDatabasePlugin = <TConfig>({
       nextArtifacts: ManagementIndexArtifacts,
       previousArtifacts?: ManagementIndexArtifacts,
     ): Promise<void> => {
-      await Promise.all(
-        Array.from(nextArtifacts.pages.entries()).map(([key, page]) =>
-          uploadObject(key, page),
-        ),
+      await forEachWithConcurrency(
+        Array.from(nextArtifacts.pages.entries()),
+        STORAGE_OPERATION_CONCURRENCY,
+        ([key, page]) => uploadObject(key, page),
       );
 
-      await Promise.all(
-        nextArtifacts.scopes.map((scope) =>
-          uploadObject(scope.rootKey, scope.root),
-        ),
+      await forEachWithConcurrency(
+        nextArtifacts.scopes,
+        STORAGE_OPERATION_CONCURRENCY,
+        (scope) => uploadObject(scope.rootKey, scope.root),
       );
 
       if (!previousArtifacts) {
@@ -544,16 +601,20 @@ export const createBlobDatabasePlugin = <TConfig>({
         nextArtifacts.scopes.map((scope) => scope.rootKey),
       );
 
-      await Promise.all(
-        Array.from(previousArtifacts.pages.keys())
-          .filter((key) => !nextPageKeys.has(key))
-          .map((key) => deleteObject(key).catch(() => {})),
+      await forEachWithConcurrency(
+        Array.from(previousArtifacts.pages.keys()).filter(
+          (key) => !nextPageKeys.has(key),
+        ),
+        STORAGE_OPERATION_CONCURRENCY,
+        (key) => deleteObject(key).catch(() => {}),
       );
 
-      await Promise.all(
-        previousArtifacts.scopes
-          .filter((scope) => !nextRootKeys.has(scope.rootKey))
-          .map((scope) => deleteObject(scope.rootKey).catch(() => {})),
+      await forEachWithConcurrency(
+        previousArtifacts.scopes.filter(
+          (scope) => !nextRootKeys.has(scope.rootKey),
+        ),
+        STORAGE_OPERATION_CONCURRENCY,
+        (scope) => deleteObject(scope.rootKey).catch(() => {}),
       );
     };
 
@@ -954,14 +1015,19 @@ export const createBlobDatabasePlugin = <TConfig>({
       const updateJsonKeys = (await listObjects("")).filter((key) =>
         /^[^/]+\/(?:ios|android)\/[^/]+\/update\.json$/.test(key),
       );
-      const filePromises = updateJsonKeys.map(async (key) => {
-        const bundlesData = (await loadObject<Bundle[]>(key)) ?? [];
-        return bundlesData.map((bundle) => ({
-          ...bundle,
-          _updateJsonKey: key,
-        }));
-      });
-      const allBundles = (await Promise.all(filePromises)).flat();
+      const allBundles = (
+        await mapWithConcurrency(
+          updateJsonKeys,
+          STORAGE_OPERATION_CONCURRENCY,
+          async (key) => {
+            const bundlesData = (await loadObject<Bundle[]>(key)) ?? [];
+            return bundlesData.map((bundle) => ({
+              ...bundle,
+              _updateJsonKey: key,
+            }));
+          },
+        )
+      ).flat();
 
       for (const bundle of allBundles) {
         bundlesMap.set(bundle.id, bundle as BundleWithUpdateJsonKey);
@@ -1062,8 +1128,10 @@ export const createBlobDatabasePlugin = <TConfig>({
         appVersion,
       );
 
-      const result = await Promise.allSettled(
-        matchingVersions.map(async (targetAppVersion) => {
+      const result = await allSettledWithConcurrency(
+        matchingVersions,
+        STORAGE_OPERATION_CONCURRENCY,
+        async (targetAppVersion) => {
           const normalizedVersion =
             normalizeTargetAppVersion(targetAppVersion) ?? targetAppVersion;
 
@@ -1072,7 +1140,7 @@ export const createBlobDatabasePlugin = <TConfig>({
               `${channel}/${platform}/${normalizedVersion}/update.json`,
             )) ?? []
           );
-        }),
+        },
       );
 
       const bundles = result
@@ -1409,8 +1477,10 @@ export const createBlobDatabasePlugin = <TConfig>({
           }
 
           // Remove bundles from their old keys.
-          await Promise.all(
-            Object.keys(removalsByKey).map(async (oldKey) => {
+          await forEachWithConcurrency(
+            Object.keys(removalsByKey),
+            STORAGE_OPERATION_CONCURRENCY,
+            async (oldKey) => {
               const currentBundles = (await loadObject<Bundle[]>(oldKey)) ?? [];
               const updatedBundles = currentBundles.filter(
                 (b) => !removalsByKey[oldKey].includes(b.id),
@@ -1421,12 +1491,14 @@ export const createBlobDatabasePlugin = <TConfig>({
               } else {
                 await uploadObject(oldKey, updatedBundles);
               }
-            }),
+            },
           );
 
           // Add or update bundles in their new keys.
-          await Promise.all(
-            Object.keys(changedBundlesByKey).map(async (key) => {
+          await forEachWithConcurrency(
+            Object.keys(changedBundlesByKey),
+            STORAGE_OPERATION_CONCURRENCY,
+            async (key) => {
               const currentBundles = (await loadObject<Bundle[]>(key)) ?? [];
               const pureBundles = changedBundlesByKey[key].map(
                 (bundle) => bundle,
@@ -1443,7 +1515,7 @@ export const createBlobDatabasePlugin = <TConfig>({
               }
               currentBundles.sort((a, b) => b.id.localeCompare(a.id));
               await uploadObject(key, currentBundles);
-            }),
+            },
           );
 
           if (targetVersionPlatforms.size > 0) {


### PR DESCRIPTION
## Summary
- bound blob database storage/index rebuild operations to avoid unbounded Promise.all fan-out
- bound E2E remote disable reset database mutations/refetches
- move Android v0.85 E2E runtime config access from NativeModules to a generated TurboModule spec

## Self-review
- No critical/high blockers found after checking concurrency ordering, error propagation, and RN codegen registration.
- Remaining Promise.all calls in the touched areas are bounded worker pools, tiny platform fan-out, or small file/process groups.

## Verification
- pnpm vitest run --project='unit:default' plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
- pnpm --filter @hot-updater/plugin-core test:type
- pnpm exec oxlint e2e/maestro/server/controller.ts plugins/plugin-core/src/createBlobDatabasePlugin.ts plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts examples/v0.85.0/App.tsx examples/v0.85.0/src/specs/NativeE2ERuntimeConfig.ts
- node --experimental-strip-types --check e2e/maestro/server/controller.ts
- cd examples/v0.85.0/android && ./gradlew :app:compileDebugKotlin
- git diff --check

## Not tested
- Full device/provider E2E run