### PR TITLE
fix(console): make selected bundle deletion observable

### DIFF
--- a/packages/console/src/components/features/bundles/BundlesTable.tsx
+++ b/packages/console/src/components/features/bundles/BundlesTable.tsx
@@ -14,7 +14,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { Fragment, useState } from "react";
-import { toast } from "sonner";
 
 import { BundleIdDisplay } from "@/components/BundleIdDisplay";
 import { ChannelBadge } from "@/components/ChannelBadge";
@@ -23,16 +22,6 @@ import { HashValueDisplay } from "@/components/HashValueDisplay";
 import { PlatformIcon } from "@/components/PlatformIcon";
 import { RolloutPercentageBadge } from "@/components/RolloutPercentageBadge";
 import { TimestampDisplay } from "@/components/TimestampDisplay";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -44,16 +33,13 @@ import {
 } from "@/components/ui/table";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useFilterParams } from "@/hooks/useFilterParams";
-import {
-  useBundleChildCountsQuery,
-  useBundleChildrenQuery,
-  useDeleteBundleMutation,
-} from "@/lib/api";
+import { useBundleChildCountsQuery, useBundleChildrenQuery } from "@/lib/api";
 import { DEFAULT_PAGE_LIMIT } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 import { BundleChildrenPanel } from "./BundleChildrenPanel";
 import { createBundleColumns } from "./BundleTableColumns";
+import { SelectedBundlesDeleteDialog } from "./SelectedBundlesDeleteDialog";
 
 interface BundlesTableProps {
   bundles: Bundle[];
@@ -118,7 +104,6 @@ export function BundlesTable({
   const isMobile = useIsMobile();
   const [selectedBundleIds, setSelectedBundleIds] = useState<string[]>([]);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [isDeletingSelected, setIsDeletingSelected] = useState(false);
   const cursorPagination = pagination as CursorPaginationInfo | undefined;
   const bundleIds = bundles.map((bundle) => bundle.id);
   const selectedBundles = bundles.filter((bundle) =>
@@ -130,8 +115,6 @@ export function BundlesTable({
     useBundleChildCountsQuery(bundleIds);
   const { data: childBundles = [], isLoading: isChildBundlesLoading } =
     useBundleChildrenQuery(expandedBundleId ?? "");
-  const deleteBundleMutation = useDeleteBundleMutation();
-  const isDeleting = deleteBundleMutation.isPending || isDeletingSelected;
 
   const bundleColumns = createBundleColumns({
     expandedBundleId,
@@ -187,35 +170,6 @@ export function BundlesTable({
 
   const handleToggleAllBundles = () => {
     setSelectedBundleIds(allBundlesSelected ? [] : bundleIds);
-  };
-
-  const handleDeleteSelected = async () => {
-    if (isDeleting || selectedBundles.length === 0) {
-      return;
-    }
-
-    setIsDeletingSelected(true);
-    try {
-      for (const bundle of selectedBundles) {
-        await deleteBundleMutation.mutateAsync({ bundleId: bundle.id });
-      }
-      toast.success(`${selectedBundles.length} bundles deleted successfully`);
-      setSelectedBundleIds([]);
-      setDeleteDialogOpen(false);
-    } catch (error) {
-      toast.error("Failed to delete selected bundles");
-      console.error(error);
-    } finally {
-      setIsDeletingSelected(false);
-    }
-  };
-
-  const handleDeleteDialogOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && isDeleting) {
-      return;
-    }
-
-    setDeleteDialogOpen(nextOpen);
   };
 
   const startEntry =
@@ -596,40 +550,14 @@ export function BundlesTable({
         </div>
       </div>
 
-      <AlertDialog
+      <SelectedBundlesDeleteDialog
+        bundles={selectedBundles}
         open={deleteDialogOpen}
-        onOpenChange={handleDeleteDialogOpenChange}
-      >
-        <AlertDialogContent
-          onEscapeKeyDown={(event) => {
-            if (isDeleting) {
-              event.preventDefault();
-            }
-          }}
-        >
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete selected bundles?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete{" "}
-              {selectedBundles.length} bundles and remove them from storage.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(event) => {
-                event.preventDefault();
-                void handleDeleteSelected();
-              }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              disabled={isDeleting}
-            >
-              {isDeleting ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={setDeleteDialogOpen}
+        onComplete={({ failedBundleIds }) => {
+          setSelectedBundleIds([...failedBundleIds]);
+        }}
+      />
     </div>
   );
 }

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -1,0 +1,230 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SelectedBundlesDeleteDialog } from "./SelectedBundlesDeleteDialog";
+
+const { mockDeleteBundleMutation, mockToastSuccess, mockToastError } =
+  vi.hoisted(() => ({
+    mockDeleteBundleMutation: {
+      mutateAsync: vi.fn(),
+    },
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+  }));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  useDeleteBundleMutation: () => mockDeleteBundleMutation,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    readonly open: boolean;
+    readonly onOpenChange?: (open: boolean) => void;
+    readonly children: ReactNode;
+  }) =>
+    open ? (
+      <div role="dialog">
+        <button onClick={() => onOpenChange?.(false)}>Dismiss dialog</button>
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { readonly children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { readonly children: ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+function createDeferred<T>() {
+  let resolvePromise: ((value: T | PromiseLike<T>) => void) | undefined;
+  let rejectPromise: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    reject(reason?: unknown) {
+      if (!rejectPromise) {
+        throw new Error("Deferred reject was not initialized");
+      }
+
+      rejectPromise(reason);
+    },
+    resolve(value: T) {
+      if (!resolvePromise) {
+        throw new Error("Deferred resolve was not initialized");
+      }
+
+      resolvePromise(value);
+    },
+  };
+}
+
+const createBundle = (id: string, channel: string): Bundle => ({
+  id,
+  channel,
+  platform: id.endsWith("ios") ? "ios" : "android",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: "abc123",
+  storageUri: "s3://bucket/bundle.zip",
+  gitCommitHash: "deadbeef",
+  message: "Initial message",
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  rolloutCohortCount: 1000,
+  targetCohorts: [],
+});
+
+describe("SelectedBundlesDeleteDialog", () => {
+  const firstBundle = createBundle("bundle-001-ios", "stable");
+  const secondBundle = createBundle("bundle-002-android", "beta");
+  const mockOnOpenChange = vi.fn();
+  const mockOnComplete = vi.fn();
+
+  beforeEach(() => {
+    mockDeleteBundleMutation.mutateAsync.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    mockOnOpenChange.mockReset();
+    mockOnComplete.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows each selected bundle moving from queued to deleted", async () => {
+    const firstDelete = createDeferred<void>();
+    const secondDelete = createDeferred<void>();
+
+    mockDeleteBundleMutation.mutateAsync.mockImplementation(
+      ({ bundleId }: { readonly bundleId: string }) =>
+        bundleId === firstBundle.id
+          ? firstDelete.promise
+          : secondDelete.promise,
+    );
+
+    render(
+      <SelectedBundlesDeleteDialog
+        bundles={[firstBundle, secondBundle]}
+        open
+        onOpenChange={mockOnOpenChange}
+        onComplete={mockOnComplete}
+      />,
+    );
+
+    expect(screen.getAllByText("Queued")).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledWith({
+        bundleId: firstBundle.id,
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss dialog" }));
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+
+    firstDelete.resolve(undefined);
+
+    await waitFor(() => {
+      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledWith({
+        bundleId: secondBundle.id,
+      });
+    });
+
+    expect(screen.getByText("1 of 2 delete requests finished.")).toBeTruthy();
+    expect(screen.getByText("Deleted")).toBeTruthy();
+    expect(screen.getByText("Deleting")).toBeTruthy();
+
+    secondDelete.resolve(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
+    });
+
+    expect(mockOnComplete).toHaveBeenCalledWith({
+      deletedBundleIds: [firstBundle.id, secondBundle.id],
+      failedBundleIds: [],
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "2 bundles deleted successfully",
+    );
+  });
+
+  it("keeps failed bundles actionable and retries only those ids", async () => {
+    mockDeleteBundleMutation.mutateAsync
+      .mockRejectedValueOnce(new Error("storage timeout"))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    render(
+      <SelectedBundlesDeleteDialog
+        bundles={[firstBundle, secondBundle]}
+        open
+        onOpenChange={mockOnOpenChange}
+        onComplete={mockOnComplete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry failed" })).toBeTruthy();
+    });
+
+    expect(screen.getByText("storage timeout")).toBeTruthy();
+    expect(mockOnComplete).toHaveBeenCalledWith({
+      deletedBundleIds: [secondBundle.id],
+      failedBundleIds: [firstBundle.id],
+    });
+    expect(mockToastError).toHaveBeenCalledWith("1 deleted, 1 failed");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry failed" }));
+
+    await waitFor(() => {
+      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+
+    expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenLastCalledWith({
+      bundleId: firstBundle.id,
+    });
+    expect(mockOnComplete).toHaveBeenLastCalledWith({
+      deletedBundleIds: [firstBundle.id],
+      failedBundleIds: [],
+    });
+  });
+});

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -145,7 +145,7 @@ describe("SelectedBundlesDeleteDialog", () => {
       />,
     );
 
-    expect(screen.getAllByText("Queued")).toHaveLength(2);
+    expect(screen.getAllByRole("img", { name: "Queued" })).toHaveLength(2);
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
@@ -167,8 +167,8 @@ describe("SelectedBundlesDeleteDialog", () => {
     });
 
     expect(screen.getByText("1 of 2 delete requests finished.")).toBeTruthy();
-    expect(screen.getByText("Deleted")).toBeTruthy();
-    expect(screen.getByText("Deleting")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Deleted" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Deleting" })).toBeTruthy();
 
     secondDelete.resolve(undefined);
 

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -178,6 +178,9 @@ describe("SelectedBundlesDeleteDialog", () => {
       expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
     });
 
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+
     expect(mockOnComplete).toHaveBeenCalledWith({
       deletedBundleIds: [firstBundle.id, secondBundle.id],
       failedBundleIds: [],

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -145,7 +145,7 @@ describe("SelectedBundlesDeleteDialog", () => {
       />,
     );
 
-    expect(screen.getAllByRole("img", { name: "Queued" })).toHaveLength(2);
+    expect(screen.queryByRole("columnheader", { name: "Status" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
@@ -166,6 +166,8 @@ describe("SelectedBundlesDeleteDialog", () => {
       });
     });
 
+    expect(screen.getByRole("columnheader", { name: "Status" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Queued" })).toBeNull();
     expect(screen.getByText("1 of 2 delete requests finished.")).toBeTruthy();
     expect(screen.getByRole("img", { name: "Deleted" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Deleting" })).toBeTruthy();

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
@@ -1,0 +1,340 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import {
+  CheckCircle2,
+  CircleDashed,
+  LoaderCircle,
+  RotateCcw,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useDeleteBundleMutation } from "@/lib/api";
+
+interface SelectedBundlesDeleteDialogProps {
+  readonly bundles: readonly Bundle[];
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onComplete: (result: DeleteCompletionResult) => void;
+}
+
+interface DeleteCompletionResult {
+  readonly deletedBundleIds: readonly string[];
+  readonly failedBundleIds: readonly string[];
+}
+
+type DeletePhase = "confirming" | "deleting" | "complete";
+type DeleteItemStatus = "queued" | "deleting" | "deleted" | "failed";
+
+interface DeleteItem {
+  readonly bundle: Bundle;
+  readonly status: DeleteItemStatus;
+  readonly message?: string;
+}
+
+const statusLabels = {
+  queued: "Queued",
+  deleting: "Deleting",
+  deleted: "Deleted",
+  failed: "Failed",
+} as const satisfies Record<DeleteItemStatus, string>;
+
+const getDeleteErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "Delete request failed";
+
+const createDeleteItems = (bundles: readonly Bundle[]): DeleteItem[] =>
+  bundles.map((bundle) => ({
+    bundle,
+    status: "queued",
+  }));
+
+function DeleteStatusIcon({ status }: { readonly status: DeleteItemStatus }) {
+  switch (status) {
+    case "queued":
+      return <CircleDashed className="text-muted-foreground" />;
+    case "deleting":
+      return <LoaderCircle className="animate-spin text-primary" />;
+    case "deleted":
+      return <CheckCircle2 className="text-primary" />;
+    case "failed":
+      return <XCircle className="text-destructive" />;
+  }
+}
+
+function DeleteStatusBadge({ status }: { readonly status: DeleteItemStatus }) {
+  switch (status) {
+    case "failed":
+      return <Badge variant="destructive">{statusLabels[status]}</Badge>;
+    case "queued":
+      return <Badge variant="outline">{statusLabels[status]}</Badge>;
+    case "deleting":
+      return <Badge>{statusLabels[status]}</Badge>;
+    case "deleted":
+      return <Badge variant="secondary">{statusLabels[status]}</Badge>;
+  }
+}
+
+export function SelectedBundlesDeleteDialog({
+  bundles,
+  open,
+  onOpenChange,
+  onComplete,
+}: SelectedBundlesDeleteDialogProps) {
+  const deleteBundleMutation = useDeleteBundleMutation();
+  const [phase, setPhase] = useState<DeletePhase>("confirming");
+  const [items, setItems] = useState<DeleteItem[]>(() =>
+    createDeleteItems(bundles),
+  );
+  const isDeleting = phase === "deleting";
+  const totalCount = items.length;
+  const deletedCount = items.filter((item) => item.status === "deleted").length;
+  const failedCount = items.filter((item) => item.status === "failed").length;
+  const activeCount = deletedCount + failedCount;
+  const failedBundleIds = items
+    .filter((item) => item.status === "failed")
+    .map((item) => item.bundle.id);
+  const hasFailures = failedBundleIds.length > 0;
+  const title =
+    phase === "confirming" ? "Delete selected bundles?" : "Deleting bundles";
+  const description =
+    phase === "confirming"
+      ? `This action cannot be undone. This will permanently delete ${bundles.length} bundles and remove them from storage.`
+      : `${activeCount} of ${totalCount} delete requests finished.`;
+  const deleteButtonLabel = useMemo(() => {
+    if (!isDeleting) {
+      return "Delete";
+    }
+
+    const progressIndex = Math.min(activeCount + 1, totalCount);
+
+    return `Deleting ${progressIndex}/${totalCount}`;
+  }, [activeCount, isDeleting, totalCount]);
+
+  useEffect(() => {
+    if (open && phase === "confirming") {
+      setItems(createDeleteItems(bundles));
+    }
+  }, [bundles, open, phase]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isDeleting) {
+      return;
+    }
+
+    onOpenChange(nextOpen);
+
+    if (!nextOpen) {
+      setPhase("confirming");
+      setItems(createDeleteItems(bundles));
+    }
+  };
+
+  const runDeletion = async (bundleIds: readonly string[]) => {
+    if (isDeleting || bundleIds.length === 0) {
+      return;
+    }
+
+    const bundleIdSet = new Set(bundleIds);
+    const deletedBundleIds: string[] = [];
+    const nextFailedBundleIds: string[] = [];
+
+    setPhase("deleting");
+    setItems((currentItems) =>
+      currentItems.map((item) =>
+        bundleIdSet.has(item.bundle.id)
+          ? { bundle: item.bundle, status: "queued" }
+          : item,
+      ),
+    );
+
+    for (const bundleId of bundleIds) {
+      setItems((currentItems) =>
+        currentItems.map((item) =>
+          item.bundle.id === bundleId
+            ? { bundle: item.bundle, status: "deleting" }
+            : item,
+        ),
+      );
+
+      try {
+        await deleteBundleMutation.mutateAsync({ bundleId });
+        deletedBundleIds.push(bundleId);
+        setItems((currentItems) =>
+          currentItems.map((item) =>
+            item.bundle.id === bundleId
+              ? { bundle: item.bundle, status: "deleted" }
+              : item,
+          ),
+        );
+      } catch (error) {
+        nextFailedBundleIds.push(bundleId);
+        setItems((currentItems) =>
+          currentItems.map((item) =>
+            item.bundle.id === bundleId
+              ? {
+                  bundle: item.bundle,
+                  message: getDeleteErrorMessage(error),
+                  status: "failed",
+                }
+              : item,
+          ),
+        );
+      }
+    }
+
+    setPhase("complete");
+    onComplete({ deletedBundleIds, failedBundleIds: nextFailedBundleIds });
+
+    if (nextFailedBundleIds.length > 0) {
+      toast.error(
+        `${deletedBundleIds.length} deleted, ${nextFailedBundleIds.length} failed`,
+      );
+      return;
+    }
+
+    toast.success(`${deletedBundleIds.length} bundles deleted successfully`);
+  };
+
+  const handleDelete = () => {
+    void runDeletion(items.map((item) => item.bundle.id));
+  };
+
+  const handleRetryFailed = () => {
+    void runDeletion(failedBundleIds);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={!isDeleting}
+        className="sm:max-w-lg"
+        onEscapeKeyDown={(event) => {
+          if (isDeleting) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isDeleting) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <Card>
+          <CardHeader className="flex-row items-center justify-between gap-3 p-3">
+            <CardTitle className="flex items-center gap-2 text-xs">
+              <Trash2 className="text-muted-foreground" />
+              Delete log
+            </CardTitle>
+            {phase === "complete" ? (
+              <Badge variant={hasFailures ? "destructive" : "secondary"}>
+                {hasFailures ? `${failedCount} failed` : "Complete"}
+              </Badge>
+            ) : null}
+          </CardHeader>
+          <Separator />
+          <CardContent className="max-h-[42vh] overflow-y-auto p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-36">Status</TableHead>
+                  <TableHead>Bundle</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.bundle.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <DeleteStatusIcon status={item.status} />
+                        <DeleteStatusBadge status={item.status} />
+                      </div>
+                    </TableCell>
+                    <TableCell className="whitespace-normal">
+                      <div className="min-w-0">
+                        <div className="break-all font-mono text-xs text-foreground">
+                          {item.bundle.id}
+                        </div>
+                        <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                          <span>{item.bundle.channel}</span>
+                          <span>{item.bundle.platform}</span>
+                          {item.message ? (
+                            <span className="text-destructive">
+                              {item.message}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <DialogFooter>
+          {phase === "confirming" ? (
+            <>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={totalCount === 0}
+              >
+                <Trash2 data-icon="inline-start" />
+                Delete
+              </Button>
+            </>
+          ) : null}
+          {phase === "deleting" ? (
+            <Button variant="destructive" disabled>
+              <LoaderCircle data-icon="inline-start" className="animate-spin" />
+              {deleteButtonLabel}
+            </Button>
+          ) : null}
+          {phase === "complete" ? (
+            <>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+              {hasFailures ? (
+                <Button onClick={handleRetryFailed}>
+                  <RotateCcw data-icon="inline-start" />
+                  Retry failed
+                </Button>
+              ) : null}
+            </>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
@@ -1,4 +1,5 @@
 import type { Bundle } from "@hot-updater/plugin-core";
+import type { LucideIcon } from "lucide-react";
 import {
   CheckCircle2,
   CircleDashed,
@@ -10,9 +11,8 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -21,7 +21,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Separator } from "@/components/ui/separator";
 import {
   Table,
   TableBody,
@@ -30,6 +29,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDeleteBundleMutation } from "@/lib/api";
 
 interface SelectedBundlesDeleteDialogProps {
@@ -69,30 +73,42 @@ const createDeleteItems = (bundles: readonly Bundle[]): DeleteItem[] =>
     status: "queued",
   }));
 
-function DeleteStatusIcon({ status }: { readonly status: DeleteItemStatus }) {
+function getStatusIcon(status: DeleteItemStatus): {
+  readonly className: string;
+  readonly Icon: LucideIcon;
+} {
   switch (status) {
-    case "queued":
-      return <CircleDashed className="text-muted-foreground" />;
-    case "deleting":
-      return <LoaderCircle className="animate-spin text-primary" />;
-    case "deleted":
-      return <CheckCircle2 className="text-primary" />;
     case "failed":
-      return <XCircle className="text-destructive" />;
+      return { className: "size-3.5 text-destructive", Icon: XCircle };
+    case "queued":
+      return {
+        className: "size-3.5 text-muted-foreground",
+        Icon: CircleDashed,
+      };
+    case "deleting":
+      return {
+        className: "size-3.5 animate-spin text-primary",
+        Icon: LoaderCircle,
+      };
+    case "deleted":
+      return { className: "size-3.5 text-primary", Icon: CheckCircle2 };
   }
 }
 
-function DeleteStatusBadge({ status }: { readonly status: DeleteItemStatus }) {
-  switch (status) {
-    case "failed":
-      return <Badge variant="destructive">{statusLabels[status]}</Badge>;
-    case "queued":
-      return <Badge variant="outline">{statusLabels[status]}</Badge>;
-    case "deleting":
-      return <Badge>{statusLabels[status]}</Badge>;
-    case "deleted":
-      return <Badge variant="secondary">{statusLabels[status]}</Badge>;
-  }
+function DeleteStatusIcon({ status }: { readonly status: DeleteItemStatus }) {
+  const label = statusLabels[status];
+  const { className, Icon } = getStatusIcon(status);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span aria-label={label} role="img">
+          <Icon className={className} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function SelectedBundlesDeleteDialog({
@@ -246,23 +262,11 @@ export function SelectedBundlesDeleteDialog({
         </DialogHeader>
 
         <Card>
-          <CardHeader className="flex-row items-center justify-between gap-3 p-3">
-            <CardTitle className="flex items-center gap-2 text-xs">
-              <Trash2 className="text-muted-foreground" />
-              Delete log
-            </CardTitle>
-            {phase === "complete" ? (
-              <Badge variant={hasFailures ? "destructive" : "secondary"}>
-                {hasFailures ? `${failedCount} failed` : "Complete"}
-              </Badge>
-            ) : null}
-          </CardHeader>
-          <Separator />
-          <CardContent className="max-h-[42vh] overflow-y-auto p-0">
+          <CardContent className="max-h-[50vh] overflow-y-auto p-0">
             <Table>
-              <TableHeader>
+              <TableHeader className="sticky top-0 bg-card">
                 <TableRow>
-                  <TableHead className="w-36">Status</TableHead>
+                  <TableHead className="w-12">Status</TableHead>
                   <TableHead>Bundle</TableHead>
                 </TableRow>
               </TableHeader>
@@ -270,14 +274,11 @@ export function SelectedBundlesDeleteDialog({
                 {items.map((item) => (
                   <TableRow key={item.bundle.id}>
                     <TableCell>
-                      <div className="flex items-center gap-2">
-                        <DeleteStatusIcon status={item.status} />
-                        <DeleteStatusBadge status={item.status} />
-                      </div>
+                      <DeleteStatusIcon status={item.status} />
                     </TableCell>
                     <TableCell className="whitespace-normal">
                       <div className="min-w-0">
-                        <div className="break-all font-mono text-xs text-foreground">
+                        <div className="break-all font-mono text-[11px] text-foreground">
                           {item.bundle.id}
                         </div>
                         <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-[11px] text-muted-foreground">

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
@@ -2,7 +2,6 @@ import type { Bundle } from "@hot-updater/plugin-core";
 import type { LucideIcon } from "lucide-react";
 import {
   CheckCircle2,
-  CircleDashed,
   LoaderCircle,
   RotateCcw,
   Trash2,
@@ -73,18 +72,13 @@ const createDeleteItems = (bundles: readonly Bundle[]): DeleteItem[] =>
     status: "queued",
   }));
 
-function getStatusIcon(status: DeleteItemStatus): {
+function getStatusIcon(status: Exclude<DeleteItemStatus, "queued">): {
   readonly className: string;
   readonly Icon: LucideIcon;
 } {
   switch (status) {
     case "failed":
       return { className: "size-3.5 text-destructive", Icon: XCircle };
-    case "queued":
-      return {
-        className: "size-3.5 text-muted-foreground",
-        Icon: CircleDashed,
-      };
     case "deleting":
       return {
         className: "size-3.5 animate-spin text-primary",
@@ -96,6 +90,10 @@ function getStatusIcon(status: DeleteItemStatus): {
 }
 
 function DeleteStatusIcon({ status }: { readonly status: DeleteItemStatus }) {
+  if (status === "queued") {
+    return null;
+  }
+
   const label = statusLabels[status];
   const { className, Icon } = getStatusIcon(status);
 
@@ -261,43 +259,47 @@ export function SelectedBundlesDeleteDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        <Card>
-          <CardContent className="max-h-[50vh] overflow-y-auto p-0">
-            <Table>
-              <TableHeader className="sticky top-0 bg-card">
-                <TableRow>
-                  <TableHead className="w-12">Status</TableHead>
-                  <TableHead>Bundle</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {items.map((item) => (
-                  <TableRow key={item.bundle.id}>
-                    <TableCell>
-                      <DeleteStatusIcon status={item.status} />
-                    </TableCell>
-                    <TableCell className="whitespace-normal">
-                      <div className="min-w-0">
-                        <div className="break-all font-mono text-[11px] text-foreground">
-                          {item.bundle.id}
-                        </div>
-                        <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                          <span>{item.bundle.channel}</span>
-                          <span>{item.bundle.platform}</span>
-                          {item.message ? (
-                            <span className="text-destructive">
-                              {item.message}
-                            </span>
-                          ) : null}
-                        </div>
-                      </div>
-                    </TableCell>
+        {phase === "confirming" ? null : (
+          <Card>
+            <CardContent className="max-h-[50vh] overflow-y-auto p-0">
+              <Table>
+                <TableHeader className="sticky top-0 bg-card">
+                  <TableRow>
+                    <TableHead className="w-12 text-center">Status</TableHead>
+                    <TableHead>Bundle</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
+                </TableHeader>
+                <TableBody>
+                  {items.map((item) => (
+                    <TableRow key={item.bundle.id}>
+                      <TableCell className="text-center align-middle">
+                        <div className="flex justify-center">
+                          <DeleteStatusIcon status={item.status} />
+                        </div>
+                      </TableCell>
+                      <TableCell className="whitespace-normal">
+                        <div className="min-w-0">
+                          <div className="break-all font-mono text-[11px] text-foreground">
+                            {item.bundle.id}
+                          </div>
+                          <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                            <span>{item.bundle.channel}</span>
+                            <span>{item.bundle.platform}</span>
+                            {item.message ? (
+                              <span className="text-destructive">
+                                {item.message}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
 
         <DialogFooter>
           {phase === "confirming" ? (

--- a/packages/console/src/lib/api.spec.tsx
+++ b/packages/console/src/lib/api.spec.tsx
@@ -4,8 +4,15 @@ import { act, renderHook } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { queryKeys, useUpdateBundleMutation } from "./api";
-import { updateBundle as updateBundleApi } from "./api-rpc";
+import {
+  queryKeys,
+  useDeleteBundleMutation,
+  useUpdateBundleMutation,
+} from "./api";
+import {
+  deleteBundle as deleteBundleApi,
+  updateBundle as updateBundleApi,
+} from "./api-rpc";
 
 vi.mock("./api-rpc", () => ({
   createBundle: vi.fn(),
@@ -34,6 +41,12 @@ const bundle: Bundle = {
   storageUri: "s3://bucket/bundle.zip",
   targetAppVersion: "1.0.0",
   fingerprintHash: null,
+};
+
+const otherBundle: Bundle = {
+  ...bundle,
+  id: "bundle-002",
+  fileHash: "other-hash",
 };
 
 const timeout = (ms: number) =>
@@ -114,6 +127,85 @@ describe("useUpdateBundleMutation", () => {
     expect(invalidateQueries).toHaveBeenCalledTimes(1);
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.bundles.all,
+    });
+  });
+});
+
+describe("useDeleteBundleMutation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("removes a deleted bundle from cached bundle lists", async () => {
+    vi.mocked(deleteBundleApi).mockResolvedValue({
+      success: true,
+    });
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue();
+
+    queryClient.setQueryData(queryKeys.bundle(bundle.id), bundle);
+    queryClient.setQueryData(queryKeys.bundles.list({}), {
+      data: [bundle, otherBundle],
+      pagination: {
+        total: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        currentPage: 1,
+        totalPages: 1,
+      },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDeleteBundleMutation(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        bundleId: bundle.id,
+      });
+    });
+
+    expect(
+      queryClient.getQueryData(queryKeys.bundle(bundle.id)),
+    ).toBeUndefined();
+    expect(queryClient.getQueryData(queryKeys.bundles.list({}))).toEqual({
+      data: [otherBundle],
+      pagination: {
+        total: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        currentPage: 1,
+        totalPages: 1,
+      },
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.bundles.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.bundleChildren.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.channels,
     });
   });
 });

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -69,6 +69,20 @@ function replaceBundleInQueryData(
   };
 }
 
+function removeBundleFromQueryData(
+  data: BundlesQueryData | undefined,
+  bundleId: string,
+) {
+  if (!data) {
+    return data;
+  }
+
+  return {
+    ...data,
+    data: data.data.filter((bundle) => bundle.id !== bundleId),
+  };
+}
+
 const hasOwn = (value: object, key: PropertyKey) =>
   Object.prototype.hasOwnProperty.call(value, key);
 
@@ -236,6 +250,11 @@ export function useDeleteBundleMutation() {
       deleteBundleApi({ data: params }),
     onSuccess: async (_, vars) => {
       queryClient.removeQueries({ queryKey: queryKeys.bundle(vars.bundleId) });
+      queryClient.setQueriesData(
+        { queryKey: queryKeys.bundles.all },
+        (data: BundlesQueryData | undefined) =>
+          removeBundleFromQueryData(data, vars.bundleId),
+      );
 
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.bundles.all }),


### PR DESCRIPTION
## What changed
- Replaced the selected-bundle bulk delete alert with a shadcn-composed progress dialog.
- Shows each selected bundle in a table log with queued, deleting, deleted, and failed states.
- Keeps the modal locked during active deletion, then exposes Close or Retry failed actions after completion.
- Keeps failed bundle IDs selected in the table so users can act on the remaining failures.

## Why
Bulk deletion runs sequentially and can take a long time per bundle. The previous UI only showed a generic pending button, so users could not tell which bundle was being deleted or whether individual items succeeded.

## Validation
- pnpm --filter @hot-updater/console test -- SelectedBundlesDeleteDialog.spec.tsx
- pnpm --filter @hot-updater/console test:type
- pnpm lint
- pnpm --filter @hot-updater/console build
- Browser smoke test at http://localhost:3002/: selected two bundles, opened the delete dialog, completed deletion, and verified the modal showed 2 of 2 finished with both rows marked Deleted and Close available.

## Not tested
- Full workspace pnpm -w test was not run.