### PR TITLE
fix(cloudflare): inline IN-list values to avoid D1 100-bind cap

### DIFF
--- a/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
+++ b/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
@@ -1,3 +1,25 @@
+// plugins/cloudflare/src/cloudflareWorkerDatabase.ts
+//
+// Drop-in replacement for the official Hot Updater Cloudflare worker
+// database plugin (https://github.com/gronxb/hot-updater).
+//
+// Fix: D1_ERROR "too many SQL variables ... SQLITE_ERROR"
+//
+// The upstream `buildWhereClause` and `getPatchMap` expand IN-lists as
+// `?, ?, ?, ...`. D1 caps prepared statements at 100 bound parameters,
+// so as soon as `targetAppVersionIn` / `id.in` / `bundleIds` cross ~95,
+// every request 5xxs. Values for these IN-lists come from our own DB
+// (bundle ids, target_app_version strings), so we inline them as
+// escaped SQL literals instead of binds. Empty lists short-circuit
+// (`IN ()` is a SQLite syntax error).
+//
+// Also: `getTargetAppVersionsForUpdateInfo` now sorts by `MAX(id) DESC`
+// so the returned target_app_version list is deterministic — newest
+// activity first — without needing an extra JS sort.
+//
+// No semantics change beyond those three points. Everything else is
+// byte-identical to upstream.
+
 import {
   DEFAULT_ROLLOUT_COHORT_COUNT,
   getAssetBaseStorageUri,
@@ -82,6 +104,16 @@ interface D1WorkerBundlePatchRow {
   order_index: number | null;
 }
 
+// Escape `value` as a SQL string literal, or return null if it contains
+// a character we refuse to inline (newline / NUL / backslash). Doubled
+// single-quote per the SQL standard. Only used for IN-list inlining;
+// every other parameter still goes through .bind().
+function toSqlLiteral(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (/[\n\r\0\\]/.test(value)) return null;
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 function buildWhereClause(
   conditions: QueryConditions | undefined,
 ): BuildQueryResult {
@@ -111,8 +143,14 @@ function buildWhereClause(
     if (conditions.id.in.length === 0) {
       clauses.push("1 = 0");
     } else {
-      clauses.push(`id IN (${conditions.id.in.map(() => "?").join(", ")})`);
-      params.push(...conditions.id.in);
+      const literals = conditions.id.in
+        .map(toSqlLiteral)
+        .filter((v): v is string => v !== null);
+      if (literals.length === 0) {
+        clauses.push("1 = 0");
+      } else {
+        clauses.push(`id IN (${literals.join(", ")})`);
+      }
     }
   }
 
@@ -158,12 +196,14 @@ function buildWhereClause(
     if (conditions.targetAppVersionIn.length === 0) {
       clauses.push("1 = 0");
     } else {
-      clauses.push(
-        `target_app_version IN (${conditions.targetAppVersionIn
-          .map(() => "?")
-          .join(", ")})`,
-      );
-      params.push(...conditions.targetAppVersionIn);
+      const literals = conditions.targetAppVersionIn
+        .map(toSqlLiteral)
+        .filter((v): v is string => v !== null);
+      if (literals.length === 0) {
+        clauses.push("1 = 0");
+      } else {
+        clauses.push(`target_app_version IN (${literals.join(", ")})`);
+      }
     }
   }
 
@@ -335,15 +375,24 @@ export const d1WorkerDatabase = <
           return patchMap;
         }
 
-        const placeholders = bundleIds.map(() => "?").join(", ");
+        // Inline as literals for the same reason as buildWhereClause:
+        // bundle listings can return >100 rows and would overrun D1's
+        // 100-bind cap if we used `?, ?, ?, ...`.
+        const literals = bundleIds
+          .map(toSqlLiteral)
+          .filter((v): v is string => v !== null);
+        if (literals.length === 0) {
+          return patchMap;
+        }
+
         const rows = await queryAll<D1WorkerBundlePatchRow>(
           `
             SELECT *
             FROM bundle_patches
-            WHERE bundle_id IN (${placeholders})
+            WHERE bundle_id IN (${literals.join(", ")})
             ORDER BY order_index ASC, base_bundle_id ASC
           `,
-          bundleIds,
+          [],
           context,
         );
 
@@ -391,6 +440,9 @@ export const d1WorkerDatabase = <
         },
         context?: HotUpdaterContext<TContext>,
       ): Promise<string[]> => {
+        // ORDER BY MAX(id) DESC: deterministic newest-first ordering so
+        // the downstream JS semver filter sees the freshest target
+        // groups first. No correctness impact; just predictability.
         const rows = await queryAll<{ target_app_version: string }>(
           `
             SELECT target_app_version
@@ -401,6 +453,7 @@ export const d1WorkerDatabase = <
               AND id >= ?
               AND target_app_version IS NOT NULL
             GROUP BY target_app_version
+            ORDER BY MAX(id) DESC
           `,
           [channel, platform, minBundleId],
           context,

--- a/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
+++ b/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
@@ -105,12 +105,17 @@ interface D1WorkerBundlePatchRow {
 }
 
 // Escape `value` as a SQL string literal, or return null if it contains
-// a character we refuse to inline (newline / NUL / backslash). Doubled
-// single-quote per the SQL standard. Only used for IN-list inlining;
-// every other parameter still goes through .bind().
+// a character we refuse to inline: NUL (SQLite treats as end-of-string),
+// newlines (corrupt multi-line SQL when logged), backslash (escaping
+// ambiguity). Single quotes are doubled per the SQL standard. Only used
+// for IN-list inlining; every other parameter still goes through .bind().
 function toSqlLiteral(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  if (/[\n\r\0\\]/.test(value)) return null;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    // 0 = NUL, 10 = \n, 13 = \r, 92 = backslash
+    if (code === 0 || code === 10 || code === 13 || code === 92) return null;
+  }
   return `'${value.replace(/'/g, "''")}'`;
 }
 

--- a/plugins/cloudflare/src/d1Database.spec.ts
+++ b/plugins/cloudflare/src/d1Database.spec.ts
@@ -58,13 +58,24 @@ const getFilteredRows = (sql: string, params: any[]) => {
   let filteredRows = Array.from(rows.values());
   let index = 0;
 
+  // IN-list values may be expressed as bound parameters (`?, ?, ?`) or
+  // inlined SQL string literals (`'a', 'b', 'c'`). buildWhereClause and
+  // getPatchMap inline string literals to stay under D1's 100-bind cap.
   const consumeInValues = (pattern: RegExp) => {
     const match = sql.match(pattern);
     if (!match) {
       return null;
     }
 
-    const count = (match[1]?.match(/\?/g) ?? []).length;
+    const body = match[1] ?? "";
+    const literalValues = Array.from(body.matchAll(/'((?:[^']|'')*)'/g)).map(
+      (m) => m[1].replace(/''/g, "'"),
+    );
+    if (literalValues.length > 0) {
+      return literalValues;
+    }
+
+    const count = (body.match(/\?/g) ?? []).length;
     const values = params.slice(index, index + count);
     index += count;
     return values;
@@ -189,8 +200,16 @@ vi.mock("cloudflare", () => ({
               "select * from bundle_patches where bundle_id in",
             )
           ) {
-            const selectedBundleIds = new Set(
-              params.map((value) => String(value)),
+            // getPatchMap inlines bundle_ids as SQL string literals. Fall
+            // back to `params` for older code paths that still bind.
+            const inMatch = sql.match(/bundle_id IN \(([^)]+)\)/);
+            const literalIds = Array.from(
+              (inMatch?.[1] ?? "").matchAll(/'((?:[^']|'')*)'/g),
+            ).map((m) => m[1].replace(/''/g, "'"));
+            const selectedBundleIds = new Set<string>(
+              literalIds.length > 0
+                ? literalIds
+                : params.map((value) => String(value)),
             );
             const result = Array.from(patchRows.values())
               .filter((row) => selectedBundleIds.has(row.bundle_id))
@@ -409,5 +428,75 @@ describe("d1Database plugin", () => {
         metadata: JSON.stringify({ source: "fresh" }),
       }),
     );
+  });
+
+  it("queries getUpdateInfo with 200+ distinct target_app_versions without busting D1's 100-bind cap", async () => {
+    // Regression for: D1_ERROR "too many SQL variables ... SQLITE_ERROR".
+    // buildWhereClause used to expand target_app_version IN (...) as one
+    // `?` per element. D1 caps prepared statements at 100 binds, so the
+    // query died once enough compatible target_app_version values were
+    // present. Fix inlines them as escaped SQL literals.
+    const COUNT = 200;
+    for (let i = 0; i < COUNT; i++) {
+      const id = `bundle-${String(i).padStart(4, "0")}`;
+      rows.set(id, {
+        id,
+        channel: "production",
+        enabled: 1,
+        should_force_update: 0,
+        file_hash: `hash-${i}`,
+        git_commit_hash: null,
+        message: null,
+        platform: "ios",
+        // Each row gets a distinct target range that satisfies "1.0.0".
+        target_app_version: `>=0.${i}.0`,
+        storage_uri: `s3://bucket/${id}.zip`,
+        fingerprint_hash: null,
+        metadata: "{}",
+        rollout_cohort_count: 1000,
+        target_cohorts: null,
+      });
+    }
+
+    const result = await plugin.getUpdateInfo?.({
+      appVersion: "1.0.0",
+      bundleId: "00000000-0000-0000-0000-000000000000",
+      platform: "ios",
+      channel: "production",
+      minBundleId: "00000000-0000-0000-0000-000000000000",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  it("queries getPatchMap with 200+ bundle ids without busting D1's 100-bind cap", async () => {
+    // Regression for same root cause in getPatchMap. getBundles can
+    // return more than 100 rows; mapping their ids into bundle_id IN
+    // (...) used to overrun D1's bind cap.
+    const COUNT = 200;
+    for (let i = 0; i < COUNT; i++) {
+      const id = `bundle-${String(i).padStart(4, "0")}`;
+      rows.set(id, {
+        id,
+        channel: "production",
+        enabled: 1,
+        should_force_update: 0,
+        file_hash: `hash-${i}`,
+        git_commit_hash: null,
+        message: null,
+        platform: "ios",
+        target_app_version: "1.0.0",
+        storage_uri: `s3://bucket/${id}.zip`,
+        fingerprint_hash: null,
+        metadata: "{}",
+        rollout_cohort_count: 1000,
+        target_cohorts: null,
+      });
+    }
+
+    const { data, pagination } = await plugin.getBundles({ limit: COUNT });
+    expect(data).toHaveLength(COUNT);
+    expect(pagination.total).toBe(COUNT);
   });
 });


### PR DESCRIPTION
# fix(cloudflare): inline IN-list values to avoid D1 100-bind cap

## Summary

`plugins/cloudflare/src/cloudflareWorkerDatabase.ts` expanded three
`IN (...)` clauses as `?, ?, ?, ...` and pushed each value into
`.bind(...)`:

- `buildWhereClause` — `id.in`
- `buildWhereClause` — `targetAppVersionIn`
- `getPatchMap` — `bundle_id IN (...)`

D1 caps prepared statements at **100 bound parameters**, so any of
these queries fail with `D1_ERROR: too many SQL variables ...
SQLITE_ERROR` once the array crosses ~95 entries.

The hot path is `targetAppVersionIn`: the update-check flow first calls
`getTargetAppVersionsForUpdateInfo` to fetch every distinct
`target_app_version`, semver-filters in JS, then hands the filtered
list to `getBundlesByTargetAppVersions` → `queryBundlesForUpdateInfo`
→ `buildWhereClause`. Once a project accumulates ~100 distinct
compatible range strings, every `/api/check-update` request 5xx's.

Repro logs:

```
Hot Updater handler error:
  Error: D1_ERROR: too many SQL variables at offset 386: SQLITE_ERROR
```

## Approach

The values in these IN-lists are produced by our own backend (bundle
ids are uuids; target_app_version strings come from the uploader), so
they're safe to inline as escaped SQL string literals via a small
`toSqlLiteral` helper:

```ts
function toSqlLiteral(value: unknown): string | null {
  if (typeof value !== "string") return null;
  if (/[\n\r\0\\]/.test(value)) return null;
  return `'${value.replace(/'/g, "''")}'`;
}
```

- Single quotes are doubled per the SQL standard.
- Newline / NUL / backslash are rejected defensively so a future
  malformed row can't break out of the literal.
- Empty lists short-circuit to `1 = 0` (`IN ()` is a SQLite syntax
  error).
- The 5 binds in `getUpdateInfo`'s outer CTE are unchanged — only the
  IN-list values move from bind to inline.

Also: `getTargetAppVersionsForUpdateInfo` gains `ORDER BY MAX(id) DESC`
so the returned list is deterministic newest-first. This has no
functional impact today (the downstream filter is order-insensitive)
but removes reliance on SQLite's physical row order.

## Test coverage

`d1Database.spec.ts` was relying on `?` count to parse IN-list values
out of mock SQL. Updated the spec mock to handle both forms (bound and
inlined). Added two regression tests:

1. `getUpdateInfo` with 200 distinct `target_app_version` values
   (exceeds the old cap by 2×).
2. `getBundles` returning 200 rows (drives `getPatchMap` past the cap).

Both pass; full suite (114 tests) green.

## Files changed

- `plugins/cloudflare/src/cloudflareWorkerDatabase.ts` — `toSqlLiteral`
  helper + three IN-clause sites + ORDER BY tweak.
- `plugins/cloudflare/src/d1Database.spec.ts` — mock parses both forms;
  two new regression tests.

## Notes

I considered a schema-level fix (store resolved `min_app_version` /
`max_app_version` per bundle so the read path can use a single
`BETWEEN` instead of fetch-all + semver-in-JS + IN-list). That's the
architecturally cleaner approach but it's a bigger lift (migration +
backfill + uploader change + a new semver-range resolver becomes
load-bearing) and out of scope for fixing a live incident. Happy to
follow up with that in a separate PR if it's interesting.

Closes #1034.
