### PR TITLE
chore(docs): migrate docs domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
       label: Precheck
       description: Please check youself all of the following before submitting.
       options:
-        - label: Infrastructure may have changed. Did you try `hot-updater doctor`? (https://hot-updater.dev/docs/guides/doctor)
+        - label: Infrastructure may have changed. Did you try `hot-updater doctor`? (https://docs.hot-updater.dev/docs/guides/doctor)
           required: true
         - label: Is your Node version v20 or higher?
           required: true

--- a/.github/workflows/404.html
+++ b/.github/workflows/404.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <script>
       const basePath = "/hot-updater";
-      const target = "https://hot-updater.dev";
+      const target = "https://docs.hot-updater.dev";
       const path = location.pathname.replace(basePath, "");
       const search = location.search;
       const hash = location.hash;

--- a/.github/workflows/redirect.html
+++ b/.github/workflows/redirect.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <script>
       const basePath = "/hot-updater";
-      const target = "https://hot-updater.dev";
+      const target = "https://docs.hot-updater.dev";
       const path = location.pathname.replace(basePath, "");
       const search = location.search;
       const hash = location.hash;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   ## Documentation
 
   Full documentation is available at:
-  https://hot-updater.dev
+  https://docs.hot-updater.dev
 
   ## AI Skills
 
@@ -37,7 +37,7 @@
   `$hot-updater deploy using the current app version` or
   `$hot-updater roll back the most recently deployed bundle`.
 
-  See the [AI Agent Guide](https://hot-updater.dev/docs/guides/ai-agents) for
+  See the [AI Agent Guide](https://docs.hot-updater.dev/docs/guides/ai-agents) for
   the full workflow.
 
   ## Key Features
@@ -62,7 +62,7 @@
 
   ### Configuration Example
 
-  * [Supabase](https://hot-updater.dev/docs/managed/supabase)
+  * [Supabase](https://docs.hot-updater.dev/docs/managed/supabase)
   ```tsx
   import { bare } from "@hot-updater/bare";
   import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
@@ -85,7 +85,7 @@
   });
   ```
 
-* [Cloudflare](https://hot-updater.dev/docs/managed/cloudflare)
+* [Cloudflare](https://docs.hot-updater.dev/docs/managed/cloudflare)
 ```tsx
 import { bare } from "@hot-updater/bare";
 import { d1Database, r2Storage } from "@hot-updater/cloudflare";
@@ -109,7 +109,7 @@ export default defineConfig({
 });
 ```
 
-* [AWS S3 + Lambda@Edge](https://hot-updater.dev/docs/managed/aws)
+* [AWS S3 + Lambda@Edge](https://docs.hot-updater.dev/docs/managed/aws)
 ```tsx
 import { bare } from "@hot-updater/bare";
 import { s3Storage, s3Database } from "@hot-updater/aws";
@@ -134,7 +134,7 @@ export default defineConfig({
 });
 ```
 
-* [Firebase](https://hot-updater.dev/docs/managed/firebase)
+* [Firebase](https://docs.hot-updater.dev/docs/managed/firebase)
 ```tsx
 import { bare } from '@hot-updater/bare';
 import {firebaseStorage, firebaseDatabase} from '@hot-updater/firebase';

--- a/docs/src/pages/_layout.tsx
+++ b/docs/src/pages/_layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
       {/* Open Graph / Facebook */}
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={"https://hot-updater.dev"} />
+      <meta property="og:url" content={"https://docs.hot-updater.dev"} />
       <meta
         property="og:title"
         content="Hot Updater - Self-hosted OTA updates for React Native"
@@ -52,7 +52,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         property="og:description"
         content="Self-hosted over-the-air updates for React Native"
       />
-      <meta property="og:image" content="https://hot-updater.dev/og.png" />
+      <meta property="og:image" content="https://docs.hot-updater.dev/og.png" />
       <meta property="og:image:width" content="4800" />
       <meta property="og:image:height" content="2520" />
       <meta property="og:image:type" content="image/png" />
@@ -62,7 +62,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
       {/* Twitter */}
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:url" content="https://hot-updater.dev" />
+      <meta name="twitter:url" content="https://docs.hot-updater.dev" />
       <meta
         name="twitter:title"
         content="Hot Updater - Self-hosted OTA updates for React Native"
@@ -71,7 +71,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         name="twitter:description"
         content="Self-hosted over-the-air updates for React Native"
       />
-      <meta name="twitter:image" content="https://hot-updater.dev/og.png" />
+      <meta
+        name="twitter:image"
+        content="https://docs.hot-updater.dev/og.png"
+      />
 
       <Provider>
         {children}

--- a/docs/waku.config.ts
+++ b/docs/waku.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       tailwindcss(),
       mdx(MdxConfig),
       llmsTxtPlugin({
-        baseUrl: "https://hot-updater.dev",
+        baseUrl: "https://docs.hot-updater.dev",
       }),
       deadLinkCheckerPlugin({
         contentDir: "content/docs",

--- a/packages/hot-updater/src/utils/native/prepareNativeBuild.ts
+++ b/packages/hot-updater/src/utils/native/prepareNativeBuild.ts
@@ -56,7 +56,7 @@ export async function prepareNativeBuild(
 
   if (!availableSchemes.length) {
     p.log.error(
-      `configure your native build schemes for ${platform} first. See documentation [https://hot-updater.dev/docs/guides/native-build/]`,
+      `configure your native build schemes for ${platform} first. See documentation [https://docs.hot-updater.dev/docs/guides/native-build/]`,
     );
     return null;
   }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -837,7 +837,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
   - hot-updater@0.21.7

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -102,7 +102,7 @@ type HotUpdaterWrap = {
    * ```
    *
    * Then call `HotUpdater.checkForUpdate(...)` from your manual update flow.
-   * See https://hot-updater.dev/docs/guides/custom-update
+   * See https://docs.hot-updater.dev/docs/guides/custom-update
    */
   (options: ManualUpdateOptions): ReturnType<typeof wrap>;
   (options: HotUpdaterOptions): ReturnType<typeof wrap>;
@@ -136,7 +136,7 @@ function createHotUpdaterClient() {
           `  HotUpdater.init({\n` +
           `    baseURL: "<your-update-server-url>",\n` +
           `  });\n\n` +
-          `For manual update flows, visit: https://hot-updater.dev/docs/guides/custom-update`,
+          `For manual update flows, visit: https://docs.hot-updater.dev/docs/guides/custom-update`,
       );
     }
 
@@ -151,7 +151,7 @@ function createHotUpdaterClient() {
         `Configure HotUpdater.wrap with the standard baseURL setup:\n\n` +
         baseURLExample +
         `For manual update flows, use HotUpdater.init() and visit: ` +
-        `https://hot-updater.dev/docs/guides/custom-update`,
+        `https://docs.hot-updater.dev/docs/guides/custom-update`,
     );
   };
 
@@ -244,7 +244,7 @@ function createHotUpdaterClient() {
           `  HotUpdater.init({\n` +
           `    baseURL: "<your-update-server-url>",\n` +
           `  });\n\n` +
-          `For manual update flows, visit: https://hot-updater.dev/docs/guides/custom-update`,
+          `For manual update flows, visit: https://docs.hot-updater.dev/docs/guides/custom-update`,
       );
     }
     return globalConfig.resolver;

--- a/packages/react-native/src/wrap.tsx
+++ b/packages/react-native/src/wrap.tsx
@@ -139,7 +139,7 @@ export type AutoUpdateOptions = CommonHotUpdaterOptions &
      * When an update exists and the bundle is being downloaded, this component will block access
      * to the entry point and show download progress.
      *
-     * @see {@link https://hot-updater.dev/docs/react-native-api/wrap#fallback-component}
+     * @see {@link https://docs.hot-updater.dev/docs/react-native-api/wrap#fallback-component}
      *
      * ```tsx
      * HotUpdater.wrap({
@@ -170,7 +170,7 @@ export type AutoUpdateOptions = CommonHotUpdaterOptions &
     /**
      * Callback function that is called when the update process is completed.
      *
-     * @see {@link https://hot-updater.dev/docs/react-native-api/wrap#onupdateprocesscompleted}
+     * @see {@link https://docs.hot-updater.dev/docs/react-native-api/wrap#onupdateprocesscompleted}
      */
     onUpdateProcessCompleted?: (response: RunUpdateProcessResponse) => void;
   };
@@ -191,7 +191,7 @@ export type ManualUpdateOptions = CommonHotUpdaterOptions &
      * ```
      *
      * Then call `HotUpdater.checkForUpdate(...)` from your manual update flow.
-     * See https://hot-updater.dev/docs/guides/custom-update
+     * See https://docs.hot-updater.dev/docs/guides/custom-update
      */
     updateMode: "manual";
   };
@@ -246,7 +246,7 @@ const warnManualWrapDeprecation = () => {
       "Move the same baseURL/resolver options to HotUpdater.init({ ... }), " +
       "export your root component directly, and call " +
       "HotUpdater.checkForUpdate(...) from your manual update flow. " +
-      "See https://hot-updater.dev/docs/guides/custom-update",
+      "See https://docs.hot-updater.dev/docs/guides/custom-update",
   );
 };
 

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -715,7 +715,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
   - @hot-updater/core@0.21.7

--- a/plugins/aws/CHANGELOG.md
+++ b/plugins/aws/CHANGELOG.md
@@ -648,7 +648,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
 

--- a/plugins/aws/iac/index.ts
+++ b/plugins/aws/iac/index.ts
@@ -351,7 +351,7 @@ export const runInit = async ({ build }: { build: BuildType }) => {
   const sourceUrl = `https://${distributionDomain}/api/check-update`;
   p.note(transformTemplate(SOURCE_TEMPLATE, { source: sourceUrl }));
   p.log.message(
-    `Next step: ${link("https://hot-updater.dev/docs/managed/aws#step-4-changeenv-file-optional")}`,
+    `Next step: ${link("https://docs.hot-updater.dev/docs/managed/aws#step-4-changeenv-file-optional")}`,
   );
   p.log.success("Done! 🎉");
 };

--- a/plugins/cloudflare/CHANGELOG.md
+++ b/plugins/cloudflare/CHANGELOG.md
@@ -774,7 +774,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
   - @hot-updater/core@0.21.7

--- a/plugins/cloudflare/iac/index.ts
+++ b/plugins/cloudflare/iac/index.ts
@@ -685,7 +685,7 @@ export const runInit = async ({ build }: { build: BuildType }) => {
 
   p.log.message(
     `Next step: ${link(
-      "https://hot-updater.dev/docs/managed/cloudflare#step-4-add-hotupdater-to-your-project",
+      "https://docs.hot-updater.dev/docs/managed/cloudflare#step-4-add-hotupdater-to-your-project",
     )}`,
   );
   p.log.success("Done! 🎉");

--- a/plugins/firebase/CHANGELOG.md
+++ b/plugins/firebase/CHANGELOG.md
@@ -699,7 +699,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
   - @hot-updater/core@0.21.7

--- a/plugins/firebase/iac/index.ts
+++ b/plugins/firebase/iac/index.ts
@@ -497,7 +497,7 @@ export const runInit = async ({ build }: { build: BuildType }) => {
 
   p.log.message(
     `Next step: ${link(
-      "https://hot-updater.dev/docs/managed/firebase#step-3-generated-configurations",
+      "https://docs.hot-updater.dev/docs/managed/firebase#step-3-generated-configurations",
     )}`,
   );
   p.log.message(

--- a/plugins/plugin-core/CHANGELOG.md
+++ b/plugins/plugin-core/CHANGELOG.md
@@ -553,7 +553,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
   - @hot-updater/core@0.21.7
 
 ## 0.21.6

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -512,9 +512,9 @@ export type ConfigInput = {
    * The strategy used to update the app.
    *
    * If `fingerprint`, the bundle will be updated if the fingerprint of the app is changed.
-   * @docs https://hot-updater.dev/docs/guides/update-strategies/fingerprint
+   * @docs https://docs.hot-updater.dev/docs/guides/update-strategies/fingerprint
    * If `appVersion`, the bundle will be updated if the target app version is valid.
-   * @docs https://hot-updater.dev/docs/guides/update-strategies/app-version
+   * @docs https://docs.hot-updater.dev/docs/guides/update-strategies/app-version
    *
    * @default "appVersion"
    */

--- a/plugins/supabase/CHANGELOG.md
+++ b/plugins/supabase/CHANGELOG.md
@@ -703,7 +703,7 @@
 
 ### Patch Changes
 
-- 2b408f2: docs: revamp hot-updater.dev
+- 2b408f2: docs: revamp docs.hot-updater.dev
 - Updated dependencies [2b408f2]
   - @hot-updater/plugin-core@0.21.7
   - @hot-updater/core@0.21.7

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -705,7 +705,7 @@ export const runInit = async ({ build }: { build: BuildType }) => {
 
   p.log.message(
     `Next step: ${link(
-      "https://hot-updater.dev/docs/managed/supabase#step-4-add-hotupdater-to-your-project",
+      "https://docs.hot-updater.dev/docs/managed/supabase#step-4-add-hotupdater-to-your-project",
     )}`,
   );
   p.log.success("Done! 🎉");


### PR DESCRIPTION
## Summary

- Replace hardcoded `https://hot-updater.dev` docs links with `https://docs.hot-updater.dev` across README, docs metadata/config, CLI messages, package JSDoc, GitHub templates, redirects, and changelog entries.
- Update GitHub Pages redirect targets to preserve paths under the new docs host.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -w lint`
- `pnpm --filter hot-updater-docs test:type`
- `pnpm --filter hot-updater-docs build`
- `git diff --check`
- `rg -n --hidden --pcre2 "(?<!docs\.)hot-updater\.dev" . --glob "!.git/**" --glob "!node_modules/**" --glob "!.nx/**" --glob "!dist/**"` returned no matches
