### PR TITLE
Enable private console deployment

### DIFF
--- a/.changeset/quiet-pumas-serve.md
+++ b/.changeset/quiet-pumas-serve.md
@@ -1,0 +1,9 @@
+---
+"@hot-updater/cli-tools": minor
+"@hot-updater/console": minor
+"hot-updater": minor
+---
+
+Add an experimental private console deployment path with explicit config-file
+loading, a `hot-updater-console` Node serve bin, and `hot-updater console`
+host/port/config/public binding options.

--- a/docs/content/docs/guides/console.mdx
+++ b/docs/content/docs/guides/console.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Console (Rollback & Force Update)"
-description: "Opens a localhost server based on plugins configured in `hot-updater.config.ts`. For security reasons, only localhost server is supported at the moment."
+description: "Opens a console server based on plugins configured in `hot-updater.config.ts`."
 icon: Terminal
 ---
 
@@ -46,6 +46,21 @@ Execute the following command:
 ```package-install
 npx hot-updater console
 ```
+
+The command binds to `127.0.0.1` by default. You can override the local server
+settings when running the console in a private environment:
+
+```bash
+npx hot-updater console --host 127.0.0.1 --port 1422
+npx hot-updater console --public --config /app/hot-updater.config.ts
+```
+
+<Callout type="warn">
+The console does not include built-in authentication. When exposing it outside
+your machine, protect the whole console origin with Cloudflare Access,
+oauth2-proxy, nginx Basic Auth, Tailscale, or an equivalent private access
+layer. See [Deploy Console Privately](/docs/guides/deploy-console-privately).
+</Callout>
 
 You can also use the bundle CLI for automation and CI scripts:
 

--- a/docs/content/docs/guides/deploy-console-privately.mdx
+++ b/docs/content/docs/guides/deploy-console-privately.mdx
@@ -1,0 +1,125 @@
+---
+title: "Deploy Console Privately"
+description: "Run the Hot Updater console on a private Node server behind external authentication."
+icon: Shield
+---
+
+<Callout type="warn">
+This is experimental. The console intentionally does not include users,
+passwords, sessions, RBAC, or audit logs. Put an external access layer in front
+of the entire console origin before exposing it to a network.
+</Callout>
+
+## Deployment model
+
+`@hot-updater/console` can run as a Node server. The server reads the same
+`hot-updater.config.ts` shape used by the CLI, so your container must include:
+
+- `@hot-updater/console`
+- `hot-updater`
+- the provider packages used by your config
+- the `hot-updater.config.ts` file
+- provider secrets injected as environment variables
+
+Authentication stays outside the console. Use Cloudflare Access, oauth2-proxy,
+nginx Basic Auth, Tailscale, or another private network/access proxy.
+
+Protect the whole origin, not only visible HTML routes. The generated server
+also serves framework action/function routes used by the UI.
+
+## Server command
+
+Run the package bin directly:
+
+```bash
+HOT_UPDATER_CONFIG_PATH=/app/hot-updater.config.ts \
+HOST=127.0.0.1 \
+PORT=1422 \
+npx hot-updater-console
+```
+
+The bin accepts the same runtime flags:
+
+```bash
+npx hot-updater-console --host 127.0.0.1 --port 1422 --config /app/hot-updater.config.ts
+```
+
+Use `HOST=0.0.0.0` only when another private access layer is the only published
+entrypoint.
+
+## CLI command
+
+The `hot-updater` CLI can start the console with explicit deployment settings:
+
+```bash
+npx hot-updater console --host 127.0.0.1 --port 1422 --config ./hot-updater.config.ts
+```
+
+For a container behind an auth proxy:
+
+```bash
+npx hot-updater console --public --config /app/hot-updater.config.ts
+```
+
+`--public` binds the server to `0.0.0.0` and prints a warning that external
+authentication is required.
+
+## Docker with nginx Basic Auth
+
+The repository includes a minimal Compose example at
+`examples-server/private-console-docker`.
+
+```bash
+cd examples-server/private-console-docker
+docker compose up --build
+```
+
+The example publishes nginx on `http://localhost:1422` and keeps the console
+service on the private Compose network. The sample Basic Auth credentials are
+`admin` / `changeme`; replace `.htpasswd` before using this pattern.
+
+```yaml title="docker-compose.yml"
+services:
+  console:
+    build:
+      context: ../..
+      dockerfile: examples-server/private-console-docker/Dockerfile
+    environment:
+      HOST: 0.0.0.0
+      PORT: 1422
+      HOT_UPDATER_CONFIG_PATH: /app/hot-updater.config.ts
+    expose:
+      - "1422"
+
+  nginx:
+    image: nginx:1.27-alpine
+    depends_on:
+      - console
+    ports:
+      - "1422:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./.htpasswd:/etc/nginx/.htpasswd:ro
+```
+
+## Provider secrets
+
+Keep secrets out of the image. Inject them at runtime and read them from
+`hot-updater.config.ts`.
+
+```bash
+docker run \
+  -e HOT_UPDATER_CONFIG_PATH=/app/hot-updater.config.ts \
+  -e CLOUDFLARE_ACCOUNT_ID=... \
+  -e CLOUDFLARE_API_TOKEN=... \
+  -p 1422:1422 \
+  your-console-image
+```
+
+## Operational checklist
+
+- Publish only the external access proxy.
+- Keep `hot-updater.config.ts` and provider secrets on the server side.
+- Rotate provider tokens as you would for CLI deployment credentials.
+- Use HTTPS at the access proxy.
+- Avoid path-only auth rules; protect the entire console origin.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -8,6 +8,7 @@
     "bundle-diffing",
     "rollout-cohorts",
     "console",
+    "deploy-console-privately",
     "ai-agents",
     "simulator-test",
     "channel-management",

--- a/examples-server/private-console-docker/.htpasswd
+++ b/examples-server/private-console-docker/.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$WUtjaD3i$/cla6Efy.lU/pYFxsedk3/

--- a/examples-server/private-console-docker/Dockerfile
+++ b/examples-server/private-console-docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-slim AS builder
+
+WORKDIR /repo
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages ./packages
+COPY plugins ./plugins
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @hot-updater/cli-tools build
+RUN pnpm --filter hot-updater build
+RUN pnpm --filter @hot-updater/console build
+
+FROM node:22-slim
+
+WORKDIR /repo
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=1422
+ENV HOT_UPDATER_CONFIG_PATH=/app/hot-updater.config.ts
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages ./packages
+COPY plugins ./plugins
+COPY --from=builder /repo/packages/cli-tools/dist ./packages/cli-tools/dist
+COPY --from=builder /repo/packages/hot-updater/dist ./packages/hot-updater/dist
+COPY --from=builder /repo/packages/console/.output ./packages/console/.output
+COPY examples-server/private-console-docker/hot-updater.config.ts /app/hot-updater.config.ts
+
+RUN pnpm install --prod --frozen-lockfile
+
+EXPOSE 1422
+
+CMD ["node", "packages/console/bin/serve.mjs"]

--- a/examples-server/private-console-docker/README.md
+++ b/examples-server/private-console-docker/README.md
@@ -1,0 +1,16 @@
+# Private Console Docker
+
+Experimental Docker Compose example for running `@hot-updater/console` behind
+an external authentication layer.
+
+- `console` runs the Node console server on the private Compose network.
+- `nginx` is the only service published to the host and applies Basic Auth.
+- The example password is `admin` / `changeme`; replace `.htpasswd` before use.
+- Replace `hot-updater.config.ts` with your real provider configuration and
+  inject provider secrets through environment variables.
+
+```bash
+docker compose up --build
+```
+
+Open `http://localhost:1422` and authenticate through nginx.

--- a/examples-server/private-console-docker/docker-compose.yml
+++ b/examples-server/private-console-docker/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  console:
+    build:
+      context: ../..
+      dockerfile: examples-server/private-console-docker/Dockerfile
+    environment:
+      HOST: 0.0.0.0
+      PORT: 1422
+      HOT_UPDATER_CONFIG_PATH: /app/hot-updater.config.ts
+    expose:
+      - "1422"
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    depends_on:
+      - console
+    ports:
+      - "1422:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./.htpasswd:/etc/nginx/.htpasswd:ro
+    restart: unless-stopped

--- a/examples-server/private-console-docker/hot-updater.config.ts
+++ b/examples-server/private-console-docker/hot-updater.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "hot-updater";
+
+export default defineConfig({
+  console: {
+    gitUrl: process.env.GIT_URL,
+  },
+  build: async () => null,
+  storage: () => {
+    throw new Error("Configure the storage provider for this deployment.");
+  },
+  database: () => {
+    throw new Error("Configure the database provider for this deployment.");
+  },
+});

--- a/examples-server/private-console-docker/nginx.conf
+++ b/examples-server/private-console-docker/nginx.conf
@@ -1,0 +1,16 @@
+server {
+  listen 80;
+  server_name _;
+
+  auth_basic "Hot Updater Console";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+
+  location / {
+    proxy_pass http://console:1422;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/examples-server/private-console-docker/private-console-docker.integration.spec.ts
+++ b/examples-server/private-console-docker/private-console-docker.integration.spec.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const projectRoot = path.resolve(__dirname);
+const hasDockerCompose =
+  spawnSync("docker", ["compose", "version", "--short"], {
+    stdio: "ignore",
+  }).status === 0;
+
+describe("private console Docker example", () => {
+  (hasDockerCompose ? it : it.skip)(
+    "renders a valid Compose config with nginx auth in front of the console",
+    async () => {
+      const result = spawnSync("docker", ["compose", "config"], {
+        cwd: projectRoot,
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("console:");
+      expect(result.stdout).toContain("nginx:");
+      expect(result.stdout).toContain("/etc/nginx/.htpasswd");
+      expect(result.stdout).toContain("HOT_UPDATER_CONFIG_PATH");
+      expect(
+        fs.readFileSync(path.join(projectRoot, "nginx.conf"), "utf8"),
+      ).toContain("auth_basic_user_file");
+    },
+  );
+});

--- a/packages/cli-tools/src/loadConfig.spec.ts
+++ b/packages/cli-tools/src/loadConfig.spec.ts
@@ -30,6 +30,7 @@ describe("loadConfig", () => {
 
   afterEach(async () => {
     await fs.rm(projectRoot, { recursive: true, force: true });
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -118,6 +119,119 @@ describe("loadConfig", () => {
     const config = await loadConfig(null);
 
     expect(config.releaseChannel).toBe("from-null-context");
+  });
+
+  it("loads an explicit config path outside the current working directory", async () => {
+    const configRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-explicit-config-"),
+    );
+    await writeProjectFile(
+      configRoot,
+      "custom.hot-updater.config.ts",
+      [
+        "export default {",
+        "  releaseChannel: 'from-explicit-config',",
+        "  console: {",
+        "    port: 4123,",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const { loadConfig } = await import("./loadConfig");
+      const config = await loadConfig(null, {
+        configPath: path.join(configRoot, "custom.hot-updater.config.ts"),
+      });
+
+      expect(config.releaseChannel).toBe("from-explicit-config");
+      expect(config.console.port).toBe(4123);
+    } finally {
+      await fs.rm(configRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("loads the config path from HOT_UPDATER_CONFIG_PATH", async () => {
+    const configRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-env-config-"),
+    );
+    await writeProjectFile(
+      configRoot,
+      "private-console.config.ts",
+      [
+        "export default {",
+        "  releaseChannel: 'from-env-config',",
+        "  console: {",
+        "    port: 5123,",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    vi.stubEnv(
+      "HOT_UPDATER_CONFIG_PATH",
+      path.join(configRoot, "private-console.config.ts"),
+    );
+
+    try {
+      const { loadConfig } = await import("./loadConfig");
+      const config = await loadConfig(null);
+
+      expect(config.releaseChannel).toBe("from-env-config");
+      expect(config.console.port).toBe(5123);
+    } finally {
+      await fs.rm(configRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers an explicit config path over HOT_UPDATER_CONFIG_PATH", async () => {
+    const envConfigRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-env-precedence-"),
+    );
+    const explicitConfigRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-explicit-precedence-"),
+    );
+    await writeProjectFile(
+      envConfigRoot,
+      "hot-updater.config.ts",
+      "export default { releaseChannel: 'from-env-config' };\n",
+    );
+    await writeProjectFile(
+      explicitConfigRoot,
+      "hot-updater.config.ts",
+      "export default { releaseChannel: 'from-explicit-config' };\n",
+    );
+    vi.stubEnv(
+      "HOT_UPDATER_CONFIG_PATH",
+      path.join(envConfigRoot, "hot-updater.config.ts"),
+    );
+
+    try {
+      const { loadConfig } = await import("./loadConfig");
+      const config = await loadConfig(null, {
+        configPath: path.join(explicitConfigRoot, "hot-updater.config.ts"),
+      });
+
+      expect(config.releaseChannel).toBe("from-explicit-config");
+    } finally {
+      await Promise.all([
+        fs.rm(envConfigRoot, { recursive: true, force: true }),
+        fs.rm(explicitConfigRoot, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("includes the missing explicit config path in the error message", async () => {
+    const missingConfigPath = path.join(
+      projectRoot,
+      "missing-hot-updater.config.ts",
+    );
+    const { loadConfig } = await import("./loadConfig");
+
+    await expect(
+      loadConfig(null, { configPath: missingConfigPath }),
+    ).rejects.toThrow(missingConfigPath);
   });
 
   it("preserves legacy merge semantics for arrays in user config", async () => {

--- a/packages/cli-tools/src/loadConfig.ts
+++ b/packages/cli-tools/src/loadConfig.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises";
 import path from "path";
 
 import type {
@@ -16,12 +17,17 @@ export type HotUpdaterConfigOptions = {
   channel: string;
 } | null;
 
-const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
+export type LoadHotUpdaterConfigRuntimeOptions = {
+  configPath?: string;
+  cwd?: string;
+};
+
+const getDefaultPlatformConfig = (cwd: string): ConfigInput["platform"] => {
   // Find actual Info.plist files in the ios directory
   let infoPlistPaths: string[] = []; // fallback
   try {
     const plistFiles = fg.sync("**/Info.plist", {
-      cwd: path.join(getCwd(), "ios"),
+      cwd: path.join(cwd, "ios"),
       absolute: false,
       onlyFiles: true,
       ignore: [
@@ -45,7 +51,7 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
   let androidManifestPaths: string[] = []; // fallback
   try {
     const manifestFiles = fg.sync(path.join("**", "AndroidManifest.xml"), {
-      cwd: path.join(getCwd(), "android"),
+      cwd: path.join(cwd, "android"),
       absolute: false,
       onlyFiles: true,
       ignore: ["**/build/**", "**/.gradle/**"],
@@ -65,7 +71,7 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
   let stringResourcePaths: string[] = []; // fallback
   try {
     const stringsFiles = fg.sync(path.join("**", "strings.xml"), {
-      cwd: path.join(getCwd(), "android"),
+      cwd: path.join(cwd, "android"),
       absolute: false,
       onlyFiles: true,
     });
@@ -91,7 +97,7 @@ const getDefaultPlatformConfig = (): ConfigInput["platform"] => {
   };
 };
 
-const getDefaultConfig = (): ConfigInput => {
+const getDefaultConfig = (cwd: string): ConfigInput => {
   return {
     cacheDir: path.join("node_modules", ".hot-updater"),
     releaseChannel: "production",
@@ -107,7 +113,7 @@ const getDefaultConfig = (): ConfigInput => {
     console: {
       port: 1422,
     },
-    platform: getDefaultPlatformConfig(),
+    platform: getDefaultPlatformConfig(cwd),
     nativeBuild: { android: {}, ios: {} },
     build: () => {
       throw new Error("build plugin is required");
@@ -134,17 +140,23 @@ const mergeConfigSources = (
 
 const getConfigLoaderOptions = (
   options: HotUpdaterConfigOptions,
+  runtimeOptions: Required<LoadHotUpdaterConfigRuntimeOptions>,
 ): LoadConfigOptions<ConfigInput> => {
-  const cwd = getCwd();
+  const configExtension = path.extname(runtimeOptions.configPath);
+  const configBasename = configExtension
+    ? path.basename(runtimeOptions.configPath, configExtension)
+    : undefined;
 
   return {
-    cwd,
-    stopAt: path.dirname(cwd),
+    cwd: runtimeOptions.cwd,
+    stopAt: path.dirname(runtimeOptions.cwd),
     merge: false,
     sources: [
       {
-        files: "hot-updater.config",
-        extensions: ["js", "cjs", "ts", "cts", "mjs", "mts"],
+        files: configBasename ?? "hot-updater.config",
+        extensions: configExtension
+          ? [configExtension.slice(1)]
+          : ["js", "cjs", "ts", "cts", "mjs", "mts"],
         rewrite: async (config: unknown) => {
           return typeof config === "function"
             ? (config as (options: HotUpdaterConfigOptions) => ConfigInput)(
@@ -157,12 +169,57 @@ const getConfigLoaderOptions = (
   };
 };
 
+const resolveExplicitConfigPath = async (
+  configPath: string,
+): Promise<string> => {
+  const resolvedPath = path.resolve(configPath);
+
+  try {
+    const stats = await fs.stat(resolvedPath);
+    if (!stats.isFile()) {
+      throw new Error(`Hot Updater config path is not a file: ${resolvedPath}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(resolvedPath)) {
+      throw error;
+    }
+    throw new Error(`Hot Updater config path does not exist: ${resolvedPath}`);
+  }
+
+  return resolvedPath;
+};
+
+const resolveRuntimeOptions = async (
+  runtimeOptions?: LoadHotUpdaterConfigRuntimeOptions,
+): Promise<Required<LoadHotUpdaterConfigRuntimeOptions>> => {
+  const explicitConfigPath =
+    runtimeOptions?.configPath ?? process.env["HOT_UPDATER_CONFIG_PATH"];
+
+  if (explicitConfigPath) {
+    const configPath = await resolveExplicitConfigPath(explicitConfigPath);
+    return {
+      configPath,
+      cwd: runtimeOptions?.cwd ?? path.dirname(configPath),
+    };
+  }
+
+  return {
+    configPath: "",
+    cwd: runtimeOptions?.cwd ?? getCwd(),
+  };
+};
+
 export const loadConfig = async (
   options: HotUpdaterConfigOptions,
+  runtimeOptions?: LoadHotUpdaterConfigRuntimeOptions,
 ): Promise<ConfigResponse> => {
+  const resolvedRuntimeOptions = await resolveRuntimeOptions(runtimeOptions);
   const { config } = await loadUnconfig<ConfigInput>(
-    getConfigLoaderOptions(options),
+    getConfigLoaderOptions(options, resolvedRuntimeOptions),
   );
 
-  return mergeConfigSources(config, getDefaultConfig()) as ConfigResponse;
+  return mergeConfigSources(
+    config,
+    getDefaultConfig(resolvedRuntimeOptions.cwd),
+  ) as ConfigResponse;
 };

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -59,6 +59,22 @@ pnpm test:type
 
 The console will be available at `http://localhost:3000`.
 
+## 🚢 Private Node Deployment
+
+After building the package, run the Node server entrypoint:
+
+```bash
+HOT_UPDATER_CONFIG_PATH=/app/hot-updater.config.ts \
+HOST=127.0.0.1 \
+PORT=1422 \
+npx hot-updater-console
+```
+
+Use `--host`, `--port`, and `--config` for explicit runtime settings. The
+console does not include built-in authentication; protect the whole origin with
+Cloudflare Access, oauth2-proxy, nginx Basic Auth, Tailscale, or another
+private access layer before exposing it.
+
 ## 📁 Project Structure
 
 ```

--- a/packages/console/bin/serve.mjs
+++ b/packages/console/bin/serve.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = "1422";
+
+const printHelp = () => {
+  console.log(`Usage: hot-updater-console [options]
+
+Run the Hot Updater console server.
+
+Options:
+  --host <host>     Host to bind the console server (default: 127.0.0.1)
+  --port <port>     Port to bind the console server (default: 1422)
+  --config <path>   Path to hot-updater.config file
+  -h, --help        Display help`);
+};
+
+const readValue = (args, index, option) => {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+};
+
+const parseArgs = (args) => {
+  const options = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "-h" || arg === "--help") {
+      return { help: true };
+    }
+
+    if (arg === "--host") {
+      options.host = readValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("--host=")) {
+      options.host = arg.slice("--host=".length);
+      continue;
+    }
+
+    if (arg === "--port") {
+      options.port = readValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("--port=")) {
+      options.port = arg.slice("--port=".length);
+      continue;
+    }
+
+    if (arg === "--config") {
+      options.configPath = readValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("--config=")) {
+      options.configPath = arg.slice("--config=".length);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+};
+
+const resolveConfigPath = async (configPath) => {
+  if (!configPath) {
+    return undefined;
+  }
+
+  const resolvedPath = path.resolve(configPath);
+  try {
+    const stats = await fs.stat(resolvedPath);
+    if (!stats.isFile()) {
+      throw new Error(`Config path is not a file: ${resolvedPath}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(resolvedPath)) {
+      throw error;
+    }
+    throw new Error(`Config path does not exist: ${resolvedPath}`);
+  }
+
+  return resolvedPath;
+};
+
+const isLoopbackHost = (host) =>
+  host === "127.0.0.1" || host === "localhost" || host === "::1";
+
+let options;
+try {
+  options = parseArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, "..", ".output", "server", "index.mjs");
+const host = options.host ?? process.env.HOST ?? process.env.NITRO_HOST ?? DEFAULT_HOST;
+const port = options.port ?? process.env.PORT ?? process.env.NITRO_PORT ?? DEFAULT_PORT;
+const configPath = await resolveConfigPath(
+  options.configPath ?? process.env.HOT_UPDATER_CONFIG_PATH,
+);
+
+if (configPath) {
+  process.env.HOT_UPDATER_CONFIG_PATH = configPath;
+}
+process.env.HOST = host;
+process.env.NITRO_HOST = host;
+process.env.PORT = port;
+process.env.NITRO_PORT = port;
+
+const authMessage = isLoopbackHost(host)
+  ? ""
+  : " Protect this origin with external authentication.";
+console.log(
+  `Hot Updater console listening on http://${host}:${port}.${authMessage}`,
+);
+
+await import(pathToFileURL(serverPath).href);

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -4,8 +4,12 @@
   "version": "0.32.0",
   "files": [
     ".output",
+    "bin",
     "package.json"
   ],
+  "bin": {
+    "hot-updater-console": "./bin/serve.mjs"
+  },
   "exports": {
     "./package.json": "./package.json"
   },

--- a/packages/console/src/lib/server/serve-bin.spec.ts
+++ b/packages/console/src/lib/server/serve-bin.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workspaceRoot = path.resolve(__dirname, "..", "..", "..");
+const serveBinPath = path.join(workspaceRoot, "bin", "serve.mjs");
+
+describe("hot-updater-console serve bin", () => {
+  it("prints host port and config options in help output", () => {
+    const result = spawnSync("node", [serveBinPath, "--help"], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--host");
+    expect(result.stdout).toContain("--port");
+    expect(result.stdout).toContain("--config");
+  });
+
+  it("reports a missing config path before importing the server", () => {
+    const missingConfigPath = path.join(
+      workspaceRoot,
+      "missing-hot-updater.config.ts",
+    );
+    const result = spawnSync(
+      "node",
+      [serveBinPath, "--config", missingConfigPath],
+      {
+        cwd: workspaceRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(missingConfigPath);
+  });
+});

--- a/packages/hot-updater/src/commands/console-bin.integration.spec.ts
+++ b/packages/hot-updater/src/commands/console-bin.integration.spec.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import {
+  type RuntimeChild,
+  findOpenPort,
+  formatRuntimeLogs,
+  spawnRuntime,
+  stopRuntime,
+  waitForHttpOk,
+} from "@hot-updater/test-utils/node";
+import { afterEach, describe, expect, it } from "vitest";
+
+const workspaceRoot = path.resolve(__dirname, "..", "..", "..", "..");
+const consoleRoot = path.join(workspaceRoot, "packages", "console");
+const serveBinPath = path.join(consoleRoot, "bin", "serve.mjs");
+const configPath = path.join(consoleRoot, "hot-updater.config.ts");
+
+let child: RuntimeChild | null = null;
+
+describe("hot-updater-console serve bin integration", () => {
+  afterEach(async () => {
+    if (child) {
+      await stopRuntime(child);
+      child = null;
+    }
+  });
+
+  it("serves the built console over HTTP", async () => {
+    const port = await findOpenPort();
+    const runtime = spawnRuntime({
+      command: "node",
+      args: [
+        serveBinPath,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        port.toString(),
+        "--config",
+        configPath,
+      ],
+      cwd: consoleRoot,
+    });
+    child = runtime.child;
+
+    await waitForHttpOk({
+      child: runtime.child,
+      logs: runtime.logs,
+      url: `http://127.0.0.1:${port}`,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}`);
+    const html = await response.text();
+
+    expect(response.ok, formatRuntimeLogs(runtime.logs)).toBe(true);
+    expect(html).toContain("<html");
+    expect(html).toContain("Hot Updater");
+  });
+
+  it("reports a clear error when startup cannot proceed", () => {
+    const missingConfigPath = path.join(
+      consoleRoot,
+      "missing-hot-updater.config.ts",
+    );
+    const result = spawnSync(
+      "node",
+      [serveBinPath, "--config", missingConfigPath],
+      {
+        cwd: consoleRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(missingConfigPath);
+  });
+});

--- a/packages/hot-updater/src/commands/console.spec.ts
+++ b/packages/hot-updater/src/commands/console.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isConsoleServerReady, waitForConsoleReady } from "./console";
+import {
+  isConsoleServerReady,
+  resolveConsoleLaunchOptions,
+  waitForConsoleReady,
+} from "./console";
 
 describe("isConsoleServerReady", () => {
   afterEach(() => {
@@ -81,5 +85,41 @@ describe("waitForConsoleReady", () => {
         checkReady: vi.fn().mockResolvedValue(false),
       }),
     ).rejects.toThrow("Timed out waiting for the console server on port 3000.");
+  });
+});
+
+describe("resolveConsoleLaunchOptions", () => {
+  it("passes host port and config to the console process", async () => {
+    await expect(
+      resolveConsoleLaunchOptions(
+        {
+          host: "127.0.0.1",
+          port: 4122,
+          config: "/tmp/hot-updater.config.ts",
+        },
+        { console: { gitUrl: "", port: 1422 } },
+      ),
+    ).resolves.toEqual({
+      configPath: "/tmp/hot-updater.config.ts",
+      host: "127.0.0.1",
+      port: 4122,
+      shouldWarnExternalAuth: false,
+    });
+  });
+
+  it("resolves public mode to host 0.0.0.0 and warns about external auth", async () => {
+    await expect(
+      resolveConsoleLaunchOptions(
+        {
+          public: true,
+        },
+        { console: { gitUrl: "", port: 1422 } },
+      ),
+    ).resolves.toEqual({
+      configPath: undefined,
+      host: "0.0.0.0",
+      port: 1422,
+      shouldWarnExternalAuth: true,
+    });
   });
 });

--- a/packages/hot-updater/src/commands/console.ts
+++ b/packages/hot-updater/src/commands/console.ts
@@ -23,6 +23,20 @@ type WaitForConsoleReadyOptions = {
   sleep?: (ms: number) => Promise<unknown>;
 };
 
+export type ConsoleCommandOptions = {
+  config?: string;
+  host?: string;
+  port?: number;
+  public?: boolean;
+};
+
+export type ConsoleLaunchOptions = {
+  configPath?: string;
+  host?: string;
+  port: number;
+  shouldWarnExternalAuth: boolean;
+};
+
 const getConsoleServerUrl = (port: number) => `http://127.0.0.1:${port}`;
 
 export const isConsoleServerReady = async (port: number) => {
@@ -74,34 +88,62 @@ export const waitForConsoleReady = async ({
   throw new Error(`Timed out waiting for the console server on port ${port}.`);
 };
 
-export const getConsolePort = async (config?: ConfigResponse) => {
+export const getConsolePort = async (
+  config?: Pick<ConfigResponse, "console">,
+  configPath?: string,
+) => {
   if (config?.console.port) {
     return config.console.port;
   }
 
-  const $config = await loadConfig(null);
+  const $config = await loadConfig(null, { configPath });
   return $config.console.port;
 };
 
+export const resolveConsoleLaunchOptions = async (
+  options: ConsoleCommandOptions,
+  config?: Pick<ConfigResponse, "console">,
+): Promise<ConsoleLaunchOptions> => {
+  const host = options.public ? "0.0.0.0" : (options.host ?? "127.0.0.1");
+  const shouldWarnExternalAuth =
+    options.public === true || host === "0.0.0.0" || host === "::";
+
+  return {
+    configPath: options.config,
+    host,
+    port: options.port ?? (await getConsolePort(config, options.config)),
+    shouldWarnExternalAuth,
+  };
+};
+
 export const openConsole = async (
-  port: number,
+  options: number | ConsoleLaunchOptions,
   listeningListener?: ((info: { port: number }) => void) | undefined,
 ) => {
+  const launchOptions: ConsoleLaunchOptions =
+    typeof options === "number"
+      ? {
+          port: options,
+          host: "127.0.0.1",
+          shouldWarnExternalAuth: false,
+        }
+      : options;
   const require = createRequire(import.meta.url);
   const consolePkgPath = require.resolve("@hot-updater/console/package.json");
   const consoleDir = path.dirname(consolePkgPath);
-  const nitroServerPath = path.join(
-    consoleDir,
-    ".output",
-    "server",
-    "index.mjs",
-  );
+  const serveBinPath = path.join(consoleDir, "bin", "serve.mjs");
+  const serveArgs = [
+    serveBinPath,
+    "--host",
+    launchOptions.host ?? "127.0.0.1",
+    "--port",
+    launchOptions.port.toString(),
+    ...(launchOptions.configPath ? ["--config", launchOptions.configPath] : []),
+  ];
 
-  const child = execa("node", [nitroServerPath], {
+  const child = execa("node", serveArgs, {
     env: {
       ...process.env,
-      PORT: port.toString(),
-      NITRO_PORT: port.toString(),
     },
     stdin: "inherit",
     stdout: "inherit",
@@ -144,8 +186,8 @@ export const openConsole = async (
   });
 
   try {
-    await waitForConsoleReady({ child, port });
-    listeningListener?.({ port });
+    await waitForConsoleReady({ child, port: launchOptions.port });
+    listeningListener?.({ port: launchOptions.port });
   } catch (error) {
     cleanupProcessListeners();
     stopChild("SIGTERM");

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -21,7 +21,11 @@ import {
 } from "@/commandOptions";
 import { handleAppVersion } from "@/commands/appVersion";
 import { buildAndroidNative, buildIosNative } from "@/commands/buildNative";
-import { getConsolePort, openConsole } from "@/commands/console";
+import {
+  type ConsoleCommandOptions,
+  openConsole,
+  resolveConsoleLaunchOptions,
+} from "@/commands/console";
 import {
   type DeployOptions,
   deploy,
@@ -70,6 +74,14 @@ const parseRolloutCohortCount = (value: string) => {
     throw new InvalidArgumentError("must be an integer between 0 and 1000");
   }
   return count;
+};
+
+const parsePortOption = (value: string) => {
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new InvalidArgumentError("must be an integer between 1 and 65535");
+  }
+  return port;
 };
 
 const program = new Command();
@@ -363,12 +375,21 @@ program
 program
   .command("console")
   .description("open the console")
-  .action(async () => {
+  .option("--host <host>", "host to bind the console server")
+  .option("--port <port>", "port to bind the console server", parsePortOption)
+  .option("--config <path>", "path to hot-updater.config file")
+  .option("--public", "bind to 0.0.0.0 for externally protected access")
+  .action(async (options: ConsoleCommandOptions) => {
     printBanner();
 
-    const port = await getConsolePort();
+    const launchOptions = await resolveConsoleLaunchOptions(options);
+    if (launchOptions.shouldWarnExternalAuth) {
+      p.log.warn(
+        "Console has no built-in authentication. Put Cloudflare Access, oauth2-proxy, nginx basic auth, Tailscale, or another private access layer in front of it.",
+      );
+    }
 
-    await openConsole(port);
+    await openConsole(launchOptions);
   });
 
 program


### PR DESCRIPTION
## Summary
- add explicit config-path loading through `loadConfig(..., { configPath, cwd })` and `HOT_UPDATER_CONFIG_PATH`
- add the `hot-updater-console` Node serve bin and route `hot-updater console` through host/port/config/public launch options
- document "Deploy Console Privately" with an nginx Basic Auth Docker Compose example and external-auth-only guidance

Refs #540

## Verification
- `pnpm exec vitest run packages/cli-tools/src/loadConfig.spec.ts packages/hot-updater/src/commands/console.spec.ts`
- `pnpm --dir packages/console exec vitest run src/lib/server/serve-bin.spec.ts`
- `pnpm exec vitest run --project=integration:default packages/hot-updater/src/commands/console-bin.integration.spec.ts`
- `pnpm exec vitest run --project=integration:default examples-server/private-console-docker/private-console-docker.integration.spec.ts`
- `pnpm --filter @hot-updater/cli-tools test:type`
- `pnpm --filter @hot-updater/console test:type`
- `pnpm --filter hot-updater test:type` after `@hot-updater/cli-tools` build
- `pnpm --filter @hot-updater/cli-tools build`
- `pnpm --filter hot-updater build`
- `pnpm --dir docs test:type`
- `pnpm --dir docs build`
- `node packages/hot-updater/dist/index.mjs console --help`

## Notes
- The console still has no built-in authentication; the docs and runtime warnings require an external access layer for public binding.
- Full workspace unit/integration suites were not run.
- The Docker image build itself was not run; the Compose example is covered by `docker compose config` smoke.
- Existing local changes in `examples/v0.85.0/hot-updater.config.ts` were left untouched and are not part of this PR.