### PR TITLE
fix(expo): read EAS private key secret files

### DIFF
--- a/packages/react-native/plugin/src/withHotUpdater.spec.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.spec.ts
@@ -1,6 +1,95 @@
-import { describe, expect, it } from "vitest";
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+} from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { transformAndroid, transformIOS } from "./transformers";
+import { getPublicKeyFromConfig } from "./withHotUpdater";
+
+const originalPrivateKeyEnv = process.env.HOT_UPDATER_PRIVATE_KEY;
+const tempDirs: string[] = [];
+
+const createKeyPair = () =>
+  generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+vi.mock("hot-updater", () => ({
+  getPublicKeyFromPrivate: (privateKeyPEM: string) => {
+    const privateKey = createPrivateKey(privateKeyPEM);
+    return createPublicKey(privateKey).export({
+      type: "spki",
+      format: "pem",
+    });
+  },
+  loadPrivateKey: async (privateKeyPath: string) =>
+    readFile(privateKeyPath, "utf-8"),
+}));
+
+afterEach(async () => {
+  if (originalPrivateKeyEnv === undefined) {
+    delete process.env.HOT_UPDATER_PRIVATE_KEY;
+  } else {
+    process.env.HOT_UPDATER_PRIVATE_KEY = originalPrivateKeyEnv;
+  }
+
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+  );
+});
+
+describe("getPublicKeyFromConfig", () => {
+  it("reads HOT_UPDATER_PRIVATE_KEY as a file path", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "hot-updater-env-key-"));
+    tempDirs.push(dir);
+    const { privateKey, publicKey } = createKeyPair();
+    const privateKeyPath = path.join(dir, "eas-secret");
+
+    await writeFile(privateKeyPath, privateKey);
+    process.env.HOT_UPDATER_PRIVATE_KEY = privateKeyPath;
+
+    await expect(getPublicKeyFromConfig({ enabled: true })).resolves.toBe(
+      publicKey.trim(),
+    );
+  });
+
+  it("keeps inline private key env support", async () => {
+    const { privateKey, publicKey } = createKeyPair();
+
+    process.env.HOT_UPDATER_PRIVATE_KEY = privateKey;
+
+    await expect(getPublicKeyFromConfig({ enabled: true })).resolves.toBe(
+      publicKey.trim(),
+    );
+  });
+
+  it("falls back to signing.privateKeyPath", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "hot-updater-file-key-"));
+    tempDirs.push(dir);
+    const { privateKey, publicKey } = createKeyPair();
+    const privateKeyPath = path.join(dir, "private-key.pem");
+
+    await writeFile(privateKeyPath, privateKey);
+
+    await expect(
+      getPublicKeyFromConfig({ enabled: true, privateKeyPath }),
+    ).resolves.toBe(publicKey.trim());
+  });
+});
 
 describe("withHotUpdater - Test Cases", () => {
   describe("Android", () => {

--- a/packages/react-native/plugin/src/withHotUpdater.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.ts
@@ -100,7 +100,7 @@ const getFingerprint = async () => {
  * 3. Public key file (derived from privateKeyPath)
  * 4. Skip with warning (graceful fallback)
  */
-const getPublicKeyFromConfig = async (
+export const getPublicKeyFromConfig = async (
   signingConfig: { enabled?: boolean; privateKeyPath?: string } | undefined,
 ): Promise<string | null> => {
   // If signing not enabled, no public key needed
@@ -108,12 +108,15 @@ const getPublicKeyFromConfig = async (
     return null;
   }
 
-  // Priority 1: Environment variable with private key PEM (EAS builds)
   const envPrivateKey = process.env.HOT_UPDATER_PRIVATE_KEY;
   if (envPrivateKey) {
     try {
-      const { getPublicKeyFromPrivate } = await loadHotUpdater();
-      const publicKeyPEM = getPublicKeyFromPrivate(envPrivateKey);
+      const { getPublicKeyFromPrivate, loadPrivateKey } =
+        await loadHotUpdater();
+      const envPrivateKeyPEM = envPrivateKey.includes("-----BEGIN")
+        ? envPrivateKey
+        : await loadPrivateKey(envPrivateKey);
+      const publicKeyPEM = getPublicKeyFromPrivate(envPrivateKeyPEM);
       console.log(
         "[hot-updater] Using public key extracted from HOT_UPDATER_PRIVATE_KEY environment variable",
       );


### PR DESCRIPTION
## Summary

Fixes #810.

EAS Build can expose `HOT_UPDATER_PRIVATE_KEY` secrets as a filesystem path under `eas-environment-secrets` instead of the raw PEM string. The Expo config plugin previously passed that path directly to `getPublicKeyFromPrivate`, which produced the OpenSSL decoder failure shown in the issue.

This change keeps inline PEM support, and when the env value is not PEM-like it loads the value as a private-key file path before extracting the public key.

## Validation

- `pnpm exec vitest run --config packages/react-native/vitest.config.mts plugin/src/withHotUpdater.spec.ts -t 'reads HOT_UPDATER_PRIVATE_KEY as a file path'`
- `pnpm exec vitest run --config packages/react-native/vitest.config.mts plugin/src/withHotUpdater.spec.ts -t 'keeps inline private key env support'`
- `pnpm exec vitest run --config packages/react-native/vitest.config.mts plugin/src/withHotUpdater.spec.ts -t 'falls back to signing.privateKeyPath'`
- `pnpm exec vitest run --config packages/react-native/vitest.config.mts plugin/src/withHotUpdater.spec.ts`
- `pnpm exec oxfmt --check packages/react-native/plugin/src/withHotUpdater.ts packages/react-native/plugin/src/withHotUpdater.spec.ts`
- `pnpm exec oxlint packages/react-native/plugin/src/withHotUpdater.ts packages/react-native/plugin/src/withHotUpdater.spec.ts`
- `pnpm --filter @hot-updater/react-native test:type`
- `pnpm --filter @hot-updater/react-native build:plugin`
- Built plugin Node scenario with `HOT_UPDATER_PRIVATE_KEY` set to a temp private-key file path: `env-file-path pass=true`
