### PR TITLE
fix(cli-tools): upload brotli assets when copying bundles

### DIFF
--- a/.changeset/bright-bundles-copy.md
+++ b/.changeset/bright-bundles-copy.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/cli-tools": patch
+---
+
+Fix copied bundle promotion to upload Brotli Hermes bundle assets expected by manifest-driven update checks.

--- a/packages/cli-tools/src/promoteBundle.spec.ts
+++ b/packages/cli-tools/src/promoteBundle.spec.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { brotliDecompressSync } from "node:zlib";
 
 import type {
   Bundle,
@@ -372,6 +373,100 @@ describe("createCopiedBundleArchive", () => {
           targetChannel: "beta",
         }),
       ).rejects.toThrow(LEGACY_BUNDLE_ERROR);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("uploads copied Hermes bundle assets with the brotli artifact name", async () => {
+    const { archivePath, cleanup } = await createSourceArchive("zip", {
+      "assets/logo.png": "logo",
+      "index.ios.bundle": "hermes bytecode",
+      "manifest.json": JSON.stringify({
+        bundleId: baseBundle.id,
+        assets: {
+          "assets/logo.png": {
+            fileHash: "logo-hash",
+          },
+          "index.ios.bundle": {
+            fileHash: "bundle-hash",
+          },
+        },
+      }),
+    });
+    const uploadedFiles = new Map<string, string>();
+    const storagePlugin: NodeStoragePlugin = {
+      name: "mockStorage",
+      supportedProtocol: "s3",
+      profiles: {
+        node: {
+          delete: vi.fn(),
+          downloadFile: vi.fn(async (_storageUri, filePath) => {
+            await fs.copyFile(archivePath, filePath);
+          }),
+          exists: vi.fn(async () => false),
+          upload: vi.fn(async (key, filePath) => {
+            const uploadPath = path.join(
+              path.dirname(archivePath),
+              "uploads",
+              key,
+            );
+            const finalPath = path.join(uploadPath, path.basename(filePath));
+            await fs.mkdir(path.dirname(finalPath), { recursive: true });
+            await fs.copyFile(filePath, finalPath);
+            uploadedFiles.set(
+              path.posix.join(key, path.basename(filePath)),
+              finalPath,
+            );
+            return {
+              storageUri: `s3://bucket/${path
+                .relative(
+                  path.join(path.dirname(archivePath), "uploads"),
+                  finalPath,
+                )
+                .split(path.sep)
+                .join("/")}`,
+            };
+          }),
+        },
+      },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(await fs.readFile(archivePath));
+      }),
+    );
+
+    try {
+      const { uploadedStorageUris } = await createCopiedBundleArchive({
+        bundle: baseBundle,
+        config,
+        nextBundleId: "bundle-copy-id",
+        storagePlugin,
+        targetChannel: "beta",
+      });
+
+      expect(uploadedStorageUris).toEqual(
+        expect.arrayContaining([
+          "s3://bucket/bundle-copy-id/files/assets/logo.png",
+          "s3://bucket/bundle-copy-id/files/index.ios.bundle.br",
+        ]),
+      );
+      expect(uploadedStorageUris).not.toContain(
+        "s3://bucket/bundle-copy-id/files/index.ios.bundle",
+      );
+
+      const uploadedBundlePath = uploadedFiles.get(
+        "bundle-copy-id/files/index.ios.bundle.br",
+      );
+      expect(uploadedBundlePath).toBeDefined();
+      expect(
+        brotliDecompressSync(
+          await fs.readFile(uploadedBundlePath as string),
+        ).toString("utf8"),
+      ).toBe("hermes bytecode");
     } finally {
       await cleanup();
     }

--- a/packages/cli-tools/src/promoteBundle.spec.ts
+++ b/packages/cli-tools/src/promoteBundle.spec.ts
@@ -381,14 +381,14 @@ describe("createCopiedBundleArchive", () => {
   it("uploads copied Hermes bundle assets with the brotli artifact name", async () => {
     const { archivePath, cleanup } = await createSourceArchive("zip", {
       "assets/logo.png": "logo",
-      "index.ios.bundle": "hermes bytecode",
+      "main.ios.bundle": "hermes bytecode",
       "manifest.json": JSON.stringify({
         bundleId: baseBundle.id,
         assets: {
           "assets/logo.png": {
             fileHash: "logo-hash",
           },
-          "index.ios.bundle": {
+          "main.ios.bundle": {
             fileHash: "bundle-hash",
           },
         },
@@ -451,15 +451,15 @@ describe("createCopiedBundleArchive", () => {
       expect(uploadedStorageUris).toEqual(
         expect.arrayContaining([
           "s3://bucket/bundle-copy-id/files/assets/logo.png",
-          "s3://bucket/bundle-copy-id/files/index.ios.bundle.br",
+          "s3://bucket/bundle-copy-id/files/main.ios.bundle.br",
         ]),
       );
       expect(uploadedStorageUris).not.toContain(
-        "s3://bucket/bundle-copy-id/files/index.ios.bundle",
+        "s3://bucket/bundle-copy-id/files/main.ios.bundle",
       );
 
       const uploadedBundlePath = uploadedFiles.get(
-        "bundle-copy-id/files/index.ios.bundle.br",
+        "bundle-copy-id/files/main.ios.bundle.br",
       );
       expect(uploadedBundlePath).toBeDefined();
       expect(

--- a/packages/cli-tools/src/promoteBundle.ts
+++ b/packages/cli-tools/src/promoteBundle.ts
@@ -1,8 +1,10 @@
 import crypto from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { createBrotliCompress, brotliDecompressSync } from "node:zlib";
 
 import {
   getManifestFileHash,
@@ -81,6 +83,26 @@ const getRelativeStorageDir = (relativePath: string) => {
 const isBrotliManifestBundleAsset = (relativePath: string) =>
   /(^|\/)index\.[^/]+\.bundle$/.test(relativePath.replace(/\\/g, "/"));
 
+function resolvePreparedUploadPath(rootDir: string, assetPath: string) {
+  const normalizedAssetPath = assetPath.replaceAll("\\", "/");
+  const outputPath = path.resolve(
+    rootDir,
+    "upload-artifacts",
+    `${normalizedAssetPath}.br`,
+  );
+  const relativePath = path.relative(rootDir, outputPath);
+
+  if (
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath) ||
+    normalizedAssetPath.startsWith("/")
+  ) {
+    throw new Error(`Invalid manifest asset path: ${assetPath}`);
+  }
+
+  return outputPath;
+}
+
 async function prepareManifestAssetUploadFile({
   assetPath,
   sourcePath,
@@ -94,10 +116,12 @@ async function prepareManifestAssetUploadFile({
     return sourcePath;
   }
 
-  const uploadPath = path.join(workDir, `${path.basename(assetPath)}.br`);
-  await fs.writeFile(
-    uploadPath,
-    brotliCompressSync(await fs.readFile(sourcePath)),
+  const uploadPath = resolvePreparedUploadPath(workDir, assetPath);
+  await fs.mkdir(path.dirname(uploadPath), { recursive: true });
+  await pipeline(
+    createReadStream(sourcePath),
+    createBrotliCompress(),
+    createWriteStream(uploadPath),
   );
   return uploadPath;
 }

--- a/packages/cli-tools/src/promoteBundle.ts
+++ b/packages/cli-tools/src/promoteBundle.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { brotliDecompressSync } from "node:zlib";
+import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
 
 import {
   getManifestFileHash,
@@ -77,6 +77,30 @@ const getRelativeStorageDir = (relativePath: string) => {
   const dirname = path.posix.dirname(normalized);
   return dirname === "." ? "" : dirname;
 };
+
+const isBrotliManifestBundleAsset = (relativePath: string) =>
+  /(^|\/)index\.[^/]+\.bundle$/.test(relativePath.replace(/\\/g, "/"));
+
+async function prepareManifestAssetUploadFile({
+  assetPath,
+  sourcePath,
+  workDir,
+}: {
+  assetPath: string;
+  sourcePath: string;
+  workDir: string;
+}) {
+  if (!isBrotliManifestBundleAsset(assetPath)) {
+    return sourcePath;
+  }
+
+  const uploadPath = path.join(workDir, `${path.basename(assetPath)}.br`);
+  await fs.writeFile(
+    uploadPath,
+    brotliCompressSync(await fs.readFile(sourcePath)),
+  );
+  return uploadPath;
+}
 
 const replaceStorageUriLeaf = (storageUri: string, nextLeaf: string) => {
   const storageUrl = new URL(storageUri);
@@ -352,9 +376,15 @@ export async function createCopiedBundleArchive({
       const uploadKey = [nextBundleId, "files", relativeDir]
         .filter(Boolean)
         .join("/");
+      const sourcePath = path.join(extractDir, assetPath);
+      const uploadPath = await prepareManifestAssetUploadFile({
+        assetPath,
+        sourcePath,
+        workDir,
+      });
       const assetUpload = await storagePlugin.profiles.node.upload(
         uploadKey,
-        path.join(extractDir, assetPath),
+        uploadPath,
       );
       uploadedStorageUris.push(assetUpload.storageUri);
     }

--- a/packages/cli-tools/src/promoteBundle.ts
+++ b/packages/cli-tools/src/promoteBundle.ts
@@ -80,8 +80,8 @@ const getRelativeStorageDir = (relativePath: string) => {
   return dirname === "." ? "" : dirname;
 };
 
-const isBrotliManifestBundleAsset = (relativePath: string) =>
-  /(^|\/)index\.[^/]+\.bundle$/.test(relativePath.replace(/\\/g, "/"));
+const isBundleAsset = (relativePath: string) =>
+  /(^|\/)[^/]+\.(ios|android)\.bundle$/.test(relativePath.replace(/\\/g, "/"));
 
 function resolvePreparedUploadPath(rootDir: string, assetPath: string) {
   const normalizedAssetPath = assetPath.replaceAll("\\", "/");
@@ -112,7 +112,7 @@ async function prepareManifestAssetUploadFile({
   sourcePath: string;
   workDir: string;
 }) {
-  if (!isBrotliManifestBundleAsset(assetPath)) {
+  if (!isBundleAsset(assetPath)) {
     return sourcePath;
   }
 


### PR DESCRIPTION
## Summary

Fixes copied bundle promotion so Hermes bundle assets are uploaded with the Brotli artifact name expected by manifest-driven update checks.

When `promoteBundle` copies a bundle to another channel, it rewrites the manifest and re-uploads the archive, manifest, and manifest assets. The server resolves `index.<platform>.bundle` changed assets as `index.<platform>.bundle.br` and marks them with `compression: "br"`, matching deploy behavior. Copy promotion previously uploaded the extracted `index.<platform>.bundle` without the `.br` suffix, which left update-check responses pointing at a missing object.

This change Brotli-compresses copied manifest bundle assets before upload and stores them as `index.<platform>.bundle.br`, while leaving the archive and manifest paths unchanged.

## Validation

- `pnpm --filter @hot-updater/core --filter @hot-updater/plugin-core build`
- `pnpm --filter @hot-updater/js build`
- `pnpm exec vitest run packages/cli-tools/src/promoteBundle.spec.ts`
- `pnpm --filter @hot-updater/cli-tools test:type`
- `pnpm exec oxfmt --check packages/cli-tools/src/promoteBundle.ts packages/cli-tools/src/promoteBundle.spec.ts`
