### PR TITLE
test(e2e): cover iOS compatible update cold restart

### DIFF
--- a/e2e/detox/scenario-contract.spec.ts
+++ b/e2e/detox/scenario-contract.spec.ts
@@ -1545,7 +1545,8 @@ describe("Detox scenario contract", () => {
     const stages = await scenarioStages("force-update-auto-reload");
 
     // When: the Detox scenario is inspected.
-    // Then: it waits pending first, reloads, then verifies the stable launch.
+    // Then: it waits pending first, reloads, then proves the active bundle
+    // survives a cold relaunch.
     expect(stages).toEqual([
       "deploy force update bundle",
       "launch force update app",
@@ -1553,7 +1554,18 @@ describe("Detox scenario contract", () => {
       "wait force update metadata pending",
       "reload force update",
       "wait force update metadata stable",
+      "assert force update runtime bundle",
       "assert force update launch",
+      "assert force update crash history empty",
+      "capture force update post-reload state",
+      "assert force update metadata active",
+      "terminate force update app",
+      "cold relaunch force update app",
+      "assert force update cold runtime bundle",
+      "assert force update cold launch",
+      "assert force update cold crash history empty",
+      "capture force update cold state",
+      "assert force update cold metadata active",
     ]);
     expect(
       (
@@ -1571,6 +1583,18 @@ describe("Detox scenario contract", () => {
         )
       ).verificationPending,
     ).toBe(false);
+    expect(
+      await controlStepBody(
+        "force-update-auto-reload",
+        "assert force update metadata active",
+      ),
+    ).toEqual({ bundleId: "$forceBundleId" });
+    expect(
+      await controlStepBody(
+        "force-update-auto-reload",
+        "assert force update cold metadata active",
+      ),
+    ).toEqual({ bundleId: "$forceBundleId" });
   });
 
   it("models archive-to-diff OTA install and metadata verification sequence", async () => {

--- a/e2e/detox/scenario-contract.spec.ts
+++ b/e2e/detox/scenario-contract.spec.ts
@@ -92,6 +92,7 @@ const defaultDetoxScenarioNames = [
   "target-cohorts-only",
   "target-cohorts-rollout-interaction",
   "targeted-cohort-switchback",
+  "compatible-update-cold-restart",
   "force-update-auto-reload",
   "disabled-bundle-rollback-to-builtin",
   "disabled-bundle-rollback-to-previous-ota",
@@ -237,7 +238,7 @@ describe("Detox scenario contract", () => {
 
     expect(detoxScenarios).toEqual(defaultDetoxScenarioNames);
     expect(listDetoxScenarioNames()).toEqual(defaultDetoxScenarioNames);
-    expect(new Set(listDetoxScenarioNames()).size).toBe(14);
+    expect(new Set(listDetoxScenarioNames()).size).toBe(15);
   });
 
   it("uses Detox-owned scenario lookup in the runner", async () => {
@@ -1595,6 +1596,60 @@ describe("Detox scenario contract", () => {
         "assert force update cold metadata active",
       ),
     ).toEqual({ bundleId: "$forceBundleId" });
+  });
+
+  it("models compatible-update-cold-restart through a cold launch", async () => {
+    const stages = await scenarioStages("compatible-update-cold-restart");
+
+    expect(stages).toEqual([
+      "deploy compatible update bundle",
+      "launch compatible update app",
+      "install compatible update",
+      "assert compatible update action result",
+      "wait compatible metadata pending",
+      "reload compatible update",
+      "wait compatible metadata stable",
+      "assert compatible runtime bundle",
+      "assert compatible launch",
+      "assert compatible crash history empty",
+      "capture compatible post-reload state",
+      "assert compatible metadata active",
+      "terminate compatible update app",
+      "cold relaunch compatible update app",
+      "assert compatible cold runtime bundle",
+      "assert compatible cold launch",
+      "assert compatible cold crash history empty",
+      "capture compatible cold state",
+      "assert compatible cold metadata active",
+    ]);
+    expect(
+      (
+        await controlStepBody(
+          "compatible-update-cold-restart",
+          "wait compatible metadata pending",
+        )
+      ).verificationPending,
+    ).toBe(true);
+    expect(
+      (
+        await controlStepBody(
+          "compatible-update-cold-restart",
+          "wait compatible metadata stable",
+        )
+      ).verificationPending,
+    ).toBe(false);
+    expect(
+      await controlStepBody(
+        "compatible-update-cold-restart",
+        "assert compatible metadata active",
+      ),
+    ).toEqual({ bundleId: "$bundleId" });
+    expect(
+      await controlStepBody(
+        "compatible-update-cold-restart",
+        "assert compatible cold metadata active",
+      ),
+    ).toEqual({ bundleId: "$bundleId" });
   });
 
   it("models archive-to-diff OTA install and metadata verification sequence", async () => {

--- a/e2e/detox/scenarios.ts
+++ b/e2e/detox/scenarios.ts
@@ -2,6 +2,7 @@ import { bspatchArchiveToDiffOtaScenario } from "./scenarios/bspatch-archive-to-
 import { bspatchConsecutiveDiffOtaScenario } from "./scenarios/bspatch-consecutive-diff-ota.ts";
 import { bspatchDisabledChainRollbackScenario } from "./scenarios/bspatch-disabled-chain-rollback.ts";
 import { bspatchManifestDiffFallbackScenario } from "./scenarios/bspatch-manifest-diff-fallback.ts";
+import { compatibleUpdateColdRestartScenario } from "./scenarios/compatible-update-cold-restart.ts";
 import { disabledBundleRollbackToBuiltinScenario } from "./scenarios/disabled-bundle-rollback-to-builtin.ts";
 import { disabledBundleRollbackToPreviousOtaScenario } from "./scenarios/disabled-bundle-rollback-to-previous-ota.ts";
 import { forceUpdateAutoReloadScenario } from "./scenarios/force-update-auto-reload.ts";
@@ -31,6 +32,7 @@ const detoxScenarios: readonly DetoxScenarioDefinition[] = [
   targetCohortsOnlyScenario,
   targetCohortsRolloutInteractionScenario,
   targetedCohortSwitchbackScenario,
+  compatibleUpdateColdRestartScenario,
   forceUpdateAutoReloadScenario,
   disabledBundleRollbackToBuiltinScenario,
   disabledBundleRollbackToPreviousOtaScenario,

--- a/e2e/detox/scenarios/compatible-update-cold-restart.ts
+++ b/e2e/detox/scenarios/compatible-update-cold-restart.ts
@@ -1,0 +1,105 @@
+import type { DetoxScenarioDefinition } from "./types.ts";
+
+export const compatibleUpdateColdRestartScenario: DetoxScenarioDefinition = {
+  name: "compatible-update-cold-restart",
+  run: async (app) => {
+    await app.control(
+      "deploy compatible update bundle",
+      "/e2e/jobs/deploy-bundle",
+      {
+        channel: "production",
+        marker: "compatible-cold-restart-detox",
+        mode: "reset",
+        safeBundleIds: [],
+        targetAppVersion: "1.0.x",
+      },
+      {
+        saveResultAs: "bundleId",
+      },
+    );
+    await app.launch("launch compatible update app");
+    await app.tap(
+      "install compatible update",
+      "action-install-current-channel-update",
+    );
+    await app.assertText(
+      "assert compatible update action result",
+      "update-action-result",
+      "current-channel -> installed $bundleId",
+      { exactText: true },
+    );
+    await app.control(
+      "wait compatible metadata pending",
+      "/e2e/jobs/wait-for-metadata",
+      {
+        bundleId: "$bundleId",
+        verificationPending: true,
+      },
+    );
+    await app.reload("reload compatible update");
+    await app.control(
+      "wait compatible metadata stable",
+      "/e2e/jobs/wait-for-metadata",
+      {
+        bundleId: "$bundleId",
+        verificationPending: false,
+      },
+    );
+    await app.assertText(
+      "assert compatible runtime bundle",
+      "runtime-bundle-id",
+      "$bundleId",
+    );
+    await app.assertText(
+      "assert compatible launch",
+      "launch-status-result",
+      "Current Launch Status: STABLE",
+    );
+    await app.assertText(
+      "assert compatible crash history empty",
+      "crash-history-count",
+      "0",
+    );
+    await app.control(
+      "capture compatible post-reload state",
+      "/e2e/capture-state",
+      {
+        prefix: "compatible-update-post-reload",
+      },
+    );
+    await app.control(
+      "assert compatible metadata active",
+      "/e2e/assert-metadata-active",
+      {
+        bundleId: "$bundleId",
+      },
+    );
+    await app.terminate("terminate compatible update app");
+    await app.launch("cold relaunch compatible update app");
+    await app.assertText(
+      "assert compatible cold runtime bundle",
+      "runtime-bundle-id",
+      "$bundleId",
+    );
+    await app.assertText(
+      "assert compatible cold launch",
+      "launch-status-result",
+      "Current Launch Status: STABLE",
+    );
+    await app.assertText(
+      "assert compatible cold crash history empty",
+      "crash-history-count",
+      "0",
+    );
+    await app.control("capture compatible cold state", "/e2e/capture-state", {
+      prefix: "compatible-update-cold-relaunch",
+    });
+    await app.control(
+      "assert compatible cold metadata active",
+      "/e2e/assert-metadata-active",
+      {
+        bundleId: "$bundleId",
+      },
+    );
+  },
+};

--- a/e2e/detox/scenarios/force-update-auto-reload.ts
+++ b/e2e/detox/scenarios/force-update-auto-reload.ts
@@ -41,9 +41,60 @@ export const forceUpdateAutoReloadScenario: DetoxScenarioDefinition = {
       },
     );
     await app.assertText(
+      "assert force update runtime bundle",
+      "runtime-bundle-id",
+      "$forceBundleId",
+    );
+    await app.assertText(
       "assert force update launch",
       "launch-status-result",
       "Current Launch Status: STABLE",
+    );
+    await app.assertText(
+      "assert force update crash history empty",
+      "crash-history-count",
+      "0",
+    );
+    await app.control(
+      "capture force update post-reload state",
+      "/e2e/capture-state",
+      {
+        prefix: "force-update-post-reload",
+      },
+    );
+    await app.control(
+      "assert force update metadata active",
+      "/e2e/assert-metadata-active",
+      {
+        bundleId: "$forceBundleId",
+      },
+    );
+    await app.terminate("terminate force update app");
+    await app.launch("cold relaunch force update app");
+    await app.assertText(
+      "assert force update cold runtime bundle",
+      "runtime-bundle-id",
+      "$forceBundleId",
+    );
+    await app.assertText(
+      "assert force update cold launch",
+      "launch-status-result",
+      "Current Launch Status: STABLE",
+    );
+    await app.assertText(
+      "assert force update cold crash history empty",
+      "crash-history-count",
+      "0",
+    );
+    await app.control("capture force update cold state", "/e2e/capture-state", {
+      prefix: "force-update-cold-relaunch",
+    });
+    await app.control(
+      "assert force update cold metadata active",
+      "/e2e/assert-metadata-active",
+      {
+        bundleId: "$forceBundleId",
+      },
     );
   },
 };

--- a/examples/v0.85.0/ios/HotUpdaterExample.xcodeproj/project.pbxproj
+++ b/examples/v0.85.0/ios/HotUpdaterExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0C80B921A6F3F58F76C31292 /* libPods-HotUpdaterExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-HotUpdaterExample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
+		761780EF2CA45674006654EE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EE2CA45674006654EE /* SceneDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		E412685610C001DD639E1636 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
@@ -23,6 +24,7 @@
 		5709B34CF0A7D63546082F79 /* Pods-HotUpdaterExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HotUpdaterExample.release.xcconfig"; path = "Target Support Files/Pods-HotUpdaterExample/Pods-HotUpdaterExample.release.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-HotUpdaterExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HotUpdaterExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HotUpdaterExample/AppDelegate.swift; sourceTree = "<group>"; };
+		761780EE2CA45674006654EE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HotUpdaterExample/SceneDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = HotUpdaterExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -44,6 +46,7 @@
 			children = (
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
+				761780EE2CA45674006654EE /* SceneDelegate.swift */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
@@ -247,6 +250,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
+				761780EF2CA45674006654EE /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/v0.85.0/ios/HotUpdaterExample/AppDelegate.swift
+++ b/examples/v0.85.0/ios/HotUpdaterExample/AppDelegate.swift
@@ -16,6 +16,43 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    configureReactNativeFactory()
+
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }
+
+  func startReactNative(
+    in window: UIWindow,
+    launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) {
+    let factory = configureReactNativeFactory()
+    self.window = window
+
+    factory.startReactNative(
+      withModuleName: "HotUpdaterExample",
+      in: window,
+      launchOptions: launchOptions
+    )
+  }
+
+  private func configureReactNativeFactory() -> RCTReactNativeFactory {
+    if let reactNativeFactory = reactNativeFactory {
+      return reactNativeFactory
+    }
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
@@ -23,15 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
 
-    window = UIWindow(frame: UIScreen.main.bounds)
-
-    factory.startReactNative(
-      withModuleName: "HotUpdaterExample",
-      in: window,
-      launchOptions: launchOptions
-    )
-
-    return true
+    return factory
   }
 
   func application(

--- a/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
+++ b/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
@@ -54,6 +54,23 @@
 		<array>
 			<string>arm64</string>
 		</array>
+		<key>UIApplicationSceneManifest</key>
+		<dict>
+			<key>UIApplicationSupportsMultipleScenes</key>
+			<false/>
+			<key>UISceneConfigurations</key>
+			<dict>
+				<key>UIWindowSceneSessionRoleApplication</key>
+				<array>
+					<dict>
+						<key>UISceneConfigurationName</key>
+						<string>Default Configuration</string>
+						<key>UISceneDelegateClassName</key>
+						<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
 		<key>UISupportedInterfaceOrientations</key>
 		<array>
 			<string>UIInterfaceOrientationPortrait</string>

--- a/examples/v0.85.0/ios/HotUpdaterExample/SceneDelegate.swift
+++ b/examples/v0.85.0/ios/HotUpdaterExample/SceneDelegate.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else {
+      return
+    }
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+      return
+    }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+    appDelegate.startReactNative(in: window)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `compatible-update-cold-restart` Detox scenario for the issue #1074 repro shape: normal compatible production bundle install, stable reload, full app terminate, cold relaunch, then bundle identity checks.
- Converts the iOS v0.85 example startup path to use `SceneDelegate`, so the repro now exercises a scene-based cold launch instead of the previous AppDelegate-only window path.
- Extends `force-update-auto-reload` with the same cold-start identity checks so forced updates also prove persistence across a real app restart.
- Captures post-reload and cold-relaunch state snapshots, and asserts runtime bundle id, `STABLE` launch status, empty crash history, and active metadata.

## Context

Reproduction probe for https://github.com/gronxb/hot-updater/issues/1074#issuecomment-4899072366.

The target comment says the goal is a normal compatible update: iOS downloads/installs the bundle, `notifyAppReady` reports `STABLE`, crash history is empty, but after closing and reopening the app it loads the old bundle and repeats the update flow. The new scenario makes that exact cold-start boundary part of the default Detox suite, and the latest commit routes the iOS app through `SceneDelegate` to match the reported app shape more closely.

## Validation

- Red check before adding the normal scenario: `pnpm -w exec vitest run e2e/detox/scenario-contract.spec.ts -t "compatible-update-cold-restart"` failed with `Unknown Detox scenario: compatible-update-cold-restart`.
- Green targeted check: `pnpm -w exec vitest run e2e/detox/scenario-contract.spec.ts -t "compatible-update-cold-restart"`.
- Green full contract check: `pnpm -w exec vitest run e2e/detox/scenario-contract.spec.ts`.
- Green repo lint: `pnpm -w lint`.
- Local plist/diff checks after adding SceneDelegate: `plutil -lint examples/v0.85.0/ios/HotUpdaterExample/Info.plist`, `git diff --check`, and full scenario contract test passed.
- Local direct `xcodebuild` is blocked by stale local Pods privacy file paths in `examples/v0.85.0/ios/Pods.xcodeproj`; the authoritative native build/runtime validation is the `hot-updater-agent` standalone run below.

## Hot Updater Agent

- Previous `standalone-s3` iOS run on `ecc9fd3d` passed, but that run did not use `SceneDelegate`.
- Latest `standalone-s3` iOS run on `a8ccff08` used the SceneDelegate startup path. Job `job-20260707020312-wknnb5` reached and passed `compatible-update-cold-restart`, including post-reload and cold-relaunch bundle identity, `STABLE` launch report, empty crash history, and active metadata checks.
- The same latest full suite later failed in unrelated disabled-bundle rollback scenarios after the standalone storage/API path returned `connect ECONNREFUSED 127.0.0.1:19007`; final count was `13 passed, 2 failed, 15 total`.
