### PR TITLE
fix(expo): transform DOM components emitted by JSX runtime

### DIFF
--- a/.changeset/lemon-birds-melt.md
+++ b/.changeset/lemon-birds-melt.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/expo": patch
+---
+
+fix(expo): transform DOM components emitted by JSX runtime

--- a/plugins/expo/src/babel-utils.ts
+++ b/plugins/expo/src/babel-utils.ts
@@ -1,0 +1,145 @@
+import type * as babelTypes from "@babel/types";
+
+function isWebViewExpression(
+  t: typeof babelTypes,
+  node: babelTypes.Node | null | undefined,
+): boolean {
+  return (
+    (t.isIdentifier(node) &&
+      (node.name === "WebView" || node.name.endsWith("WebView"))) ||
+    (t.isMemberExpression(node) &&
+      t.isIdentifier(node.property, { name: "WebView" }))
+  );
+}
+
+function isJsxRuntimeCallee(
+  t: typeof babelTypes,
+  callee: babelTypes.CallExpression["callee"],
+): boolean {
+  if (t.isIdentifier(callee)) {
+    return ["jsx", "jsxs", "jsxDEV"].some((name) => callee.name.endsWith(name));
+  }
+
+  if (t.isMemberExpression(callee)) {
+    return (
+      t.isIdentifier(callee.property) &&
+      ["jsx", "jsxs", "jsxDEV"].includes(callee.property.name)
+    );
+  }
+
+  if (t.isSequenceExpression(callee)) {
+    return isJsxRuntimeCallee(
+      t,
+      callee.expressions[callee.expressions.length - 1],
+    );
+  }
+
+  return false;
+}
+
+export function isSupportedWebViewCall(
+  t: typeof babelTypes,
+  callExpression: babelTypes.CallExpression,
+  propsNode: babelTypes.ObjectExpression,
+): boolean {
+  if (callExpression.arguments[1] !== propsNode) return false;
+  if (!isWebViewExpression(t, callExpression.arguments[0])) return false;
+
+  if (
+    t.isMemberExpression(callExpression.callee) &&
+    t.isIdentifier(callExpression.callee.property, { name: "createElement" })
+  ) {
+    return true;
+  }
+
+  return isJsxRuntimeCallee(t, callExpression.callee);
+}
+
+export function buildHotUpdaterDomProps(
+  t: typeof babelTypes,
+  fileName: string,
+  spreadIdentifier?: babelTypes.Identifier,
+): babelTypes.CallExpression {
+  const overrideUri = t.objectProperty(
+    t.identifier("overrideUri"),
+    t.callExpression(
+      t.memberExpression(
+        t.arrayExpression([
+          t.identifier("baseURL"),
+          t.stringLiteral("www.bundle"),
+          t.stringLiteral(fileName),
+        ]),
+        t.identifier("join"),
+      ),
+      [t.stringLiteral("/")],
+    ),
+  );
+
+  const hotDomProps = spreadIdentifier
+    ? [
+        t.spreadElement(
+          t.memberExpression(spreadIdentifier, t.identifier("dom")),
+        ),
+        overrideUri,
+      ]
+    : [overrideUri];
+
+  const conditionalObject = t.conditionalExpression(
+    t.identifier("baseURL"),
+    t.objectExpression([
+      t.objectProperty(t.identifier("dom"), t.objectExpression(hotDomProps)),
+      t.objectProperty(t.identifier("filePath"), t.stringLiteral(fileName)),
+    ]),
+    t.objectExpression([
+      t.objectProperty(t.identifier("filePath"), t.stringLiteral(fileName)),
+    ]),
+  );
+
+  const arrowFunction = t.arrowFunctionExpression(
+    [t.identifier("baseURL")],
+    conditionalObject,
+  );
+
+  const safeGetBaseURL = t.conditionalExpression(
+    t.logicalExpression(
+      "&&",
+      t.binaryExpression(
+        "!==",
+        t.unaryExpression("typeof", t.identifier("globalThis"), true),
+        t.stringLiteral("undefined"),
+      ),
+      t.memberExpression(
+        t.identifier("globalThis"),
+        t.identifier("HotUpdaterGetBaseURL"),
+      ),
+    ),
+    t.callExpression(
+      t.memberExpression(
+        t.identifier("globalThis"),
+        t.identifier("HotUpdaterGetBaseURL"),
+      ),
+      [],
+    ),
+    t.unaryExpression("void", t.numericLiteral(0)),
+  );
+
+  return t.callExpression(arrowFunction, [safeGetBaseURL]);
+}
+
+export function isWebViewJsxName(
+  t: typeof babelTypes,
+  name:
+    | babelTypes.JSXNamespacedName
+    | babelTypes.JSXMemberExpression
+    | babelTypes.JSXIdentifier,
+): boolean {
+  if (t.isJSXIdentifier(name)) {
+    return name.name === "WebView" || name.name.endsWith("WebView");
+  }
+
+  if (t.isJSXMemberExpression(name)) {
+    return isWebViewJsxName(t, name.property);
+  }
+
+  return false;
+}

--- a/plugins/expo/src/babel.spec.ts
+++ b/plugins/expo/src/babel.spec.ts
@@ -9,7 +9,9 @@ type TransformResult = {
 type TransformSync = (
   code: string,
   options: {
-    plugins: unknown[];
+    filename?: string;
+    plugins?: unknown[];
+    presets?: unknown[];
     configFile: false;
     babelrc: false;
   },
@@ -19,20 +21,34 @@ const require = createRequire(import.meta.url);
 const { transformSync } = require("@babel/core") as {
   transformSync: TransformSync;
 };
+const presetTypescript = require("@babel/preset-typescript") as unknown;
 
 async function transformCode(code: string): Promise<string | null> {
-  try {
-    const { default: babelPlugin } = await import("./babel");
-    const result = transformSync(code, {
-      plugins: [babelPlugin],
-      configFile: false,
-      babelrc: false,
-    });
+  const { default: babelPlugin } = await import("./babel");
+  const result = transformSync(code, {
+    plugins: [babelPlugin],
+    configFile: false,
+    babelrc: false,
+  });
 
-    return result?.code ?? null;
-  } finally {
-    // Clear ESM module state between test cases.
-  }
+  return result?.code ?? null;
+}
+
+async function transformTsxCode(
+  code: string,
+  useHotUpdaterPlugin: boolean,
+  trailingPlugins: unknown[] = [],
+): Promise<string | null> {
+  const { default: babelPlugin } = await import("./babel");
+  const result = transformSync(code, {
+    filename: "App.tsx",
+    presets: [[presetTypescript, { allExtensions: true, isTSX: true }]],
+    plugins: useHotUpdaterPlugin ? [babelPlugin, ...trailingPlugins] : [],
+    configFile: false,
+    babelrc: false,
+  });
+
+  return result?.code ?? null;
 }
 
 describe("Babel Plugin - Hot Updater", () => {
@@ -85,6 +101,59 @@ describe("Babel Plugin - Hot Updater", () => {
       expect(result).toContain("overrideUri");
     });
 
+    it("transforms JSX WebView filePath attributes into overrideUri spreads", async () => {
+      const result = await transformTsxCode(
+        `
+          import { WebView } from "react-native-webview";
+
+          export function DomComponent() {
+            return <WebView filePath="index.html" />;
+          }
+        `,
+        true,
+      );
+
+      expect(result).toContain("globalThis.HotUpdaterGetBaseURL");
+      expect(result).toContain('"www.bundle"');
+      expect(result).toContain("overrideUri");
+      expect(result).toContain('"index.html"');
+    });
+
+    it("transforms JSX WebView filePath variables before trailing Babel plugins", async () => {
+      const trailingPlugin = () => ({
+        name: "trailing-test-plugin",
+        visitor: {},
+      });
+
+      const result = await transformTsxCode(
+        `
+          import { WebView } from "react-native-webview";
+
+          const filePath = "component.html";
+
+          export function DomComponent() {
+            return <WebView filePath={filePath} />;
+          }
+        `,
+        true,
+        [trailingPlugin],
+      );
+
+      expect(result).toContain("globalThis.HotUpdaterGetBaseURL");
+      expect(result).toContain("overrideUri");
+      expect(result).toContain('"component.html"');
+    });
+
+    it("transforms automatic JSX runtime WebView calls", async () => {
+      const result = await transformCode(`
+        (0, jsxRuntime.jsx)(WebView, { filePath: "index.html" });
+      `);
+
+      expect(result).toContain("globalThis.HotUpdaterGetBaseURL");
+      expect(result).toContain("overrideUri");
+      expect(result).toContain('"index.html"');
+    });
+
     it("does not transform non-html file paths", async () => {
       const result = await transformCode(`
         React.createElement(WebView, { filePath: "index.js" });
@@ -101,6 +170,77 @@ describe("Babel Plugin - Hot Updater", () => {
 
       expect(result).not.toContain("overrideUri");
       expect(result).toContain('"index.html"');
+    });
+
+    it("does not change ordinary Expo app files without DOM filePath props", async () => {
+      const appCode = `
+        import { StatusBar } from "expo-status-bar";
+        import { useMemo, useState } from "react";
+        import { Button, Platform, ScrollView, Text, View } from "react-native";
+        import {
+          checkAndApplyUpdates,
+          getHotUpdaterDiagnostics,
+          initHotUpdater,
+        } from "./hotUpdater";
+
+        initHotUpdater();
+
+        export default function App() {
+          const [status, setStatus] = useState("Release build installed.");
+          const diagnostics = useMemo(
+            () => [["Platform", Platform.OS], ...getHotUpdaterDiagnostics()],
+            [],
+          );
+
+          const checkForUpdate = () => {
+            setStatus("Checking for update...");
+            checkAndApplyUpdates(setStatus).catch((error: unknown) => {
+              setStatus(error instanceof Error ? error.message : String(error));
+            });
+          };
+
+          return (
+            <ScrollView>
+              <Text>{status}</Text>
+              <View>
+                <Button title="Check and apply update" onPress={checkForUpdate} />
+              </View>
+              <View>
+                {diagnostics.map(([label, value]) => (
+                  <View key={label}>
+                    <Text>{label}</Text>
+                    <Text>{value}</Text>
+                  </View>
+                ))}
+              </View>
+              <StatusBar style="auto" />
+            </ScrollView>
+          );
+        }
+      `;
+
+      const withoutPlugin = await transformTsxCode(appCode, false);
+      const withPlugin = await transformTsxCode(appCode, true);
+
+      expect(withPlugin).toBe(withoutPlugin);
+      expect(withPlugin).not.toContain("HotUpdaterGetBaseURL");
+      expect(withPlugin).not.toContain("overrideUri");
+    });
+
+    it("does not change ordinary Expo registerRootComponent entry files", async () => {
+      const entryCode = `
+        import { registerRootComponent } from "expo";
+
+        import App from "./App";
+
+        registerRootComponent(App);
+      `;
+
+      const withoutPlugin = await transformTsxCode(entryCode, false);
+      const withPlugin = await transformTsxCode(entryCode, true);
+
+      expect(withPlugin).toBe(withoutPlugin);
+      expect(withPlugin).toContain("registerRootComponent(App)");
     });
   });
 });

--- a/plugins/expo/src/babel.ts
+++ b/plugins/expo/src/babel.ts
@@ -1,14 +1,25 @@
 import type * as babelTypes from "@babel/types";
 
+import {
+  buildHotUpdaterDomProps,
+  isSupportedWebViewCall,
+  isWebViewJsxName,
+} from "./babel-utils";
+
 type ObjectExpressionPath = {
   node: babelTypes.ObjectExpression;
   parent: babelTypes.Node;
 };
 
+type JSXOpeningElementPath = {
+  node: babelTypes.JSXOpeningElement;
+};
+
 type ProgramPath = {
   node: babelTypes.Program;
   traverse(visitor: {
-    ObjectExpression(path: ObjectExpressionPath): void;
+    ObjectExpression?(path: ObjectExpressionPath): void;
+    JSXOpeningElement?(path: JSXOpeningElementPath): void;
   }): void;
 };
 
@@ -21,12 +32,6 @@ type HotUpdaterBabelPlugin = {
   };
 };
 
-/**
- * Hot Updater Babel Plugin
- *
- * This plugin transforms Expo DOM component filePath to overrideUri for OTA
- * updates.
- */
 export default function ({
   types: t,
 }: {
@@ -37,7 +42,6 @@ export default function ({
     visitor: {
       Program: {
         exit(programPath) {
-          // Collect filePath declarations
           const filePathDeclarations = new Map<string, string>();
 
           programPath.node.body.forEach((node) => {
@@ -59,7 +63,6 @@ export default function ({
             }
           });
 
-          // Transform filePath properties
           programPath.traverse({
             ObjectExpression(objPath) {
               const filePathProp = objPath.node.properties.find(
@@ -73,29 +76,10 @@ export default function ({
 
               if (!filePathProp || !t.isObjectProperty(filePathProp)) return;
 
-              // Verify parent is createElement(WebView, ...)
               const parent = objPath.parent;
-              if (
-                !t.isCallExpression(parent) ||
-                !t.isMemberExpression(parent.callee) ||
-                !t.isIdentifier(parent.callee.property, {
-                  name: "createElement",
-                })
-              ) {
-                return;
-              }
+              if (!t.isCallExpression(parent)) return;
+              if (!isSupportedWebViewCall(t, parent, objPath.node)) return;
 
-              const firstArg = parent.arguments[0];
-              const isWebView =
-                (t.isIdentifier(firstArg) &&
-                  (firstArg.name === "WebView" ||
-                    firstArg.name.endsWith("WebView"))) ||
-                (t.isMemberExpression(firstArg) &&
-                  t.isIdentifier(firstArg.property, { name: "WebView" }));
-
-              if (!isWebView) return;
-
-              // Get fileName
               const filePathValue = filePathProp.value;
               let fileName: string;
 
@@ -111,117 +95,74 @@ export default function ({
                 return;
               }
 
-              // Find spread element
               const spreadElement = objPath.node.properties.find((prop) =>
                 t.isSpreadElement(prop),
               ) as babelTypes.SpreadElement | undefined;
 
-              // Create IIFE: ((baseURL) => baseURL ? { dom: {...}, filePath: "..." } : { filePath: "..." })(HotUpdaterGetBaseURL())
-              const conditionalObject = t.conditionalExpression(
-                t.identifier("baseURL"),
-                // If baseURL exists: { dom: { overrideUri: [...].join("/") }, filePath: "hash.html" }
-                t.objectExpression([
-                  t.objectProperty(
-                    t.identifier("dom"),
-                    t.objectExpression(
-                      spreadElement && t.isIdentifier(spreadElement.argument)
-                        ? [
-                            t.spreadElement(
-                              t.memberExpression(
-                                spreadElement.argument,
-                                t.identifier("dom"),
-                              ),
-                            ),
-                            t.objectProperty(
-                              t.identifier("overrideUri"),
-                              t.callExpression(
-                                t.memberExpression(
-                                  t.arrayExpression([
-                                    t.identifier("baseURL"),
-                                    t.stringLiteral("www.bundle"),
-                                    t.stringLiteral(fileName),
-                                  ]),
-                                  t.identifier("join"),
-                                ),
-                                [t.stringLiteral("/")],
-                              ),
-                            ),
-                          ]
-                        : [
-                            t.objectProperty(
-                              t.identifier("overrideUri"),
-                              t.callExpression(
-                                t.memberExpression(
-                                  t.arrayExpression([
-                                    t.identifier("baseURL"),
-                                    t.stringLiteral("www.bundle"),
-                                    t.stringLiteral(fileName),
-                                  ]),
-                                  t.identifier("join"),
-                                ),
-                                [t.stringLiteral("/")],
-                              ),
-                            ),
-                          ],
-                    ),
-                  ),
-                  t.objectProperty(
-                    t.identifier("filePath"),
-                    t.stringLiteral(fileName),
-                  ),
-                ]),
-                // Else: { filePath: "hash.html" }
-                t.objectExpression([
-                  t.objectProperty(
-                    t.identifier("filePath"),
-                    t.stringLiteral(fileName),
-                  ),
-                ]),
-              );
-
-              const arrowFunction = t.arrowFunctionExpression(
-                [t.identifier("baseURL")],
-                conditionalObject,
-              );
-
-              const safeGetBaseURL = t.conditionalExpression(
-                t.logicalExpression(
-                  "&&",
-                  t.binaryExpression(
-                    "!==",
-                    t.unaryExpression(
-                      "typeof",
-                      t.identifier("globalThis"),
-                      true,
-                    ),
-                    t.stringLiteral("undefined"),
-                  ),
-                  t.memberExpression(
-                    t.identifier("globalThis"),
-                    t.identifier("HotUpdaterGetBaseURL"),
-                  ),
-                ),
-                t.callExpression(
-                  t.memberExpression(
-                    t.identifier("globalThis"),
-                    t.identifier("HotUpdaterGetBaseURL"),
-                  ),
-                  [],
-                ),
-                t.unaryExpression("void", t.numericLiteral(0)),
-              );
-
-              const iifeCall = t.callExpression(arrowFunction, [
-                safeGetBaseURL,
-              ]);
-
-              // Replace only filePath so existing spread/forwarded props keep
-              // their original order and override behavior.
               const propIndex = objPath.node.properties.indexOf(filePathProp);
               objPath.node.properties.splice(
                 propIndex,
                 1,
-                t.spreadElement(iifeCall),
+                t.spreadElement(
+                  buildHotUpdaterDomProps(
+                    t,
+                    fileName,
+                    spreadElement && t.isIdentifier(spreadElement.argument)
+                      ? spreadElement.argument
+                      : undefined,
+                  ),
+                ),
+              );
+            },
+            JSXOpeningElement(jsxPath) {
+              if (!isWebViewJsxName(t, jsxPath.node.name)) return;
+
+              const filePathAttr = jsxPath.node.attributes.find(
+                (attr) =>
+                  t.isJSXAttribute(attr) &&
+                  t.isJSXIdentifier(attr.name, { name: "filePath" }) &&
+                  (t.isStringLiteral(attr.value) ||
+                    (t.isJSXExpressionContainer(attr.value) &&
+                      t.isIdentifier(attr.value.expression))),
+              );
+
+              if (!filePathAttr || !t.isJSXAttribute(filePathAttr)) return;
+
+              let fileName: string | undefined;
+              if (
+                t.isStringLiteral(filePathAttr.value) &&
+                filePathAttr.value.value.endsWith(".html")
+              ) {
+                fileName = filePathAttr.value.value;
+              } else if (
+                t.isJSXExpressionContainer(filePathAttr.value) &&
+                t.isIdentifier(filePathAttr.value.expression)
+              ) {
+                const declaredValue = filePathDeclarations.get(
+                  filePathAttr.value.expression.name,
+                );
+                if (declaredValue) fileName = declaredValue;
+              }
+
+              if (!fileName) return;
+
+              const spreadAttribute = jsxPath.node.attributes.find((attr) =>
+                t.isJSXSpreadAttribute(attr),
+              ) as babelTypes.JSXSpreadAttribute | undefined;
+
+              const attrIndex = jsxPath.node.attributes.indexOf(filePathAttr);
+              jsxPath.node.attributes.splice(
+                attrIndex,
+                1,
+                t.jsxSpreadAttribute(
+                  buildHotUpdaterDomProps(
+                    t,
+                    fileName,
+                    spreadAttribute && t.isIdentifier(spreadAttribute.argument)
+                      ? spreadAttribute.argument
+                      : undefined,
+                  ),
+                ),
               );
             },
           });


### PR DESCRIPTION
## Summary

Fixes #1039.

This updates the Expo Babel plugin so DOM component `filePath` transforms work when Expo/Babel emits automatic JSX runtime calls. The previous plugin only handled `React.createElement(WebView, props)` props objects, so TSX DOM components lowered through `jsx`, `jsxs`, or `jsxDEV` could keep the original `filePath` without the Hot Updater `overrideUri` injection.

## What changed

- Keep the existing `React.createElement` transform path.
- Add support for JSX opening elements and automatic JSX runtime calls.
- Extract shared AST helpers into `babel-utils.ts`.
- Add regression tests for JSX attributes, JSX `filePath` variables with trailing plugins, automatic JSX runtime calls, and ordinary Expo app no-op behavior.

## RED / GREEN evidence

RED first:

- In `/tmp/hot-updater-red-issue1039`, I applied only the new regression spec to base `HEAD` and ran `pnpm --filter @hot-updater/expo test`.
- Result: 3 failures, all missing `globalThis.HotUpdaterGetBaseURL` / `overrideUri` for JSX attribute, JSX variable, and automatic JSX runtime call cases.

GREEN after fix:

- `pnpm --filter @hot-updater/expo test` -> 2 files passed, 16 tests passed
- `pnpm --filter @hot-updater/expo test:type` -> passed
- `pnpm -w lint` -> passed
- `pnpm --filter @hot-updater/expo build` -> passed

Additional repro verification:

- Issue #1039 repro Babel matrix with the reported Lingui + React Compiler + `react-native-worklets/plugin` config passes after the fix.
- Hot Updater plugin works before and after worklets in the transform probe, while app entry files remain no-op. User-facing guidance should still keep `react-native-worklets/plugin` last.
