### PR TITLE
fix(react-native): verify cached bundle integrity

### DIFF
--- a/.changeset/tidy-bundles-verify.md
+++ b/.changeset/tidy-bundles-verify.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Verify manifest-tracked cached bundles before reuse and launch on Android and iOS.

--- a/.changeset/tidy-bundles-verify.md
+++ b/.changeset/tidy-bundles-verify.md
@@ -2,4 +2,5 @@
 "@hot-updater/react-native": patch
 ---
 
-Verify manifest-tracked cached bundles before reuse and launch on Android and iOS.
+Verify manifest-tracked cached bundles before reuse and launch on Android and iOS,
+and reject unverifiable legacy cache paths when bundle signing is enabled.

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -540,22 +540,29 @@ class BundleFileStorageService(
 
     private fun extractBundleIdFromCurrentURL(): String? {
         val currentUrl = preferences.getItem("HotUpdaterBundleURL") ?: return null
+        return extractBundleIdFromURL(currentUrl)
+    }
+
+    private fun extractBundleIdFromURL(url: String): String? {
         // "bundle-store/abc123/index.android.bundle" -> "abc123"
         val regex = Regex("bundle-store/([^/]+)/")
-        return regex.find(currentUrl)?.groupValues?.get(1)
+        return regex.find(url)?.groupValues?.get(1)
     }
 
     private fun resolveBundleFile(bundleDir: File): File? {
-        val manifest = readManifestFromBundleDir(bundleDir)
+        val manifestFile = File(bundleDir, "manifest.json")
+        val manifest = parseBundleManifestFromFile(manifestFile)
+        if (manifestFile.isFile && manifest == null) {
+            Log.w(TAG, "Rejecting bundle with invalid manifest: ${manifestFile.absolutePath}")
+            return null
+        }
+
         val manifestBundlePath =
-            (manifest?.get("assets") as? Map<*, *>)
+            manifest
+                ?.assets
                 ?.keys
-                ?.mapNotNull { key ->
-                    (key as? String)
-                        ?.trim()
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.takeIf { File(it).name.endsWith(".android.bundle") }
-                }?.singleOrNull()
+                ?.filter { File(it).name.endsWith(".android.bundle") }
+                ?.singleOrNull()
 
         if (manifestBundlePath != null) {
             try {
@@ -568,6 +575,10 @@ class BundleFileStorageService(
                         canonicalBundleFilePath.startsWith("$canonicalBundleDirPath${File.separator}")
 
                 if (isWithinBundleDir && canonicalBundleFile.isFile) {
+                    val expectedAsset = manifest.assets.getValue(manifestBundlePath)
+                    if (!isManifestBundleFileValid(canonicalBundleFile, expectedAsset)) {
+                        return null
+                    }
                     return canonicalBundleFile
                 }
             } catch (e: Exception) {
@@ -575,7 +586,59 @@ class BundleFileStorageService(
             }
         }
 
-        return File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
+        val fallbackBundleFile = File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
+            ?: return null
+        if (!isFileWithinDirectory(fallbackBundleFile, bundleDir)) {
+            return null
+        }
+        val fallbackAsset = manifest?.assets?.get("index.android.bundle")
+        if (fallbackAsset != null && !isManifestBundleFileValid(fallbackBundleFile, fallbackAsset)) {
+            return null
+        }
+        return fallbackBundleFile
+    }
+
+    private fun isManifestBundleFileValid(
+        bundleFile: File,
+        expectedAsset: ParsedManifestAsset,
+    ): Boolean =
+        try {
+            verifyManifestAssetFile(bundleFile, expectedAsset)
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "Cached bundle failed integrity verification ${bundleFile.absolutePath}: ${e.message}")
+            false
+        }
+
+    private fun isSameFile(
+        first: File,
+        second: File,
+    ): Boolean =
+        try {
+            first.canonicalFile == second.canonicalFile
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun isFileWithinDirectory(
+        file: File,
+        directory: File,
+    ): Boolean =
+        try {
+            val canonicalFilePath = file.canonicalFile.path
+            val canonicalDirectoryPath = directory.canonicalFile.path
+            canonicalFilePath.startsWith("$canonicalDirectoryPath${File.separator}")
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun isPathWithinDirectory(
+        file: File,
+        directory: File,
+    ): Boolean {
+        val filePath = file.absoluteFile.path
+        val directoryPath = directory.absoluteFile.path
+        return filePath.startsWith("$directoryPath${File.separator}")
     }
 
     private fun findBundleFile(bundleId: String): File? {
@@ -1095,6 +1158,20 @@ class BundleFileStorageService(
             preferences.setItem("HotUpdaterBundleURL", null)
             Log.d(TAG, "getCachedBundleURL: file doesn't exist, cleared preference")
             return null
+        }
+
+        val bundleId = extractBundleIdFromURL(urlString)
+        if (bundleId != null) {
+            val bundleDir = File(getBundleStoreDir(), bundleId)
+            if (isPathWithinDirectory(file, bundleDir)) {
+                val resolvedBundleFile = resolveBundleFile(bundleDir)
+                if (resolvedBundleFile == null || !isSameFile(file, resolvedBundleFile)) {
+                    preferences.setItem("HotUpdaterBundleURL", null)
+                    Log.w(TAG, "getCachedBundleURL: cached bundle failed integrity validation")
+                    return null
+                }
+                return resolvedBundleFile.absolutePath
+            }
         }
         return urlString
     }

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -592,8 +592,9 @@ class BundleFileStorageService(
             }
         }
 
-        val fallbackBundleFile = File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
-            ?: return null
+        val fallbackBundleFile =
+            File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
+                ?: return null
         if (!isFileWithinDirectory(fallbackBundleFile, bundleDir)) {
             return null
         }

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -551,9 +551,15 @@ class BundleFileStorageService(
 
     private fun resolveBundleFile(bundleDir: File): File? {
         val manifestFile = File(bundleDir, "manifest.json")
+        val hasManifestEntry =
+            manifestFile.exists() || bundleDir.list()?.contains(manifestFile.name) == true
         val manifest = parseBundleManifestFromFile(manifestFile)
-        if (manifestFile.isFile && manifest == null) {
+        if (hasManifestEntry && manifest == null) {
             Log.w(TAG, "Rejecting bundle with invalid manifest: ${manifestFile.absolutePath}")
+            return null
+        }
+        if (!hasManifestEntry && SignatureVerifier.isSigningEnabled(context)) {
+            Log.w(TAG, "Rejecting cached bundle without a manifest while signing is enabled")
             return null
         }
 
@@ -591,9 +597,11 @@ class BundleFileStorageService(
         if (!isFileWithinDirectory(fallbackBundleFile, bundleDir)) {
             return null
         }
-        val fallbackAsset = manifest?.assets?.get("index.android.bundle")
-        if (fallbackAsset != null && !isManifestBundleFileValid(fallbackBundleFile, fallbackAsset)) {
-            return null
+        if (manifest != null) {
+            val fallbackAsset = manifest.assets["index.android.bundle"] ?: return null
+            if (!isManifestBundleFileValid(fallbackBundleFile, fallbackAsset)) {
+                return null
+            }
         }
         return fallbackBundleFile
     }
@@ -1172,6 +1180,11 @@ class BundleFileStorageService(
                 }
                 return resolvedBundleFile.absolutePath
             }
+        }
+        if (SignatureVerifier.isSigningEnabled(context)) {
+            preferences.setItem("HotUpdaterBundleURL", null)
+            Log.w(TAG, "getCachedBundleURL: rejected unverified legacy path while signing is enabled")
+            return null
         }
         return urlString
     }

--- a/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
@@ -1,6 +1,8 @@
 package com.hotupdater
 
 import android.content.ContextWrapper
+import android.content.pm.ApplicationInfo
+import android.content.res.Resources
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -41,6 +43,34 @@ class BundleFileStorageServiceTest {
         writeManifest(bundleDir, listOf("dist/foo.android.bundle"))
 
         assertResolvedBundlePath(service, bundleDir, expectedBundleFile)
+    }
+
+    @Test
+    fun `resolveBundleFile rejects corrupted manifest bundle`() {
+        val rootDir = temporaryFolder.newFolder("corrupted-manifest-bundle")
+        val service = createService(rootDir)
+        val bundleDir = createBundleDir(rootDir, "bundle-corrupted")
+        val bundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeManifest(bundleDir, listOf("index.android.bundle"))
+
+        bundleFile.writeText("corrupted-content")
+
+        assertNull(invokeResolveBundleFile(service, bundleDir))
+    }
+
+    @Test
+    fun `getCachedBundleURL clears corrupted manifest bundle`() {
+        val rootDir = temporaryFolder.newFolder("corrupted-cached-bundle")
+        val preferences = InMemoryPreferencesService()
+        val service = createService(rootDir, preferences)
+        val bundleDir = createBundleDir(rootDir, "bundle-corrupted")
+        val bundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeManifest(bundleDir, listOf("index.android.bundle"))
+        preferences.setItem("HotUpdaterBundleURL", bundleFile.absolutePath)
+        bundleFile.writeText("corrupted-content")
+
+        assertNull(service.getCachedBundleURL())
+        assertNull(preferences.getItem("HotUpdaterBundleURL"))
     }
 
     @Test
@@ -150,6 +180,38 @@ class BundleFileStorageServiceTest {
         assertNull(metadata?.stableBundleId)
         assertFalse(metadata?.verificationPending ?: true)
         assertEquals(stableBundleFile.canonicalFile.absolutePath, preferences.getItem("HotUpdaterBundleURL"))
+    }
+
+    @Test
+    fun `prepareLaunch rolls back corrupted staging and selects stable bundle`() {
+        val rootDir = temporaryFolder.newFolder("rollback-corrupted-staging")
+        val service = createService(rootDir)
+
+        val stagingDir = createBundleDir(rootDir, "staging-bundle")
+        val stagingBundleFile = writeFile(stagingDir, "index.android.bundle")
+        writeManifest(stagingDir, listOf("index.android.bundle"))
+        stagingBundleFile.writeText("corrupted-content")
+
+        val stableDir = createBundleDir(rootDir, "stable-bundle")
+        val stableBundleFile = writeFile(stableDir, "index.android.bundle")
+        writeManifest(stableDir, listOf("index.android.bundle"))
+
+        writeMetadata(
+            rootDir,
+            BundleMetadata(
+                isolationKey = TEST_ISOLATION_KEY,
+                stableBundleId = stableDir.name,
+                stagingBundleId = stagingDir.name,
+                verificationPending = true,
+            ),
+        )
+
+        val selection = service.prepareLaunch(null)
+
+        assertEquals(stableBundleFile.canonicalFile.absolutePath, selection.bundleUrl)
+        assertEquals(stableDir.name, selection.launchedBundleId)
+        assertFalse(selection.shouldRollbackOnCrash)
+        assertFalse(stagingDir.exists())
     }
 
     @Test
@@ -295,13 +357,24 @@ class BundleFileStorageServiceTest {
         preferences: InMemoryPreferencesService = InMemoryPreferencesService(),
     ): BundleFileStorageService =
         BundleFileStorageService(
-            ContextWrapper(null),
+            TestContext(),
             TestFileSystemService(rootDir),
             UnusedDownloadService,
             DecompressService(),
             preferences,
             TEST_ISOLATION_KEY,
         )
+
+    private class TestContext : ContextWrapper(null) {
+        @Suppress("DEPRECATION")
+        private val testResources = Resources(null, null, null)
+
+        override fun getResources(): Resources = testResources
+
+        override fun getPackageName(): String = "com.hotupdater.test"
+
+        override fun getApplicationInfo(): ApplicationInfo = ApplicationInfo()
+    }
 
     private fun createBundleDir(
         rootDir: File,
@@ -315,7 +388,14 @@ class BundleFileStorageServiceTest {
         val assets =
             JSONObject().apply {
                 assetPaths.forEach { assetPath ->
-                    put(assetPath, JSONObject().put("fileHash", "$assetPath-hash"))
+                    val assetFile = File(bundleDir, assetPath)
+                    val fileHash =
+                        if (assetFile.isFile) {
+                            HashUtils.calculateSHA256(assetFile)
+                        } else {
+                            "$assetPath-hash"
+                        }
+                    put(assetPath, JSONObject().put("fileHash", fileHash))
                 }
             }
 

--- a/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
@@ -74,29 +74,40 @@ class BundleFileStorageServiceTest {
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has no android bundle candidate`() {
+    fun `resolveBundleFile rejects untracked root index when manifest has no android bundle candidate`() {
         val rootDir = temporaryFolder.newFolder("no-android-candidate")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-no-candidate")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeManifest(bundleDir, listOf("index.ios.bundle", "assets/image.png"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has multiple android bundle candidates`() {
+    fun `resolveBundleFile rejects untracked root index when manifest has multiple android bundle candidates`() {
         val rootDir = temporaryFolder.newFolder("multiple-android-candidates")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-multiple-candidates")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeFile(bundleDir, "foo.android.bundle")
         writeFile(bundleDir, "dist/bar.android.bundle")
         writeManifest(bundleDir, listOf("foo.android.bundle", "dist/bar.android.bundle"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
+    }
+
+    @Test
+    fun `resolveBundleFile rejects non regular manifest entry`() {
+        val rootDir = temporaryFolder.newFolder("non-regular-manifest")
+        val service = createService(rootDir)
+        val bundleDir = createBundleDir(rootDir, "bundle-non-regular-manifest")
+        writeFile(bundleDir, "index.android.bundle")
+        File(bundleDir, "manifest.json").mkdir()
+
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
@@ -130,6 +141,38 @@ class BundleFileStorageServiceTest {
         val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
 
         assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+    }
+
+    @Test
+    fun `resolveBundleFile rejects legacy root index when signing is enabled`() {
+        val rootDir = temporaryFolder.newFolder("signed-legacy-root-index")
+        val service = createService(rootDir)
+        val bundleDir = createBundleDir(rootDir, "bundle-signed-legacy")
+        writeFile(bundleDir, "index.android.bundle")
+
+        HotUpdaterConfig.publicKey = "configured-for-test"
+        try {
+            assertNull(invokeResolveBundleFile(service, bundleDir))
+        } finally {
+            HotUpdaterConfig.clear()
+        }
+    }
+
+    @Test
+    fun `getCachedBundleURL clears unmanaged path when signing is enabled`() {
+        val rootDir = temporaryFolder.newFolder("signed-unmanaged-cache")
+        val preferences = InMemoryPreferencesService()
+        val service = createService(rootDir, preferences)
+        val unmanagedBundle = writeFile(rootDir, "legacy/index.android.bundle")
+        preferences.setItem("HotUpdaterBundleURL", unmanagedBundle.absolutePath)
+
+        HotUpdaterConfig.publicKey = "configured-for-test"
+        try {
+            assertNull(service.getCachedBundleURL())
+            assertNull(preferences.getItem("HotUpdaterBundleURL"))
+        } finally {
+            HotUpdaterConfig.clear()
+        }
     }
 
     @Test

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -1283,13 +1283,19 @@ class BundleFileStorageService: BundleStorageService {
 
         let manifestPath = (directoryPath as NSString).appendingPathComponent("manifest.json")
         let manifest: ParsedBundleManifest?
-        if fileSystem.fileExists(atPath: manifestPath) {
+        let hasManifestEntry = fileSystem.fileExists(atPath: manifestPath)
+            || ((try? fileSystem.contentsOfDirectory(atPath: directoryPath))?.contains("manifest.json") == true)
+        if hasManifestEntry {
             guard let parsedManifest = parseBundleManifest(fromFile: manifestPath) else {
                 NSLog("[BundleStorage] Rejecting bundle with invalid manifest: \(manifestPath)")
                 return .success(nil)
             }
             manifest = parsedManifest
         } else {
+            guard !SignatureVerifier.isSigningEnabled() else {
+                NSLog("[BundleStorage] Rejecting cached bundle without a manifest while signing is enabled")
+                return .success(nil)
+            }
             manifest = nil
         }
 
@@ -1354,15 +1360,26 @@ class BundleFileStorageService: BundleStorageService {
         manifest: ParsedBundleManifest?
     ) -> Bool {
         let directoryURL = URL(fileURLWithPath: directoryPath, isDirectory: true)
-            .resolvingSymlinksInPath()
             .standardizedFileURL
         let bundleURL = URL(fileURLWithPath: bundlePath)
-            .resolvingSymlinksInPath()
             .standardizedFileURL
         let directoryPrefix = directoryURL.path.hasSuffix("/")
             ? directoryURL.path
             : "\(directoryURL.path)/"
         guard bundleURL.path.hasPrefix(directoryPrefix) else {
+            return false
+        }
+
+        let resolvedDirectoryURL = directoryURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let resolvedBundleURL = bundleURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let resolvedDirectoryPrefix = resolvedDirectoryURL.path.hasSuffix("/")
+            ? resolvedDirectoryURL.path
+            : "\(resolvedDirectoryURL.path)/"
+        guard resolvedBundleURL.path.hasPrefix(resolvedDirectoryPrefix) else {
             return false
         }
 
@@ -1372,15 +1389,15 @@ class BundleFileStorageService: BundleStorageService {
 
         let relativePath = String(bundleURL.path.dropFirst(directoryPrefix.count))
         guard let expectedAsset = manifest.assets[relativePath] else {
-            return true
+            return false
         }
 
         do {
-            try verifyManifestAssetFile(atPath: bundleURL.path, asset: expectedAsset)
+            try verifyManifestAssetFile(atPath: resolvedBundleURL.path, asset: expectedAsset)
             return true
         } catch {
             NSLog(
-                "[BundleStorage] Cached bundle failed integrity verification \(bundleURL.path): \(error.localizedDescription)"
+                "[BundleStorage] Cached bundle failed integrity verification \(resolvedBundleURL.path): \(error.localizedDescription)"
             )
             return false
         }
@@ -1499,13 +1516,13 @@ class BundleFileStorageService: BundleStorageService {
             }
 
             guard case .success(let storeDirectory) = bundleStoreDir() else {
-                return bundleURL
+                return try allowLegacyCachedBundleURL(bundleURL)
             }
             let storeURL = URL(fileURLWithPath: storeDirectory, isDirectory: true).standardizedFileURL
             let cachedFileURL = URL(fileURLWithPath: bundleURL.path).standardizedFileURL
             let storePrefix = storeURL.path.hasSuffix("/") ? storeURL.path : "\(storeURL.path)/"
             guard cachedFileURL.path.hasPrefix(storePrefix) else {
-                return bundleURL
+                return try allowLegacyCachedBundleURL(bundleURL)
             }
 
             let relativePath = String(cachedFileURL.path.dropFirst(storePrefix.count))
@@ -1526,6 +1543,15 @@ class BundleFileStorageService: BundleStorageService {
             NSLog("[BundleStorage] Error getting cached bundle URL: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    private func allowLegacyCachedBundleURL(_ bundleURL: URL) throws -> URL? {
+        guard SignatureVerifier.isSigningEnabled() else {
+            return bundleURL
+        }
+        try preferences.setItem(nil, forKey: "HotUpdaterBundleURL")
+        NSLog("[BundleStorage] Rejected unverified legacy path while signing is enabled")
+        return nil
     }
     
     /**

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -1281,14 +1281,40 @@ class BundleFileStorageService: BundleStorageService {
     func findBundleFile(in directoryPath: String) -> Result<String?, Error> {
         NSLog("[BundleStorage] Searching for bundle file in directory: \(directoryPath)")
 
+        let manifestPath = (directoryPath as NSString).appendingPathComponent("manifest.json")
+        let manifest: ParsedBundleManifest?
+        if fileSystem.fileExists(atPath: manifestPath) {
+            guard let parsedManifest = parseBundleManifest(fromFile: manifestPath) else {
+                NSLog("[BundleStorage] Rejecting bundle with invalid manifest: \(manifestPath)")
+                return .success(nil)
+            }
+            manifest = parsedManifest
+        } else {
+            manifest = nil
+        }
+
         let iosBundlePath = (directoryPath as NSString).appendingPathComponent("index.ios.bundle")
         if self.fileSystem.fileExists(atPath: iosBundlePath) {
+            guard isManifestBundleFileValid(
+                atPath: iosBundlePath,
+                in: directoryPath,
+                manifest: manifest
+            ) else {
+                return .success(nil)
+            }
             NSLog("[BundleStorage] Found iOS bundle atPath: \(iosBundlePath)")
             return .success(iosBundlePath)
         }
 
         let mainBundlePath = (directoryPath as NSString).appendingPathComponent("main.jsbundle")
         if self.fileSystem.fileExists(atPath: mainBundlePath) {
+            guard isManifestBundleFileValid(
+                atPath: mainBundlePath,
+                in: directoryPath,
+                manifest: manifest
+            ) else {
+                return .success(nil)
+            }
             NSLog("[BundleStorage] Found main bundle atPath: \(mainBundlePath)")
             return .success(mainBundlePath)
         }
@@ -1301,6 +1327,13 @@ class BundleFileStorageService: BundleStorageService {
             for file in contents {
                 if file.hasSuffix(".bundle") {
                     let bundlePath = (directoryPath as NSString).appendingPathComponent(file)
+                    guard isManifestBundleFileValid(
+                        atPath: bundlePath,
+                        in: directoryPath,
+                        manifest: manifest
+                    ) else {
+                        return .success(nil)
+                    }
                     NSLog("[BundleStorage] Found alternative bundle atPath: \(bundlePath)")
                     return .success(bundlePath)
                 }
@@ -1312,6 +1345,44 @@ class BundleFileStorageService: BundleStorageService {
         } catch let error {
             NSLog("[BundleStorage] Error reading directory contents: \(error.localizedDescription)")
             return .failure(error)
+        }
+    }
+
+    private func isManifestBundleFileValid(
+        atPath bundlePath: String,
+        in directoryPath: String,
+        manifest: ParsedBundleManifest?
+    ) -> Bool {
+        let directoryURL = URL(fileURLWithPath: directoryPath, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let bundleURL = URL(fileURLWithPath: bundlePath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let directoryPrefix = directoryURL.path.hasSuffix("/")
+            ? directoryURL.path
+            : "\(directoryURL.path)/"
+        guard bundleURL.path.hasPrefix(directoryPrefix) else {
+            return false
+        }
+
+        guard let manifest else {
+            return true
+        }
+
+        let relativePath = String(bundleURL.path.dropFirst(directoryPrefix.count))
+        guard let expectedAsset = manifest.assets[relativePath] else {
+            return true
+        }
+
+        do {
+            try verifyManifestAssetFile(atPath: bundleURL.path, asset: expectedAsset)
+            return true
+        } catch {
+            NSLog(
+                "[BundleStorage] Cached bundle failed integrity verification \(bundleURL.path): \(error.localizedDescription)"
+            )
+            return false
         }
     }
         
@@ -1426,7 +1497,31 @@ class BundleFileStorageService: BundleStorageService {
                   self.fileSystem.fileExists(atPath: bundleURL.path) else {
                 return nil
             }
-            return bundleURL
+
+            guard case .success(let storeDirectory) = bundleStoreDir() else {
+                return bundleURL
+            }
+            let storeURL = URL(fileURLWithPath: storeDirectory, isDirectory: true).standardizedFileURL
+            let cachedFileURL = URL(fileURLWithPath: bundleURL.path).standardizedFileURL
+            let storePrefix = storeURL.path.hasSuffix("/") ? storeURL.path : "\(storeURL.path)/"
+            guard cachedFileURL.path.hasPrefix(storePrefix) else {
+                return bundleURL
+            }
+
+            let relativePath = String(cachedFileURL.path.dropFirst(storePrefix.count))
+            guard let bundleId = relativePath.split(separator: "/").first else {
+                try self.preferences.setItem(nil, forKey: "HotUpdaterBundleURL")
+                return nil
+            }
+            let bundleDirectory = (storeDirectory as NSString).appendingPathComponent(String(bundleId))
+            guard case .success(let resolvedPath) = findBundleFile(in: bundleDirectory),
+                  let resolvedPath,
+                  URL(fileURLWithPath: resolvedPath).standardizedFileURL.path == cachedFileURL.path
+            else {
+                try self.preferences.setItem(nil, forKey: "HotUpdaterBundleURL")
+                return nil
+            }
+            return URL(fileURLWithPath: resolvedPath)
         } catch {
             NSLog("[BundleStorage] Error getting cached bundle URL: \(error.localizedDescription)")
             return nil

--- a/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
@@ -11,6 +11,7 @@ private func hotUpdaterApplyBsdiffPatchForTest(
     _ outputPath: NSString
 ) -> ObjCBool
 
+@Suite(.serialized)
 struct BundleFileStorageServiceTests {
     @Test
     func findBundleFileRejectsCorruptedManifestBundle() throws {
@@ -37,6 +38,120 @@ struct BundleFileStorageServiceTests {
             return
         }
         #expect(bundlePath == nil)
+    }
+
+    @Test
+    func findBundleFileRejectsSymlinkToUntrackedBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "symlinked-bundle"
+        )
+        try writeBundle(in: bundleDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: bundleDirectory, bundleId: "symlinked-bundle")
+
+        let bundleURL = bundleDirectory.appendingPathComponent("index.ios.bundle")
+        let payloadURL = bundleDirectory.appendingPathComponent("payload.bundle")
+        try FileManager.default.removeItem(at: bundleURL)
+        try Data("untracked-content".utf8).write(to: payloadURL)
+        try FileManager.default.createSymbolicLink(
+            at: bundleURL,
+            withDestinationURL: payloadURL
+        )
+
+        let result = service.findBundleFile(in: bundleDirectory.path)
+
+        guard case .success(let bundlePath) = result else {
+            Issue.record("Expected bundle lookup to complete")
+            return
+        }
+        #expect(bundlePath == nil)
+    }
+
+    @Test
+    func findBundleFileRejectsUntrackedBundleWhenManifestExists() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "untracked-bundle"
+        )
+        try writeBundle(in: bundleDirectory, bundleFileName: "index.ios.bundle")
+        try writeBundle(in: bundleDirectory, bundleFileName: "tracked.asset")
+        try writeManifest(
+            in: bundleDirectory,
+            bundleId: "untracked-bundle",
+            assetPaths: ["tracked.asset"]
+        )
+
+        let result = service.findBundleFile(in: bundleDirectory.path)
+
+        guard case .success(let bundlePath) = result else {
+            Issue.record("Expected bundle lookup to complete")
+            return
+        }
+        #expect(bundlePath == nil)
+    }
+
+    @Test
+    func findBundleFileRejectsLegacyBundleWhenSigningIsEnabled() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            HotUpdaterConfig.shared.clear()
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "signed-legacy-bundle"
+        )
+        try writeBundle(in: bundleDirectory, bundleFileName: "index.ios.bundle")
+        HotUpdaterConfig.shared.publicKey = "configured-for-test"
+
+        let result = service.findBundleFile(in: bundleDirectory.path)
+
+        guard case .success(let bundlePath) = result else {
+            Issue.record("Expected bundle lookup to complete")
+            return
+        }
+        #expect(bundlePath == nil)
+    }
+
+    @Test
+    func getCachedBundleURLClearsUnmanagedPathWhenSigningIsEnabled() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            HotUpdaterConfig.shared.clear()
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let preferences = InMemoryPreferencesService()
+        let service = makeStorageService(
+            documentsDirectory: workingDirectory,
+            preferences: preferences
+        )
+        let unmanagedDirectory = workingDirectory.appendingPathComponent("legacy", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: unmanagedDirectory,
+            withIntermediateDirectories: true
+        )
+        let unmanagedBundle = unmanagedDirectory.appendingPathComponent("index.ios.bundle")
+        try Data("legacy-bundle".utf8).write(to: unmanagedBundle)
+        try preferences.setItem(unmanagedBundle.absoluteString, forKey: "HotUpdaterBundleURL")
+        HotUpdaterConfig.shared.publicKey = "configured-for-test"
+
+        #expect(service.getCachedBundleURL() == nil)
+        #expect(try preferences.getItem(forKey: "HotUpdaterBundleURL") == nil)
     }
 
     @Test

--- a/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
@@ -13,6 +13,101 @@ private func hotUpdaterApplyBsdiffPatchForTest(
 
 struct BundleFileStorageServiceTests {
     @Test
+    func findBundleFileRejectsCorruptedManifestBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "corrupted-bundle"
+        )
+        try writeBundle(in: bundleDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: bundleDirectory, bundleId: "corrupted-bundle")
+        try Data("corrupted-content".utf8).write(
+            to: bundleDirectory.appendingPathComponent("index.ios.bundle")
+        )
+
+        let result = service.findBundleFile(in: bundleDirectory.path)
+
+        guard case .success(let bundlePath) = result else {
+            Issue.record("Expected bundle lookup to complete")
+            return
+        }
+        #expect(bundlePath == nil)
+    }
+
+    @Test
+    func getCachedBundleURLClearsCorruptedManifestBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let preferences = InMemoryPreferencesService()
+        let service = makeStorageService(
+            documentsDirectory: workingDirectory,
+            preferences: preferences
+        )
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "corrupted-bundle"
+        )
+        let bundleURL = bundleDirectory.appendingPathComponent("index.ios.bundle")
+        try writeBundle(in: bundleDirectory, bundleFileName: bundleURL.lastPathComponent)
+        try writeManifest(in: bundleDirectory, bundleId: "corrupted-bundle")
+        try preferences.setItem(bundleURL.absoluteString, forKey: "HotUpdaterBundleURL")
+        try Data("corrupted-content".utf8).write(to: bundleURL)
+
+        #expect(service.getCachedBundleURL() == nil)
+        #expect(try preferences.getItem(forKey: "HotUpdaterBundleURL") == nil)
+    }
+
+    @Test
+    func prepareLaunchRollsBackCorruptedStagingAndSelectsStableBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let stagingDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "staging-bundle"
+        )
+        try writeBundle(in: stagingDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: stagingDirectory, bundleId: "staging-bundle")
+        try Data("corrupted-content".utf8).write(
+            to: stagingDirectory.appendingPathComponent("index.ios.bundle")
+        )
+
+        let stableDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "stable-bundle"
+        )
+        try writeBundle(in: stableDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+        try writeMetadata(
+            documentsDirectory: workingDirectory,
+            BundleMetadata(
+                isolationKey: testIsolationKey,
+                stableBundleId: "stable-bundle",
+                stagingBundleId: "staging-bundle",
+                verificationPending: true
+            )
+        )
+
+        let selection = service.prepareLaunch(bundle: .main, pendingRecovery: nil)
+
+        #expect(selection.bundleURL?.path == stableDirectory.appendingPathComponent("index.ios.bundle").path)
+        #expect(selection.launchedBundleId == "stable-bundle")
+        #expect(selection.shouldRollbackOnCrash == false)
+        #expect(FileManager.default.fileExists(atPath: stagingDirectory.path) == false)
+    }
+
+    @Test
     func getBundleIdFallsBackToBuiltInWhileStagingVerificationIsPending() throws {
         let workingDirectory = try makeWorkingDirectory()
         defer {
@@ -266,8 +361,9 @@ private func writeManifest(
     assetPaths: [String] = ["index.ios.bundle"]
 ) throws {
     let assets = assetPaths.reduce(into: [String: [String: String]]()) { result, path in
+        let assetURL = bundleDirectory.appendingPathComponent(path)
         result[path] = [
-            "fileHash": "bundle-hash",
+            "fileHash": HashUtils.calculateSHA256(fileURL: assetURL) ?? "\(path)-hash",
         ]
     }
     let manifest: [String: Any] = [


### PR DESCRIPTION
## Summary

- verify the selected cached JavaScript bundle against its manifest SHA-256 before reuse and launch on Android and iOS
- reuse existing per-asset signature verification when bundle signing is enabled
- reject malformed manifests, untracked executable bundles, and unsafe symlink/path substitutions
- clear corrupt cached URLs so existing rollback or redownload behavior can recover safely
- preserve manifest-less legacy caches in unsigned mode while failing closed for unverifiable legacy paths in signed mode

## Validation

- Android BundleFileStorageService tests: 22 passed
- iOS BundleFileStorageService tests: 14 passed
- iOS Swift package tests: 27 passed
- workspace lint passed
- React Native package typecheck passed
- changeset status passed

## Rollout note

Signing-enabled caches created before per-asset manifest signatures were available may fall back to the embedded bundle and require a fresh OTA download.