### PR TITLE
fix(server): keep update bundle reuse in helpers

### DIFF
--- a/packages/server/src/db/pluginCore.spec.ts
+++ b/packages/server/src/db/pluginCore.spec.ts
@@ -4,6 +4,7 @@ import type {
   DatabasePlugin,
   RequestEnvContext,
 } from "@hot-updater/plugin-core";
+import { createDatabasePluginGetUpdateInfo } from "@hot-updater/plugin-core";
 import { describe, expect, it, vi } from "vitest";
 
 import { createPluginDatabaseCore } from "./pluginCore";
@@ -330,6 +331,202 @@ describe("createPluginDatabaseCore", () => {
     expect(JSON.stringify(updateInfo)).not.toContain(
       "__hotUpdaterCurrentBundle",
     );
+  });
+
+  it("seeds request bundle identity map from provider update lookups", async () => {
+    const targetBundle = {
+      ...baseBundle,
+      id: "00000000-0000-0000-0000-000000000002",
+      fileHash: "hash-2",
+      manifestStorageUri: "s3://bucket/target/manifest.json",
+      manifestFileHash: "sig:target-manifest",
+      assetBaseStorageUri: "s3://bucket/target/files",
+    };
+    const manifests = new Map([
+      [
+        targetBundle.manifestStorageUri,
+        JSON.stringify({
+          bundleId: targetBundle.id,
+          assets: {
+            "index.ios.bundle": {
+              fileHash: "target-bundle-hash",
+            },
+          },
+        }),
+      ],
+    ]);
+    const getBundleById = vi.fn<DatabasePlugin<TestContext>["getBundleById"]>(
+      async () => {
+        throw new Error("unexpected provider bundle reread");
+      },
+    );
+    const getUpdateInfo = createDatabasePluginGetUpdateInfo<TestContext>({
+      getBundlesByFingerprint: async () => [],
+      getBundlesByTargetAppVersions: async () => [targetBundle],
+      listTargetAppVersions: async () => ["1.0.0"],
+    });
+    const plugin: DatabasePlugin<TestContext> = {
+      name: "seeded-fast-path-plugin",
+      async appendBundle() {},
+      async commitBundle() {},
+      async deleteBundle() {},
+      getBundleById,
+      async getBundles() {
+        return {
+          data: [targetBundle],
+          pagination: {
+            currentPage: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            total: 1,
+            totalPages: 1,
+          },
+        };
+      },
+      getUpdateInfo,
+      async getChannels() {
+        return ["production"];
+      },
+      async updateBundle() {},
+    };
+
+    const core = createPluginDatabaseCore(
+      () => plugin,
+      async (storageUri) => {
+        if (!storageUri) return null;
+        const url = new URL(storageUri);
+        return `https://assets.example.com/${url.host}${url.pathname}`;
+      },
+      {
+        readStorageText: async (storageUri) =>
+          manifests.get(storageUri) ?? null,
+      },
+    );
+    const context: TestContext = {
+      env: {
+        assetHost: "https://assets.example.com",
+      },
+      request: new Request("https://updates.example.com"),
+    };
+
+    const updateInfo = await core.api.getAppUpdateInfo(updateArgs, context);
+
+    expect(updateInfo).toMatchObject({
+      changedAssets: {
+        "index.ios.bundle": {
+          file: {
+            compression: "br",
+            url: "https://assets.example.com/bucket/target/files/index.ios.bundle.br",
+          },
+          fileHash: "target-bundle-hash",
+        },
+      },
+      id: targetBundle.id,
+      manifestFileHash: "sig:target-manifest",
+      manifestUrl: "https://assets.example.com/bucket/target/manifest.json",
+    });
+    expect(getBundleById).not.toHaveBeenCalled();
+  });
+
+  it("does not reread providers for current bundles outside direct update lookup results", async () => {
+    const targetBundle = {
+      ...baseBundle,
+      id: "00000000-0000-0000-0000-000000000003",
+      fileHash: "hash-3",
+      manifestStorageUri: "s3://bucket/target/manifest.json",
+      manifestFileHash: "sig:target-manifest",
+      assetBaseStorageUri: "s3://bucket/target/files",
+    };
+    const manifests = new Map([
+      [
+        targetBundle.manifestStorageUri,
+        JSON.stringify({
+          bundleId: targetBundle.id,
+          assets: {
+            "index.ios.bundle": {
+              fileHash: "target-bundle-hash",
+            },
+            "image.png": {
+              fileHash: "target-image-hash",
+            },
+          },
+        }),
+      ],
+    ]);
+    const getBundleById = vi.fn<DatabasePlugin<TestContext>["getBundleById"]>(
+      async () => {
+        throw new Error("unexpected provider current bundle reread");
+      },
+    );
+    const getUpdateInfo = createDatabasePluginGetUpdateInfo<TestContext>({
+      getBundlesByFingerprint: async () => [],
+      getBundlesByTargetAppVersions: async () => [targetBundle],
+      listTargetAppVersions: async () => ["1.0.0"],
+    });
+    const plugin: DatabasePlugin<TestContext> = {
+      name: "seeded-current-miss-plugin",
+      async appendBundle() {},
+      async commitBundle() {},
+      async deleteBundle() {},
+      getBundleById,
+      async getBundles() {
+        throw new Error("unexpected provider scan");
+      },
+      getUpdateInfo,
+      async getChannels() {
+        return ["production"];
+      },
+      async updateBundle() {},
+    };
+
+    const core = createPluginDatabaseCore(
+      () => plugin,
+      async (storageUri) => {
+        if (!storageUri) return null;
+        const url = new URL(storageUri);
+        return `https://assets.example.com/${url.host}${url.pathname}`;
+      },
+      {
+        readStorageText: async (storageUri) =>
+          manifests.get(storageUri) ?? null,
+      },
+    );
+    const context: TestContext = {
+      env: {
+        assetHost: "https://assets.example.com",
+      },
+      request: new Request("https://updates.example.com"),
+    };
+
+    const updateInfo = await core.api.getAppUpdateInfo(
+      {
+        ...updateArgs,
+        bundleId: "00000000-0000-0000-0000-0000000000aa",
+      },
+      context,
+    );
+
+    expect(updateInfo).toMatchObject({
+      changedAssets: {
+        "image.png": {
+          file: {
+            url: "https://assets.example.com/bucket/target/files/image.png",
+          },
+          fileHash: "target-image-hash",
+        },
+        "index.ios.bundle": {
+          file: {
+            compression: "br",
+            url: "https://assets.example.com/bucket/target/files/index.ios.bundle.br",
+          },
+          fileHash: "target-bundle-hash",
+        },
+      },
+      id: targetBundle.id,
+      manifestFileHash: "sig:target-manifest",
+      manifestUrl: "https://assets.example.com/bucket/target/manifest.json",
+    });
+    expect(getBundleById).not.toHaveBeenCalled();
   });
 
   it("resolves manifest changed assets from deterministic content-addressed storage", async () => {

--- a/packages/server/src/db/pluginCore.ts
+++ b/packages/server/src/db/pluginCore.ts
@@ -13,6 +13,7 @@ import {
   type DatabaseBundleQueryOrder,
   type DatabaseBundleQueryWhere,
   type DatabasePlugin,
+  getRequestUpdateBundleSeeds,
   type HotUpdaterContext,
   semverSatisfies,
 } from "@hot-updater/plugin-core";
@@ -357,16 +358,29 @@ export function createPluginDatabaseCore<TContext = unknown>(
         return baseResponse;
       }
 
+      const requestBundleSeeds = getRequestUpdateBundleSeeds(context);
       const requestBundles = createRequestBundleIdentityMap({
         context,
         loadBundleById: (bundleId, requestContext) =>
           getPlugin().getBundleById(bundleId, requestContext),
-        seeds: [],
+        seeds: requestBundleSeeds,
       });
+      const getCurrentBundle = () => {
+        if (args.bundleId === NIL_UUID) {
+          return null;
+        }
+
+        const seededCurrentBundle = requestBundles.peek(args.bundleId);
+        if (seededCurrentBundle || requestBundleSeeds.length > 0) {
+          return seededCurrentBundle;
+        }
+
+        return requestBundles.get(args.bundleId);
+      };
       const [fileUrl, targetBundle, currentBundle] = await Promise.all([
         resolveFileUrl(storageUri ?? null, context),
         requestBundles.get(info.id),
-        args.bundleId === NIL_UUID ? null : requestBundles.get(args.bundleId),
+        getCurrentBundle(),
       ]);
       const baseResponse: AppUpdateAvailableInfo = { ...rest, fileUrl };
       const manifestArtifacts = await resolveManifestArtifacts({

--- a/packages/server/src/db/requestBundleIdentityMap.ts
+++ b/packages/server/src/db/requestBundleIdentityMap.ts
@@ -54,5 +54,8 @@ export const createRequestBundleIdentityMap = <TContext = unknown>({
     return lookup;
   };
 
-  return { get };
+  const peek = (bundleId: string): Bundle | null =>
+    bundles.get(bundleId) ?? null;
+
+  return { get, peek };
 };

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createBlobDatabasePlugin } from "./createBlobDatabasePlugin";
+import { getRequestUpdateBundleSeeds } from "./requestUpdateBundleState";
 import type { Bundle } from "./types";
 
 const DEFAULT_BUNDLE: Omit<
@@ -365,6 +366,45 @@ describe("blobDatabase plugin", () => {
       "production/ios/target-app-versions.json",
       "production/ios/*/update.json",
     ]);
+  });
+
+  it("seeds request bundles from direct app-version update checks", async () => {
+    const latestBundle = createBundleJson(
+      "production",
+      "ios",
+      "*",
+      "00000000-0000-0000-0000-000000000002",
+    );
+    const previousBundle = createBundleJson(
+      "production",
+      "ios",
+      "*",
+      "00000000-0000-0000-0000-000000000001",
+    );
+    const context = {
+      request: new Request("https://updates.example.com"),
+    };
+
+    seedUpdateManifests([previousBundle, latestBundle]);
+
+    await expect(
+      plugin.getUpdateInfo?.(
+        {
+          _updateStrategy: "appVersion",
+          appVersion: "1.0.0",
+          bundleId: previousBundle.id,
+          platform: "ios",
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({
+      id: latestBundle.id,
+      status: "UPDATE",
+    });
+
+    expect(
+      getRequestUpdateBundleSeeds(context).map((bundle) => bundle.id),
+    ).toEqual([latestBundle.id, previousBundle.id]);
   });
 
   it("uses fingerprint manifests directly for update checks", async () => {

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -1,4 +1,3 @@
-import { getUpdateInfo as getManifestUpdateInfo } from "@hot-updater/js";
 import { orderBy } from "es-toolkit";
 import semver from "semver";
 
@@ -7,6 +6,7 @@ import { createDatabasePlugin } from "./createDatabasePlugin";
 import { filterCompatibleAppVersions } from "./filterCompatibleAppVersions";
 import { paginateBundles } from "./paginateBundles";
 import { bundleMatchesQueryWhere, sortBundles } from "./queryBundles";
+import { resolveUpdateInfoFromBundles } from "./resolveUpdateInfoFromBundles";
 import type {
   AppVersionGetBundlesArgs,
   Bundle,
@@ -16,6 +16,7 @@ import type {
   DatabasePluginHooks,
   FingerprintGetBundlesArgs,
   GetBundlesArgs,
+  HotUpdaterContext,
   UpdateInfo,
 } from "./types";
 
@@ -1159,14 +1160,17 @@ export const createBlobDatabasePlugin = <TConfig>({
       }
     }
 
-    const getAppVersionUpdateInfo = async ({
-      appVersion,
-      bundleId,
-      channel = "production",
-      cohort,
-      minBundleId,
-      platform,
-    }: AppVersionGetBundlesArgs): Promise<UpdateInfo | null> => {
+    const getAppVersionUpdateInfo = async (
+      {
+        appVersion,
+        bundleId,
+        channel = "production",
+        cohort,
+        minBundleId,
+        platform,
+      }: AppVersionGetBundlesArgs,
+      context?: HotUpdaterContext,
+    ): Promise<UpdateInfo | null> => {
       const targetVersionsKey = `${channel}/${platform}/target-app-versions.json`;
       const targetAppVersions =
         (await loadOptionalObject<string[]>(targetVersionsKey)) ?? [];
@@ -1192,41 +1196,50 @@ export const createBlobDatabasePlugin = <TConfig>({
         )
       ).flat();
 
-      const info = await getManifestUpdateInfo(bundles, {
-        _updateStrategy: "appVersion",
-        appVersion,
-        bundleId,
-        channel,
-        cohort,
-        minBundleId,
-        platform,
+      return resolveUpdateInfoFromBundles({
+        args: {
+          _updateStrategy: "appVersion",
+          appVersion,
+          bundleId,
+          channel,
+          cohort,
+          minBundleId,
+          platform,
+        },
+        bundles,
+        context,
       });
-      return info;
     };
 
-    const getFingerprintUpdateInfo = async ({
-      bundleId,
-      channel = "production",
-      cohort,
-      fingerprintHash,
-      minBundleId,
-      platform,
-    }: FingerprintGetBundlesArgs): Promise<UpdateInfo | null> => {
+    const getFingerprintUpdateInfo = async (
+      {
+        bundleId,
+        channel = "production",
+        cohort,
+        fingerprintHash,
+        minBundleId,
+        platform,
+      }: FingerprintGetBundlesArgs,
+      context?: HotUpdaterContext,
+    ): Promise<UpdateInfo | null> => {
       const bundles =
         (await loadOptionalObject<Bundle[]>(
           `${channel}/${platform}/${fingerprintHash}/update.json`,
         )) ?? [];
 
-      const info = await getManifestUpdateInfo(bundles, {
-        _updateStrategy: "fingerprint",
-        bundleId,
-        channel,
-        cohort,
-        fingerprintHash,
-        minBundleId,
-        platform,
+      return resolveUpdateInfoFromBundles({
+        args: {
+          _updateStrategy: "fingerprint",
+          bundleId,
+          channel,
+          cohort,
+          fingerprintHash,
+          minBundleId,
+          platform,
+        },
+        bundles,
+        context,
       });
-      return info;
     };
 
     const addAppVersionInvalidationPaths = (
@@ -1390,12 +1403,12 @@ export const createBlobDatabasePlugin = <TConfig>({
           return removeBundleInternalKeys(matchedBundle);
         },
 
-        async getUpdateInfo(args: GetBundlesArgs) {
+        async getUpdateInfo(args: GetBundlesArgs, context?: HotUpdaterContext) {
           if (args._updateStrategy === "appVersion") {
-            return getAppVersionUpdateInfo(args);
+            return getAppVersionUpdateInfo(args, context);
           }
 
-          return getFingerprintUpdateInfo(args);
+          return getFingerprintUpdateInfo(args, context);
         },
 
         async getBundles(options) {

--- a/plugins/plugin-core/src/createDatabasePluginGetUpdateInfo.ts
+++ b/plugins/plugin-core/src/createDatabasePluginGetUpdateInfo.ts
@@ -5,9 +5,9 @@ import {
   NIL_UUID,
   type UpdateInfo,
 } from "@hot-updater/core";
-import { getUpdateInfo as getManifestUpdateInfo } from "@hot-updater/js";
 
 import { filterCompatibleAppVersions } from "./filterCompatibleAppVersions";
+import { resolveUpdateInfoFromBundles } from "./resolveUpdateInfoFromBundles";
 import type { Bundle, HotUpdaterContext } from "./types";
 
 type AppVersionLookupArgs = {
@@ -83,14 +83,20 @@ export const createDatabasePluginGetUpdateInfo = <TContext = unknown>({
             )
           : [];
 
-      const info = await getManifestUpdateInfo(bundles, normalizedArgs);
-      return info;
+      return resolveUpdateInfoFromBundles({
+        args: normalizedArgs,
+        bundles,
+        context,
+      });
     }
 
     const normalizedArgs = normalizeFingerprintArgs(args);
     const bundles = await getBundlesByFingerprint(normalizedArgs, context);
 
-    const info = await getManifestUpdateInfo(bundles, normalizedArgs);
-    return info;
+    return resolveUpdateInfoFromBundles({
+      args: normalizedArgs,
+      bundles,
+      context,
+    });
   };
 };

--- a/plugins/plugin-core/src/index.ts
+++ b/plugins/plugin-core/src/index.ts
@@ -12,6 +12,8 @@ export * from "./generateMinBundleId";
 export * from "./parseStorageUri";
 export * from "./paginateBundles";
 export * from "./queryBundles";
+export { getRequestUpdateBundleSeeds } from "./requestUpdateBundleState";
+export * from "./resolveUpdateInfoFromBundles";
 export * from "./semverSatisfies";
 export * from "./storageProfile";
 export * from "./types";

--- a/plugins/plugin-core/src/requestUpdateBundleState.ts
+++ b/plugins/plugin-core/src/requestUpdateBundleState.ts
@@ -1,0 +1,44 @@
+import type { Bundle, HotUpdaterContext } from "./types";
+
+const requestUpdateBundleSeeds = new WeakMap<object, readonly Bundle[]>();
+
+const isWeakMapKey = (value: unknown): value is object =>
+  (typeof value === "object" && value !== null) || typeof value === "function";
+
+const toBundleSeeds = (
+  seeds: readonly (Bundle | null | undefined)[],
+): readonly Bundle[] => seeds.filter((seed): seed is Bundle => !!seed);
+
+export const seedRequestUpdateBundles = <TContext = unknown>(
+  context: HotUpdaterContext<TContext> | undefined,
+  seeds: readonly (Bundle | null | undefined)[],
+) => {
+  if (!isWeakMapKey(context)) {
+    return;
+  }
+
+  const nextSeeds = toBundleSeeds(seeds);
+  if (nextSeeds.length === 0) {
+    return;
+  }
+
+  const bundlesById = new Map<string, Bundle>();
+  for (const seed of requestUpdateBundleSeeds.get(context) ?? []) {
+    bundlesById.set(seed.id, seed);
+  }
+  for (const seed of nextSeeds) {
+    bundlesById.set(seed.id, seed);
+  }
+
+  requestUpdateBundleSeeds.set(context, [...bundlesById.values()]);
+};
+
+export const getRequestUpdateBundleSeeds = <TContext = unknown>(
+  context: HotUpdaterContext<TContext> | undefined,
+): readonly Bundle[] => {
+  if (!isWeakMapKey(context)) {
+    return [];
+  }
+
+  return requestUpdateBundleSeeds.get(context) ?? [];
+};

--- a/plugins/plugin-core/src/resolveUpdateInfoFromBundles.ts
+++ b/plugins/plugin-core/src/resolveUpdateInfoFromBundles.ts
@@ -1,0 +1,32 @@
+import type { GetBundlesArgs, UpdateInfo } from "@hot-updater/core";
+import { NIL_UUID } from "@hot-updater/core";
+import { getUpdateInfo as getManifestUpdateInfo } from "@hot-updater/js";
+
+import { seedRequestUpdateBundles } from "./requestUpdateBundleState";
+import type { Bundle, HotUpdaterContext } from "./types";
+
+export interface ResolveUpdateInfoFromBundlesOptions<TContext = unknown> {
+  readonly args: GetBundlesArgs;
+  readonly bundles: Bundle[];
+  readonly context?: HotUpdaterContext<TContext>;
+}
+
+const findSeedBundle = (bundles: readonly Bundle[], bundleId: string) =>
+  bundles.find((bundle) => bundle.id === bundleId);
+
+export const resolveUpdateInfoFromBundles = async <TContext = unknown>({
+  args,
+  bundles,
+  context,
+}: ResolveUpdateInfoFromBundlesOptions<TContext>): Promise<UpdateInfo | null> => {
+  const info = await getManifestUpdateInfo(bundles, args);
+  if (!info) {
+    return null;
+  }
+
+  seedRequestUpdateBundles(context, [
+    findSeedBundle(bundles, info.id),
+    args.bundleId === NIL_UUID ? null : findSeedBundle(bundles, args.bundleId),
+  ]);
+  return info;
+};


### PR DESCRIPTION
## Summary

- keep per-request update bundle reuse in the server/core + plugin-core helper layer
- add `resolveUpdateInfoFromBundles` so direct manifest update checks seed request-local bundle state without provider code handling identity-map internals
- keep `seedRequestUpdateBundles` internal to plugin-core modules while exposing only the server-readable seed accessor

## Context

#1046 added a per-request identity map, but the provider `getUpdateInfo` path still selected bundles from already-loaded manifest lists and returned only `UpdateInfo`. Server artifact resolution then had no object identity seed for those selected bundles, so it could still re-read target/current bundles by id.

This PR moves that missing bridge into plugin-core helpers instead of requiring provider authors to think about request-local cache seeding. Blob/direct lookup providers stay on direct manifest reads, and the server consumes request seeds consistently when resolving update artifacts.

## Verification

- `pnpm exec vitest run packages/server/src/db/pluginCore.spec.ts packages/server/src/db/requestBundleIdentityMap.spec.ts plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts plugins/plugin-core/src/createDatabasePlugin.spec.ts plugins/plugin-core/src/createDatabasePluginGetUpdateInfo.spec.ts`
- `pnpm --filter @hot-updater/plugin-core test:type`
- `pnpm --filter @hot-updater/server test:type`
- `pnpm exec oxlint packages/server/src/db/pluginCore.ts packages/server/src/db/pluginCore.spec.ts packages/server/src/db/requestBundleIdentityMap.ts plugins/plugin-core/src/createBlobDatabasePlugin.ts plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts plugins/plugin-core/src/createDatabasePluginGetUpdateInfo.ts plugins/plugin-core/src/index.ts plugins/plugin-core/src/requestUpdateBundleState.ts plugins/plugin-core/src/resolveUpdateInfoFromBundles.ts`
- `pnpm --filter @hot-updater/plugin-core build`
- `pnpm --filter @hot-updater/server build`
- `pnpm --filter @hot-updater/aws build`
