### PR TITLE
feat(hot-updater): add `--provider` and `--build` flags to `init`

### DIFF
--- a/.changeset/init-noninteractive-flags.md
+++ b/.changeset/init-noninteractive-flags.md
@@ -1,0 +1,15 @@
+---
+"hot-updater": minor
+---
+
+feat(hot-updater): add `--provider` and `--build` flags to `init`
+
+`hot-updater init` always prompts for the build plugin and the provider. These optional flags pre-answer those two prompts so `init` can run without interaction:
+
+```
+hot-updater init --provider cloudflare --build expo
+```
+
+When a flag is omitted, the prompt is shown as before. Values are validated against the known choices.
+
+This is aimed at the Cloudflare redeploy flow described in #849: with a populated `.env.hotupdater`, re-running `init` redeploys the worker and applies pending migrations, and these flags remove the two prompts that otherwise block it from running unattended. Providers still prompt for any value that is not already present in `.env.hotupdater`.

--- a/packages/hot-updater/src/commands/init.ts
+++ b/packages/hot-updater/src/commands/init.ts
@@ -11,6 +11,44 @@ const REQUIRED_PACKAGES = {
   devDependencies: ["dotenv"],
 };
 
+interface BuildPluginChoice {
+  name: string;
+  label: string;
+  hint?: string;
+  dependencies: string[];
+  devDependencies: string[];
+}
+
+const BUILD_PLUGINS: Record<"bare" | "rock" | "expo", BuildPluginChoice> = {
+  bare: {
+    name: "bare",
+    label: "Bare",
+    hint: "React Native CLI",
+    dependencies: [],
+    devDependencies: ["@hot-updater/bare"],
+  },
+  rock: {
+    name: "rock",
+    label: "Rock",
+    hint: "React Native Enterprise Framework by Callstack",
+    dependencies: [],
+    devDependencies: ["@hot-updater/rock"],
+  },
+  expo: {
+    name: "expo",
+    label: "Expo",
+    dependencies: [],
+    devDependencies: ["@hot-updater/expo"],
+  },
+};
+
+const PROVIDER_LABELS = {
+  cloudflare: "Cloudflare D1 + R2 + Worker",
+  aws: "AWS S3 + Lambda@Edge",
+  supabase: "Supabase",
+  firebase: "Firebase",
+} as const;
+
 const PACKAGE_MAP = {
   supabase: {
     dependencies: [],
@@ -34,61 +72,60 @@ const PACKAGE_MAP = {
   },
 } as const;
 
-export const init = async () => {
+type BuildPluginKey = keyof typeof BUILD_PLUGINS;
+type Provider = keyof typeof PACKAGE_MAP;
+
+export interface InitOptions {
+  build?: BuildPluginKey;
+  provider?: Provider;
+}
+
+const resolveBuildPlugin = async (flag?: BuildPluginKey) => {
+  if (flag) {
+    return BUILD_PLUGINS[flag];
+  }
+
+  const selected = await p.select<BuildPluginChoice>({
+    message: "Select a build plugin",
+    options: Object.values(BUILD_PLUGINS).map((plugin) => ({
+      value: plugin,
+      label: plugin.label,
+      hint: plugin.hint,
+    })),
+  });
+
+  if (p.isCancel(selected)) {
+    process.exit(0);
+  }
+
+  return selected;
+};
+
+const resolveProvider = async (flag?: Provider): Promise<Provider> => {
+  if (flag) {
+    return flag;
+  }
+
+  const selected = await p.select<Provider>({
+    message: "Select a provider",
+    options: (Object.keys(PROVIDER_LABELS) as Provider[]).map((value) => ({
+      value,
+      label: PROVIDER_LABELS[value],
+    })),
+  });
+
+  if (p.isCancel(selected)) {
+    process.exit(0);
+  }
+
+  return selected;
+};
+
+export const init = async (options: InitOptions = {}) => {
   printBanner();
 
-  const buildPluginPackage = await p.select({
-    message: "Select a build plugin",
-    options: [
-      {
-        value: {
-          name: "bare",
-          dependencies: [],
-          devDependencies: ["@hot-updater/bare"],
-        },
-        hint: "React Native CLI",
-        label: "Bare",
-      },
-      {
-        value: {
-          name: "rock",
-          dependencies: [],
-          devDependencies: ["@hot-updater/rock"],
-        },
-        hint: "React Native Enterprise Framework by Callstack",
-        label: "Rock",
-      },
-      {
-        value: {
-          name: "expo",
-          dependencies: [],
-          devDependencies: ["@hot-updater/expo"],
-        },
-        label: "Expo",
-      },
-    ],
-  });
-
-  if (p.isCancel(buildPluginPackage)) {
-    process.exit(0);
-  }
-
-  const provider = await p.select({
-    message: "Select a provider",
-    options: [
-      {
-        value: "cloudflare",
-        label: "Cloudflare D1 + R2 + Worker",
-      },
-      { value: "aws", label: "AWS S3 + Lambda@Edge" },
-      { value: "supabase", label: "Supabase" },
-      { value: "firebase", label: "Firebase" },
-    ],
-  });
-
-  if (p.isCancel(provider)) {
-    process.exit(0);
-  }
+  const buildPluginPackage = await resolveBuildPlugin(options.build);
+  const provider = await resolveProvider(options.provider);
 
   try {
     await ensureInstallPackages({

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -79,7 +79,22 @@ program
   .description(banner(version))
   .version(version as string);
 
-program.command("init").description("Initialize Hot Updater").action(init);
+program
+  .command("init")
+  .description("Initialize Hot Updater")
+  .addOption(
+    new Option(
+      "--provider <provider>",
+      "provider to use; skips the prompt",
+    ).choices(["cloudflare", "aws", "supabase", "firebase"]),
+  )
+  .addOption(
+    new Option(
+      "--build <plugin>",
+      "build plugin to use; skips the prompt",
+    ).choices(["bare", "rock", "expo"]),
+  )
+  .action((options) => init(options));
 
 program
   .command("doctor")


### PR DESCRIPTION
## What

Adds two optional flags to `hot-updater init`:

```
hot-updater init --provider cloudflare --build expo
```

`--provider` (cloudflare, aws, supabase, firebase) and `--build` (bare, rock, expo) pre-answer the two prompts that `init` always shows. When a flag is omitted the prompt is shown exactly as before, so this is fully backward compatible. Values are validated with commander's `.choices()`, matching the existing `bundle promote --action` option.

Closes #1059. Background in #849.

## Why

Per #849, re-running `hot-updater init` is the intended way to redeploy the worker after bumping the SDK. On Cloudflare that path is idempotent: it reuses the existing `.env.hotupdater` values and applies only the migrations that are needed. The only thing forcing interaction on a re-run is the build plugin and provider selects at the top of `init`. These flags remove them, so the redeploy can run unattended (for example a CI job that bumps `@hot-updater/cloudflare` and redeploys).

## Scope, and where I am unsure

I want to be upfront that this is a small, pragmatic change that helps my own workflow, and I do not think it is the complete answer to non-interactive `init`:

- It only removes the two top-level prompts. It does not make `init` guaranteed non-interactive. On Cloudflare, any value missing from `.env.hotupdater` still falls back to its own prompt (account, R2 bucket, D1, worker name), and worker-deploy auth still uses the wrangler OAuth session, so a fully headless run also needs a valid wrangler login.
- The reuse-existing-env behavior that turns a re-run into a redeploy looks, as far as I can tell, mostly like a Cloudflare property. AWS and Supabase `runInit` prompt on every run and do not read existing `.env.hotupdater`, so for those providers these flags only skip the two selects and the rest stays interactive. Firebase appears to read the env partially.

So this is best read as a convenience that makes the Cloudflare redeploy flow scriptable, not a full `--non-interactive` mode. A complete version (error instead of prompt when a required value is missing, consistent env reuse across providers) would be a larger change across each provider's iac. Happy to follow up on that if you think it is worth doing, or to adjust the framing/flag names to your preference.

## Testing

- `pnpm --filter hot-updater test:type` passes.
- `oxfmt` and `oxlint` clean on the changed files.
- Built and smoke-tested the CLI: both flags appear in `init --help`, and an invalid value is rejected by commander (`--provider bogus` reports the allowed choices).

A changeset is included (`hot-updater` minor).

---

This PR was assisted by Claude Code.
