### PR TITLE
fix(cli): unify doctor update targets

### DIFF
--- a/.changeset/unified-doctor-targets.md
+++ b/.changeset/unified-doctor-targets.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": minor
+---
+
+Unify doctor infrastructure update targets so runtime and migration requirements share one version target source.

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -166,13 +166,13 @@ describe("infrastructure version helpers", () => {
     expect(getRequiredInfrastructureVersion("0.31.0")).toBe("0.31.0");
     expect(getRequiredInfrastructureVersion("0.31.9")).toBe("0.31.0");
     expect(getRequiredInfrastructureVersion("0.32.0")).toBe("0.32.0");
-    expect(getRequiredInfrastructureVersion("0.32.1")).toBe("0.32.0");
+    expect(getRequiredInfrastructureVersion("0.33.0")).toBe("0.33.0");
   });
 
   it("resolves the latest server runtime target required by a package version", () => {
     expect(getRequiredServerVersion("0.32.0")).toBe("0.32.0");
-    expect(getRequiredServerVersion("0.32.1")).toBe("0.32.1");
-    expect(getRequiredServerVersion("0.32.9")).toBe("0.32.1");
+    expect(getRequiredServerVersion("0.33.0")).toBe("0.33.0");
+    expect(getRequiredServerVersion("0.32.9")).toBe("0.32.0");
   });
 
   it("does not require an update just because the server package version is newer", () => {
@@ -902,11 +902,11 @@ describe("doctor", () => {
     });
   });
 
-  it("should require a server redeploy when the server runtime is below the required target", async () => {
+  it("should require an infrastructure update when the server runtime is below the required target", async () => {
     mockReadPackageUp.mockResolvedValue({
       packageJson: {
         dependencies: {
-          "hot-updater": "0.32.1",
+          "hot-updater": "0.33.0",
         },
       },
       path: "/mock/cwd/package.json",
@@ -926,16 +926,19 @@ describe("doctor", () => {
     expect(result).toMatchObject({
       success: false,
       details: {
-        hotUpdaterVersion: "0.32.1",
+        hotUpdaterVersion: "0.33.0",
         infrastructure: {
           serverVersion: "0.32.0",
-          requiredVersion: "0.32.1",
+          requiredVersion: "0.33.0",
           needsUpdate: true,
-          updateReason:
-            "Server redeploy required: provider update checks reuse selected bundles",
+          updateReason: "provider update checks reuse selected bundles",
           remediation: {
             fixability: "blocked",
-            commands: ["redeploy update-check server"],
+            commands: [
+              "hot-updater init",
+              "hot-updater db migrate",
+              "hot-updater db generate",
+            ],
           },
         },
       },

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -788,9 +788,7 @@ export async function doctor(
         details.infrastructure.error !== undefined ||
         details.infrastructure.needsUpdate === true
       ) {
-        details.infrastructure.remediation = createInfrastructureRemediation(
-          details.infrastructure.requirement,
-        );
+        details.infrastructure.remediation = createInfrastructureRemediation();
       }
     }
 
@@ -954,11 +952,9 @@ export const handleDoctor = async ({
     p.log.message(ui.block("Infrastructure", lines));
 
     if (infrastructure.needsUpdate) {
-      const updateLabel =
-        infrastructure.requirement === "server"
-          ? "Server redeploy required"
-          : "Infrastructure update required";
-      p.log.error(`${updateLabel}: ${infrastructure.requiredVersion}+`);
+      p.log.error(
+        `Infrastructure update required: ${infrastructure.requiredVersion}+`,
+      );
       if (infrastructure.updateReason) {
         p.log.info(`Reason: ${infrastructure.updateReason}`);
       }

--- a/packages/hot-updater/src/commands/doctorInfrastructure.ts
+++ b/packages/hot-updater/src/commands/doctorInfrastructure.ts
@@ -1,7 +1,6 @@
 import {
   getRequiredUpdateTarget,
   isInfrastructureUpdateRequired,
-  type InfrastructureRequirement,
   type RequiredUpdateTarget,
 } from "./doctorInfrastructureTargets";
 
@@ -17,7 +16,6 @@ export interface InfrastructureStatus {
   versionEndpoint: string;
   serverVersion?: string;
   requiredVersion: string;
-  requirement?: InfrastructureRequirement;
   needsUpdate?: boolean;
   updateReason?: string;
   error?: string;
@@ -40,8 +38,6 @@ const INFRASTRUCTURE_RECOVERY_COMMANDS = [
   "hot-updater db generate",
 ] as const;
 
-const SERVER_RECOVERY_COMMANDS = ["redeploy update-check server"] as const;
-
 export function resolveVersionEndpoint(serverBaseUrl: string): string {
   const url = new URL(serverBaseUrl.trim());
   const pathname = url.pathname.replace(/\/+$/, "");
@@ -52,25 +48,15 @@ export function resolveVersionEndpoint(serverBaseUrl: string): string {
   return url.toString();
 }
 
-export const createInfrastructureRemediation = (
-  requirement: InfrastructureRequirement = "infrastructure",
-): InfrastructureRemediation => {
-  if (requirement === "server") {
+export const createInfrastructureRemediation =
+  (): InfrastructureRemediation => {
     return {
       fixability: "blocked",
       reason:
-        "Server runtime changes need provider credentials, environment variables, and redeploy access.",
-      commands: [...SERVER_RECOVERY_COMMANDS],
+        "Server infrastructure changes usually need provider credentials, environment variables, and redeploy access.",
+      commands: [...INFRASTRUCTURE_RECOVERY_COMMANDS],
     };
-  }
-
-  return {
-    fixability: "blocked",
-    reason:
-      "Server infrastructure changes usually need provider credentials, environment variables, and redeploy access.",
-    commands: [...INFRASTRUCTURE_RECOVERY_COMMANDS],
   };
-};
 
 export async function checkInfrastructureStatus({
   serverBaseUrl,
@@ -98,7 +84,6 @@ export async function checkInfrastructureStatus({
           baseUrl,
           versionEndpoint,
           requiredVersion,
-          requirement: "infrastructure",
           needsUpdate: true,
           updateReason: "Version endpoint not found",
         };
@@ -132,12 +117,8 @@ export async function checkInfrastructureStatus({
       versionEndpoint,
       serverVersion: data.version,
       requiredVersion,
-      requirement: needsUpdate ? requiredTarget.kind : undefined,
       needsUpdate,
-      updateReason:
-        needsUpdate && requiredTarget.kind === "server"
-          ? `Server redeploy required: ${requiredTarget.note}`
-          : undefined,
+      updateReason: needsUpdate ? requiredTarget.note : undefined,
     };
   } catch (error) {
     return {

--- a/packages/hot-updater/src/commands/doctorInfrastructureTargets.ts
+++ b/packages/hot-updater/src/commands/doctorInfrastructureTargets.ts
@@ -1,19 +1,13 @@
 import * as semver from "semver";
 
-export type InfrastructureRequirement = "infrastructure" | "server";
-
-interface InfrastructureUpdateTarget {
-  version: string;
-  note: string;
+export interface UpdateTarget {
+  readonly version: string;
+  readonly note: string;
 }
 
-export interface RequiredUpdateTarget {
-  version: string;
-  kind: InfrastructureRequirement;
-  note: string;
-}
+export type RequiredUpdateTarget = UpdateTarget;
 
-export const INFRASTRUCTURE_UPDATE_TARGETS = [
+export const UPDATE_TARGETS = [
   {
     version: "0.13.0",
     note: "Initial provider infrastructure migrations",
@@ -42,62 +36,42 @@ export const INFRASTRUCTURE_UPDATE_TARGETS = [
     version: "0.32.0",
     note: "Content-addressed manifest asset routing",
   },
-] as const satisfies readonly [
-  InfrastructureUpdateTarget,
-  ...InfrastructureUpdateTarget[],
-];
-
-export const SERVER_UPDATE_TARGETS = [
   {
-    version: "0.32.1",
+    version: "0.33.0",
     note: "provider update checks reuse selected bundles",
   },
-] as const satisfies readonly [
-  InfrastructureUpdateTarget,
-  ...InfrastructureUpdateTarget[],
-];
+] as const satisfies readonly [UpdateTarget, ...UpdateTarget[]];
 
-const getTargetVersionAt = ({
+const getTargetAt = ({
   index,
   label,
   targets,
 }: {
   index: number;
   label: string;
-  targets: readonly InfrastructureUpdateTarget[];
-}): string => {
+  targets: readonly UpdateTarget[];
+}): UpdateTarget => {
   const target = targets.at(index);
   if (!target) {
     throw new Error(`${label} must not be empty`);
   }
-  return target.version;
+  return target;
 };
 
 const getLatestKnownTargetVersion = () => {
-  const infrastructureVersion = getTargetVersionAt({
+  return getTargetAt({
     index: -1,
-    label: "INFRASTRUCTURE_UPDATE_TARGETS",
-    targets: INFRASTRUCTURE_UPDATE_TARGETS,
-  });
-  const serverVersion = getTargetVersionAt({
-    index: -1,
-    label: "SERVER_UPDATE_TARGETS",
-    targets: SERVER_UPDATE_TARGETS,
-  });
-
-  return semver.gte(serverVersion, infrastructureVersion)
-    ? serverVersion
-    : infrastructureVersion;
+    label: "UPDATE_TARGETS",
+    targets: UPDATE_TARGETS,
+  }).version;
 };
 
 const getRequiredTarget = ({
-  fallbackVersion,
   hotUpdaterVersion,
   targets,
 }: {
-  fallbackVersion: string;
   hotUpdaterVersion: string;
-  targets: readonly InfrastructureUpdateTarget[];
+  targets: readonly UpdateTarget[];
 }) => {
   const current = semver.coerce(hotUpdaterVersion)?.version;
 
@@ -105,7 +79,7 @@ const getRequiredTarget = ({
     return null;
   }
 
-  let requiredTarget: InfrastructureUpdateTarget | null = null;
+  let requiredTarget: UpdateTarget | null = null;
 
   for (const target of targets) {
     if (semver.lte(target.version, current)) {
@@ -113,51 +87,24 @@ const getRequiredTarget = ({
     }
   }
 
-  return requiredTarget ?? { version: fallbackVersion, note: "" };
-};
-
-const getRequiredInfrastructureTarget = (
-  hotUpdaterVersion: string,
-): InfrastructureUpdateTarget => {
-  const fallbackVersion = getTargetVersionAt({
-    index: 0,
-    label: "INFRASTRUCTURE_UPDATE_TARGETS",
-    targets: INFRASTRUCTURE_UPDATE_TARGETS,
-  });
-
   return (
-    getRequiredTarget({
-      fallbackVersion,
-      hotUpdaterVersion,
-      targets: INFRASTRUCTURE_UPDATE_TARGETS,
-    }) ?? {
-      version: getTargetVersionAt({
-        index: -1,
-        label: "INFRASTRUCTURE_UPDATE_TARGETS",
-        targets: INFRASTRUCTURE_UPDATE_TARGETS,
-      }),
-      note: "",
-    }
+    requiredTarget ??
+    getTargetAt({
+      index: 0,
+      label: "UPDATE_TARGETS",
+      targets,
+    })
   );
 };
 
-const getRequiredServerTarget = (
-  hotUpdaterVersion: string,
-): InfrastructureUpdateTarget | null =>
-  getRequiredTarget({
-    fallbackVersion: getRequiredInfrastructureVersion(hotUpdaterVersion),
-    hotUpdaterVersion,
-    targets: SERVER_UPDATE_TARGETS,
-  });
-
 export function getRequiredInfrastructureVersion(
-  hotUpdaterVersion: string = getTargetVersionAt({
+  hotUpdaterVersion: string = getTargetAt({
     index: -1,
-    label: "INFRASTRUCTURE_UPDATE_TARGETS",
-    targets: INFRASTRUCTURE_UPDATE_TARGETS,
-  }),
+    label: "UPDATE_TARGETS",
+    targets: UPDATE_TARGETS,
+  }).version,
 ): string {
-  return getRequiredInfrastructureTarget(hotUpdaterVersion).version;
+  return getRequiredUpdateTarget(hotUpdaterVersion).version;
 }
 
 export function getRequiredServerVersion(
@@ -169,26 +116,17 @@ export function getRequiredServerVersion(
 export function getRequiredUpdateTarget(
   hotUpdaterVersion: string = getLatestKnownTargetVersion(),
 ): RequiredUpdateTarget {
-  const infrastructureTarget =
-    getRequiredInfrastructureTarget(hotUpdaterVersion);
-  const serverTarget = getRequiredServerTarget(hotUpdaterVersion);
-
-  if (
-    serverTarget &&
-    semver.gt(serverTarget.version, infrastructureTarget.version)
-  ) {
-    return {
-      version: serverTarget.version,
-      kind: "server",
-      note: serverTarget.note,
-    };
-  }
-
-  return {
-    version: infrastructureTarget.version,
-    kind: "infrastructure",
-    note: infrastructureTarget.note,
-  };
+  return (
+    getRequiredTarget({
+      hotUpdaterVersion,
+      targets: UPDATE_TARGETS,
+    }) ??
+    getTargetAt({
+      index: -1,
+      label: "UPDATE_TARGETS",
+      targets: UPDATE_TARGETS,
+    })
+  );
 }
 
 export function isInfrastructureUpdateRequired({


### PR DESCRIPTION
## Summary

- collapse doctor infrastructure and server runtime update targets into one ordered `UPDATE_TARGETS` source
- remove the `kind`/`requirement` split so `0.33.0` follows the same infrastructure update path as prior required versions
- add a minor changeset for `hot-updater`

## Context

The doctor command was tracking infrastructure and server runtime requirements in separate arrays even though both ultimately compare the server `/version` response against the package-required target and tell users to update the same infrastructure surface. Keeping separate target kinds made future versions easy to add in the wrong place and produced a separate server redeploy remediation path for the same update action.

This PR keeps the existing helper exports for callers, but backs them with one `UPDATE_TARGETS` list and one remediation flow.

## Validation

- `pnpm exec vitest run packages/hot-updater/src/commands/doctor.spec.ts`
- `pnpm --filter hot-updater test:type`
- `pnpm exec oxfmt --check packages/hot-updater/src/commands/doctorInfrastructureTargets.ts packages/hot-updater/src/commands/doctorInfrastructure.ts packages/hot-updater/src/commands/doctor.ts packages/hot-updater/src/commands/doctor.spec.ts`
- `pnpm exec oxlint packages/hot-updater/src/commands/doctorInfrastructureTargets.ts packages/hot-updater/src/commands/doctorInfrastructure.ts packages/hot-updater/src/commands/doctor.ts packages/hot-updater/src/commands/doctor.spec.ts`
- `pnpm --filter hot-updater build`

## Not tested

- Live provider infrastructure migration against real cloud credentials.
