### PR TITLE
fix(expo): disable minify when Hermes is enabled

### DIFF
--- a/.changeset/fancy-meteors-push.md
+++ b/.changeset/fancy-meteors-push.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/expo": patch
+---
+
+fix(expo): disable minify when Hermes is enabled

--- a/plugins/expo/src/expo.ts
+++ b/plugins/expo/src/expo.ts
@@ -53,6 +53,7 @@ const runBundle = async ({
   const bundleOutput = path.join(buildPath, `${filename}.bundle`);
   const entryFile = resolveMain(cwd);
   const bundleId = uuidv7();
+  const enableHermes = isHermesEnabled(cwd, platform);
 
   const args = [
     "expo",
@@ -65,6 +66,9 @@ const runBundle = async ({
     bundleOutput,
     "--dev",
     String(false),
+    // disable minify when enableHermes is true
+    "--minify",
+    String(!enableHermes),
     "--assets-dest",
     buildPath,
     ...(sourcemap ? ["--sourcemap-output", `${bundleOutput}.map`] : []),
@@ -86,7 +90,6 @@ const runBundle = async ({
     }
   }
 
-  const enableHermes = isHermesEnabled(cwd, platform);
   if (enableHermes) {
     const { hermesVersion } = await compileHermes({
       cwd,


### PR DESCRIPTION
Closes #1080

### What

Pass `--minify false` to `expo export:embed` when Hermes is enabled — same behavior as the bare plugin (#309) and the official React Native embed pipeline (`react-native-xcode.sh` / gradle; "Hermes doesn't require JS minification", facebook/hermes#452).

### Why

Without this flag, `expo export:embed --dev false` defaults to minify=true, so OTA bundles are built from **terser-minified JS → hermesc** — a combination the embedded build never produces. On RN 0.85 (Hermes V1), hermesc's default optimizer miscompiles certain terser output patterns, causing deterministic OTA-only runtime crashes (see #1080 for the full single-variable isolation matrix: unminified=OK / minified=crash / minified+`-O0`=OK).

### Notes

- Reuses the existing `isHermesEnabled` check (hoisted above the args array), mirroring the bare plugin's `String(!enableHermes)` style and comment.
- Verified in production: after applying this change and redeploying, the crash disappeared on both iOS and Android; the resulting `.hbc` is marginally smaller than the minified-input build.
