### PR TITLE
fix(cloudflare): avoid D1 bind cap for IN filters

### DIFF
--- a/.changeset/quiet-d1-bundles.md
+++ b/.changeset/quiet-d1-bundles.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/cloudflare": patch
+---
+
+Avoid Cloudflare D1's 100-parameter limit for large IN-list queries.

--- a/packages/test-utils/src/setupBundleMethodsTestSuite.ts
+++ b/packages/test-utils/src/setupBundleMethodsTestSuite.ts
@@ -524,6 +524,40 @@ export const setupBundleMethodsTestSuite = ({
       expect(secondPage.pagination.hasPreviousPage).toBe(true);
     });
 
+    it("should list more than 100 bundles in one page", async () => {
+      const bundles: Bundle[] = Array.from({ length: 200 }, (_, index) => {
+        const bundleNumber = index + 1;
+        return {
+          id: `00000000-0000-0000-0000-${String(bundleNumber).padStart(
+            12,
+            "0",
+          )}`,
+          platform: "ios",
+          shouldForceUpdate: false,
+          enabled: true,
+          fileHash: `hash-many-${bundleNumber}`,
+          gitCommitHash: null,
+          message: `Many bundle ${bundleNumber}`,
+          channel: "production",
+          storageUri: `mock://test/many-${bundleNumber}.zip`,
+          targetAppVersion: "1.0.0",
+          fingerprintHash: null,
+        };
+      });
+
+      for (const bundle of bundles) {
+        await insertBundle(bundle);
+      }
+
+      const result = await getBundles({
+        orderBy: { field: "id", direction: "desc" },
+        limit: 200,
+      });
+
+      expect(result.data).toHaveLength(200);
+      expect(result.pagination.total).toBe(200);
+    });
+
     it("should support null and not-null bundle filters", async () => {
       const bundles: Bundle[] = [
         {

--- a/packages/test-utils/src/setupGetUpdateInfoTestSuite.ts
+++ b/packages/test-utils/src/setupGetUpdateInfoTestSuite.ts
@@ -1159,6 +1159,36 @@ export const setupGetUpdateInfoTestSuite = ({
 
       expect(update).toBeNull();
     });
+
+    it("applies update when many distinct target app versions are compatible", async () => {
+      const bundles: Bundle[] = Array.from({ length: 200 }, (_, index) => {
+        const bundleNumber = index + 1;
+        return {
+          ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
+          targetAppVersion: `>=0.${index}.0`,
+          enabled: true,
+          id: `00000000-0000-0000-0000-${String(bundleNumber).padStart(
+            12,
+            "0",
+          )}`,
+          shouldForceUpdate: false,
+        };
+      });
+
+      const update = await getUpdateInfo(bundles, {
+        appVersion: "1.0.0",
+        bundleId: NIL_UUID,
+        platform: "ios",
+        _updateStrategy: "appVersion",
+      });
+
+      expect(update).toMatchObject({
+        id: "00000000-0000-0000-0000-000000000200",
+        message: "hello",
+        shouldForceUpdate: false,
+        status: "UPDATE",
+      });
+    });
   });
 
   describe("fingerprint strategy", () => {

--- a/plugins/cloudflare/src/cloudflareWorkerDatabase.spec.ts
+++ b/plugins/cloudflare/src/cloudflareWorkerDatabase.spec.ts
@@ -1,0 +1,260 @@
+import type { DatabasePlugin } from "@hot-updater/plugin-core";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { d1Database, type RequestEnvContext } from "./worker";
+
+type WorkerBundleRow = {
+  id: string;
+  channel: string;
+  enabled: number;
+  should_force_update: number;
+  file_hash: string;
+  git_commit_hash: string | null;
+  message: string | null;
+  platform: "ios" | "android";
+  target_app_version: string | null;
+  storage_uri: string;
+  fingerprint_hash: string | null;
+  metadata: string;
+  manifest_storage_uri: string | null;
+  manifest_file_hash: string | null;
+  asset_base_storage_uri: string | null;
+  rollout_cohort_count: number | null;
+  target_cohorts: string | null;
+};
+
+type WorkerPatchRow = {
+  id: string;
+  bundle_id: string;
+  base_bundle_id: string;
+  base_file_hash: string;
+  patch_file_hash: string;
+  patch_storage_uri: string;
+  order_index: number | null;
+};
+
+type TestEnv = {
+  DB: ReturnType<typeof createD1Binding>;
+  JWT_SECRET: string;
+  BUCKET: {
+    get: (key: string) => Promise<{ text: () => Promise<string> } | null>;
+  };
+};
+
+const rows = new Map<string, WorkerBundleRow>();
+const patchRows = new Map<string, WorkerPatchRow>();
+
+const createBundleRow = (index: number): WorkerBundleRow => {
+  const id = `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
+  return {
+    id,
+    channel: "production",
+    enabled: 1,
+    should_force_update: 0,
+    file_hash: `hash-${index}`,
+    git_commit_hash: null,
+    message: null,
+    platform: "ios",
+    target_app_version: `>=0.${index}.0`,
+    storage_uri: `r2://bucket/${id}.zip`,
+    fingerprint_hash: null,
+    metadata: "{}",
+    manifest_storage_uri: null,
+    manifest_file_hash: null,
+    asset_base_storage_uri: null,
+    rollout_cohort_count: 1000,
+    target_cohorts: null,
+  };
+};
+
+const normalizeSql = (sql: string) => sql.replace(/\s+/g, " ").trim();
+
+const filterRows = (sql: string, params: unknown[]) => {
+  let filteredRows = Array.from(rows.values());
+  let index = 0;
+
+  if (sql.includes("channel = ?")) {
+    const channel = params[index++];
+    filteredRows = filteredRows.filter((row) => row.channel === channel);
+  }
+
+  if (sql.includes("platform = ?")) {
+    const platform = params[index++];
+    filteredRows = filteredRows.filter((row) => row.platform === platform);
+  }
+
+  if (sql.includes("enabled = ?")) {
+    const enabled = Number(params[index++]);
+    filteredRows = filteredRows.filter((row) => row.enabled === enabled);
+  }
+
+  if (sql.includes("id >= ?")) {
+    const id = String(params[index++]);
+    filteredRows = filteredRows.filter((row) => row.id.localeCompare(id) >= 0);
+  }
+
+  if (sql.includes("target_app_version IS NOT NULL")) {
+    filteredRows = filteredRows.filter(
+      (row) => row.target_app_version !== null,
+    );
+  }
+
+  const inMatch = sql.match(/target_app_version IN \(([^)]+)\)/);
+  if (inMatch) {
+    const body = inMatch[1] ?? "";
+    const inValues = body.includes("json_each(")
+      ? (JSON.parse(String(params[index++])) as unknown[])
+      : params.slice(index, index + (body.match(/\?/g) ?? []).length);
+    const values = new Set(inValues);
+    filteredRows = filteredRows.filter((row) =>
+      values.has(row.target_app_version),
+    );
+    if (!body.includes("json_each(")) {
+      index += inValues.length;
+    }
+  }
+
+  return { filteredRows, index };
+};
+
+function createD1Binding() {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          if (params.length > 100) {
+            throw new Error(
+              "D1_ERROR: too many SQL variables at offset 386: SQLITE_ERROR",
+            );
+          }
+
+          return {
+            async all<T>() {
+              const normalizedSql = normalizeSql(sql).toLowerCase();
+
+              if (
+                normalizedSql.startsWith(
+                  "select target_app_version from bundles",
+                )
+              ) {
+                const { filteredRows } = filterRows(sql, params);
+                const targetAppVersions = Array.from(
+                  new Set(
+                    filteredRows
+                      .map((row) => row.target_app_version)
+                      .filter(
+                        (targetAppVersion): targetAppVersion is string =>
+                          targetAppVersion !== null,
+                      ),
+                  ),
+                ).map((targetAppVersion) => ({
+                  target_app_version: targetAppVersion,
+                }));
+
+                return { results: targetAppVersions as T[] };
+              }
+
+              if (
+                normalizedSql.startsWith(
+                  "select count(*) as total from bundles",
+                )
+              ) {
+                const { filteredRows } = filterRows(sql, params);
+                return { results: [{ total: filteredRows.length }] as T[] };
+              }
+
+              if (normalizedSql.startsWith("select * from bundles")) {
+                const { filteredRows, index } = filterRows(sql, params);
+                const limit = Number(params[index] ?? filteredRows.length);
+                const offset = Number(params[index + 1] ?? 0);
+                const result = filteredRows
+                  .sort((left, right) => right.id.localeCompare(left.id))
+                  .slice(offset, offset + limit);
+
+                return { results: result as T[] };
+              }
+
+              if (
+                normalizedSql.startsWith(
+                  "select * from bundle_patches where bundle_id in",
+                )
+              ) {
+                const selectedBundleIds = new Set(
+                  normalizedSql.includes("json_each")
+                    ? (JSON.parse(String(params[0])) as unknown[]).map(String)
+                    : params.map(String),
+                );
+                const result = Array.from(patchRows.values()).filter((row) =>
+                  selectedBundleIds.has(row.bundle_id),
+                );
+
+                return { results: result as T[] };
+              }
+
+              throw new Error(`Unsupported SQL in D1 worker mock: ${sql}`);
+            },
+            async first<T>() {
+              return (await this.all<T>()).results?.[0] ?? null;
+            },
+            async run() {
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("cloudflare worker d1Database", () => {
+  let plugin: DatabasePlugin<RequestEnvContext<TestEnv>>;
+  let context: RequestEnvContext<TestEnv>;
+
+  beforeEach(() => {
+    rows.clear();
+    patchRows.clear();
+    plugin = d1Database<RequestEnvContext<TestEnv>>()();
+    context = {
+      env: {
+        DB: createD1Binding(),
+        JWT_SECRET: "test-secret",
+        BUCKET: {
+          get: async () => null,
+        },
+      },
+    };
+  });
+
+  it("queries getUpdateInfo with 200 distinct target_app_versions without exceeding D1's 100-bind cap", async () => {
+    for (let index = 0; index < 200; index++) {
+      const row = createBundleRow(index);
+      rows.set(row.id, row);
+    }
+
+    const result = await plugin.getUpdateInfo?.(
+      {
+        appVersion: "1.0.0",
+        bundleId: "00000000-0000-0000-0000-000000000000",
+        platform: "ios",
+        channel: "production",
+        minBundleId: "00000000-0000-0000-0000-000000000000",
+        _updateStrategy: "appVersion",
+      },
+      context,
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  it("queries patches for 200 listed bundles without exceeding D1's 100-bind cap", async () => {
+    for (let index = 0; index < 200; index++) {
+      const row = createBundleRow(index);
+      rows.set(row.id, row);
+    }
+
+    const result = await plugin.getBundles({ limit: 200 }, context);
+
+    expect(result.data).toHaveLength(200);
+    expect(result.pagination.total).toBe(200);
+  });
+});

--- a/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
+++ b/plugins/cloudflare/src/cloudflareWorkerDatabase.ts
@@ -52,6 +52,19 @@ interface BuildQueryResult {
   params: unknown[];
 }
 
+const buildJsonEachInClause = (
+  columnName: string,
+  values: string[],
+  params: unknown[],
+) => {
+  if (values.length === 0) {
+    return "1 = 0";
+  }
+
+  params.push(JSON.stringify(values));
+  return `${columnName} IN (SELECT value FROM json_each(?))`;
+};
+
 interface D1WorkerBundleRow {
   id: string;
   channel: string;
@@ -108,12 +121,7 @@ function buildWhereClause(
   }
 
   if (conditions.id?.in) {
-    if (conditions.id.in.length === 0) {
-      clauses.push("1 = 0");
-    } else {
-      clauses.push(`id IN (${conditions.id.in.map(() => "?").join(", ")})`);
-      params.push(...conditions.id.in);
-    }
+    clauses.push(buildJsonEachInClause("id", conditions.id.in, params));
   }
 
   if (conditions.id?.eq) {
@@ -155,16 +163,13 @@ function buildWhereClause(
   }
 
   if (conditions.targetAppVersionIn) {
-    if (conditions.targetAppVersionIn.length === 0) {
-      clauses.push("1 = 0");
-    } else {
-      clauses.push(
-        `target_app_version IN (${conditions.targetAppVersionIn
-          .map(() => "?")
-          .join(", ")})`,
-      );
-      params.push(...conditions.targetAppVersionIn);
-    }
+    clauses.push(
+      buildJsonEachInClause(
+        "target_app_version",
+        conditions.targetAppVersionIn,
+        params,
+      ),
+    );
   }
 
   if (conditions.fingerprintHash !== undefined) {
@@ -335,15 +340,14 @@ export const d1WorkerDatabase = <
           return patchMap;
         }
 
-        const placeholders = bundleIds.map(() => "?").join(", ");
         const rows = await queryAll<D1WorkerBundlePatchRow>(
           `
             SELECT *
             FROM bundle_patches
-            WHERE bundle_id IN (${placeholders})
+            WHERE bundle_id IN (SELECT value FROM json_each(?))
             ORDER BY order_index ASC, base_bundle_id ASC
           `,
-          bundleIds,
+          [JSON.stringify(bundleIds)],
           context,
         );
 

--- a/plugins/cloudflare/src/d1Database.spec.ts
+++ b/plugins/cloudflare/src/d1Database.spec.ts
@@ -64,7 +64,13 @@ const getFilteredRows = (sql: string, params: any[]) => {
       return null;
     }
 
-    const count = (match[1]?.match(/\?/g) ?? []).length;
+    const body = match[1] ?? "";
+    if (body.includes("json_each(")) {
+      const values = JSON.parse(String(params[index++])) as unknown;
+      return Array.isArray(values) ? values : [];
+    }
+
+    const count = (body.match(/\?/g) ?? []).length;
     const values = params.slice(index, index + count);
     index += count;
     return values;
@@ -169,6 +175,12 @@ vi.mock("cloudflare", () => ({
             params?: any[];
           },
         ) => {
+          if (params.length > 100) {
+            throw new Error(
+              "D1_ERROR: too many SQL variables at offset 386: SQLITE_ERROR",
+            );
+          }
+
           const normalizedSql = sql.replace(/\s+/g, " ").trim().toLowerCase();
 
           if (
@@ -190,7 +202,9 @@ vi.mock("cloudflare", () => ({
             )
           ) {
             const selectedBundleIds = new Set(
-              params.map((value) => String(value)),
+              normalizedSql.includes("json_each")
+                ? (JSON.parse(String(params[0])) as unknown[]).map(String)
+                : params.map((value) => String(value)),
             );
             const result = Array.from(patchRows.values())
               .filter((row) => selectedBundleIds.has(row.bundle_id))

--- a/plugins/cloudflare/src/d1Database.ts
+++ b/plugins/cloudflare/src/d1Database.ts
@@ -34,6 +34,19 @@ interface BuildQueryResult {
   params: any[];
 }
 
+const buildJsonEachInClause = (
+  columnName: string,
+  values: string[],
+  params: any[],
+) => {
+  if (values.length === 0) {
+    return "1 = 0";
+  }
+
+  params.push(JSON.stringify(values));
+  return `${columnName} IN (SELECT value FROM json_each(?))`;
+};
+
 interface D1BundleRow {
   id: string;
   channel: string;
@@ -94,12 +107,7 @@ function buildWhereClause(conditions: QueryConditions): BuildQueryResult {
   }
 
   if (conditions.id?.in) {
-    if (conditions.id.in.length === 0) {
-      clauses.push("1 = 0");
-    } else {
-      clauses.push(`id IN (${conditions.id.in.map(() => "?").join(", ")})`);
-      params.push(...conditions.id.in);
-    }
+    clauses.push(buildJsonEachInClause("id", conditions.id.in, params));
   }
 
   if (conditions.id?.eq) {
@@ -141,16 +149,13 @@ function buildWhereClause(conditions: QueryConditions): BuildQueryResult {
   }
 
   if (conditions.targetAppVersionIn) {
-    if (conditions.targetAppVersionIn.length === 0) {
-      clauses.push("1 = 0");
-    } else {
-      clauses.push(
-        `target_app_version IN (${conditions.targetAppVersionIn
-          .map(() => "?")
-          .join(", ")})`,
-      );
-      params.push(...conditions.targetAppVersionIn);
-    }
+    clauses.push(
+      buildJsonEachInClause(
+        "target_app_version",
+        conditions.targetAppVersionIn,
+        params,
+      ),
+    );
   }
 
   if (conditions.fingerprintHash !== undefined) {
@@ -275,18 +280,17 @@ export const d1Database = createDatabasePlugin<D1DatabaseConfig>({
         return patchMap;
       }
 
-      const placeholders = bundleIds.map(() => "?").join(", ");
       const sql = minify(`
         SELECT *
         FROM bundle_patches
-        WHERE bundle_id IN (${placeholders})
+        WHERE bundle_id IN (SELECT value FROM json_each(?))
         ORDER BY order_index ASC, base_bundle_id ASC
       `);
 
       const result = await cf.d1.database.query(config.databaseId, {
         account_id: config.accountId,
         sql,
-        params: bundleIds,
+        params: [JSON.stringify(bundleIds)],
       });
       const rows = await resolvePage<D1BundlePatchRow>(result);
 


### PR DESCRIPTION
## Summary

- replace Cloudflare D1 `IN (?, ?, ...)` expansion with `IN (SELECT value FROM json_each(?))`
- apply the same fix to CLI-side `d1Database` and Worker runtime `d1Database`
- add shared regression coverage for 200-bundle pages and 200 compatible target app versions
- add Worker runtime-specific D1 binding coverage for the same bind-cap failure mode

## Root cause

Cloudflare D1 caps prepared statements at 100 bound parameters. The Cloudflare database plugins expanded `id.in`, `targetAppVersionIn`, and patch bundle-id lookups into one bound parameter per value, so sufficiently large update-check or bundle-list queries could fail with `D1_ERROR: too many SQL variables ... SQLITE_ERROR`.

This keeps values bound, but binds each list as a single JSON array and lets SQLite expand it through `json_each(?)`.

Closes #1034.
Supersedes #1035.

Co-authored-by: KeyEu <key.eu@datium.xyz>

## Validation

- `pnpm -w lint`
- `pnpm --filter @hot-updater/cloudflare test:type`
- `pnpm --filter @hot-updater/test-utils test:type`
- `pnpm exec vitest run plugins/cloudflare/src/d1Database.spec.ts plugins/cloudflare/src/cloudflareWorkerDatabase.spec.ts --reporter=dot`