### PR TITLE
feat(plugin-core): add experimental database connector v2

### DIFF
--- a/.changeset/tidy-wolves-connect.md
+++ b/.changeset/tidy-wolves-connect.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/plugin-core": minor
+---
+
+Add the Experimental database connector v2 contract, deterministic identity helpers, structural reference behavior, and in-memory connector under the `database-v2` subpath.

--- a/docs/experimental-database-v2-rfc.md
+++ b/docs/experimental-database-v2-rfc.md
@@ -1,0 +1,71 @@
+# Experimental Database Connector v2
+
+Status: maintainer RFC; Experimental reference implementation only.
+
+Database connector v2 freezes an ORM-neutral contract before any SQL or managed
+provider integration. It is published only from
+`@hot-updater/plugin-core/database-v2`; the package root, database plugin v1,
+server, CLI, console, and provider acceptance paths remain unchanged.
+
+## Trust and topology
+
+An authenticating host derives a non-empty `tenantId` and `principalId` and
+passes them as an immutable `AssertedDatabaseScope`. The connector enforces the
+assertion but does not authenticate a raw caller, and opaque `context` cannot
+override either ID. Tenant rows are shared by principals authorized into that
+tenant. Cursor and receipt identity additionally bind the principal to avoid
+cross-principal disclosure or replay.
+
+The trust boundary validates and snapshots caller-supplied data, but it is not a
+same-realm code sandbox. The host must preserve the integrity of JavaScript
+intrinsics and globals while connector code runs. A Proxy trap or callback that
+mutates ambient globals, prototypes, Promise behavior, or platform APIs is
+arbitrary code execution in the connector's realm and is outside this contract.
+Untrusted code requiring that isolation must run in a separate realm or process.
+
+The lifecycle is connector -> connection -> session. Connections and sessions
+are independently open, closing, or closed; sessions can also be committing or
+poisoned. A session permits at most one active commit. An indeterminate backend
+outcome poisons it: reads and unrelated writes fail closed until an identical
+scope, change-set ID, and payload retry produces a definitive result. Close is
+idempotent, waits for active work, and never closes a borrowed client.
+
+## Identity and reference behavior
+
+Change-set payload, asserted scope, and manifest tuple identities use separate,
+versioned SHA-256 domains. Canonical JSON preserves array order, sorts plain
+object keys by raw UTF-16 code units, does not normalize Unicode, and rejects
+unsupported descriptors, values, cycles, sparse arrays, invalid surrogates,
+`-0`, and non-finite numbers. Committed and rejected receipt identities include
+tenant, principal, change-set ID, and canonical payload hash.
+
+The fixed reference manifest certifies only the checked-in tuple: native memory
+adapter, JavaScript ES2022 runtime, `reference-memory-v1` schema, atomic
+single-process commit, and opaque keyset cursors. The reference connector is
+process-local, non-durable, retains its store and receipt index for the connector
+object's lifetime, and may grow without a public disposal API. It is not a claim
+of server, provider, multi-process, or general runtime support.
+
+## Conformance and next gate
+
+The structural conformance suite in `@hot-updater/test-utils` checks scope
+isolation, atomicity, deterministic replay and conflict, cursor binding,
+unknown-outcome recovery, and lifecycle behavior without importing plugin-core
+implementation types. Maintainer validation for this Experimental change also
+consumed packed local artifacts through ESM, CJS, and strict NodeNext
+declarations and ran the checked-in SDK driver.
+
+Extraction into a dedicated package and a Kysely adapter are deferred until
+this Experimental contract is stable, SQL scope/schema ownership is designed,
+and a server acceptance path exists. Any future Kysely, Drizzle, Prisma, or
+managed-provider connector must declare a truthful implementation tuple, derive
+its manifest digest from that complete tuple, and pass conformance for the exact
+runtime, adapter, driver, target, schema, capability, and ownership claims it
+publishes. Method presence or marketing compatibility is never certification.
+
+## Explicit non-goals
+
+- No database plugin v1 migration or compatibility bridge.
+- No server, CLI, console, or managed-provider integration in this slice.
+- No Kysely, Drizzle, Prisma, SQL schema, migration, or dialect implementation.
+- No durability, cross-process, GA, certified-provider, or all-runtime claim.

--- a/packages/test-utils/src/database-v2-conforming.spec.ts
+++ b/packages/test-utils/src/database-v2-conforming.spec.ts
@@ -1,0 +1,4 @@
+import { createScriptedDatabaseConnectorV2Harness } from "./database-v2/spec-support/scriptedHarness";
+import { setupDatabaseConnectorV2TestSuite } from "./setupDatabaseConnectorV2TestSuite";
+
+setupDatabaseConnectorV2TestSuite(createScriptedDatabaseConnectorV2Harness());

--- a/packages/test-utils/src/database-v2-state-meta.spec.ts
+++ b/packages/test-utils/src/database-v2-state-meta.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { runDatabaseV2LifecycleScenario } from "./database-v2/lifecycleScenario";
+import { createScriptedDatabaseConnectorV2Harness } from "./database-v2/spec-support/scriptedHarness";
+import {
+  runDatabaseV2ConcurrentCommitScenario,
+  runDatabaseV2UnknownRecoveryScenario,
+} from "./database-v2/stateScenarios";
+
+describe("database-v2 state conformance negative controls", () => {
+  it("detects backend I/O from the rejected concurrent commit", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "concurrent-backend-io",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2ConcurrentCommitScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "concurrent-zero-io",
+    });
+  });
+
+  it("detects reads allowed while a session is poisoned", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "allow-poisoned-read",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2UnknownRecoveryScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "unknown-recovery",
+    });
+  });
+
+  it("detects session use after close", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "allow-use-after-close",
+    ]);
+
+    // When / Then
+    await expect(runDatabaseV2LifecycleScenario(harness)).rejects.toMatchObject(
+      {
+        name: "DatabaseConnectorV2ConformanceViolation",
+        check: "lifecycle",
+      },
+    );
+  });
+
+  it("detects connection close that leaves child sessions open", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "leave-child-sessions-open",
+    ]);
+
+    // When / Then
+    await expect(runDatabaseV2LifecycleScenario(harness)).rejects.toMatchObject(
+      {
+        name: "DatabaseConnectorV2ConformanceViolation",
+        check: "lifecycle",
+      },
+    );
+  });
+
+  it("detects connection close resolving before an active child", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "resolve-connection-close-early",
+    ]);
+
+    // When / Then
+    await expect(runDatabaseV2LifecycleScenario(harness)).rejects.toMatchObject(
+      {
+        name: "DatabaseConnectorV2ConformanceViolation",
+        check: "lifecycle-close-wait",
+      },
+    );
+  });
+});

--- a/packages/test-utils/src/database-v2-storage-meta.spec.ts
+++ b/packages/test-utils/src/database-v2-storage-meta.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  runDatabaseV2CursorBindingScenario,
+  runDatabaseV2HappyReadAndScopeScenario,
+} from "./database-v2/readScenarios";
+import {
+  runDatabaseV2AtomicityScenario,
+  runDatabaseV2ReplayScenario,
+} from "./database-v2/receiptScenarios";
+import { createScriptedDatabaseConnectorV2Harness } from "./database-v2/spec-support/scriptedHarness";
+
+describe("database-v2 storage conformance negative controls", () => {
+  it("detects a partial write for a rejected atomic change set", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness(["partial-write"]);
+
+    // When / Then
+    await expect(runDatabaseV2AtomicityScenario(harness)).rejects.toMatchObject(
+      {
+        name: "DatabaseConnectorV2ConformanceViolation",
+        check: "atomicity",
+      },
+    );
+  });
+
+  it("detects a cursor accepted under another principal or query", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "accept-foreign-cursor",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2CursorBindingScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "cursor-binding",
+    });
+  });
+
+  it("detects rows leaking across asserted tenants", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "cross-tenant-read",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2HappyReadAndScopeScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "scope-isolation",
+    });
+  });
+
+  it("detects replay that reapplies a domain mutation", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "reapply-replay",
+    ]);
+
+    // When / Then
+    await expect(runDatabaseV2ReplayScenario(harness)).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "replay-identity",
+    });
+  });
+
+  it("detects an empty principal accepted as asserted scope", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "accept-empty-principal",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2HappyReadAndScopeScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "malformed-input",
+    });
+  });
+
+  it("detects backend I/O attempted before invalid scope rejection", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "invalid-scope-backend-io",
+    ]);
+
+    // When / Then
+    await expect(
+      runDatabaseV2HappyReadAndScopeScenario(harness),
+    ).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "scope-zero-io",
+    });
+  });
+
+  it("detects a payload collision that replaces the original receipt", async () => {
+    // Given
+    const harness = createScriptedDatabaseConnectorV2Harness([
+      "replace-receipt-on-collision",
+    ]);
+
+    // When / Then
+    await expect(runDatabaseV2ReplayScenario(harness)).rejects.toMatchObject({
+      name: "DatabaseConnectorV2ConformanceViolation",
+      check: "replay-identity",
+    });
+  });
+});

--- a/packages/test-utils/src/database-v2-surface.spec.ts
+++ b/packages/test-utils/src/database-v2-surface.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+describe("database-v2 conformance public surface", () => {
+  it("exports the reusable structural suite", async () => {
+    // Given
+    const testUtils = await import("./index");
+
+    // When
+    const candidate = Reflect.get(
+      testUtils,
+      "setupDatabaseConnectorV2TestSuite",
+    );
+
+    // Then
+    expect(candidate).toBeTypeOf("function");
+  });
+});

--- a/packages/test-utils/src/database-v2/assertions.ts
+++ b/packages/test-utils/src/database-v2/assertions.ts
@@ -1,0 +1,62 @@
+export type DatabaseConnectorV2ConformanceCheck =
+  | "atomicity"
+  | "concurrent-zero-io"
+  | "cursor-binding"
+  | "happy-read"
+  | "lifecycle"
+  | "lifecycle-close-wait"
+  | "malformed-input"
+  | "replay-identity"
+  | "scope-isolation"
+  | "scope-zero-io"
+  | "unknown-recovery";
+
+export class DatabaseConnectorV2ConformanceViolation extends Error {
+  override readonly name = "DatabaseConnectorV2ConformanceViolation";
+
+  constructor(
+    readonly check: DatabaseConnectorV2ConformanceCheck,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function assertDatabaseConnectorV2(
+  condition: boolean,
+  check: DatabaseConnectorV2ConformanceCheck,
+  message: string,
+): asserts condition {
+  if (!condition) {
+    throw new DatabaseConnectorV2ConformanceViolation(check, message);
+  }
+}
+
+export async function assertDatabaseConnectorV2Error(
+  action: () => Promise<unknown>,
+  code: string,
+  check: DatabaseConnectorV2ConformanceCheck,
+): Promise<void> {
+  const result = await action().then(
+    () => ({ kind: "fulfilled" }) as const,
+    (error: unknown) => ({ error, kind: "rejected" }) as const,
+  );
+
+  assertDatabaseConnectorV2(
+    result.kind === "rejected",
+    check,
+    `expected ${code}, but the operation fulfilled`,
+  );
+
+  const error = result.error;
+  const actualCode =
+    typeof error === "object" && error !== null
+      ? Reflect.get(error, "code")
+      : undefined;
+
+  assertDatabaseConnectorV2(
+    actualCode === code,
+    check,
+    `expected ${code}, received ${String(actualCode)}`,
+  );
+}

--- a/packages/test-utils/src/database-v2/fixtures.ts
+++ b/packages/test-utils/src/database-v2/fixtures.ts
@@ -1,0 +1,73 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type {
+  DatabaseConnectorV2TestChangeSet,
+  DatabaseConnectorV2TestScope,
+} from "./types";
+
+export const DATABASE_V2_SCOPE_ALPHA = {
+  tenantId: "tenant-alpha",
+  principalId: "principal-alpha",
+  context: { marker: "alpha" },
+} as const satisfies DatabaseConnectorV2TestScope;
+
+export const DATABASE_V2_SCOPE_BETA = {
+  tenantId: "tenant-alpha",
+  principalId: "principal-beta",
+  context: { marker: "beta" },
+} as const satisfies DatabaseConnectorV2TestScope;
+
+export const DATABASE_V2_SCOPE_OTHER_TENANT = {
+  tenantId: "tenant-other",
+  principalId: "principal-alpha",
+  context: { marker: "other" },
+} as const satisfies DatabaseConnectorV2TestScope;
+
+export function createDatabaseV2TestBundle(
+  id: string,
+  channel: string,
+): Bundle {
+  return {
+    id,
+    platform: "ios",
+    shouldForceUpdate: false,
+    enabled: true,
+    fileHash: `hash-${id}`,
+    gitCommitHash: null,
+    message: `bundle-${id}`,
+    channel,
+    storageUri: `memory://${id}`,
+    targetAppVersion: "1.0.0",
+    fingerprintHash: null,
+  };
+}
+
+export function createDatabaseV2PutChangeSet(
+  id: string,
+  bundles: readonly Bundle[],
+): DatabaseConnectorV2TestChangeSet {
+  return {
+    id,
+    changes: bundles.map((value) => ({
+      type: "put",
+      value,
+      precondition: { state: "absent" },
+    })),
+  };
+}
+
+export const DATABASE_V2_BUNDLE_IDS = {
+  first: "018f12ab-1234-7abc-8def-000000000001",
+  second: "018f12ab-1234-7abc-8def-000000000002",
+  third: "018f12ab-1234-7abc-8def-000000000003",
+  fourth: "018f12ab-1234-7abc-8def-000000000004",
+} as const;
+
+export const DATABASE_V2_CHANGE_SET_IDS = {
+  seed: "10000000-0000-4000-8000-000000000001",
+  replay: "10000000-0000-4000-8000-000000000002",
+  concurrentA: "10000000-0000-4000-8000-000000000003",
+  concurrentB: "10000000-0000-4000-8000-000000000004",
+  unknown: "10000000-0000-4000-8000-000000000005",
+  malformed: "10000000-0000-4000-8000-000000000006",
+} as const;

--- a/packages/test-utils/src/database-v2/inputScenario.ts
+++ b/packages/test-utils/src/database-v2/inputScenario.ts
@@ -1,0 +1,70 @@
+import {
+  assertDatabaseConnectorV2,
+  assertDatabaseConnectorV2Error,
+} from "./assertions";
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_CHANGE_SET_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  createDatabaseV2TestBundle,
+} from "./fixtures";
+import type {
+  DatabaseConnectorV2TestChangeSet,
+  DatabaseConnectorV2TestHarness,
+} from "./types";
+
+export async function runDatabaseV2MalformedChangeSetScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("malformed-change-set");
+  const connection = await subject.connector.connect();
+  const session = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const bundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const beforeAttempts = subject.instrumentation.backendCommitAttempts();
+  const invalidChangeSets: readonly DatabaseConnectorV2TestChangeSet[] = [
+    {
+      id: "not-a-change-set-id",
+      changes: [
+        {
+          type: "put",
+          value: bundle,
+          precondition: { state: "absent" },
+        },
+      ],
+    },
+    { id: DATABASE_V2_CHANGE_SET_IDS.malformed, changes: [] },
+    {
+      id: DATABASE_V2_CHANGE_SET_IDS.malformed,
+      changes: [
+        { type: "put", value: bundle, precondition: { state: "absent" } },
+        { type: "put", value: bundle, precondition: { state: "absent" } },
+      ],
+    },
+    {
+      id: DATABASE_V2_CHANGE_SET_IDS.malformed,
+      changes: [
+        {
+          type: "put",
+          value: bundle,
+          precondition: { state: "revision", revision: "" },
+        },
+      ],
+    },
+  ];
+
+  for (const changeSet of invalidChangeSets) {
+    await assertDatabaseConnectorV2Error(
+      () => session.applyChangeSet(changeSet),
+      "INVALID_CHANGE_SET",
+      "malformed-input",
+    );
+  }
+  assertDatabaseConnectorV2(
+    subject.instrumentation.backendCommitAttempts() === beforeAttempts,
+    "malformed-input",
+    "malformed change sets must fail before backend I/O",
+  );
+}

--- a/packages/test-utils/src/database-v2/lifecycleScenario.ts
+++ b/packages/test-utils/src/database-v2/lifecycleScenario.ts
@@ -1,0 +1,104 @@
+import {
+  assertDatabaseConnectorV2,
+  assertDatabaseConnectorV2Error,
+} from "./assertions";
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_CHANGE_SET_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  createDatabaseV2PutChangeSet,
+  createDatabaseV2TestBundle,
+} from "./fixtures";
+import type { DatabaseConnectorV2TestHarness } from "./types";
+
+export async function runDatabaseV2LifecycleScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("lifecycle");
+  const firstConnection = await subject.connector.connect();
+  const secondConnection = await subject.connector.connect();
+  const firstSession = await firstConnection.openSession(
+    DATABASE_V2_SCOPE_ALPHA,
+  );
+  const secondSession = await secondConnection.openSession(
+    DATABASE_V2_SCOPE_ALPHA,
+  );
+  const bundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  await firstSession.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.seed, [bundle]),
+  );
+
+  await Promise.all([firstSession.close(), firstSession.close()]);
+  await assertDatabaseConnectorV2Error(
+    () => firstSession.bundles.get(bundle.id),
+    "SESSION_CLOSED",
+    "lifecycle",
+  );
+  assertDatabaseConnectorV2(
+    (await secondSession.bundles.get(bundle.id))?.value.id === bundle.id,
+    "lifecycle",
+    "closing one session or connection must not close an independent connection",
+  );
+
+  await Promise.all([firstConnection.close(), firstConnection.close()]);
+  await assertDatabaseConnectorV2Error(
+    () => firstConnection.openSession(DATABASE_V2_SCOPE_ALPHA),
+    "CONNECTION_CLOSED",
+    "lifecycle",
+  );
+  const freshConnection = await subject.connector.connect();
+  const freshSession = await freshConnection.openSession(
+    DATABASE_V2_SCOPE_ALPHA,
+  );
+  assertDatabaseConnectorV2(
+    (await freshSession.bundles.get(bundle.id))?.value.id === bundle.id,
+    "lifecycle",
+    "a new connection must retain connector-lifetime state",
+  );
+
+  const idleSubject = await harness.createSubject("lifecycle");
+  const idleConnection = await idleSubject.connector.connect();
+  const idleSession = await idleConnection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  await idleConnection.close();
+  await assertDatabaseConnectorV2Error(
+    () => idleSession.bundles.channels(),
+    "SESSION_CLOSED",
+    "lifecycle",
+  );
+
+  const raceSubject = await harness.createSubject("lifecycle");
+  const raceConnection = await raceSubject.connector.connect();
+  const raceSession = await raceConnection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  raceSubject.faults.holdNextCommit();
+  const activeCommit = raceSession.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.concurrentA, [
+      bundle,
+    ]),
+  );
+  await raceSubject.faults.waitForHeldCommit();
+  const connectionClose = raceConnection.close();
+  const closeState = await Promise.race([
+    connectionClose,
+    Promise.resolve("pending" as const),
+  ]);
+  assertDatabaseConnectorV2(
+    closeState === "pending",
+    "lifecycle-close-wait",
+    "connection close must remain pending while a child commit is active",
+  );
+  raceSubject.faults.releaseHeldCommit();
+  const [receipt] = await Promise.all([activeCommit, connectionClose]);
+  assertDatabaseConnectorV2(
+    receipt.outcome === "committed",
+    "lifecycle",
+    "close must wait for the active commit rather than cancel or race it",
+  );
+  await assertDatabaseConnectorV2Error(
+    () => raceSession.bundles.get(bundle.id),
+    "SESSION_CLOSED",
+    "lifecycle",
+  );
+}

--- a/packages/test-utils/src/database-v2/readScenarios.ts
+++ b/packages/test-utils/src/database-v2/readScenarios.ts
@@ -1,0 +1,193 @@
+import {
+  assertDatabaseConnectorV2,
+  assertDatabaseConnectorV2Error,
+} from "./assertions";
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_CHANGE_SET_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  DATABASE_V2_SCOPE_BETA,
+  DATABASE_V2_SCOPE_OTHER_TENANT,
+  createDatabaseV2PutChangeSet,
+  createDatabaseV2TestBundle,
+} from "./fixtures";
+import type { DatabaseConnectorV2TestHarness } from "./types";
+
+export async function runDatabaseV2HappyReadAndScopeScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("happy-read-and-scope");
+  const connection = await subject.connector.connect();
+  const alpha = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const first = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const second = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.second,
+    "staging",
+  );
+
+  const receipt = await alpha.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.seed, [
+      first,
+      second,
+    ]),
+  );
+  assertDatabaseConnectorV2(
+    receipt.outcome === "committed",
+    "happy-read",
+    "the seed change set must commit",
+  );
+
+  const found = await alpha.bundles.get(first.id);
+  assertDatabaseConnectorV2(
+    found?.value.id === first.id && found.revision.length > 0,
+    "happy-read",
+    "get must return the bundle with an opaque non-empty revision",
+  );
+  const page = await alpha.bundles.page({ limit: 10 });
+  assertDatabaseConnectorV2(
+    page.data.length === 2 && page.pagination.total === 2,
+    "happy-read",
+    "page must return all tenant rows and the full filtered total",
+  );
+  const channels = await alpha.bundles.channels();
+  assertDatabaseConnectorV2(
+    channels.includes("production") && channels.includes("staging"),
+    "happy-read",
+    "channels must expose the tenant's distinct channels",
+  );
+
+  const beta = await connection.openSession(DATABASE_V2_SCOPE_BETA);
+  const shared = await beta.bundles.get(first.id);
+  assertDatabaseConnectorV2(
+    shared?.value.id === first.id,
+    "scope-isolation",
+    "another asserted principal in the same tenant must see tenant rows",
+  );
+
+  const otherTenant = await connection.openSession(
+    DATABASE_V2_SCOPE_OTHER_TENANT,
+  );
+  const isolated = await otherTenant.bundles.page({ limit: 10 });
+  assertDatabaseConnectorV2(
+    isolated.data.length === 0 && isolated.pagination.total === 0,
+    "scope-isolation",
+    "another tenant must not observe tenant rows",
+  );
+
+  const spoofed = await connection.openSession({
+    tenantId: "tenant-other",
+    principalId: "principal-spoof",
+    context: {
+      marker: "spoof",
+      tenantId: DATABASE_V2_SCOPE_ALPHA.tenantId,
+      principalId: DATABASE_V2_SCOPE_ALPHA.principalId,
+    },
+  });
+  const spoofBundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.third,
+    "spoof-check",
+  );
+  await spoofed.applyChangeSet(
+    createDatabaseV2PutChangeSet("10000000-0000-4000-8000-000000000007", [
+      spoofBundle,
+    ]),
+  );
+  assertDatabaseConnectorV2(
+    (await alpha.bundles.get(spoofBundle.id)) === null,
+    "scope-isolation",
+    "opaque context must not override asserted tenant or principal identifiers",
+  );
+
+  const beforeInvalidTenant =
+    subject.instrumentation.backendOperationAttempts();
+  await assertDatabaseConnectorV2Error(
+    () =>
+      connection.openSession({
+        tenantId: "",
+        principalId: DATABASE_V2_SCOPE_ALPHA.principalId,
+        context: { marker: "invalid" },
+      }),
+    "INVALID_SCOPE",
+    "malformed-input",
+  );
+  assertDatabaseConnectorV2(
+    subject.instrumentation.backendOperationAttempts() === beforeInvalidTenant,
+    "scope-zero-io",
+    "an empty tenant must fail before any observable backend I/O",
+  );
+  const beforeInvalidPrincipal =
+    subject.instrumentation.backendOperationAttempts();
+  await assertDatabaseConnectorV2Error(
+    () =>
+      connection.openSession({
+        tenantId: DATABASE_V2_SCOPE_ALPHA.tenantId,
+        principalId: "",
+        context: { marker: "invalid" },
+      }),
+    "INVALID_SCOPE",
+    "malformed-input",
+  );
+  assertDatabaseConnectorV2(
+    subject.instrumentation.backendOperationAttempts() ===
+      beforeInvalidPrincipal,
+    "scope-zero-io",
+    "an empty principal must fail before any observable backend I/O",
+  );
+}
+
+export async function runDatabaseV2CursorBindingScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("cursor-binding");
+  const connection = await subject.connector.connect();
+  const alpha = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const bundles = [
+    createDatabaseV2TestBundle(DATABASE_V2_BUNDLE_IDS.first, "production"),
+    createDatabaseV2TestBundle(DATABASE_V2_BUNDLE_IDS.second, "production"),
+    createDatabaseV2TestBundle(DATABASE_V2_BUNDLE_IDS.third, "production"),
+  ];
+  await alpha.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.seed, bundles),
+  );
+
+  const query = {
+    limit: 1,
+    orderBy: { field: "id", direction: "asc" },
+  } as const;
+  const firstPage = await alpha.bundles.page(query);
+  const cursor = firstPage.pagination.nextCursor;
+  assertDatabaseConnectorV2(
+    cursor !== null && firstPage.data.length === 1,
+    "cursor-binding",
+    "the first page must expose one returned navigation cursor",
+  );
+  const nextPage = await alpha.bundles.page({
+    ...query,
+    cursor: { after: cursor },
+  });
+  assertDatabaseConnectorV2(
+    nextPage.data[0]?.value.id === DATABASE_V2_BUNDLE_IDS.second,
+    "cursor-binding",
+    "a valid after cursor must advance in the requested order",
+  );
+
+  const beta = await connection.openSession(DATABASE_V2_SCOPE_BETA);
+  await assertDatabaseConnectorV2Error(
+    () => beta.bundles.page({ ...query, cursor: { after: cursor } }),
+    "INVALID_CURSOR",
+    "cursor-binding",
+  );
+  await assertDatabaseConnectorV2Error(
+    () => alpha.bundles.page({ limit: 2, cursor: { after: cursor } }),
+    "INVALID_CURSOR",
+    "cursor-binding",
+  );
+  await assertDatabaseConnectorV2Error(
+    () => alpha.bundles.page({ limit: 1, cursor: { after: "tampered" } }),
+    "INVALID_CURSOR",
+    "malformed-input",
+  );
+}

--- a/packages/test-utils/src/database-v2/receiptScenarios.ts
+++ b/packages/test-utils/src/database-v2/receiptScenarios.ts
@@ -1,0 +1,155 @@
+import { assertDatabaseConnectorV2 } from "./assertions";
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_CHANGE_SET_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  DATABASE_V2_SCOPE_BETA,
+  createDatabaseV2PutChangeSet,
+  createDatabaseV2TestBundle,
+} from "./fixtures";
+import type {
+  DatabaseConnectorV2TestChangeSet,
+  DatabaseConnectorV2TestHarness,
+} from "./types";
+
+export async function runDatabaseV2AtomicityScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("atomicity");
+  const connection = await subject.connector.connect();
+  const session = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const first = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const missingRevision = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.second,
+    "production",
+  );
+  const beforeMutations = subject.instrumentation.domainMutationCount();
+  const changeSet: DatabaseConnectorV2TestChangeSet = {
+    id: DATABASE_V2_CHANGE_SET_IDS.seed,
+    changes: [
+      { type: "put", value: first, precondition: { state: "absent" } },
+      {
+        type: "put",
+        value: missingRevision,
+        precondition: { state: "revision", revision: "missing-revision" },
+      },
+    ],
+  };
+
+  const receipt = await session.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    receipt.outcome === "rejected" && receipt.reason === "conflict",
+    "atomicity",
+    "one failed precondition must reject the whole change set",
+  );
+  assertDatabaseConnectorV2(
+    subject.instrumentation.domainMutationCount() === beforeMutations &&
+      (await session.bundles.get(first.id)) === null &&
+      (await session.bundles.get(missingRevision.id)) === null,
+    "atomicity",
+    "a rejected multi-change commit must not partially write rows",
+  );
+
+  const sameSessionReplay = await session.applyChangeSet(changeSet);
+  const freshSession = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const freshSessionReplay = await freshSession.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    sameSessionReplay.outcome === "rejected" &&
+      freshSessionReplay.outcome === "rejected" &&
+      sameSessionReplay.reason === receipt.reason &&
+      freshSessionReplay.canonicalPayloadHash ===
+        receipt.canonicalPayloadHash &&
+      subject.instrumentation.domainMutationCount() === beforeMutations,
+    "replay-identity",
+    "rejected receipts must replay in same and fresh sessions without row writes",
+  );
+}
+
+export async function runDatabaseV2ReplayScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("receipt-replay");
+  const connection = await subject.connector.connect();
+  const alpha = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const bundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const changeSet = createDatabaseV2PutChangeSet(
+    DATABASE_V2_CHANGE_SET_IDS.replay,
+    [bundle],
+  );
+  const committed = await alpha.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    committed.outcome === "committed",
+    "replay-identity",
+    "the initial change set must commit",
+  );
+  const afterCommit = subject.instrumentation.domainMutationCount();
+  const replayed = await alpha.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    replayed.outcome === "replayed" &&
+      replayed.canonicalPayloadHash === committed.canonicalPayloadHash &&
+      replayed.scopeId === committed.scopeId &&
+      replayed.revisions[bundle.id] === committed.revisions[bundle.id] &&
+      subject.instrumentation.domainMutationCount() === afterCommit,
+    "replay-identity",
+    "same-session replay must preserve identity/revisions without domain writes",
+  );
+
+  const freshConnection = await subject.connector.connect();
+  const freshAlpha = await freshConnection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const freshReplay = await freshAlpha.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    freshReplay.outcome === "replayed" &&
+      freshReplay.revisions[bundle.id] === committed.revisions[bundle.id] &&
+      subject.instrumentation.domainMutationCount() === afterCommit,
+    "replay-identity",
+    "fresh-session replay must preserve the connector-lifetime receipt",
+  );
+
+  const collisionBundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.second,
+    "collision",
+  );
+  const collision = await freshAlpha.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.replay, [
+      collisionBundle,
+    ]),
+  );
+  assertDatabaseConnectorV2(
+    collision.outcome === "rejected" &&
+      collision.reason === "conflict" &&
+      subject.instrumentation.domainMutationCount() === afterCommit,
+    "replay-identity",
+    "same ID with a different payload must conflict without replacing the receipt",
+  );
+  const originalAfterCollision = await freshAlpha.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    originalAfterCollision.outcome === "replayed" &&
+      originalAfterCollision.scopeId === committed.scopeId &&
+      originalAfterCollision.canonicalPayloadHash ===
+        committed.canonicalPayloadHash &&
+      originalAfterCollision.revisions[bundle.id] ===
+        committed.revisions[bundle.id] &&
+      subject.instrumentation.domainMutationCount() === afterCommit,
+    "replay-identity",
+    "a payload collision must not replace the original replay receipt",
+  );
+
+  const beta = await freshConnection.openSession(DATABASE_V2_SCOPE_BETA);
+  const independent = await beta.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.replay, [
+      collisionBundle,
+    ]),
+  );
+  assertDatabaseConnectorV2(
+    independent.outcome === "committed" &&
+      independent.scopeId !== committed.scopeId,
+    "replay-identity",
+    "the same ID under another principal must be an independent attempt",
+  );
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedCommitSubjects.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedCommitSubjects.ts
@@ -1,0 +1,102 @@
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_SCOPE_BETA,
+  createDatabaseV2TestBundle,
+} from "../fixtures";
+import type { DatabaseConnectorV2TestSubject } from "../types";
+import {
+  committedReceipt,
+  createConnectedSubject,
+  createScriptedContext,
+  createScriptedSession,
+  hasDefect,
+  rejectedReceipt,
+  ScriptedConnectorError,
+  type ScriptedHarnessDefect,
+} from "./scriptedSupport";
+
+const firstBundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.first,
+  "production",
+);
+const firstRow = { value: firstBundle, revision: "revision:first" } as const;
+export function createAtomicSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  return createConnectedSubject(context, async () =>
+    createScriptedSession({
+      get: async (id) =>
+        hasDefect(context, "partial-write") &&
+        id === DATABASE_V2_BUNDLE_IDS.first
+          ? firstRow
+          : null,
+      apply: async (changeSet) => {
+        context.backendCommits += 1;
+        if (hasDefect(context, "partial-write")) {
+          context.domainMutations = 1;
+        }
+        return rejectedReceipt(changeSet.id);
+      },
+    }),
+  );
+}
+
+export function createMalformedSubject(): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext([]);
+  return createConnectedSubject(context, async () =>
+    createScriptedSession({
+      apply: async () => {
+        throw new ScriptedConnectorError("INVALID_CHANGE_SET");
+      },
+    }),
+  );
+}
+
+export function createReplaySubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  let applyCalls = 0;
+  const revisions = {
+    [DATABASE_V2_BUNDLE_IDS.first]: "revision:first",
+  };
+  return createConnectedSubject(context, async (scope) =>
+    createScriptedSession({
+      apply: async (changeSet) => {
+        applyCalls += 1;
+        context.backendCommits += 1;
+        if (applyCalls === 1) {
+          context.domainMutations = 1;
+          return { ...committedReceipt(changeSet), revisions };
+        }
+        if (applyCalls === 2 && hasDefect(context, "reapply-replay")) {
+          context.domainMutations += 1;
+        }
+        if (applyCalls === 4) {
+          return rejectedReceipt(changeSet.id);
+        }
+        if (
+          applyCalls === 5 &&
+          hasDefect(context, "replace-receipt-on-collision")
+        ) {
+          return rejectedReceipt(changeSet.id);
+        }
+        if (scope.principalId === DATABASE_V2_SCOPE_BETA.principalId) {
+          context.domainMutations += 1;
+          return {
+            ...committedReceipt(changeSet, "scope:tenant-alpha:principal-beta"),
+            revisions: {
+              [DATABASE_V2_BUNDLE_IDS.second]: "revision:second",
+            },
+          };
+        }
+        return {
+          ...committedReceipt(changeSet),
+          outcome: "replayed",
+          revisions,
+        };
+      },
+    }),
+  );
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedHarness.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedHarness.ts
@@ -1,0 +1,66 @@
+import type {
+  DatabaseConnectorV2TestHarness,
+  DatabaseConnectorV2TestScenario,
+  DatabaseConnectorV2TestSubject,
+} from "../types";
+import {
+  createAtomicSubject,
+  createMalformedSubject,
+  createReplaySubject,
+} from "./scriptedCommitSubjects";
+import { createLifecycleSubject } from "./scriptedLifecycleSubjects";
+import {
+  createCursorSubject,
+  createHappyReadSubject,
+} from "./scriptedReadSubjects";
+import {
+  createConcurrentSubject,
+  createUnknownSubject,
+} from "./scriptedStateSubjects";
+import {
+  ScriptedConnectorError,
+  type ScriptedHarnessDefect,
+} from "./scriptedSupport";
+
+function createSubject(
+  scenario: DatabaseConnectorV2TestScenario,
+  defects: readonly ScriptedHarnessDefect[],
+  lifecycleOrdinal: number,
+): DatabaseConnectorV2TestSubject {
+  switch (scenario) {
+    case "atomicity":
+      return createAtomicSubject(defects);
+    case "concurrent-commit":
+      return createConcurrentSubject(defects);
+    case "cursor-binding":
+      return createCursorSubject(defects);
+    case "happy-read-and-scope":
+      return createHappyReadSubject(defects);
+    case "lifecycle":
+      return createLifecycleSubject(lifecycleOrdinal, defects);
+    case "malformed-change-set":
+      return createMalformedSubject();
+    case "receipt-replay":
+      return createReplaySubject(defects);
+    case "unknown-recovery":
+      return createUnknownSubject(defects);
+    default:
+      throw new ScriptedConnectorError(
+        `UNSCRIPTED_SCENARIO:${String(scenario)}`,
+      );
+  }
+}
+
+export function createScriptedDatabaseConnectorV2Harness(
+  defects: readonly ScriptedHarnessDefect[] = [],
+): DatabaseConnectorV2TestHarness {
+  let lifecycleSubjects = 0;
+  return {
+    createSubject: (scenario) => {
+      if (scenario === "lifecycle") {
+        lifecycleSubjects += 1;
+      }
+      return createSubject(scenario, defects, lifecycleSubjects);
+    },
+  };
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedLifecycleSubjects.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedLifecycleSubjects.ts
@@ -1,0 +1,129 @@
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  createDatabaseV2TestBundle,
+} from "../fixtures";
+import type {
+  DatabaseConnectorV2TestConnection,
+  DatabaseConnectorV2TestSubject,
+} from "../types";
+import {
+  committedReceipt,
+  createScriptedConnection,
+  createScriptedContext,
+  createScriptedSession,
+  createScriptedSubject,
+  hasDefect,
+  ScriptedConnectorError,
+  type ScriptedContext,
+  type ScriptedHarnessDefect,
+  type ScriptedSession,
+} from "./scriptedSupport";
+
+const bundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.first,
+  "production",
+);
+const row = { value: bundle, revision: "revision:first" } as const;
+const retainedScript: ScriptedSession = {
+  get: async () => row,
+};
+
+function closedScript(allowCalls: boolean): ScriptedSession {
+  const rejectClosed = () => {
+    if (!allowCalls) {
+      throw new ScriptedConnectorError("SESSION_CLOSED");
+    }
+  };
+  return {
+    get: async () => {
+      rejectClosed();
+      return null;
+    },
+    channels: async () => {
+      rejectClosed();
+      return [];
+    },
+  };
+}
+
+function createPrimaryConnection(
+  context: ScriptedContext,
+): DatabaseConnectorV2TestConnection {
+  let openCalls = 0;
+  return createScriptedConnection(async () => {
+    openCalls += 1;
+    if (openCalls > 1) {
+      throw new ScriptedConnectorError("CONNECTION_CLOSED");
+    }
+    const script = closedScript(hasDefect(context, "allow-use-after-close"));
+    return createScriptedSession(script);
+  });
+}
+
+function createPrimarySubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  let connectCalls = 0;
+  return createScriptedSubject(context, () => {
+    connectCalls += 1;
+    if (connectCalls === 1) {
+      return createPrimaryConnection(context);
+    }
+    return createScriptedConnection(async () =>
+      createScriptedSession(retainedScript),
+    );
+  });
+}
+
+function createIdleSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  const script = closedScript(hasDefect(context, "leave-child-sessions-open"));
+  return createScriptedSubject(context, () =>
+    createScriptedConnection(async () => createScriptedSession(script)),
+  );
+}
+
+function createRaceSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  const session = createScriptedSession({
+    ...closedScript(false),
+    apply: async (changeSet) => {
+      context.backendCommits += 1;
+      context.heldEntered.resolve();
+      await context.heldRelease.promise;
+      return committedReceipt(changeSet, "scope:race");
+    },
+  });
+  return createScriptedSubject(context, () =>
+    createScriptedConnection(
+      async () => session,
+      () => {
+        if (hasDefect(context, "resolve-connection-close-early")) {
+          return Promise.resolve();
+        }
+        return context.heldRelease.promise;
+      },
+    ),
+  );
+}
+
+export function createLifecycleSubject(
+  ordinal: number,
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  switch (ordinal) {
+    case 1:
+      return createPrimarySubject(defects);
+    case 2:
+      return createIdleSubject(defects);
+    case 3:
+      return createRaceSubject(defects);
+    default:
+      throw new ScriptedConnectorError("UNSCRIPTED_LIFECYCLE_SUBJECT");
+  }
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedReadSubjects.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedReadSubjects.ts
@@ -1,0 +1,90 @@
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  createDatabaseV2TestBundle,
+} from "../fixtures";
+import type {
+  DatabaseConnectorV2TestPageQuery,
+  DatabaseConnectorV2TestScope,
+  DatabaseConnectorV2TestSubject,
+} from "../types";
+import {
+  createConnectedSubject,
+  createScriptedContext,
+  createScriptedPage,
+  createScriptedSession,
+  hasDefect,
+  ScriptedConnectorError,
+  type ScriptedHarnessDefect,
+} from "./scriptedSupport";
+
+const firstBundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.first,
+  "production",
+);
+const secondBundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.second,
+  "staging",
+);
+const firstRow = { value: firstBundle, revision: "revision:first" } as const;
+const secondRow = { value: secondBundle, revision: "revision:second" } as const;
+
+export function createHappyReadSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  const openSession = async (scope: DatabaseConnectorV2TestScope) => {
+    const acceptedEmptyPrincipal =
+      scope.principalId.length === 0 &&
+      hasDefect(context, "accept-empty-principal");
+    if (scope.tenantId.length === 0 || scope.principalId.length === 0) {
+      if (!acceptedEmptyPrincipal) {
+        if (hasDefect(context, "invalid-scope-backend-io")) {
+          context.backendOperations += 1;
+        }
+        throw new ScriptedConnectorError("INVALID_SCOPE");
+      }
+    }
+    context.backendOperations += 1;
+    const sameTenant = scope.tenantId === DATABASE_V2_SCOPE_ALPHA.tenantId;
+    const visible = sameTenant || hasDefect(context, "cross-tenant-read");
+    return createScriptedSession({
+      get: async (id) =>
+        visible && id === DATABASE_V2_BUNDLE_IDS.first ? firstRow : null,
+      page: async () =>
+        visible
+          ? createScriptedPage([firstRow, secondRow], 2)
+          : createScriptedPage([], 0),
+      channels: async () => (visible ? ["production", "staging"] : []),
+    });
+  };
+  return createConnectedSubject(context, openSession);
+}
+
+function cursorPage(query: DatabaseConnectorV2TestPageQuery) {
+  if (query.cursor === undefined) {
+    return createScriptedPage([firstRow], 3, "cursor:first");
+  }
+  if (query.limit === 1 && query.cursor.after === "cursor:first") {
+    return createScriptedPage([secondRow], 3, "cursor:second");
+  }
+  throw new ScriptedConnectorError("INVALID_CURSOR");
+}
+
+export function createCursorSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  return createConnectedSubject(context, async (scope) =>
+    createScriptedSession({
+      page: async (query) => {
+        const foreignPrincipal =
+          scope.principalId !== DATABASE_V2_SCOPE_ALPHA.principalId;
+        if (foreignPrincipal && !hasDefect(context, "accept-foreign-cursor")) {
+          throw new ScriptedConnectorError("INVALID_CURSOR");
+        }
+        return cursorPage(query);
+      },
+    }),
+  );
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedStateSubjects.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedStateSubjects.ts
@@ -1,0 +1,87 @@
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  createDatabaseV2TestBundle,
+} from "../fixtures";
+import type { DatabaseConnectorV2TestSubject } from "../types";
+import {
+  committedReceipt,
+  createConnectedSubject,
+  createScriptedContext,
+  createScriptedSession,
+  hasDefect,
+  ScriptedConnectorError,
+  unknownReceipt,
+  type ScriptedHarnessDefect,
+} from "./scriptedSupport";
+
+const firstBundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.first,
+  "production",
+);
+const durableBundle = createDatabaseV2TestBundle(
+  DATABASE_V2_BUNDLE_IDS.second,
+  "durable",
+);
+export function createConcurrentSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  let applyCalls = 0;
+  return createConnectedSubject(context, async () =>
+    createScriptedSession({
+      apply: async (changeSet) => {
+        applyCalls += 1;
+        if (applyCalls === 2) {
+          if (hasDefect(context, "concurrent-backend-io")) {
+            context.backendCommits += 1;
+          }
+          throw new ScriptedConnectorError("CONCURRENT_COMMIT");
+        }
+        context.backendCommits += 1;
+        context.heldEntered.resolve();
+        await context.heldRelease.promise;
+        return committedReceipt(changeSet);
+      },
+    }),
+  );
+}
+
+export function createUnknownSubject(
+  defects: readonly ScriptedHarnessDefect[],
+): DatabaseConnectorV2TestSubject {
+  const context = createScriptedContext(defects);
+  let applyCalls = 0;
+  let getCalls = 0;
+  return createConnectedSubject(context, async () =>
+    createScriptedSession({
+      get: async () => {
+        getCalls += 1;
+        if (getCalls <= 2 && !hasDefect(context, "allow-poisoned-read")) {
+          throw new ScriptedConnectorError("SESSION_POISONED");
+        }
+        if (getCalls === 3) {
+          return { value: firstBundle, revision: "revision:first" };
+        }
+        if (getCalls === 4) {
+          return { value: durableBundle, revision: "revision:durable" };
+        }
+        return null;
+      },
+      apply: async (changeSet) => {
+        applyCalls += 1;
+        context.backendCommits += 1;
+        if (applyCalls === 2) {
+          throw new ScriptedConnectorError("SESSION_POISONED");
+        }
+        if (applyCalls === 1 || applyCalls === 3 || applyCalls === 5) {
+          return unknownReceipt(changeSet);
+        }
+        if (applyCalls === 6) {
+          const committed = committedReceipt(changeSet);
+          return { ...committed, outcome: "replayed" };
+        }
+        return committedReceipt(changeSet);
+      },
+    }),
+  );
+}

--- a/packages/test-utils/src/database-v2/spec-support/scriptedSupport.ts
+++ b/packages/test-utils/src/database-v2/spec-support/scriptedSupport.ts
@@ -1,0 +1,207 @@
+import type {
+  DatabaseConnectorV2TestChangeSet,
+  DatabaseConnectorV2TestConnection,
+  DatabaseConnectorV2TestPage,
+  DatabaseConnectorV2TestReceipt,
+  DatabaseConnectorV2TestRepository,
+  DatabaseConnectorV2TestScope,
+  DatabaseConnectorV2TestSession,
+  DatabaseConnectorV2TestSubject,
+  DatabaseConnectorV2TestVersionedBundle,
+} from "../types";
+
+export type ScriptedHarnessDefect =
+  | "accept-empty-principal"
+  | "accept-foreign-cursor"
+  | "allow-poisoned-read"
+  | "allow-use-after-close"
+  | "concurrent-backend-io"
+  | "cross-tenant-read"
+  | "invalid-scope-backend-io"
+  | "leave-child-sessions-open"
+  | "partial-write"
+  | "reapply-replay"
+  | "resolve-connection-close-early"
+  | "replace-receipt-on-collision";
+
+export class ScriptedConnectorError extends Error {
+  override readonly name = "ScriptedConnectorError";
+
+  constructor(readonly code: string) {
+    super(code);
+  }
+}
+
+interface ScriptedDeferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+}
+
+export interface ScriptedContext {
+  readonly defects: readonly ScriptedHarnessDefect[];
+  backendOperations: number;
+  backendCommits: number;
+  domainMutations: number;
+  readonly heldEntered: ScriptedDeferred;
+  readonly heldRelease: ScriptedDeferred;
+}
+
+function createDeferred(): ScriptedDeferred {
+  let resolvePromise: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: () => resolvePromise(),
+  };
+}
+
+export function createScriptedContext(
+  defects: readonly ScriptedHarnessDefect[],
+): ScriptedContext {
+  return {
+    defects,
+    backendOperations: 0,
+    backendCommits: 0,
+    domainMutations: 0,
+    heldEntered: createDeferred(),
+    heldRelease: createDeferred(),
+  };
+}
+
+export function hasDefect(
+  context: ScriptedContext,
+  defect: ScriptedHarnessDefect,
+): boolean {
+  return context.defects.includes(defect);
+}
+
+export function createScriptedSubject(
+  context: ScriptedContext,
+  connect: () => DatabaseConnectorV2TestConnection,
+): DatabaseConnectorV2TestSubject {
+  return {
+    connector: {
+      connect,
+    },
+    instrumentation: {
+      backendOperationAttempts: () => context.backendOperations,
+      backendCommitAttempts: () => context.backendCommits,
+      domainMutationCount: () => context.domainMutations,
+    },
+    faults: {
+      holdNextCommit: () => undefined,
+      waitForHeldCommit: () => context.heldEntered.promise,
+      releaseHeldCommit: () => context.heldRelease.resolve(),
+      interruptNextCommit: () => undefined,
+    },
+  };
+}
+
+export function createScriptedConnection(
+  openSession: (
+    scope: DatabaseConnectorV2TestScope,
+  ) => Promise<DatabaseConnectorV2TestSession>,
+  close: () => Promise<void> = async () => undefined,
+): DatabaseConnectorV2TestConnection {
+  return { openSession, close };
+}
+
+export interface ScriptedSession {
+  readonly get?: DatabaseConnectorV2TestRepository["get"];
+  readonly page?: DatabaseConnectorV2TestRepository["page"];
+  readonly channels?: DatabaseConnectorV2TestRepository["channels"];
+  readonly apply?: DatabaseConnectorV2TestSession["applyChangeSet"];
+  readonly close?: DatabaseConnectorV2TestSession["close"];
+}
+
+export function createScriptedSession(
+  script: ScriptedSession,
+): DatabaseConnectorV2TestSession {
+  return {
+    bundles: {
+      get: script.get ?? (async () => null),
+      page: script.page ?? (async () => createScriptedPage([], 0)),
+      channels: script.channels ?? (async () => []),
+    },
+    applyChangeSet:
+      script.apply ?? (async (changeSet) => committedReceipt(changeSet)),
+    close: script.close ?? (async () => undefined),
+  };
+}
+
+export function createConnectedSubject(
+  context: ScriptedContext,
+  openSession: DatabaseConnectorV2TestConnection["openSession"],
+  close?: DatabaseConnectorV2TestConnection["close"],
+): DatabaseConnectorV2TestSubject {
+  return createScriptedSubject(context, () =>
+    createScriptedConnection(openSession, close),
+  );
+}
+
+export function createScriptedPage(
+  data: readonly DatabaseConnectorV2TestVersionedBundle[],
+  total: number,
+  nextCursor: string | null = null,
+): DatabaseConnectorV2TestPage {
+  return {
+    data,
+    pagination: {
+      total,
+      hasNextPage: nextCursor !== null,
+      hasPreviousPage: false,
+      nextCursor,
+      previousCursor: null,
+    },
+  };
+}
+
+type DurableReceipt = Extract<
+  DatabaseConnectorV2TestReceipt,
+  { readonly outcome: "committed" | "replayed" }
+>;
+
+export function committedReceipt(
+  changeSet: DatabaseConnectorV2TestChangeSet,
+  scopeId = "scope:tenant-alpha:principal-alpha",
+): DurableReceipt {
+  const firstChange = changeSet.changes[0];
+  const bundleId =
+    firstChange?.type === "put" ? firstChange.value.id : firstChange?.id;
+  return {
+    changeSetId: changeSet.id,
+    scopeId,
+    canonicalPayloadHash: `payload:${changeSet.id}`,
+    outcome: "committed",
+    revisions:
+      bundleId === undefined ? {} : { [bundleId]: "revision:scripted" },
+  };
+}
+
+export function rejectedReceipt(
+  changeSetId: string,
+): DatabaseConnectorV2TestReceipt {
+  return {
+    changeSetId,
+    scopeId: "scope:tenant-alpha:principal-alpha",
+    canonicalPayloadHash: "payload:rejected",
+    outcome: "rejected",
+    reason: "conflict",
+  };
+}
+
+export function unknownReceipt(
+  changeSet: DatabaseConnectorV2TestChangeSet,
+): DatabaseConnectorV2TestReceipt {
+  return {
+    changeSetId: changeSet.id,
+    scopeId: "scope:tenant-alpha:principal-alpha",
+    canonicalPayloadHash: `payload:${changeSet.id}`,
+    outcome: "unknown",
+    reason: "transport-unknown",
+    sessionState: "poisoned",
+    retry: "identical-scope-id-and-payload-only",
+  };
+}

--- a/packages/test-utils/src/database-v2/stateScenarios.ts
+++ b/packages/test-utils/src/database-v2/stateScenarios.ts
@@ -1,0 +1,149 @@
+import {
+  assertDatabaseConnectorV2,
+  assertDatabaseConnectorV2Error,
+} from "./assertions";
+import {
+  DATABASE_V2_BUNDLE_IDS,
+  DATABASE_V2_CHANGE_SET_IDS,
+  DATABASE_V2_SCOPE_ALPHA,
+  createDatabaseV2PutChangeSet,
+  createDatabaseV2TestBundle,
+} from "./fixtures";
+import type { DatabaseConnectorV2TestHarness } from "./types";
+
+export async function runDatabaseV2ConcurrentCommitScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("concurrent-commit");
+  const connection = await subject.connector.connect();
+  const session = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const first = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const second = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.second,
+    "production",
+  );
+  subject.faults.holdNextCommit();
+  const commitA = session.applyChangeSet(
+    createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.concurrentA, [
+      first,
+    ]),
+  );
+  await subject.faults.waitForHeldCommit();
+  const attemptsDuringA = subject.instrumentation.backendCommitAttempts();
+
+  try {
+    await assertDatabaseConnectorV2Error(
+      () =>
+        session.applyChangeSet(
+          createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.concurrentB, [
+            second,
+          ]),
+        ),
+      "CONCURRENT_COMMIT",
+      "concurrent-zero-io",
+    );
+    assertDatabaseConnectorV2(
+      subject.instrumentation.backendCommitAttempts() === attemptsDuringA,
+      "concurrent-zero-io",
+      "the second concurrent commit must be rejected before backend I/O",
+    );
+  } finally {
+    subject.faults.releaseHeldCommit();
+  }
+
+  const committed = await commitA;
+  assertDatabaseConnectorV2(
+    committed.outcome === "committed",
+    "concurrent-zero-io",
+    "releasing the held first commit must let it finish",
+  );
+}
+
+export async function runDatabaseV2UnknownRecoveryScenario(
+  harness: DatabaseConnectorV2TestHarness,
+): Promise<void> {
+  const subject = await harness.createSubject("unknown-recovery");
+  const connection = await subject.connector.connect();
+  const session = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const bundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.first,
+    "production",
+  );
+  const changeSet = createDatabaseV2PutChangeSet(
+    DATABASE_V2_CHANGE_SET_IDS.unknown,
+    [bundle],
+  );
+
+  subject.faults.interruptNextCommit("before-durability");
+  const firstUnknown = await session.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    firstUnknown.outcome === "unknown",
+    "unknown-recovery",
+    "an interrupted commit must return an unknown receipt",
+  );
+  await assertDatabaseConnectorV2Error(
+    () => session.bundles.get(bundle.id),
+    "SESSION_POISONED",
+    "unknown-recovery",
+  );
+  await assertDatabaseConnectorV2Error(
+    () =>
+      session.applyChangeSet(
+        createDatabaseV2PutChangeSet(DATABASE_V2_CHANGE_SET_IDS.concurrentB, [
+          bundle,
+        ]),
+      ),
+    "SESSION_POISONED",
+    "unknown-recovery",
+  );
+
+  subject.faults.interruptNextCommit("before-durability");
+  const secondUnknown = await session.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    secondUnknown.outcome === "unknown",
+    "unknown-recovery",
+    "a repeated identical interruption must keep the session poisoned",
+  );
+  await assertDatabaseConnectorV2Error(
+    () => session.bundles.get(bundle.id),
+    "SESSION_POISONED",
+    "unknown-recovery",
+  );
+
+  const recovered = await session.applyChangeSet(changeSet);
+  assertDatabaseConnectorV2(
+    recovered.outcome === "committed" &&
+      (await session.bundles.get(bundle.id))?.value.id === bundle.id,
+    "unknown-recovery",
+    "an identical definitive retry must recover and unpoison the session",
+  );
+
+  const durableBundle = createDatabaseV2TestBundle(
+    DATABASE_V2_BUNDLE_IDS.second,
+    "durable",
+  );
+  const durableChange = createDatabaseV2PutChangeSet(
+    "10000000-0000-4000-8000-000000000008",
+    [durableBundle],
+  );
+  subject.faults.interruptNextCommit("after-durability");
+  const afterDurability = await session.applyChangeSet(durableChange);
+  assertDatabaseConnectorV2(
+    afterDurability.outcome === "unknown",
+    "unknown-recovery",
+    "an after-durability interruption must still report unknown",
+  );
+  await session.close();
+  const fresh = await connection.openSession(DATABASE_V2_SCOPE_ALPHA);
+  const durableReplay = await fresh.applyChangeSet(durableChange);
+  assertDatabaseConnectorV2(
+    durableReplay.outcome === "replayed" &&
+      (await fresh.bundles.get(durableBundle.id))?.value.id ===
+        durableBundle.id,
+    "unknown-recovery",
+    "fresh-session exact retry must discover a durable committed receipt",
+  );
+}

--- a/packages/test-utils/src/database-v2/types.ts
+++ b/packages/test-utils/src/database-v2/types.ts
@@ -1,0 +1,170 @@
+import type { Bundle } from "@hot-updater/core";
+
+export type DatabaseConnectorV2TestMaybePromise<T> = T | Promise<T>;
+
+export interface DatabaseConnectorV2TestContext {
+  readonly marker: string;
+  readonly tenantId?: string;
+  readonly principalId?: string;
+}
+
+export interface DatabaseConnectorV2TestScope {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly context: DatabaseConnectorV2TestContext;
+}
+
+export interface DatabaseConnectorV2TestVersionedBundle {
+  readonly value: Bundle;
+  readonly revision: string;
+}
+
+export interface DatabaseConnectorV2TestWhere {
+  readonly channel?: string;
+  readonly platform?: Bundle["platform"];
+  readonly enabled?: boolean;
+  readonly id?: {
+    readonly eq?: string;
+    readonly gt?: string;
+    readonly gte?: string;
+    readonly lt?: string;
+    readonly lte?: string;
+    readonly in?: readonly string[];
+  };
+  readonly targetAppVersion?: string | null;
+  readonly targetAppVersionIn?: readonly string[];
+  readonly targetAppVersionNotNull?: boolean;
+  readonly fingerprintHash?: string | null;
+}
+
+export interface DatabaseConnectorV2TestPageQuery {
+  readonly where?: DatabaseConnectorV2TestWhere;
+  readonly limit: number;
+  readonly cursor?:
+    | { readonly after: string; readonly before?: never }
+    | { readonly before: string; readonly after?: never };
+  readonly orderBy?: {
+    readonly field: "id";
+    readonly direction: "asc" | "desc";
+  };
+}
+
+export interface DatabaseConnectorV2TestPage {
+  readonly data: readonly DatabaseConnectorV2TestVersionedBundle[];
+  readonly pagination: {
+    readonly total: number;
+    readonly hasNextPage: boolean;
+    readonly hasPreviousPage: boolean;
+    readonly nextCursor: string | null;
+    readonly previousCursor: string | null;
+  };
+}
+
+export type DatabaseConnectorV2TestChange =
+  | {
+      readonly type: "put";
+      readonly value: Bundle;
+      readonly precondition:
+        | { readonly state: "absent" }
+        | { readonly state: "revision"; readonly revision: string };
+    }
+  | {
+      readonly type: "delete";
+      readonly id: string;
+      readonly precondition: {
+        readonly state: "revision";
+        readonly revision: string;
+      };
+    };
+
+export interface DatabaseConnectorV2TestChangeSet {
+  readonly id: string;
+  readonly changes: readonly DatabaseConnectorV2TestChange[];
+}
+
+export type DatabaseConnectorV2TestReceipt =
+  | {
+      readonly changeSetId: string;
+      readonly scopeId: string;
+      readonly canonicalPayloadHash: string;
+      readonly outcome: "committed" | "replayed";
+      readonly revisions: Readonly<Record<string, string>>;
+    }
+  | {
+      readonly changeSetId: string;
+      readonly scopeId: string;
+      readonly canonicalPayloadHash: string;
+      readonly outcome: "rejected";
+      readonly reason: "conflict" | "unsupported";
+    }
+  | {
+      readonly changeSetId: string;
+      readonly scopeId: string;
+      readonly canonicalPayloadHash: string;
+      readonly outcome: "unknown";
+      readonly reason: "transport-unknown";
+      readonly sessionState: "poisoned";
+      readonly retry: "identical-scope-id-and-payload-only";
+    };
+
+export interface DatabaseConnectorV2TestRepository {
+  get(id: string): Promise<DatabaseConnectorV2TestVersionedBundle | null>;
+  page(
+    query: DatabaseConnectorV2TestPageQuery,
+  ): Promise<DatabaseConnectorV2TestPage>;
+  channels(): Promise<readonly string[]>;
+}
+
+export interface DatabaseConnectorV2TestSession {
+  readonly bundles: DatabaseConnectorV2TestRepository;
+  applyChangeSet(
+    changeSet: DatabaseConnectorV2TestChangeSet,
+  ): Promise<DatabaseConnectorV2TestReceipt>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseConnectorV2TestConnection {
+  openSession(
+    scope: DatabaseConnectorV2TestScope,
+  ): Promise<DatabaseConnectorV2TestSession>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseConnectorV2TestConnector {
+  connect(): DatabaseConnectorV2TestMaybePromise<DatabaseConnectorV2TestConnection>;
+}
+
+export interface DatabaseConnectorV2TestInstrumentation {
+  backendOperationAttempts(): number;
+  backendCommitAttempts(): number;
+  domainMutationCount(): number;
+}
+
+export interface DatabaseConnectorV2TestFaults {
+  holdNextCommit(): void;
+  waitForHeldCommit(): Promise<void>;
+  releaseHeldCommit(): void;
+  interruptNextCommit(stage: "before-durability" | "after-durability"): void;
+}
+
+export interface DatabaseConnectorV2TestSubject {
+  readonly connector: DatabaseConnectorV2TestConnector;
+  readonly instrumentation: DatabaseConnectorV2TestInstrumentation;
+  readonly faults: DatabaseConnectorV2TestFaults;
+}
+
+export type DatabaseConnectorV2TestScenario =
+  | "atomicity"
+  | "concurrent-commit"
+  | "cursor-binding"
+  | "happy-read-and-scope"
+  | "lifecycle"
+  | "malformed-change-set"
+  | "receipt-replay"
+  | "unknown-recovery";
+
+export interface DatabaseConnectorV2TestHarness {
+  createSubject(
+    scenario: DatabaseConnectorV2TestScenario,
+  ): DatabaseConnectorV2TestMaybePromise<DatabaseConnectorV2TestSubject>;
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -2,3 +2,4 @@ export * from "./setupBundleMethodsTestSuite";
 export * from "./setupBsdiffManifestUpdateInfoTestSuite";
 export * from "./setupGetUpdateInfoTestSuite";
 export * from "./setupSemverSatisfiesTestSuite";
+export * from "./setupDatabaseConnectorV2TestSuite";

--- a/packages/test-utils/src/setupDatabaseConnectorV2TestSuite.ts
+++ b/packages/test-utils/src/setupDatabaseConnectorV2TestSuite.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "vitest";
+
+import { runDatabaseV2MalformedChangeSetScenario } from "./database-v2/inputScenario";
+import { runDatabaseV2LifecycleScenario } from "./database-v2/lifecycleScenario";
+import {
+  runDatabaseV2CursorBindingScenario,
+  runDatabaseV2HappyReadAndScopeScenario,
+} from "./database-v2/readScenarios";
+import {
+  runDatabaseV2AtomicityScenario,
+  runDatabaseV2ReplayScenario,
+} from "./database-v2/receiptScenarios";
+import {
+  runDatabaseV2ConcurrentCommitScenario,
+  runDatabaseV2UnknownRecoveryScenario,
+} from "./database-v2/stateScenarios";
+import type { DatabaseConnectorV2TestHarness } from "./database-v2/types";
+
+export function setupDatabaseConnectorV2TestSuite(
+  harness: DatabaseConnectorV2TestHarness,
+): void {
+  describe("database connector v2 structural conformance", () => {
+    it("reads and lists tenant data while enforcing trusted asserted scope", async () => {
+      await runDatabaseV2HappyReadAndScopeScenario(harness);
+    });
+
+    it("binds opaque cursors to principal and query identity", async () => {
+      await runDatabaseV2CursorBindingScenario(harness);
+    });
+
+    it("applies every change atomically", async () => {
+      await runDatabaseV2AtomicityScenario(harness);
+    });
+
+    it("rejects malformed change sets before backend I/O", async () => {
+      await runDatabaseV2MalformedChangeSetScenario(harness);
+    });
+
+    it("replays receipts across sessions and separates principals", async () => {
+      await runDatabaseV2ReplayScenario(harness);
+    });
+
+    it("rejects a concurrent commit before second backend I/O", async () => {
+      await runDatabaseV2ConcurrentCommitScenario(harness);
+    });
+
+    it("fails closed and recovers only through identical replay", async () => {
+      await runDatabaseV2UnknownRecoveryScenario(harness);
+    });
+
+    it("enforces connector, connection, and session lifecycle", async () => {
+      await runDatabaseV2LifecycleScenario(harness);
+    });
+  });
+}
+
+export {
+  DatabaseConnectorV2ConformanceViolation,
+  type DatabaseConnectorV2ConformanceCheck,
+} from "./database-v2/assertions";
+export type {
+  DatabaseConnectorV2TestChange,
+  DatabaseConnectorV2TestChangeSet,
+  DatabaseConnectorV2TestConnection,
+  DatabaseConnectorV2TestConnector,
+  DatabaseConnectorV2TestContext,
+  DatabaseConnectorV2TestFaults,
+  DatabaseConnectorV2TestHarness,
+  DatabaseConnectorV2TestInstrumentation,
+  DatabaseConnectorV2TestPage,
+  DatabaseConnectorV2TestPageQuery,
+  DatabaseConnectorV2TestReceipt,
+  DatabaseConnectorV2TestRepository,
+  DatabaseConnectorV2TestScenario,
+  DatabaseConnectorV2TestScope,
+  DatabaseConnectorV2TestSession,
+  DatabaseConnectorV2TestSubject,
+  DatabaseConnectorV2TestVersionedBundle,
+  DatabaseConnectorV2TestWhere,
+} from "./database-v2/types";

--- a/plugins/plugin-core/package.json
+++ b/plugins/plugin-core/package.json
@@ -12,6 +12,16 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./database-v2": {
+      "import": {
+        "types": "./dist/database-v2/index.d.mts",
+        "default": "./dist/database-v2/index.mjs"
+      },
+      "require": {
+        "types": "./dist/database-v2/index.d.cts",
+        "default": "./dist/database-v2/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/plugins/plugin-core/src/database-v2/backend.ts
+++ b/plugins/plugin-core/src/database-v2/backend.ts
@@ -1,0 +1,46 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type {
+  BundleChangeSetV2,
+  BundlePageQueryV2,
+  BundlePageV2,
+} from "./bundles";
+import type { MaybePromise, Sha256Digest, Versioned } from "./common";
+
+export interface DatabaseBackendScopeV2 {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly scopeId: string;
+}
+
+export interface DatabaseBackendCommitRequestV2 {
+  readonly scope: DatabaseBackendScopeV2;
+  readonly changeSet: BundleChangeSetV2;
+  readonly canonicalPayloadHash: string;
+}
+
+export interface DatabaseBackendV2 {
+  get(
+    scope: DatabaseBackendScopeV2,
+    id: string,
+  ): Promise<Versioned<Bundle> | null>;
+  page(
+    scope: DatabaseBackendScopeV2,
+    query: BundlePageQueryV2,
+  ): Promise<BundlePageV2>;
+  channels(scope: DatabaseBackendScopeV2): Promise<readonly string[]>;
+  commit(request: DatabaseBackendCommitRequestV2): Promise<unknown>;
+}
+
+export type DatabaseConnectionResourceV2 =
+  | { readonly ownership: "borrowed" }
+  | {
+      readonly ownership: "owned";
+      dispose(): MaybePromise<void>;
+    };
+
+export interface DatabaseConnectionRuntimeV2Options {
+  readonly backend: DatabaseBackendV2;
+  readonly resource: DatabaseConnectionResourceV2;
+  readonly sha256?: Sha256Digest;
+}

--- a/plugins/plugin-core/src/database-v2/bundleOptionalValidation.ts
+++ b/plugins/plugin-core/src/database-v2/bundleOptionalValidation.ts
@@ -1,0 +1,116 @@
+import type { BundleMetadata, BundlePatchArtifact } from "@hot-updater/core";
+
+import {
+  invalidBundleFieldV2,
+  readOptionalBundleFieldV2,
+  requireBundleRecordV2,
+  requireBundleShapeV2,
+  requireBundleStringV2,
+  requireNullableBundleStringV2,
+} from "./bundleValidationPrimitives";
+
+const PATCH_KEYS = [
+  "baseBundleId",
+  "baseFileHash",
+  "patchFileHash",
+  "patchStorageUri",
+] as const;
+
+export const parseOptionalNullableBundleStringV2 = (
+  bundle: Record<string, unknown>,
+  key: string,
+): string | null | undefined => {
+  const value = readOptionalBundleFieldV2(bundle, key);
+  return value === undefined
+    ? undefined
+    : requireNullableBundleStringV2(value, key);
+};
+
+export const parseBundleMetadataV2 = (
+  bundle: Record<string, unknown>,
+): BundleMetadata | undefined => {
+  const value = readOptionalBundleFieldV2(bundle, "metadata");
+  if (value === undefined) return undefined;
+  const metadata = requireBundleRecordV2(value, "bundle metadata");
+  requireBundleShapeV2(metadata, {
+    allowed: ["app_version"],
+    required: [],
+    label: "bundle metadata",
+  });
+  const appVersion = readOptionalBundleFieldV2(metadata, "app_version");
+  return appVersion === undefined
+    ? {}
+    : {
+        app_version: requireBundleStringV2(appVersion, "metadata app version"),
+      };
+};
+
+const parseBundlePatchV2 = (value: unknown): BundlePatchArtifact => {
+  const patch = requireBundleRecordV2(value, "bundle patch");
+  requireBundleShapeV2(patch, {
+    allowed: PATCH_KEYS,
+    required: PATCH_KEYS,
+    label: "bundle patch",
+  });
+  return {
+    baseBundleId: requireBundleStringV2(
+      Reflect.get(patch, "baseBundleId"),
+      "patch base bundle ID",
+    ),
+    baseFileHash: requireBundleStringV2(
+      Reflect.get(patch, "baseFileHash"),
+      "patch base file hash",
+    ),
+    patchFileHash: requireBundleStringV2(
+      Reflect.get(patch, "patchFileHash"),
+      "patch file hash",
+    ),
+    patchStorageUri: requireBundleStringV2(
+      Reflect.get(patch, "patchStorageUri"),
+      "patch storage URI",
+    ),
+  };
+};
+
+export const parseBundlePatchesV2 = (
+  bundle: Record<string, unknown>,
+): BundlePatchArtifact[] | null | undefined => {
+  const value = readOptionalBundleFieldV2(bundle, "patches");
+  if (value === undefined || value === null) return value;
+  if (!Array.isArray(value)) {
+    return invalidBundleFieldV2("bundle patches must be an array or null");
+  }
+  return value.map(parseBundlePatchV2);
+};
+
+export const parseBundleRolloutV2 = (
+  bundle: Record<string, unknown>,
+): number | null | undefined => {
+  const value = readOptionalBundleFieldV2(bundle, "rolloutCohortCount");
+  if (value === undefined || value === null) return value;
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > 1000
+  ) {
+    return invalidBundleFieldV2(
+      "bundle rollout cohort count must be an integer from 0 to 1000 or null",
+    );
+  }
+  return value;
+};
+
+export const parseBundleTargetCohortsV2 = (
+  bundle: Record<string, unknown>,
+): string[] | null | undefined => {
+  const value = readOptionalBundleFieldV2(bundle, "targetCohorts");
+  if (value === undefined || value === null) return value;
+  if (!Array.isArray(value)) {
+    return invalidBundleFieldV2(
+      "bundle target cohorts must be an array or null",
+    );
+  }
+  return value.map((cohort) => requireBundleStringV2(cohort, "target cohort"));
+};

--- a/plugins/plugin-core/src/database-v2/bundleValidation.hostileTestCases.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidation.hostileTestCases.ts
@@ -1,0 +1,92 @@
+import type { MalformedBundleCase } from "./bundleValidation.testCases";
+import { createCompleteBundle } from "./bundleValidation.testFixtures";
+
+export const hostileBundleCases = (): readonly MalformedBundleCase[] => [
+  {
+    label: "Bundle accessor",
+    create: (observeGetter) => {
+      const bundle = createCompleteBundle();
+      Object.defineProperty(bundle, "channel", {
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return "production";
+        },
+      });
+      return bundle;
+    },
+  },
+  {
+    label: "nested patch accessor",
+    create: (observeGetter) => {
+      const bundle = createCompleteBundle();
+      Object.defineProperty(bundle.patches[0], "patchFileHash", {
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return "patch-hash";
+        },
+      });
+      return bundle;
+    },
+  },
+  {
+    label: "Bundle symbol key",
+    create: () => {
+      const bundle = createCompleteBundle();
+      Reflect.set(bundle, Symbol("hidden"), true);
+      return bundle;
+    },
+  },
+  {
+    label: "nested patch symbol key",
+    create: () => {
+      const bundle = createCompleteBundle();
+      Reflect.set(bundle.patches[0], Symbol("hidden"), true);
+      return bundle;
+    },
+  },
+  {
+    label: "Bundle prototype",
+    create: () => Object.create(createCompleteBundle()),
+  },
+  {
+    label: "nested patch prototype",
+    create: () => {
+      const bundle = createCompleteBundle();
+      Reflect.set(bundle, "patches", [Object.create(bundle.patches[0])]);
+      return bundle;
+    },
+  },
+  {
+    label: "hostile Bundle proxy",
+    create: (observeGetter) =>
+      new Proxy(createCompleteBundle(), {
+        get: (target, key, receiver) => {
+          observeGetter();
+          return Reflect.get(target, key, receiver);
+        },
+        ownKeys: () => {
+          throw new RangeError("hostile ownKeys");
+        },
+      }),
+  },
+  {
+    label: "hostile nested patch proxy",
+    create: (observeGetter) => {
+      const bundle = createCompleteBundle();
+      Reflect.set(bundle, "patches", [
+        new Proxy(bundle.patches[0], {
+          get: (target, key, receiver) => {
+            observeGetter();
+            return Reflect.get(target, key, receiver);
+          },
+          getOwnPropertyDescriptor: () => {
+            throw new RangeError("hostile descriptor");
+          },
+        }),
+      ]);
+      return bundle;
+    },
+  },
+];

--- a/plugins/plugin-core/src/database-v2/bundleValidation.spec.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidation.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { hostileBundleCases } from "./bundleValidation.hostileTestCases";
+import { malformedBundleCases } from "./bundleValidation.testCases";
+import {
+  createCompleteBundle,
+  createPutChangeSet,
+} from "./bundleValidation.testFixtures";
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+import { createRuntimeScope } from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+const applyUntypedChangeSet = (
+  session: object,
+  changeSet: unknown,
+): Promise<unknown> =>
+  Reflect.apply(Reflect.get(session, "applyChangeSet"), session, [changeSet]);
+
+describe("database-v2 Bundle boundary", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("accepts every supported Bundle field", async () => {
+    // Given a complete value matching the public Bundle contract
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+
+    // When the value crosses the runtime boundary
+    await applyUntypedChangeSet(
+      session,
+      createPutChangeSet(createCompleteBundle()),
+    );
+
+    // Then the parsed value reaches the backend unchanged
+    expect(backend.commitAttempts).toBe(1);
+    expect(backend.observedCommits[0]?.changeSet.changes[0]).toMatchObject({
+      type: "put",
+      value: createCompleteBundle(),
+    });
+  });
+
+  it("rejects an id-only put before it becomes durable", async () => {
+    // Given an untyped put whose value omits the Bundle contract
+    const connector = createInMemoryDatabaseConnectorV2();
+    const connection = await connector.connect();
+    const session = await connection.openSession(IN_MEMORY_TEST_SCOPE);
+    const changeSet = {
+      id: "10000000-0000-4000-8000-000000000190",
+      changes: [
+        {
+          type: "put",
+          value: { id: IN_MEMORY_TEST_IDS.first },
+          precondition: { state: "absent" },
+        },
+      ],
+    };
+
+    // When the malformed value crosses the public runtime boundary
+    await expect(
+      applyUntypedChangeSet(session, changeSet),
+    ).rejects.toMatchObject({ code: "INVALID_CHANGE_SET" });
+
+    // Then no malformed row or non-string channel becomes durable
+    await expect(
+      session.bundles.get(IN_MEMORY_TEST_IDS.first),
+    ).resolves.toBeNull();
+    await expect(session.bundles.channels()).resolves.toEqual([]);
+    await connection.close();
+  });
+
+  for (const malformed of [
+    ...malformedBundleCases(),
+    ...hostileBundleCases(),
+  ]) {
+    it(`rejects ${malformed.label} before backend I/O`, async () => {
+      // Given one malformed Bundle field or hostile descriptor shape
+      const { backend, connection } =
+        createSubject<MutableScopeFixture["context"]>();
+      const session = await connection.openSession(createRuntimeScope());
+      let getterCalls = 0;
+      const bundle = malformed.create(() => {
+        getterCalls += 1;
+      });
+
+      // When the malformed value crosses the runtime boundary
+      await expect(
+        applyUntypedChangeSet(session, createPutChangeSet(bundle)),
+      ).rejects.toMatchObject({ code: "INVALID_CHANGE_SET" });
+
+      // Then validation executes no getter and performs no backend operation
+      expect(getterCalls).toBe(0);
+      expect(backend.commitAttempts).toBe(0);
+      expect(backend.readAttempts).toBe(0);
+      expect(backend.observedCommits).toEqual([]);
+      expect(backend.rows.size).toBe(0);
+      expect(backend.receipts.size).toBe(0);
+    });
+  }
+});

--- a/plugins/plugin-core/src/database-v2/bundleValidation.testCases.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidation.testCases.ts
@@ -1,0 +1,152 @@
+import { createCompleteBundle } from "./bundleValidation.testFixtures";
+
+export type MalformedBundleCase = {
+  readonly label: string;
+  readonly create: (observeGetter: () => void) => unknown;
+};
+
+const replaceField = (field: string, value: unknown): unknown => {
+  const bundle = createCompleteBundle();
+  Reflect.set(bundle, field, value);
+  return bundle;
+};
+
+const removeField = (field: string): unknown => {
+  const bundle = createCompleteBundle();
+  Reflect.deleteProperty(bundle, field);
+  return bundle;
+};
+
+export const malformedBundleCases = (): readonly MalformedBundleCase[] => [
+  { label: "missing platform", create: () => removeField("platform") },
+  { label: "invalid platform", create: () => replaceField("platform", "web") },
+  {
+    label: "non-boolean force flag",
+    create: () => replaceField("shouldForceUpdate", 0),
+  },
+  {
+    label: "non-boolean enabled flag",
+    create: () => replaceField("enabled", "yes"),
+  },
+  {
+    label: "non-string file hash",
+    create: () => replaceField("fileHash", null),
+  },
+  {
+    label: "non-string storage URI",
+    create: () => replaceField("storageUri", 7),
+  },
+  {
+    label: "invalid nullable git hash",
+    create: () => replaceField("gitCommitHash", false),
+  },
+  {
+    label: "invalid nullable message",
+    create: () => replaceField("message", 1),
+  },
+  { label: "non-string channel", create: () => replaceField("channel", null) },
+  {
+    label: "invalid nullable target version",
+    create: () => replaceField("targetAppVersion", true),
+  },
+  {
+    label: "invalid nullable fingerprint",
+    create: () => replaceField("fingerprintHash", {}),
+  },
+  { label: "null metadata", create: () => replaceField("metadata", null) },
+  {
+    label: "invalid metadata version",
+    create: () => replaceField("metadata", { app_version: 1 }),
+  },
+  {
+    label: "unknown metadata field",
+    create: () => replaceField("metadata", { unexpected: "value" }),
+  },
+  {
+    label: "invalid manifest URI",
+    create: () => replaceField("manifestStorageUri", 1),
+  },
+  {
+    label: "invalid manifest hash",
+    create: () => replaceField("manifestFileHash", false),
+  },
+  {
+    label: "invalid asset base URI",
+    create: () => replaceField("assetBaseStorageUri", []),
+  },
+  { label: "non-array patches", create: () => replaceField("patches", {}) },
+  { label: "null patch item", create: () => replaceField("patches", [null]) },
+  {
+    label: "incomplete patch item",
+    create: () => replaceField("patches", [{ baseBundleId: "base" }]),
+  },
+  {
+    label: "unknown patch field",
+    create: () =>
+      replaceField("patches", [
+        {
+          baseBundleId: "base",
+          baseFileHash: "base-hash",
+          patchFileHash: "patch-hash",
+          patchStorageUri: "memory://patch",
+          unexpected: true,
+        },
+      ]),
+  },
+  {
+    label: "non-string nested patch hash",
+    create: () =>
+      replaceField("patches", [
+        {
+          baseBundleId: "base",
+          baseFileHash: 1,
+          patchFileHash: "patch-hash",
+          patchStorageUri: "memory://patch",
+        },
+      ]),
+  },
+  {
+    label: "invalid legacy patch base",
+    create: () => replaceField("patchBaseBundleId", 1),
+  },
+  {
+    label: "invalid legacy base hash",
+    create: () => replaceField("patchBaseFileHash", false),
+  },
+  {
+    label: "invalid legacy patch hash",
+    create: () => replaceField("patchFileHash", {}),
+  },
+  {
+    label: "invalid legacy patch URI",
+    create: () => replaceField("patchStorageUri", []),
+  },
+  {
+    label: "non-finite rollout",
+    create: () => replaceField("rolloutCohortCount", Number.POSITIVE_INFINITY),
+  },
+  {
+    label: "negative-zero rollout",
+    create: () => replaceField("rolloutCohortCount", -0),
+  },
+  {
+    label: "fractional rollout",
+    create: () => replaceField("rolloutCohortCount", 0.5),
+  },
+  {
+    label: "out-of-range rollout",
+    create: () => replaceField("rolloutCohortCount", 1001),
+  },
+  {
+    label: "non-array target cohorts",
+    create: () => replaceField("targetCohorts", "beta"),
+  },
+  {
+    label: "non-string target cohort",
+    create: () => replaceField("targetCohorts", ["beta", 1]),
+  },
+  {
+    label: "unknown Bundle field",
+    create: () => replaceField("unexpected", true),
+  },
+];

--- a/plugins/plugin-core/src/database-v2/bundleValidation.testFixtures.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidation.testFixtures.ts
@@ -1,0 +1,29 @@
+import { IN_MEMORY_TEST_IDS } from "./inMemoryConnector.testFixtures";
+import { createRuntimeBundle } from "./sessionRuntime.testFixtures";
+
+export const createCompleteBundle = () => ({
+  ...createRuntimeBundle(IN_MEMORY_TEST_IDS.first),
+  metadata: { app_version: "1.0.0" },
+  manifestStorageUri: "memory://manifest",
+  manifestFileHash: "manifest-hash",
+  assetBaseStorageUri: "memory://assets",
+  patches: [
+    {
+      baseBundleId: IN_MEMORY_TEST_IDS.second,
+      baseFileHash: "base-hash",
+      patchFileHash: "patch-hash",
+      patchStorageUri: "memory://patch",
+    },
+  ],
+  patchBaseBundleId: IN_MEMORY_TEST_IDS.second,
+  patchBaseFileHash: "base-hash",
+  patchFileHash: "patch-hash",
+  patchStorageUri: "memory://patch",
+  rolloutCohortCount: 500,
+  targetCohorts: ["internal", "beta"],
+});
+
+export const createPutChangeSet = (value: unknown) => ({
+  id: "10000000-0000-4000-8000-000000000193",
+  changes: [{ type: "put", value, precondition: { state: "absent" } }],
+});

--- a/plugins/plugin-core/src/database-v2/bundleValidation.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidation.ts
@@ -1,0 +1,145 @@
+import type { Bundle, Platform } from "@hot-updater/core";
+
+import {
+  parseBundleMetadataV2,
+  parseBundlePatchesV2,
+  parseBundleRolloutV2,
+  parseBundleTargetCohortsV2,
+  parseOptionalNullableBundleStringV2,
+} from "./bundleOptionalValidation";
+import {
+  invalidBundleFieldV2,
+  requireBundleBooleanV2,
+  requireBundleRecordV2,
+  requireBundleShapeV2,
+  requireBundleStringV2,
+  requireNonEmptyBundleStringV2,
+  requireNullableBundleStringV2,
+} from "./bundleValidationPrimitives";
+
+const BUNDLE_KEYS = [
+  "id",
+  "platform",
+  "shouldForceUpdate",
+  "enabled",
+  "fileHash",
+  "storageUri",
+  "gitCommitHash",
+  "message",
+  "channel",
+  "targetAppVersion",
+  "fingerprintHash",
+  "metadata",
+  "manifestStorageUri",
+  "manifestFileHash",
+  "assetBaseStorageUri",
+  "patches",
+  "patchBaseBundleId",
+  "patchBaseFileHash",
+  "patchFileHash",
+  "patchStorageUri",
+  "rolloutCohortCount",
+  "targetCohorts",
+] as const;
+
+const REQUIRED_BUNDLE_KEYS = BUNDLE_KEYS.slice(0, 11);
+
+const parsePlatform = (value: unknown): Platform => {
+  if (value !== "ios" && value !== "android") {
+    return invalidBundleFieldV2("bundle platform must be ios or android");
+  }
+  return value;
+};
+
+export const parseBundleSnapshotV2 = (value: unknown): Bundle => {
+  const bundle = requireBundleRecordV2(value, "put value");
+  requireBundleShapeV2(bundle, {
+    allowed: BUNDLE_KEYS,
+    required: REQUIRED_BUNDLE_KEYS,
+    label: "put value",
+  });
+  const metadata = parseBundleMetadataV2(bundle);
+  const manifestStorageUri = parseOptionalNullableBundleStringV2(
+    bundle,
+    "manifestStorageUri",
+  );
+  const manifestFileHash = parseOptionalNullableBundleStringV2(
+    bundle,
+    "manifestFileHash",
+  );
+  const assetBaseStorageUri = parseOptionalNullableBundleStringV2(
+    bundle,
+    "assetBaseStorageUri",
+  );
+  const patches = parseBundlePatchesV2(bundle);
+  const patchBaseBundleId = parseOptionalNullableBundleStringV2(
+    bundle,
+    "patchBaseBundleId",
+  );
+  const patchBaseFileHash = parseOptionalNullableBundleStringV2(
+    bundle,
+    "patchBaseFileHash",
+  );
+  const patchFileHash = parseOptionalNullableBundleStringV2(
+    bundle,
+    "patchFileHash",
+  );
+  const patchStorageUri = parseOptionalNullableBundleStringV2(
+    bundle,
+    "patchStorageUri",
+  );
+  const rolloutCohortCount = parseBundleRolloutV2(bundle);
+  const targetCohorts = parseBundleTargetCohortsV2(bundle);
+
+  return {
+    id: requireNonEmptyBundleStringV2(Reflect.get(bundle, "id"), "bundle ID"),
+    platform: parsePlatform(Reflect.get(bundle, "platform")),
+    shouldForceUpdate: requireBundleBooleanV2(
+      Reflect.get(bundle, "shouldForceUpdate"),
+      "bundle force-update flag",
+    ),
+    enabled: requireBundleBooleanV2(
+      Reflect.get(bundle, "enabled"),
+      "bundle enabled flag",
+    ),
+    fileHash: requireBundleStringV2(
+      Reflect.get(bundle, "fileHash"),
+      "bundle file hash",
+    ),
+    storageUri: requireBundleStringV2(
+      Reflect.get(bundle, "storageUri"),
+      "bundle storage URI",
+    ),
+    gitCommitHash: requireNullableBundleStringV2(
+      Reflect.get(bundle, "gitCommitHash"),
+      "bundle git commit hash",
+    ),
+    message: requireNullableBundleStringV2(
+      Reflect.get(bundle, "message"),
+      "bundle message",
+    ),
+    channel: requireBundleStringV2(
+      Reflect.get(bundle, "channel"),
+      "bundle channel",
+    ),
+    targetAppVersion: requireNullableBundleStringV2(
+      Reflect.get(bundle, "targetAppVersion"),
+      "bundle target app version",
+    ),
+    fingerprintHash: requireNullableBundleStringV2(
+      Reflect.get(bundle, "fingerprintHash"),
+      "bundle fingerprint hash",
+    ),
+    ...(metadata === undefined ? {} : { metadata }),
+    ...(manifestStorageUri === undefined ? {} : { manifestStorageUri }),
+    ...(manifestFileHash === undefined ? {} : { manifestFileHash }),
+    ...(assetBaseStorageUri === undefined ? {} : { assetBaseStorageUri }),
+    ...(patches === undefined ? {} : { patches }),
+    ...(patchBaseBundleId === undefined ? {} : { patchBaseBundleId }),
+    ...(patchBaseFileHash === undefined ? {} : { patchBaseFileHash }),
+    ...(patchFileHash === undefined ? {} : { patchFileHash }),
+    ...(patchStorageUri === undefined ? {} : { patchStorageUri }),
+    ...(rolloutCohortCount === undefined ? {} : { rolloutCohortCount }),
+    ...(targetCohorts === undefined ? {} : { targetCohorts }),
+  };
+};

--- a/plugins/plugin-core/src/database-v2/bundleValidationPrimitives.ts
+++ b/plugins/plugin-core/src/database-v2/bundleValidationPrimitives.ts
@@ -1,0 +1,82 @@
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+export type BundleShapeV2 = {
+  readonly allowed: readonly string[];
+  readonly required: readonly string[];
+  readonly label: string;
+};
+
+const invalidBundle = (message: string): never => {
+  throw new DatabaseConnectorErrorV2("INVALID_CHANGE_SET", message);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const requireBundleRecordV2 = (
+  value: unknown,
+  label: string,
+): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    return invalidBundle(`${label} must be an object`);
+  }
+  return value;
+};
+
+export const requireBundleShapeV2 = (
+  value: Record<string, unknown>,
+  shape: BundleShapeV2,
+): void => {
+  const keys = Object.keys(value);
+  if (
+    keys.some((key) => !shape.allowed.includes(key)) ||
+    shape.required.some((key) => !Object.hasOwn(value, key))
+  ) {
+    invalidBundle(`${shape.label} has an invalid shape`);
+  }
+};
+
+export const requireBundleStringV2 = (
+  value: unknown,
+  label: string,
+): string => {
+  if (typeof value !== "string") {
+    return invalidBundle(`${label} must be a string`);
+  }
+  return value;
+};
+
+export const requireNonEmptyBundleStringV2 = (
+  value: unknown,
+  label: string,
+): string => {
+  const parsed = requireBundleStringV2(value, label);
+  if (parsed.trim().length === 0) {
+    return invalidBundle(`${label} must be a non-empty string`);
+  }
+  return parsed;
+};
+
+export const requireBundleBooleanV2 = (
+  value: unknown,
+  label: string,
+): boolean => {
+  if (typeof value !== "boolean") {
+    return invalidBundle(`${label} must be a boolean`);
+  }
+  return value;
+};
+
+export const requireNullableBundleStringV2 = (
+  value: unknown,
+  label: string,
+): string | null =>
+  value === null ? null : requireBundleStringV2(value, label);
+
+export const readOptionalBundleFieldV2 = (
+  value: Record<string, unknown>,
+  key: string,
+): unknown => (Object.hasOwn(value, key) ? Reflect.get(value, key) : undefined);
+
+export const invalidBundleFieldV2 = (message: string): never =>
+  invalidBundle(message);

--- a/plugins/plugin-core/src/database-v2/bundles.ts
+++ b/plugins/plugin-core/src/database-v2/bundles.ts
@@ -1,0 +1,72 @@
+import type { Bundle, Platform } from "@hot-updater/core";
+
+import type { Versioned } from "./common";
+
+export interface BundleWhereV2 {
+  readonly channel?: string;
+  readonly platform?: Platform;
+  readonly enabled?: boolean;
+  readonly id?: {
+    readonly eq?: string;
+    readonly gt?: string;
+    readonly gte?: string;
+    readonly lt?: string;
+    readonly lte?: string;
+    readonly in?: readonly string[];
+  };
+  readonly targetAppVersion?: string | null;
+  readonly targetAppVersionIn?: readonly string[];
+  readonly targetAppVersionNotNull?: boolean;
+  readonly fingerprintHash?: string | null;
+}
+
+export interface BundlePageQueryV2 {
+  readonly where?: BundleWhereV2;
+  readonly limit: number;
+  readonly cursor?:
+    | { readonly after: string; readonly before?: never }
+    | { readonly before: string; readonly after?: never };
+  readonly orderBy?: {
+    readonly field: "id";
+    readonly direction: "asc" | "desc";
+  };
+}
+
+export interface BundlePageV2 {
+  readonly data: readonly Versioned<Bundle>[];
+  readonly pagination: {
+    readonly total: number;
+    readonly hasNextPage: boolean;
+    readonly hasPreviousPage: boolean;
+    readonly nextCursor: string | null;
+    readonly previousCursor: string | null;
+  };
+}
+
+export interface BundleRepositoryV2 {
+  get(id: string): Promise<Versioned<Bundle> | null>;
+  page(query: BundlePageQueryV2): Promise<BundlePageV2>;
+  channels(): Promise<readonly string[]>;
+}
+
+export type BundleChangeV2 =
+  | {
+      readonly type: "put";
+      readonly value: Bundle;
+      readonly precondition:
+        | { readonly state: "absent" }
+        | { readonly state: "revision"; readonly revision: string };
+    }
+  | {
+      readonly type: "delete";
+      readonly id: string;
+      readonly precondition: {
+        readonly state: "revision";
+        readonly revision: string;
+      };
+    };
+
+export interface BundleChangeSetV2 {
+  readonly id: string;
+  readonly changes: readonly BundleChangeV2[];
+}

--- a/plugins/plugin-core/src/database-v2/canonicalIdentity.spec.ts
+++ b/plugins/plugin-core/src/database-v2/canonicalIdentity.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+
+import type { BundleChangeV2 } from "./bundles";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import {
+  canonicalizeDatabaseValueV1,
+  hashDatabaseChangeSetPayloadV1,
+  hashDatabaseScopeV1,
+} from "./index";
+
+const orderedChanges = [
+  {
+    type: "delete",
+    id: "a",
+    precondition: { state: "revision", revision: "r1" },
+  },
+  {
+    type: "delete",
+    id: "b",
+    precondition: { state: "revision", revision: "r2" },
+  },
+] satisfies readonly BundleChangeV2[];
+
+const expectCanonicalizationFailure = (value: unknown): void => {
+  expect(() => canonicalizeDatabaseValueV1(value)).toThrowError(
+    expect.objectContaining({
+      name: "DatabaseConnectorErrorV2",
+      code: "CANONICALIZATION_FAILED",
+    }),
+  );
+};
+
+describe("canonicalizeDatabaseValueV1", () => {
+  it("emits stable JSON for nested keys, Unicode, numbers, and absent fields", () => {
+    // Given equivalent objects with different insertion orders
+    const first = {
+      z: [3, { β: "café", a: true }],
+      a: { present: 0 },
+    };
+    const second = {
+      a: { present: 0 },
+      z: [3, { a: true, β: "café" }],
+    };
+
+    // When each object is canonicalized
+    const firstCanonical = canonicalizeDatabaseValueV1(first);
+    const secondCanonical = canonicalizeDatabaseValueV1(second);
+
+    // Then the checked-in literal vector is identical
+    expect(firstCanonical).toBe(
+      '{"a":{"present":0},"z":[3,{"a":true,"β":"café"}]}',
+    );
+    expect(secondCanonical).toBe(firstCanonical);
+    expect(
+      canonicalizeDatabaseValueV1([
+        0,
+        1e-7,
+        1e21,
+        0.000001,
+        Number.MAX_SAFE_INTEGER,
+        "é",
+        "e\u0301",
+      ]),
+    ).toBe('[0,1e-7,1e+21,0.000001,9007199254740991,"é","é"]');
+  });
+
+  it("rejects unsupported primitive and number classes with typed errors", () => {
+    // Given every unsupported primitive or number class
+    const rejectedValues: readonly unknown[] = [
+      undefined,
+      1n,
+      Symbol("value"),
+      () => true,
+      -0,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      "\ud800",
+      "\udfff",
+    ];
+
+    // When and Then each value is canonicalized
+    for (const value of rejectedValues) {
+      expectCanonicalizationFailure(value);
+    }
+  });
+
+  it("rejects sparse, decorated, accessor, and non-enumerable arrays", () => {
+    // Given malformed arrays from each rejected descriptor class
+    const sparse: unknown[] = [];
+    sparse.length = 1;
+    const decorated: unknown[] = [1];
+    Object.defineProperty(decorated, "extra", {
+      enumerable: true,
+      value: 2,
+    });
+    const accessor: unknown[] = [1];
+    Object.defineProperty(accessor, "0", {
+      enumerable: true,
+      get: () => 1,
+    });
+    const nonEnumerable: unknown[] = [1];
+    Object.defineProperty(nonEnumerable, "0", {
+      enumerable: false,
+      value: 1,
+    });
+
+    // When and Then each array is canonicalized
+    for (const value of [sparse, decorated, accessor, nonEnumerable]) {
+      expectCanonicalizationFailure(value);
+    }
+  });
+
+  it("rejects symbol, accessor, hidden, inherited, cyclic, and bad-key objects", () => {
+    // Given malformed objects from each rejected structural class
+    class InheritedValue {
+      readonly own = true;
+    }
+    const accessor = Object.defineProperty({}, "value", {
+      enumerable: true,
+      get: () => 1,
+    });
+    const hidden = Object.defineProperty({}, "value", {
+      enumerable: false,
+      value: 1,
+    });
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    const badKey = { "\ud800": true };
+
+    // When and Then each object is canonicalized
+    for (const value of [
+      { [Symbol("hidden")]: true },
+      accessor,
+      hidden,
+      new InheritedValue(),
+      new Date(0),
+      cyclic,
+      badKey,
+      { optional: undefined },
+    ]) {
+      expectCanonicalizationFailure(value);
+    }
+  });
+
+  it("validates descriptors before reading any property value", () => {
+    // Given an invalid symbol key beside an enumerable getter
+    let getterCalls = 0;
+    const value = Object.defineProperty(
+      { [Symbol("invalid")]: true },
+      "unread",
+      {
+        enumerable: true,
+        get: () => {
+          getterCalls += 1;
+          return "should-not-run";
+        },
+      },
+    );
+
+    // When canonicalization rejects the descriptor set
+    expectCanonicalizationFailure(value);
+
+    // Then it never invokes the getter
+    expect(getterCalls).toBe(0);
+  });
+
+  it("serializes dense proxied arrays without reading live length", () => {
+    // Given a dense array whose live property reads are hostile
+    let getCalls = 0;
+    const value = new Proxy(["first", "second"], {
+      get: () => {
+        getCalls += 1;
+        throw new RangeError("array live read");
+      },
+    });
+
+    // When the array is canonicalized from its own descriptors
+    const canonical = canonicalizeDatabaseValueV1(value);
+
+    // Then no get trap runs and the descriptor snapshot determines the bytes
+    expect(canonical).toBe('["first","second"]');
+    expect(getCalls).toBe(0);
+  });
+
+  it("converts hostile array descriptor inspection into a typed error", () => {
+    // Given an array Proxy that refuses descriptor inspection
+    const value = new Proxy(["first"], {
+      getOwnPropertyDescriptor: () => {
+        throw new RangeError("descriptor inspection failed");
+      },
+    });
+
+    // When and Then the array crosses the canonical identity boundary
+    expectCanonicalizationFailure(value);
+  });
+});
+
+describe("database-v2 versioned hashes", () => {
+  it("matches literal change-set vectors and preserves operation order", async () => {
+    // Given ordered normalized changes and their reverse
+    const reversedChanges = [...orderedChanges].reverse();
+
+    // When each payload is hashed
+    const orderedHash = await hashDatabaseChangeSetPayloadV1(orderedChanges);
+    const reversedHash = await hashDatabaseChangeSetPayloadV1(reversedChanges);
+
+    // Then both match independent literal SHA-256 vectors and differ
+    expect(orderedHash).toBe(
+      "sha256:e11b5a6fd7acb815c7293dadd9ab78a6b977ac69c11e1f76453880c27a0bf916",
+    );
+    expect(reversedHash).toBe(
+      "sha256:33cfc4daf97a75b10ab4db50e08eb50355041be4b18d32a7931d844b7ceaae1c",
+    );
+    expect(reversedHash).not.toBe(orderedHash);
+  });
+
+  it("hashes exactly tenant and principal in a separate domain", async () => {
+    // Given the same asserted IDs with unrelated contexts
+    const scope = { principalId: "principal-a", tenantId: "tenant-a" };
+
+    // When the scope identity is hashed
+    const hash = await hashDatabaseScopeV1(scope);
+
+    // Then it matches the checked-in scope-domain vector
+    expect(hash).toBe(
+      "sha256:0446f3b9ed66598af4648c82ec418e91e26c4a7d2af8cc19b7894c6e753c22ff",
+    );
+  });
+
+  it("fails closed when an injected digest is not exactly 32 bytes", async () => {
+    // Given digest providers that return the wrong size or throw
+    const shortDigest = async (): Promise<Uint8Array> => new Uint8Array(31);
+    const failedDigest = async (): Promise<Uint8Array> => {
+      throw new TypeError("digest unavailable");
+    };
+
+    // When and Then each provider is used
+    await expect(
+      hashDatabaseScopeV1(
+        { principalId: "principal-a", tenantId: "tenant-a" },
+        shortDigest,
+      ),
+    ).rejects.toMatchObject({ code: "DIGEST_UNAVAILABLE" });
+    await expect(
+      hashDatabaseScopeV1(
+        { principalId: "principal-a", tenantId: "tenant-a" },
+        failedDigest,
+      ),
+    ).rejects.toBeInstanceOf(DatabaseConnectorErrorV2);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/canonicalIdentity.ts
+++ b/plugins/plugin-core/src/database-v2/canonicalIdentity.ts
@@ -1,0 +1,167 @@
+import {
+  addWeakSetValueV2,
+  createWeakSetV2,
+  deleteWeakSetValueV2,
+  hasWeakSetValueV2,
+} from "./collectionIntrinsics";
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+const failCanonicalization = (message: string): never => {
+  throw new DatabaseConnectorErrorV2("CANONICALIZATION_FAILED", message);
+};
+
+const validateUnicodeScalars = (value: string): void => {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        failCanonicalization("string contains an unpaired high surrogate");
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      failCanonicalization("string contains an unpaired low surrogate");
+    }
+  }
+};
+
+const serializeJsonToken = (value: string | number): string => {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    return failCanonicalization("value has no JSON token");
+  }
+  return serialized;
+};
+
+const isAccessor = (descriptor: PropertyDescriptor): boolean =>
+  Object.hasOwn(descriptor, "get") || Object.hasOwn(descriptor, "set");
+
+const validateDataDescriptor = (
+  descriptor: PropertyDescriptor,
+  label: string,
+): void => {
+  if (!descriptor.enumerable) {
+    failCanonicalization(`${label} must be enumerable`);
+  }
+  if (isAccessor(descriptor)) {
+    failCanonicalization(`${label} must be a data property`);
+  }
+};
+
+const serializeArray = (
+  value: readonly unknown[],
+  ancestors: WeakSet<object>,
+): string => {
+  if (Object.getPrototypeOf(value) !== Array.prototype) {
+    return failCanonicalization("array has a non-plain prototype");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Object.getOwnPropertySymbols(descriptors).length > 0) {
+    return failCanonicalization("array has an own symbol key");
+  }
+  const entries = Object.entries(descriptors);
+  const names = entries.map(([name]) => name);
+  const lengthDescriptor: PropertyDescriptor | undefined = entries.find(
+    ([name]) => name === "length",
+  )?.[1];
+  if (
+    lengthDescriptor === undefined ||
+    isAccessor(lengthDescriptor) ||
+    lengthDescriptor.enumerable
+  ) {
+    return failCanonicalization("array is sparse or has extra properties");
+  }
+  const length = lengthDescriptor.value;
+  if (
+    typeof length !== "number" ||
+    !Number.isInteger(length) ||
+    length < 0 ||
+    names.length !== length + 1
+  ) {
+    return failCanonicalization("array is sparse or has extra properties");
+  }
+  const itemDescriptors: PropertyDescriptor[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (descriptor === undefined) {
+      return failCanonicalization("array is sparse");
+    }
+    validateDataDescriptor(descriptor, `array index ${index}`);
+    itemDescriptors.push(descriptor);
+  }
+  return `[${itemDescriptors
+    .map((descriptor) => serializeValue(descriptor.value, ancestors))
+    .join(",")}]`;
+};
+
+const serializeObject = (value: object, ancestors: WeakSet<object>): string => {
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return failCanonicalization("object has a non-plain prototype");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Object.getOwnPropertySymbols(descriptors).length > 0) {
+    return failCanonicalization("object has an own symbol key");
+  }
+  const entries = Object.entries(descriptors);
+  for (const [key, descriptor] of entries) {
+    validateUnicodeScalars(key);
+    validateDataDescriptor(descriptor, `object property ${key}`);
+  }
+  entries.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return `{${entries
+    .map(
+      ([key, descriptor]) =>
+        `${serializeJsonToken(key)}:${serializeValue(descriptor.value, ancestors)}`,
+    )
+    .join(",")}}`;
+};
+
+const serializeValue = (value: unknown, ancestors: WeakSet<object>): string => {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    validateUnicodeScalars(value);
+    return serializeJsonToken(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Object.is(value, -0)) {
+      return failCanonicalization("number must be finite and must not be -0");
+    }
+    return serializeJsonToken(value);
+  }
+  if (typeof value !== "object") {
+    return failCanonicalization(`unsupported value type: ${typeof value}`);
+  }
+  if (hasWeakSetValueV2(ancestors, value)) {
+    return failCanonicalization("value contains a cycle");
+  }
+  addWeakSetValueV2(ancestors, value);
+  const serialized = Array.isArray(value)
+    ? serializeArray(value, ancestors)
+    : serializeObject(value, ancestors);
+  deleteWeakSetValueV2(ancestors, value);
+  return serialized;
+};
+
+export const canonicalizeDatabaseValueV1 = (value: unknown): string => {
+  try {
+    return serializeValue(value, createWeakSetV2<object>());
+  } catch (error) {
+    if (error instanceof DatabaseConnectorErrorV2) {
+      throw error;
+    }
+    throw new DatabaseConnectorErrorV2(
+      "CANONICALIZATION_FAILED",
+      "value could not be inspected safely",
+      { cause: error },
+    );
+  }
+};
+
+export const snapshotCanonicalDatabaseValueV1 = <T>(value: T): T =>
+  JSON.parse(canonicalizeDatabaseValueV1(value));

--- a/plugins/plugin-core/src/database-v2/changeSetValidation.ts
+++ b/plugins/plugin-core/src/database-v2/changeSetValidation.ts
@@ -1,0 +1,143 @@
+import type { BundleChangeSetV2 } from "./bundles";
+import { parseBundleSnapshotV2 } from "./bundleValidation";
+import { snapshotCanonicalDatabaseValueV1 } from "./canonicalIdentity";
+import {
+  addSetValueV2,
+  createSetV2,
+  hasSetValueV2,
+} from "./collectionIntrinsics";
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+const CHANGE_SET_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const invalidChangeSet = (message: string, cause?: unknown): never => {
+  throw new DatabaseConnectorErrorV2(
+    "INVALID_CHANGE_SET",
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireRecord = (
+  value: unknown,
+  label: string,
+): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    return invalidChangeSet(`${label} must be an object`);
+  }
+  return value;
+};
+
+const requireExactKeys = (
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void => {
+  const keys = Object.keys(value);
+  if (
+    keys.length !== allowed.length ||
+    keys.some((key) => !allowed.includes(key))
+  ) {
+    invalidChangeSet(`${label} has an invalid shape`);
+  }
+};
+
+const requireNonEmptyString = (value: unknown, label: string): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return invalidChangeSet(`${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+const requireArray = (value: unknown, label: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    return invalidChangeSet(`${label} must be an array`);
+  }
+  return value;
+};
+
+const validatePrecondition = (value: unknown, allowAbsent: boolean): void => {
+  const precondition = requireRecord(value, "change precondition");
+  const state = Reflect.get(precondition, "state");
+  if (state === "absent" && allowAbsent) {
+    requireExactKeys(precondition, ["state"], "absent precondition");
+    return;
+  }
+  if (state === "revision") {
+    requireExactKeys(
+      precondition,
+      ["state", "revision"],
+      "revision precondition",
+    );
+    requireNonEmptyString(
+      Reflect.get(precondition, "revision"),
+      "revision precondition",
+    );
+    return;
+  }
+  invalidChangeSet("change precondition has an invalid state");
+};
+
+const validateChange = (value: unknown): string => {
+  const change = requireRecord(value, "bundle change");
+  const type = Reflect.get(change, "type");
+  if (type === "put") {
+    requireExactKeys(change, ["type", "value", "precondition"], "put change");
+    const bundle = parseBundleSnapshotV2(Reflect.get(change, "value"));
+    const id = bundle.id;
+    validatePrecondition(Reflect.get(change, "precondition"), true);
+    return id;
+  }
+  if (type === "delete") {
+    requireExactKeys(change, ["type", "id", "precondition"], "delete change");
+    const id = requireNonEmptyString(Reflect.get(change, "id"), "bundle ID");
+    validatePrecondition(Reflect.get(change, "precondition"), false);
+    return id;
+  }
+  return invalidChangeSet("bundle change has an invalid type");
+};
+
+const validateCanonicalShape = (changeSet: BundleChangeSetV2): void => {
+  const candidate = requireRecord(changeSet, "change set");
+  requireExactKeys(candidate, ["id", "changes"], "change set");
+  const id = Reflect.get(candidate, "id");
+  if (typeof id !== "string" || !CHANGE_SET_ID_PATTERN.test(id)) {
+    invalidChangeSet(
+      "change set ID must be a canonical lowercase UUID v4 or v7",
+    );
+  }
+  const changes = requireArray(Reflect.get(candidate, "changes"), "changes");
+  if (changes.length === 0) {
+    invalidChangeSet("change set must contain at least one change");
+  }
+  const bundleIds = changes.map(validateChange);
+  const seen = createSetV2<string>();
+  for (const bundleId of bundleIds) {
+    if (hasSetValueV2(seen, bundleId)) {
+      invalidChangeSet(
+        "change set must contain one final change per bundle ID",
+      );
+    }
+    addSetValueV2(seen, bundleId);
+  }
+};
+
+export const snapshotDatabaseChangeSetV2 = (
+  changeSet: BundleChangeSetV2,
+): BundleChangeSetV2 => {
+  let snapshot: BundleChangeSetV2;
+  try {
+    snapshot = snapshotCanonicalDatabaseValueV1(changeSet);
+  } catch (error) {
+    if (error instanceof Error) {
+      return invalidChangeSet("change set cannot be inspected safely");
+    }
+    return invalidChangeSet("change set inspection threw a non-error value");
+  }
+  validateCanonicalShape(snapshot);
+  return snapshot;
+};

--- a/plugins/plugin-core/src/database-v2/collectionIntrinsics.ts
+++ b/plugins/plugin-core/src/database-v2/collectionIntrinsics.ts
@@ -1,0 +1,79 @@
+const MapConstructor = Map;
+const SetConstructor = Set;
+const WeakSetConstructor = WeakSet;
+const reflectApply = Reflect.apply;
+const mapDelete = Map.prototype.delete;
+const mapForEach = Map.prototype.forEach;
+const mapGet = Map.prototype.get;
+const mapSet = Map.prototype.set;
+const setAdd = Set.prototype.add;
+const setDelete = Set.prototype.delete;
+const setForEach = Set.prototype.forEach;
+const setHas = Set.prototype.has;
+const weakSetAdd = WeakSet.prototype.add;
+const weakSetDelete = WeakSet.prototype.delete;
+const weakSetHas = WeakSet.prototype.has;
+
+export const createMapV2 = <K, V>(): Map<K, V> => new MapConstructor<K, V>();
+
+export const getMapValueV2 = <K, V>(map: Map<K, V>, key: K): V | undefined =>
+  reflectApply(mapGet, map, [key]);
+
+export const setMapValueV2 = <K, V>(map: Map<K, V>, key: K, value: V): void => {
+  reflectApply(mapSet, map, [key, value]);
+};
+
+export const deleteMapValueV2 = <K, V>(map: Map<K, V>, key: K): boolean =>
+  reflectApply(mapDelete, map, [key]);
+
+export const mapValuesV2 = <K, V>(map: Map<K, V>): readonly V[] => {
+  const values: V[] = [];
+  reflectApply(mapForEach, map, [
+    (value: V) => {
+      values[values.length] = value;
+    },
+  ]);
+  return values;
+};
+
+export const createSetV2 = <T>(): Set<T> => new SetConstructor<T>();
+
+export const addSetValueV2 = <T>(set: Set<T>, value: T): void => {
+  reflectApply(setAdd, set, [value]);
+};
+
+export const hasSetValueV2 = <T>(set: Set<T>, value: T): boolean =>
+  reflectApply(setHas, set, [value]);
+
+export const deleteSetValueV2 = <T>(set: Set<T>, value: T): boolean =>
+  reflectApply(setDelete, set, [value]);
+
+export const setValuesV2 = <T>(set: Set<T>): readonly T[] => {
+  const values: T[] = [];
+  reflectApply(setForEach, set, [
+    (value: T) => {
+      values[values.length] = value;
+    },
+  ]);
+  return values;
+};
+
+export const createWeakSetV2 = <T extends WeakKey>(): WeakSet<T> =>
+  new WeakSetConstructor<T>();
+
+export const addWeakSetValueV2 = <T extends WeakKey>(
+  set: WeakSet<T>,
+  value: T,
+): void => {
+  reflectApply(weakSetAdd, set, [value]);
+};
+
+export const hasWeakSetValueV2 = <T extends WeakKey>(
+  set: WeakSet<T>,
+  value: T,
+): boolean => reflectApply(weakSetHas, set, [value]);
+
+export const deleteWeakSetValueV2 = <T extends WeakKey>(
+  set: WeakSet<T>,
+  value: T,
+): boolean => reflectApply(weakSetDelete, set, [value]);

--- a/plugins/plugin-core/src/database-v2/common.ts
+++ b/plugins/plugin-core/src/database-v2/common.ts
@@ -1,0 +1,20 @@
+export type MaybePromise<T> = T | Promise<T>;
+
+export type Sha256Digest = (bytes: Uint8Array) => MaybePromise<Uint8Array>;
+
+/**
+ * An immutable scope asserted by a trusted host.
+ *
+ * The host authenticates the caller and derives both identifiers. A connector
+ * enforces this assertion but does not authenticate arbitrary callers.
+ */
+export interface AssertedDatabaseScope<TContext> {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly context: TContext;
+}
+
+export interface Versioned<T> {
+  readonly value: T;
+  readonly revision: string;
+}

--- a/plugins/plugin-core/src/database-v2/connector.ts
+++ b/plugins/plugin-core/src/database-v2/connector.ts
@@ -1,0 +1,22 @@
+import type { BundleChangeSetV2, BundleRepositoryV2 } from "./bundles";
+import type { AssertedDatabaseScope, MaybePromise } from "./common";
+import type { DatabaseConnectorManifestV2 } from "./manifest";
+import type { CommitReceiptV2 } from "./receipts";
+
+export interface DatabaseSessionV2 {
+  readonly bundles: BundleRepositoryV2;
+  applyChangeSet(changeSet: BundleChangeSetV2): Promise<CommitReceiptV2>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseConnectionV2<TContext> {
+  openSession(
+    scope: AssertedDatabaseScope<TContext>,
+  ): Promise<DatabaseSessionV2>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseConnectorV2<TContext = unknown> {
+  readonly manifest: DatabaseConnectorManifestV2;
+  connect(): MaybePromise<DatabaseConnectionV2<TContext>>;
+}

--- a/plugins/plugin-core/src/database-v2/databaseIdentity.ts
+++ b/plugins/plugin-core/src/database-v2/databaseIdentity.ts
@@ -1,0 +1,205 @@
+import type { BundleChangeV2 } from "./bundles";
+import {
+  canonicalizeDatabaseValueV1,
+  snapshotCanonicalDatabaseValueV1,
+} from "./canonicalIdentity";
+import type { AssertedDatabaseScope, Sha256Digest } from "./common";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import type { DatabaseManifestTupleV2 } from "./manifest";
+import { parseDatabaseManifestTupleV2 } from "./manifestValidation";
+import { encodeUtf8V2 } from "./utf8";
+
+const CHANGE_SET_DOMAIN = "hot-updater.database.change-set.v1\0";
+const HEX_NIBBLES = Object.freeze([
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+]);
+const MANIFEST_DOMAIN = "hot-updater.database.manifest.v1\0";
+const SCOPE_DOMAIN = "hot-updater.database.scope.v1\0";
+const Uint8ArrayConstructor = Uint8Array;
+const reflectApply = Reflect.apply;
+const setUint8Array = Uint8Array.prototype.set;
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const typedArrayByteLength = Object.getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  "byteLength",
+)?.get;
+const typedArrayTag = Object.getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  Symbol.toStringTag,
+)?.get;
+
+const defaultSha256: Sha256Digest = async (
+  bytes: Uint8Array,
+): Promise<Uint8Array> => {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle === undefined) {
+    throw new DatabaseConnectorErrorV2(
+      "DIGEST_UNAVAILABLE",
+      "WebCrypto SHA-256 is unavailable",
+    );
+  }
+  return new Uint8Array(await subtle.digest("SHA-256", bytes));
+};
+
+const digestIdentity = async (
+  domain: string,
+  value: unknown,
+  sha256: Sha256Digest | undefined,
+): Promise<string> => {
+  const bytes = encodeUtf8V2(`${domain}${canonicalizeDatabaseValueV1(value)}`);
+  let digest: Uint8Array;
+  try {
+    digest = await (sha256 ?? defaultSha256)(bytes);
+  } catch (error) {
+    if (
+      sha256 === undefined &&
+      error instanceof DatabaseConnectorErrorV2 &&
+      error.code === "DIGEST_UNAVAILABLE"
+    ) {
+      throw error;
+    }
+    throw new DatabaseConnectorErrorV2(
+      "DIGEST_UNAVAILABLE",
+      "SHA-256 provider failed",
+    );
+  }
+  let digestLength: number;
+  try {
+    if (
+      typedArrayByteLength === undefined ||
+      typedArrayTag === undefined ||
+      reflectApply(typedArrayTag, digest, []) !== "Uint8Array"
+    ) {
+      throw new TypeError("digest is not a Uint8Array");
+    }
+    digestLength = reflectApply(typedArrayByteLength, digest, []);
+  } catch {
+    throw new DatabaseConnectorErrorV2(
+      "DIGEST_UNAVAILABLE",
+      "SHA-256 provider returned an unreadable digest",
+    );
+  }
+  if (digestLength !== 32) {
+    throw new DatabaseConnectorErrorV2(
+      "DIGEST_UNAVAILABLE",
+      "SHA-256 provider must return exactly 32 bytes",
+    );
+  }
+  let digestSnapshot: Uint8Array;
+  try {
+    digestSnapshot = new Uint8ArrayConstructor(32);
+    reflectApply(setUint8Array, digestSnapshot, [digest]);
+  } catch {
+    throw new DatabaseConnectorErrorV2(
+      "DIGEST_UNAVAILABLE",
+      "SHA-256 provider returned an unreadable digest",
+    );
+  }
+  let hex = "";
+  for (let index = 0; index < digestLength; index += 1) {
+    const byte = digestSnapshot[index];
+    hex += HEX_NIBBLES[byte >> 4] + HEX_NIBBLES[byte & 0x0f];
+  }
+  return `sha256:${hex}`;
+};
+
+const captureScopeIdentity = (scope: unknown) => {
+  try {
+    if (
+      typeof scope !== "object" ||
+      scope === null ||
+      Array.isArray(scope) ||
+      Object.getPrototypeOf(scope) !== Object.prototype ||
+      Object.getOwnPropertySymbols(scope).length > 0
+    ) {
+      throw new DatabaseConnectorErrorV2(
+        "CANONICALIZATION_FAILED",
+        "scope identity must be a plain object without symbol keys",
+      );
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(scope);
+    const keys = Object.keys(descriptors);
+    if (
+      keys.some(
+        (key) =>
+          key !== "tenantId" &&
+          key !== "principalId" &&
+          key !== "context" &&
+          key !== "scopeId",
+      )
+    ) {
+      throw new DatabaseConnectorErrorV2(
+        "CANONICALIZATION_FAILED",
+        "scope identity has an invalid shape",
+      );
+    }
+    const tenant = Reflect.get(descriptors, "tenantId");
+    const principal = Reflect.get(descriptors, "principalId");
+    if (
+      tenant === undefined ||
+      principal === undefined ||
+      tenant.enumerable !== true ||
+      principal.enumerable !== true ||
+      Object.hasOwn(tenant, "get") ||
+      Object.hasOwn(tenant, "set") ||
+      Object.hasOwn(principal, "get") ||
+      Object.hasOwn(principal, "set") ||
+      typeof tenant.value !== "string" ||
+      tenant.value.trim().length === 0 ||
+      typeof principal.value !== "string" ||
+      principal.value.trim().length === 0
+    ) {
+      throw new DatabaseConnectorErrorV2(
+        "CANONICALIZATION_FAILED",
+        "scope identifiers must be enumerable non-empty string data properties",
+      );
+    }
+    return { principalId: principal.value, tenantId: tenant.value };
+  } catch (error) {
+    if (error instanceof DatabaseConnectorErrorV2) {
+      throw error;
+    }
+    throw new DatabaseConnectorErrorV2(
+      "CANONICALIZATION_FAILED",
+      "scope identity could not be inspected safely",
+    );
+  }
+};
+
+export const hashDatabaseChangeSetPayloadV1 = (
+  changes: readonly BundleChangeV2[],
+  sha256?: Sha256Digest,
+): Promise<string> => digestIdentity(CHANGE_SET_DOMAIN, { changes }, sha256);
+
+export const hashDatabaseScopeV1 = async (
+  scope: Pick<AssertedDatabaseScope<unknown>, "tenantId" | "principalId">,
+  sha256?: Sha256Digest,
+): Promise<string> =>
+  await digestIdentity(SCOPE_DOMAIN, captureScopeIdentity(scope), sha256);
+
+export const hashDatabaseManifestTupleV1 = (
+  tuple: DatabaseManifestTupleV2,
+  sha256?: Sha256Digest,
+): Promise<string> => {
+  const snapshot = snapshotCanonicalDatabaseValueV1<unknown>(tuple);
+  return digestIdentity(
+    MANIFEST_DOMAIN,
+    parseDatabaseManifestTupleV2(snapshot),
+    sha256,
+  );
+};

--- a/plugins/plugin-core/src/database-v2/databaseSessionRuntime.ts
+++ b/plugins/plugin-core/src/database-v2/databaseSessionRuntime.ts
@@ -1,0 +1,256 @@
+import type { DatabaseBackendScopeV2, DatabaseBackendV2 } from "./backend";
+import type { BundleChangeSetV2, BundleRepositoryV2 } from "./bundles";
+import { snapshotDatabaseChangeSetV2 } from "./changeSetValidation";
+import type { Sha256Digest } from "./common";
+import type { DatabaseSessionV2 } from "./connector";
+import { hashDatabaseChangeSetPayloadV1 } from "./databaseIdentity";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import type { CommitReceiptV2 } from "./receipts";
+import { validateCommitReceiptV2 } from "./receiptValidation";
+import type {
+  DatabaseSessionStateV2,
+  PoisonedCommitIdentityV2,
+  PreparedCommitV2,
+} from "./sessionState";
+
+interface DatabaseSessionRuntimeV2Options {
+  readonly backend: DatabaseBackendV2;
+  readonly scope: DatabaseBackendScopeV2;
+  readonly sha256?: Sha256Digest;
+  readonly onClosed: (session: DatabaseSessionRuntimeV2) => void;
+}
+
+interface ActiveAttemptV2 {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+}
+
+const createActiveAttempt = (): ActiveAttemptV2 => {
+  let resolve = (): void => {
+    throw new TypeError("active attempt was not initialized");
+  };
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+};
+
+const sessionError = (
+  code:
+    | "CONCURRENT_COMMIT"
+    | "SESSION_POISONED"
+    | "SESSION_CLOSING"
+    | "SESSION_CLOSED",
+  message: string,
+): DatabaseConnectorErrorV2 => new DatabaseConnectorErrorV2(code, message);
+
+export class DatabaseSessionRuntimeV2 implements DatabaseSessionV2 {
+  private state: DatabaseSessionStateV2 = "open";
+  private poison: PoisonedCommitIdentityV2 | null = null;
+  private activeAttempt: Promise<void> | null = null;
+  private closeCompletion: Promise<void> | null = null;
+  private readonly backend: DatabaseBackendV2;
+  private readonly scope: DatabaseBackendScopeV2;
+  private readonly sha256: Sha256Digest | undefined;
+  private readonly onClosed: (session: DatabaseSessionRuntimeV2) => void;
+
+  readonly bundles: BundleRepositoryV2 = {
+    get: async (id) => {
+      this.assertReadable();
+      return await this.backend.get(this.scope, id);
+    },
+    page: async (query) => {
+      this.assertReadable();
+      return await this.backend.page(this.scope, query);
+    },
+    channels: async () => {
+      this.assertReadable();
+      return await this.backend.channels(this.scope);
+    },
+  };
+
+  constructor(options: DatabaseSessionRuntimeV2Options) {
+    this.backend = options.backend;
+    this.scope = options.scope;
+    this.sha256 = options.sha256;
+    this.onClosed = options.onClosed;
+  }
+
+  async applyChangeSet(changeSet: BundleChangeSetV2): Promise<CommitReceiptV2> {
+    const recovery = this.reserveCommit();
+    const active = createActiveAttempt();
+    this.activeAttempt = active.promise;
+    try {
+      const prepared = this.prepareCommit(changeSet, recovery);
+      return await this.executeCommit(prepared);
+    } finally {
+      if (this.state === "committing") {
+        this.restoreAfterPreparation(recovery);
+      }
+      active.resolve();
+      this.activeAttempt = null;
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.closeCompletion !== null) {
+      return this.closeCompletion;
+    }
+    if (this.state === "closed") {
+      return Promise.resolve();
+    }
+    this.state = "closing";
+    const active = this.activeAttempt ?? Promise.resolve();
+    this.closeCompletion = active.then(() => {
+      this.state = "closed";
+      this.poison = null;
+      this.onClosed(this);
+    });
+    return this.closeCompletion;
+  }
+
+  private reserveCommit(): PoisonedCommitIdentityV2 | null {
+    switch (this.state) {
+      case "committing":
+        throw sessionError("CONCURRENT_COMMIT", "a commit is already active");
+      case "closing":
+        throw sessionError("SESSION_CLOSING", "session is closing");
+      case "closed":
+        throw sessionError("SESSION_CLOSED", "session is closed");
+      case "open": {
+        this.state = "committing";
+        return null;
+      }
+      case "poisoned": {
+        const poison = this.poison;
+        if (poison === null) {
+          throw sessionError("SESSION_POISONED", "session is poisoned");
+        }
+        this.state = "committing";
+        return poison;
+      }
+    }
+  }
+
+  private prepareCommit(
+    changeSet: BundleChangeSetV2,
+    recovery: PoisonedCommitIdentityV2 | null,
+  ): PreparedCommitV2 {
+    const snapshot = snapshotDatabaseChangeSetV2(changeSet);
+    if (recovery !== null && recovery.changeSetId !== snapshot.id) {
+      throw sessionError(
+        "SESSION_POISONED",
+        "only the exact unknown commit may be retried",
+      );
+    }
+    return { changeSet: snapshot, recovery };
+  }
+
+  private async executeCommit(
+    prepared: PreparedCommitV2,
+  ): Promise<CommitReceiptV2> {
+    const payloadHash = await this.hashChangeSet(prepared);
+    if (
+      prepared.recovery !== null &&
+      prepared.recovery.canonicalPayloadHash !== payloadHash
+    ) {
+      this.restoreAfterPreparation(prepared.recovery);
+      throw sessionError(
+        "SESSION_POISONED",
+        "only the exact unknown payload may be retried",
+      );
+    }
+    const expected = {
+      changeSetId: prepared.changeSet.id,
+      scopeId: this.scope.scopeId,
+      canonicalPayloadHash: payloadHash,
+    };
+    let receipt: unknown;
+    try {
+      receipt = await this.backend.commit({
+        scope: this.scope,
+        changeSet: prepared.changeSet,
+        canonicalPayloadHash: payloadHash,
+      });
+    } catch {
+      this.poisonWith(expected);
+      throw new DatabaseConnectorErrorV2(
+        "CONNECTOR_PROTOCOL_VIOLATION",
+        "backend commit did not return a receipt",
+      );
+    }
+    try {
+      const validated = validateCommitReceiptV2(
+        receipt,
+        expected,
+        prepared.changeSet,
+      );
+      if (validated.outcome === "unknown") {
+        this.poisonWith(expected);
+      } else {
+        this.poison = null;
+        this.transitionWhenOpen("open");
+      }
+      return validated;
+    } catch (error) {
+      this.poisonWith(expected);
+      throw error;
+    }
+  }
+
+  private async hashChangeSet(prepared: PreparedCommitV2): Promise<string> {
+    try {
+      return await hashDatabaseChangeSetPayloadV1(
+        prepared.changeSet.changes,
+        this.sha256,
+      );
+    } catch (error) {
+      this.restoreAfterPreparation(prepared.recovery);
+      if (
+        error instanceof DatabaseConnectorErrorV2 &&
+        error.code === "CANONICALIZATION_FAILED"
+      ) {
+        throw new DatabaseConnectorErrorV2(
+          "INVALID_CHANGE_SET",
+          "change set payload is not canonicalizable",
+        );
+      }
+      throw error;
+    }
+  }
+
+  private assertReadable(): void {
+    switch (this.state) {
+      case "open":
+        return;
+      case "poisoned":
+        throw sessionError("SESSION_POISONED", "session is poisoned");
+      case "committing":
+        throw sessionError("CONCURRENT_COMMIT", "a commit is active");
+      case "closing":
+        throw sessionError("SESSION_CLOSING", "session is closing");
+      case "closed":
+        throw sessionError("SESSION_CLOSED", "session is closed");
+    }
+  }
+
+  private poisonWith(identity: PoisonedCommitIdentityV2): void {
+    this.poison = identity;
+    this.transitionWhenOpen("poisoned");
+  }
+
+  private restoreAfterPreparation(
+    recovery: PoisonedCommitIdentityV2 | null,
+  ): void {
+    this.poison = recovery;
+    this.transitionWhenOpen(recovery === null ? "open" : "poisoned");
+  }
+
+  private transitionWhenOpen(
+    state: Extract<DatabaseSessionStateV2, "open" | "poisoned">,
+  ): void {
+    if (this.state !== "closing" && this.state !== "closed") {
+      this.state = state;
+    }
+  }
+}

--- a/plugins/plugin-core/src/database-v2/digestBoundary.spec.ts
+++ b/plugins/plugin-core/src/database-v2/digestBoundary.spec.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+
+import { hashDatabaseScopeV1 } from "./databaseIdentity";
+
+const scope = { principalId: "principal-a", tenantId: "tenant-a" };
+
+describe("SHA-256 provider result boundary", () => {
+  it("does not use Number.prototype.toString to format digest bytes", async () => {
+    // Given a provider that installs a hostile numeric formatter
+    const originalToString = Number.prototype.toString;
+    let hookCalls = 0;
+
+    // When provider-time mutation precedes source-boundary formatting
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(Number.prototype, "toString", {
+          configurable: true,
+          writable: true,
+          value: function (radix?: number) {
+            if (radix === 16) {
+              hookCalls += 1;
+              return "number-hook";
+            }
+            return Reflect.apply(originalToString, this, [radix]);
+          },
+        });
+        return new Uint8Array(32);
+      });
+    } finally {
+      Object.defineProperty(Number.prototype, "toString", {
+        configurable: true,
+        writable: true,
+        value: originalToString,
+      });
+    }
+
+    // Then mutable prototype hooks cannot corrupt the lowercase digest text
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(hookCalls).toBe(0);
+  });
+
+  it("does not use String.prototype.padStart to format digest bytes", async () => {
+    // Given a provider that installs a hostile string formatter
+    const originalPadStart = String.prototype.padStart;
+    let hookCalls = 0;
+
+    // When provider-time mutation precedes source-boundary formatting
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(String.prototype, "padStart", {
+          configurable: true,
+          writable: true,
+          value: function (length: number, fill?: string) {
+            if (length === 2 && fill === "0") {
+              hookCalls += 1;
+              return "pad-hook";
+            }
+            return Reflect.apply(originalPadStart, this, [length, fill]);
+          },
+        });
+        return new Uint8Array(32);
+      });
+    } finally {
+      Object.defineProperty(String.prototype, "padStart", {
+        configurable: true,
+        writable: true,
+        value: originalPadStart,
+      });
+    }
+
+    // Then mutable prototype hooks cannot corrupt the lowercase digest text
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(hookCalls).toBe(0);
+  });
+
+  it("does not read the typed-array length prototype after provider validation", async () => {
+    // Given a provider that installs a hostile typed-array length getter
+    const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+    const originalLength = Object.getOwnPropertyDescriptor(
+      typedArrayPrototype,
+      "length",
+    );
+    if (originalLength === undefined) {
+      throw new TypeError("typed-array length getter is unavailable");
+    }
+    let getterCalls = 0;
+
+    // When provider-time mutation precedes source-boundary formatting
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(typedArrayPrototype, "length", {
+          configurable: true,
+          get: () => {
+            getterCalls += 1;
+            return 0;
+          },
+        });
+        return new Uint8Array(32);
+      });
+    } finally {
+      Object.defineProperty(typedArrayPrototype, "length", originalLength);
+    }
+
+    // Then the validated 32-byte count determines the complete digest text
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(getterCalls).toBe(0);
+  });
+
+  it("does not resolve Reflect.apply after the digest provider returns", async () => {
+    // Given a provider that installs a stateful Reflect.apply wrapper
+    const originalApplyDescriptor = Object.getOwnPropertyDescriptor(
+      Reflect,
+      "apply",
+    );
+    if (originalApplyDescriptor === undefined) {
+      throw new TypeError("Reflect.apply descriptor is unavailable");
+    }
+    const originalApply = Reflect.apply;
+    let wrapperCalls = 0;
+
+    // When the third live lookup suppresses the intrinsic digest copy
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(Reflect, "apply", {
+          ...originalApplyDescriptor,
+          value: (...parameters: Parameters<typeof Reflect.apply>) => {
+            wrapperCalls += 1;
+            if (wrapperCalls === 3) {
+              return undefined;
+            }
+            return originalApply(...parameters);
+          },
+        });
+        return new Uint8Array(32).fill(0x5a);
+      });
+    } finally {
+      Object.defineProperty(Reflect, "apply", originalApplyDescriptor);
+    }
+
+    // Then the validated provider bytes remain the exact digest identity
+    expect(identity).toBe(`sha256:${"5a".repeat(32)}`);
+    expect(wrapperCalls).toBe(0);
+  });
+
+  it("does not resolve the Uint8Array constructor after the provider returns", async () => {
+    // Given a valid digest created before its global constructor is replaced
+    const constructorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "Uint8Array",
+    );
+    if (constructorDescriptor === undefined) {
+      throw new TypeError("Uint8Array descriptor is unavailable");
+    }
+    const digest = new Uint8Array(32).fill(0x5a);
+    let constructorCalls = 0;
+
+    // When provider-time mutation precedes snapshot allocation
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(globalThis, "Uint8Array", {
+          ...constructorDescriptor,
+          value: function ThrowingUint8Array() {
+            constructorCalls += 1;
+            throw new RangeError("snapshot constructor intercepted");
+          },
+        });
+        return digest;
+      });
+    } finally {
+      Object.defineProperty(globalThis, "Uint8Array", constructorDescriptor);
+    }
+
+    // Then snapshot allocation preserves every validated provider byte
+    expect(identity).toBe(`sha256:${"5a".repeat(32)}`);
+    expect(constructorCalls).toBe(0);
+  });
+
+  it("copies subclass bytes without invoking iterator, species, or index hooks", async () => {
+    // Given a valid 32-byte subclass with hostile dynamic access hooks
+    let iteratorCalls = 0;
+    let speciesCalls = 0;
+    let indexCalls = 0;
+    class HostileDigest extends Uint8Array {}
+    Object.defineProperty(HostileDigest.prototype, Symbol.iterator, {
+      configurable: true,
+      value: function* () {
+        iteratorCalls += 1;
+        yield 999;
+      },
+    });
+    Object.defineProperty(HostileDigest, Symbol.species, {
+      configurable: true,
+      get: () => {
+        speciesCalls += 1;
+        throw new RangeError("digest species accessed");
+      },
+    });
+    Object.defineProperty(HostileDigest.prototype, "0", {
+      configurable: true,
+      get: () => {
+        indexCalls += 1;
+        throw new RangeError("digest index accessed");
+      },
+    });
+    const digest = new HostileDigest(32);
+
+    // When the provider result crosses the public identity boundary
+    const identity = await hashDatabaseScopeV1(scope, async () => digest);
+
+    // Then only intrinsic backing bytes determine the exact digest identity
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(iteratorCalls).toBe(0);
+    expect(speciesCalls).toBe(0);
+    expect(indexCalls).toBe(0);
+  });
+
+  it("ignores an own iterator on an ordinary typed array", async () => {
+    // Given a valid 32-byte typed array whose own iterator yields invalid bytes
+    let iteratorCalls = 0;
+    const digest = new Uint8Array(32);
+    Object.defineProperty(digest, Symbol.iterator, {
+      configurable: true,
+      value: function* () {
+        iteratorCalls += 1;
+        yield -1;
+      },
+    });
+
+    // When the provider result is encoded
+    const identity = await hashDatabaseScopeV1(scope, async () => digest);
+
+    // Then it remains exactly one lowercase 32-byte SHA-256 representation
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(identity).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(iteratorCalls).toBe(0);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/digestPublicBoundary.spec.ts
+++ b/plugins/plugin-core/src/database-v2/digestPublicBoundary.spec.ts
@@ -1,0 +1,179 @@
+import { runInNewContext } from "node:vm";
+
+import { describe, expect, it } from "vitest";
+
+import { hashDatabaseScopeV1 } from "./index";
+
+const scope = { principalId: "public-principal", tenantId: "public-tenant" };
+
+describe("public SHA-256 provider result boundary", () => {
+  it("encodes identity input without a host TextEncoder", async () => {
+    // Given an ES2022 host without the optional TextEncoder platform API
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "TextEncoder",
+    );
+    let identity: string;
+
+    // When a caller supplies the required SHA-256 implementation
+    try {
+      Reflect.deleteProperty(globalThis, "TextEncoder");
+      identity = await hashDatabaseScopeV1(scope, () => new Uint8Array(32));
+    } finally {
+      if (descriptor !== undefined) {
+        Object.defineProperty(globalThis, "TextEncoder", descriptor);
+      }
+    }
+
+    // Then hashing remains available without any undeclared host dependency
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+  });
+
+  it("keeps the digest exact when the typed-array length prototype is mutated", async () => {
+    // Given a public provider that installs a hostile typed-array length getter
+    const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+    const originalLength = Object.getOwnPropertyDescriptor(
+      typedArrayPrototype,
+      "length",
+    );
+    if (originalLength === undefined) {
+      throw new TypeError("typed-array length getter is unavailable");
+    }
+    let getterCalls = 0;
+
+    // When provider-time mutation precedes public-boundary formatting
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(typedArrayPrototype, "length", {
+          configurable: true,
+          get: () => {
+            getterCalls += 1;
+            return 0;
+          },
+        });
+        return new Uint8Array(32);
+      });
+    } finally {
+      Object.defineProperty(typedArrayPrototype, "length", originalLength);
+    }
+
+    // Then the public contract remains one exact lowercase SHA-256 digest
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(getterCalls).toBe(0);
+  });
+
+  it("keeps the public digest exact when Reflect.apply is stateful", async () => {
+    // Given a public provider that installs a stateful Reflect.apply wrapper
+    const originalApplyDescriptor = Object.getOwnPropertyDescriptor(
+      Reflect,
+      "apply",
+    );
+    if (originalApplyDescriptor === undefined) {
+      throw new TypeError("Reflect.apply descriptor is unavailable");
+    }
+    const originalApply = Reflect.apply;
+    let wrapperCalls = 0;
+
+    // When the third live lookup suppresses the intrinsic digest copy
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(Reflect, "apply", {
+          ...originalApplyDescriptor,
+          value: (...parameters: Parameters<typeof Reflect.apply>) => {
+            wrapperCalls += 1;
+            if (wrapperCalls === 3) {
+              return undefined;
+            }
+            return originalApply(...parameters);
+          },
+        });
+        return new Uint8Array(32).fill(0x5a);
+      });
+    } finally {
+      Object.defineProperty(Reflect, "apply", originalApplyDescriptor);
+    }
+
+    // Then the public boundary returns every validated provider byte exactly
+    expect(identity).toBe(`sha256:${"5a".repeat(32)}`);
+    expect(wrapperCalls).toBe(0);
+  });
+
+  it("keeps the public digest exact when global Uint8Array is replaced", async () => {
+    // Given a public provider result created before constructor replacement
+    const constructorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "Uint8Array",
+    );
+    if (constructorDescriptor === undefined) {
+      throw new TypeError("Uint8Array descriptor is unavailable");
+    }
+    const digest = new Uint8Array(32).fill(0x5a);
+    let constructorCalls = 0;
+
+    // When the provider replaces the global constructor before returning
+    let identity: string;
+    try {
+      identity = await hashDatabaseScopeV1(scope, async () => {
+        Object.defineProperty(globalThis, "Uint8Array", {
+          ...constructorDescriptor,
+          value: function ThrowingUint8Array() {
+            constructorCalls += 1;
+            throw new RangeError("snapshot constructor intercepted");
+          },
+        });
+        return digest;
+      });
+    } finally {
+      Object.defineProperty(globalThis, "Uint8Array", constructorDescriptor);
+    }
+
+    // Then the public boundary preserves the exact digest without interception
+    expect(identity).toBe(`sha256:${"5a".repeat(32)}`);
+    expect(constructorCalls).toBe(0);
+  });
+
+  it("copies cross-realm subclass bytes without dynamic collection hooks", async () => {
+    // Given a cross-realm subclass with hostile iterator, species, and index hooks
+    const fixture = runInNewContext(`(() => {
+      const calls = { index: 0, iterator: 0, species: 0 };
+      class HostileDigest extends Uint8Array {}
+      Object.defineProperty(HostileDigest.prototype, Symbol.iterator, {
+        configurable: true,
+        value: function* () {
+          calls.iterator += 1;
+          yield 999;
+        },
+      });
+      Object.defineProperty(HostileDigest, Symbol.species, {
+        configurable: true,
+        get: () => {
+          calls.species += 1;
+          throw new RangeError("digest species accessed");
+        },
+      });
+      Object.defineProperty(HostileDigest.prototype, "0", {
+        configurable: true,
+        get: () => {
+          calls.index += 1;
+          throw new RangeError("digest index accessed");
+        },
+      });
+      return { calls, digest: new HostileDigest(32) };
+    })()`);
+
+    // When the result crosses the public source boundary
+    const identity = await Reflect.apply(hashDatabaseScopeV1, undefined, [
+      scope,
+      async () => Reflect.get(fixture, "digest"),
+    ]);
+    const calls = Reflect.get(fixture, "calls");
+
+    // Then intrinsic backing bytes alone determine the exact digest identity
+    expect(identity).toBe(`sha256:${"00".repeat(32)}`);
+    expect(Reflect.get(calls, "iterator")).toBe(0);
+    expect(Reflect.get(calls, "species")).toBe(0);
+    expect(Reflect.get(calls, "index")).toBe(0);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/errors.spec.ts
+++ b/plugins/plugin-core/src/database-v2/errors.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+describe("DatabaseConnectorErrorV2", () => {
+  it("retains its typed identity when constructed with a connector code", () => {
+    // Given
+    const cause = new TypeError("invalid tenant claim");
+
+    // When
+    const error = new DatabaseConnectorErrorV2(
+      "INVALID_SCOPE",
+      "scope is invalid",
+      { cause },
+    );
+
+    // Then
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("DatabaseConnectorErrorV2");
+    expect(error.code).toBe("INVALID_SCOPE");
+    expect(error.message).toBe("scope is invalid");
+    expect(error.cause).toBe(cause);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/errors.ts
+++ b/plugins/plugin-core/src/database-v2/errors.ts
@@ -1,0 +1,30 @@
+export type DatabaseConnectorErrorCodeV2 =
+  | "INVALID_SCOPE"
+  | "INVALID_CHANGE_SET"
+  | "INVALID_CURSOR"
+  | "INVALID_MANIFEST"
+  | "CANONICALIZATION_FAILED"
+  | "DIGEST_UNAVAILABLE"
+  | "CONCURRENT_COMMIT"
+  | "SESSION_POISONED"
+  | "SESSION_CLOSING"
+  | "SESSION_CLOSED"
+  | "CONNECTION_CLOSING"
+  | "CONNECTION_CLOSED"
+  | "CONNECTOR_PROTOCOL_VIOLATION";
+
+export class DatabaseConnectorErrorV2 extends Error {
+  override readonly name = "DatabaseConnectorErrorV2";
+  readonly code: DatabaseConnectorErrorCodeV2;
+  override readonly cause?: unknown;
+
+  constructor(
+    code: DatabaseConnectorErrorCodeV2,
+    message: string,
+    options?: { readonly cause?: unknown },
+  ) {
+    super(message, options);
+    this.code = code;
+    this.cause = options?.cause;
+  }
+}

--- a/plugins/plugin-core/src/database-v2/finalTrustRemediation.spec.ts
+++ b/plugins/plugin-core/src/database-v2/finalTrustRemediation.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+
+import { snapshotDatabaseChangeSetV2 } from "./changeSetValidation";
+import { hashDatabaseScopeV1 } from "./databaseIdentity";
+import { parseInMemoryPageQueryV2 } from "./inMemoryQuery";
+import { validateCommitReceiptV2 } from "./receiptValidation";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+const throwOnThirdOwnKeys = <T extends object>(target: T): T => {
+  let ownKeysCalls = 0;
+  return new Proxy(target, {
+    ownKeys: (proxied) => {
+      ownKeysCalls += 1;
+      if (ownKeysCalls >= 3) {
+        throw new RangeError("hostile ownKeys marker");
+      }
+      return Reflect.ownKeys(proxied);
+    },
+  });
+};
+
+const expectSyncConnectorCode = (action: () => unknown, code: string): void => {
+  expect(action).toThrowError(
+    expect.objectContaining({ name: "DatabaseConnectorErrorV2", code }),
+  );
+};
+
+const callSnapshotChangeSet = (value: unknown): unknown =>
+  Reflect.apply(snapshotDatabaseChangeSetV2, undefined, [value]);
+
+const callParsePageQuery = (value: unknown): unknown =>
+  Reflect.apply(parseInMemoryPageQueryV2, undefined, [value]);
+
+const errorProperty = (error: unknown, key: string): unknown =>
+  typeof error === "object" && error !== null
+    ? Reflect.get(error, key)
+    : undefined;
+
+describe("database-v2 final trust-boundary remediation", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("validates one canonical snapshot instead of re-reading live inputs", async () => {
+    // Given hostile inputs that fail only when their live graph is re-read
+    const changeSet = throwOnThirdOwnKeys(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+    const query = throwOnThirdOwnKeys({ limit: 10 });
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    let receiptGets = 0;
+    const expectedReceipt = {
+      changeSetId: CHANGE_SET_IDS.second,
+      scopeId: "sha256:scope",
+      canonicalPayloadHash: "sha256:payload",
+    };
+    const hostileReceipt = new Proxy(
+      {
+        ...expectedReceipt,
+        outcome: "unknown",
+        reason: "transport-unknown",
+        sessionState: "poisoned",
+        retry: "identical-scope-id-and-payload-only",
+      },
+      {
+        get: () => {
+          receiptGets += 1;
+          throw new RangeError("hostile receipt get marker");
+        },
+      },
+    );
+
+    // When each value crosses its trust boundary
+    const committed = await session.applyChangeSet(changeSet);
+    const parsed = parseInMemoryPageQueryV2(query);
+    const receipt = validateCommitReceiptV2(
+      hostileReceipt,
+      expectedReceipt,
+      createRuntimeChangeSet(CHANGE_SET_IDS.second),
+    );
+
+    // Then parsing uses detached data and never invokes live getters
+    expect(committed.outcome).toBe("committed");
+    expect(parsed.query.limit).toBe(10);
+    expect(receipt.outcome).toBe("unknown");
+    expect(receiptGets).toBe(0);
+    expect(backend.commitAttempts).toBe(1);
+  });
+
+  it("normalizes hostile inspection failures at each public boundary", () => {
+    // Given proxies whose descriptor inspection throws immediately
+    const hostile = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new RangeError("descriptor marker");
+        },
+        ownKeys: () => ["value"],
+      },
+    );
+
+    // When and Then each boundary emits its stable connector code
+    expectSyncConnectorCode(
+      () => callSnapshotChangeSet(hostile),
+      "INVALID_CHANGE_SET",
+    );
+    expectSyncConnectorCode(
+      () => callParsePageQuery(hostile),
+      "INVALID_CURSOR",
+    );
+    expectSyncConnectorCode(
+      () =>
+        validateCommitReceiptV2(
+          hostile,
+          {
+            changeSetId: CHANGE_SET_IDS.first,
+            scopeId: "sha256:scope",
+            canonicalPayloadHash: "sha256:payload",
+          },
+          createRuntimeChangeSet(CHANGE_SET_IDS.first),
+        ),
+      "CONNECTOR_PROTOCOL_VIOLATION",
+    );
+  });
+
+  it("captures scope identifiers descriptor-safely and excludes context", async () => {
+    // Given stable identifiers beside an accessor context
+    let contextGets = 0;
+    const scope = Object.defineProperty(
+      { tenantId: "tenant-a", principalId: "principal-a" },
+      "context",
+      {
+        enumerable: true,
+        get: () => {
+          contextGets += 1;
+          throw new RangeError("context marker");
+        },
+      },
+    );
+    let tenantGets = 0;
+    const accessorScope = Object.defineProperty(
+      {
+        tenantId: "placeholder",
+        principalId: "principal-a",
+        context: undefined,
+      },
+      "tenantId",
+      {
+        enumerable: true,
+        get: () => {
+          tenantGets += 1;
+          return "tenant-a";
+        },
+      },
+    );
+
+    // When the scope hash is produced and malformed identifiers are rejected
+    const hash = await hashDatabaseScopeV1(scope);
+    const accessorResult = hashDatabaseScopeV1(accessorScope);
+
+    // Then context is opaque, identifiers are never invoked, and vectors stay stable
+    expect(hash).toBe(
+      "sha256:0446f3b9ed66598af4648c82ec418e91e26c4a7d2af8cc19b7894c6e753c22ff",
+    );
+    await expect(accessorResult).rejects.toMatchObject({
+      code: "CANONICALIZATION_FAILED",
+    });
+    expect(contextGets).toBe(0);
+    expect(tenantGets).toBe(0);
+  });
+
+  it("does not expose injected digest or backend failures as runtime causes", async () => {
+    // Given attacker-controlled failures at the digest and backend seams
+    const digestMarker = new Error("injected digest marker");
+    const digest = async (): Promise<Uint8Array> => {
+      throw digestMarker;
+    };
+    const digestResultPromise = hashDatabaseScopeV1(
+      { tenantId: "tenant-a", principalId: "principal-a" },
+      digest,
+    ).then(
+      () => ({ kind: "fulfilled" }) as const,
+      (error: unknown) => ({ error, kind: "rejected" }) as const,
+    );
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const backendMarker = new Error("injected backend marker");
+    backend.commit = async () => {
+      throw backendMarker;
+    };
+
+    // When both failures cross the public runtime membrane
+    const digestResult = await digestResultPromise;
+    const backendResult = await session
+      .applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.first))
+      .then(
+        () => ({ kind: "fulfilled" }) as const,
+        (error: unknown) => ({ error, kind: "rejected" }) as const,
+      );
+
+    // Then stable public errors do not expose attacker-controlled causes
+    expect(digestResult.kind).toBe("rejected");
+    expect(backendResult.kind).toBe("rejected");
+    if (digestResult.kind === "rejected") {
+      expect(errorProperty(digestResult.error, "code")).toBe(
+        "DIGEST_UNAVAILABLE",
+      );
+      expect(errorProperty(digestResult.error, "cause")).toBeUndefined();
+      expect(errorProperty(digestResult.error, "message")).toBe(
+        "SHA-256 provider failed",
+      );
+    }
+    if (backendResult.kind === "rejected") {
+      expect(errorProperty(backendResult.error, "code")).toBe(
+        "CONNECTOR_PROTOCOL_VIOLATION",
+      );
+      expect(errorProperty(backendResult.error, "cause")).toBeUndefined();
+      expect(errorProperty(backendResult.error, "message")).toBe(
+        "backend commit did not return a receipt",
+      );
+    }
+    expect(digestMarker.message).toBe("injected digest marker");
+    expect(backendMarker.message).toBe("injected backend marker");
+  });
+
+  it("normalizes hostile digest result inspection", async () => {
+    // Given a digest result whose byte length read throws an injected marker
+    const marker = new RangeError("digest result marker");
+    const digest = async (): Promise<Uint8Array> =>
+      new Proxy(new Uint8Array(32), {
+        get: (target, key, receiver) => {
+          if (key === "byteLength") {
+            throw marker;
+          }
+          return Reflect.get(target, key, receiver);
+        },
+      });
+
+    // When the result crosses the digest provider boundary
+    const result = await hashDatabaseScopeV1(
+      { tenantId: "tenant-a", principalId: "principal-a" },
+      digest,
+    ).then(
+      () => ({ kind: "fulfilled" }) as const,
+      (error: unknown) => ({ error, kind: "rejected" }) as const,
+    );
+
+    // Then the marker is not exposed through the public error
+    expect(result.kind).toBe("rejected");
+    if (result.kind === "rejected") {
+      expect(errorProperty(result.error, "code")).toBe("DIGEST_UNAVAILABLE");
+      expect(errorProperty(result.error, "message")).toBe(
+        "SHA-256 provider returned an unreadable digest",
+      );
+      expect(errorProperty(result.error, "cause")).toBeUndefined();
+    }
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryBackend.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryBackend.ts
@@ -1,0 +1,109 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type {
+  DatabaseBackendCommitRequestV2,
+  DatabaseBackendScopeV2,
+  DatabaseBackendV2,
+} from "./backend";
+import type { BundlePageQueryV2, BundlePageV2 } from "./bundles";
+import {
+  addSetValueV2,
+  createMapV2,
+  createSetV2,
+  getMapValueV2,
+  mapValuesV2,
+  setValuesV2,
+} from "./collectionIntrinsics";
+import type { Sha256Digest, Versioned } from "./common";
+import { hashDatabaseScopeV1 } from "./databaseIdentity";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import { cloneInMemoryVersionedBundleV2 } from "./inMemoryClone";
+import {
+  commitInMemoryChangeSetV2,
+  type InMemoryCommitStateV2,
+} from "./inMemoryCommit";
+import { InMemoryCursorRegistryV2 } from "./inMemoryCursor";
+import { InMemoryCommitLockV2 } from "./inMemoryLock";
+import { paginateInMemoryBundlesV2 } from "./inMemoryPagination";
+import { parseInMemoryPageQueryV2 } from "./inMemoryQuery";
+import type { CommitReceiptV2 } from "./receipts";
+
+interface InMemoryDatabaseBackendV2Options {
+  readonly sha256?: Sha256Digest;
+}
+
+export class InMemoryDatabaseBackendV2 implements DatabaseBackendV2 {
+  private readonly state: InMemoryCommitStateV2 = {
+    receipts: createMapV2(),
+    rowsByTenant: createMapV2(),
+    nextRevision: 0,
+  };
+  private readonly cursors = new InMemoryCursorRegistryV2();
+  private readonly commitLock = new InMemoryCommitLockV2();
+  private readonly sha256: Sha256Digest | undefined;
+
+  constructor(options: InMemoryDatabaseBackendV2Options = {}) {
+    this.sha256 = options.sha256;
+  }
+
+  async get(
+    scope: DatabaseBackendScopeV2,
+    id: string,
+  ): Promise<Versioned<Bundle> | null> {
+    await this.assertScopeIntegrity(scope);
+    const tenantRows = getMapValueV2(this.state.rowsByTenant, scope.tenantId);
+    const row =
+      tenantRows === undefined ? undefined : getMapValueV2(tenantRows, id);
+    return row === undefined ? null : cloneInMemoryVersionedBundleV2(row);
+  }
+
+  async page(
+    scope: DatabaseBackendScopeV2,
+    query: BundlePageQueryV2,
+  ): Promise<BundlePageV2> {
+    await this.assertScopeIntegrity(scope);
+    const request = parseInMemoryPageQueryV2(query);
+    const tenantRows = getMapValueV2(this.state.rowsByTenant, scope.tenantId);
+    const rows = tenantRows === undefined ? [] : mapValuesV2(tenantRows);
+    return paginateInMemoryBundlesV2({
+      scope,
+      request,
+      rows,
+      cursors: this.cursors,
+    });
+  }
+
+  async channels(scope: DatabaseBackendScopeV2): Promise<readonly string[]> {
+    await this.assertScopeIntegrity(scope);
+    const tenantRows = getMapValueV2(this.state.rowsByTenant, scope.tenantId);
+    const channels = createSetV2<string>();
+    for (const row of tenantRows === undefined ? [] : mapValuesV2(tenantRows)) {
+      addSetValueV2(channels, row.value.channel);
+    }
+    return Object.freeze([...setValuesV2(channels)].sort());
+  }
+
+  async commit(request: DatabaseBackendCommitRequestV2): Promise<unknown> {
+    await this.assertScopeIntegrity(request.scope);
+    return await this.commitLock.run(
+      async (): Promise<CommitReceiptV2> =>
+        commitInMemoryChangeSetV2(request, this.state),
+    );
+  }
+
+  private async assertScopeIntegrity(
+    scope: DatabaseBackendScopeV2,
+  ): Promise<void> {
+    const expected = await hashDatabaseScopeV1(scope, this.sha256);
+    if (expected !== scope.scopeId) {
+      throw new DatabaseConnectorErrorV2(
+        "CONNECTOR_PROTOCOL_VIOLATION",
+        "backend scope identity does not match its asserted identifiers",
+      );
+    }
+  }
+}
+
+export const createInMemoryDatabaseBackendV2 = (
+  options: InMemoryDatabaseBackendV2Options = {},
+): DatabaseBackendV2 => new InMemoryDatabaseBackendV2(options);

--- a/plugins/plugin-core/src/database-v2/inMemoryClone.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryClone.ts
@@ -1,0 +1,32 @@
+import type { Bundle } from "@hot-updater/core";
+
+import { snapshotCanonicalDatabaseValueV1 } from "./canonicalIdentity";
+import type { Versioned } from "./common";
+import type { CommitReceiptV2 } from "./receipts";
+
+export const cloneInMemoryBundleV2 = (bundle: Bundle): Bundle =>
+  snapshotCanonicalDatabaseValueV1(bundle);
+
+export const cloneInMemoryVersionedBundleV2 = (
+  row: Versioned<Bundle>,
+): Versioned<Bundle> =>
+  Object.freeze({
+    value: cloneInMemoryBundleV2(row.value),
+    revision: row.revision,
+  });
+
+export const cloneInMemoryReceiptV2 = (
+  receipt: CommitReceiptV2,
+): CommitReceiptV2 => {
+  switch (receipt.outcome) {
+    case "committed":
+    case "replayed":
+      return Object.freeze({
+        ...receipt,
+        revisions: Object.freeze({ ...receipt.revisions }),
+      });
+    case "rejected":
+    case "unknown":
+      return Object.freeze({ ...receipt });
+  }
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryCommit.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryCommit.ts
@@ -1,0 +1,179 @@
+import type { DatabaseBackendCommitRequestV2 } from "./backend";
+import type { BundleChangeV2 } from "./bundles";
+import {
+  createMapV2,
+  deleteMapValueV2,
+  getMapValueV2,
+  setMapValueV2,
+} from "./collectionIntrinsics";
+import { cloneInMemoryBundleV2, cloneInMemoryReceiptV2 } from "./inMemoryClone";
+import type { InMemoryStoredBundleV2 } from "./inMemoryTypes";
+import type { CommitReceiptV2, ReceiptIdentityV2 } from "./receipts";
+
+type PersistedReceiptV2 =
+  | (ReceiptIdentityV2 & {
+      readonly outcome: "committed";
+      readonly revisions: Readonly<Record<string, string>>;
+    })
+  | (ReceiptIdentityV2 & {
+      readonly outcome: "rejected";
+      readonly reason: "conflict" | "unsupported";
+    });
+
+interface PreparedMutationV2 {
+  readonly id: string;
+  readonly revision: string;
+  readonly value: InMemoryStoredBundleV2 | null;
+}
+
+export interface InMemoryCommitStateV2 {
+  readonly receipts: Map<string, PersistedReceiptV2>;
+  readonly rowsByTenant: Map<string, Map<string, InMemoryStoredBundleV2>>;
+  nextRevision: number;
+}
+
+const bundleId = (change: BundleChangeV2): string => {
+  switch (change.type) {
+    case "put":
+      return change.value.id;
+    case "delete":
+      return change.id;
+  }
+};
+
+const receiptKey = (request: DatabaseBackendCommitRequestV2): string =>
+  JSON.stringify([
+    request.scope.tenantId,
+    request.scope.principalId,
+    request.scope.scopeId,
+    request.changeSet.id,
+  ]);
+
+const identity = (request: DatabaseBackendCommitRequestV2) => ({
+  changeSetId: request.changeSet.id,
+  scopeId: request.scope.scopeId,
+  canonicalPayloadHash: request.canonicalPayloadHash,
+});
+
+const replayPersistedReceipt = (
+  receipt: PersistedReceiptV2,
+): CommitReceiptV2 => {
+  switch (receipt.outcome) {
+    case "committed":
+      return cloneInMemoryReceiptV2({ ...receipt, outcome: "replayed" });
+    case "rejected":
+      return cloneInMemoryReceiptV2(receipt);
+  }
+};
+
+const resolveExistingReceipt = (
+  request: DatabaseBackendCommitRequestV2,
+  existing: PersistedReceiptV2,
+): CommitReceiptV2 => {
+  if (existing.canonicalPayloadHash === request.canonicalPayloadHash) {
+    return replayPersistedReceipt(existing);
+  }
+  return Object.freeze({
+    ...identity(request),
+    outcome: "rejected",
+    reason: "conflict",
+  });
+};
+
+const preconditionMatches = (
+  change: BundleChangeV2,
+  row: InMemoryStoredBundleV2 | undefined,
+): boolean => {
+  switch (change.type) {
+    case "put":
+      switch (change.precondition.state) {
+        case "absent":
+          return row === undefined;
+        case "revision":
+          return row?.revision === change.precondition.revision;
+      }
+    case "delete":
+      return row?.revision === change.precondition.revision;
+  }
+};
+
+const rejectConflict = (
+  request: DatabaseBackendCommitRequestV2,
+  key: string,
+  state: InMemoryCommitStateV2,
+): CommitReceiptV2 => {
+  const receipt = Object.freeze({
+    ...identity(request),
+    outcome: "rejected",
+    reason: "conflict",
+  }) satisfies PersistedReceiptV2;
+  setMapValueV2(state.receipts, key, receipt);
+  return cloneInMemoryReceiptV2(receipt);
+};
+
+const prepareMutations = (
+  request: DatabaseBackendCommitRequestV2,
+  rows: Map<string, InMemoryStoredBundleV2>,
+  state: InMemoryCommitStateV2,
+): readonly PreparedMutationV2[] => {
+  let revision = state.nextRevision;
+  return request.changeSet.changes.map((change) => {
+    revision += 1;
+    const nextRevision = `memory-revision-v2:${revision.toString(36)}`;
+    switch (change.type) {
+      case "put":
+        return {
+          id: change.value.id,
+          revision: nextRevision,
+          value: Object.freeze({
+            value: cloneInMemoryBundleV2(change.value),
+            revision: nextRevision,
+          }),
+        };
+      case "delete":
+        return { id: change.id, revision: nextRevision, value: null };
+    }
+  });
+};
+
+export const commitInMemoryChangeSetV2 = (
+  request: DatabaseBackendCommitRequestV2,
+  state: InMemoryCommitStateV2,
+): CommitReceiptV2 => {
+  const key = receiptKey(request);
+  const existing = getMapValueV2(state.receipts, key);
+  if (existing !== undefined) {
+    return resolveExistingReceipt(request, existing);
+  }
+  const rows =
+    getMapValueV2(state.rowsByTenant, request.scope.tenantId) ??
+    createMapV2<string, InMemoryStoredBundleV2>();
+  if (
+    request.changeSet.changes.some(
+      (change) =>
+        !preconditionMatches(change, getMapValueV2(rows, bundleId(change))),
+    )
+  ) {
+    return rejectConflict(request, key, state);
+  }
+  const mutations = prepareMutations(request, rows, state);
+  const revisions = Object.fromEntries(
+    mutations.map((mutation) => [mutation.id, mutation.revision]),
+  );
+  for (const mutation of mutations) {
+    if (mutation.value === null) {
+      deleteMapValueV2(rows, mutation.id);
+    } else {
+      setMapValueV2(rows, mutation.id, mutation.value);
+    }
+  }
+  state.nextRevision += mutations.length;
+  setMapValueV2(state.rowsByTenant, request.scope.tenantId, rows);
+  const receipt = Object.freeze({
+    ...identity(request),
+    outcome: "committed",
+    revisions: Object.freeze(revisions),
+  }) satisfies PersistedReceiptV2;
+  setMapValueV2(state.receipts, key, receipt);
+  return cloneInMemoryReceiptV2(receipt);
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryConnector.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryConnector.spec.ts
@@ -1,0 +1,81 @@
+import { setupDatabaseConnectorV2TestSuite } from "@hot-updater/test-utils";
+import { describe, expect, it } from "vitest";
+
+import * as databaseV2 from "./index";
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+import { inMemoryConnectorV2TestHarness } from "./inMemoryConnector.testHarness";
+
+setupDatabaseConnectorV2TestSuite(inMemoryConnectorV2TestHarness);
+
+describe("createInMemoryDatabaseConnectorV2", () => {
+  it("publishes the in-memory connector factory", () => {
+    const givenModule = databaseV2;
+    const whenFactory = Reflect.get(
+      givenModule,
+      "createInMemoryDatabaseConnectorV2",
+    );
+    expect(typeof whenFactory).toBe("function");
+  });
+
+  it("keeps the fixed manifest and rows for the connector lifetime", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    await givenSession.applyChangeSet(
+      createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000101", [
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first),
+      ]),
+    );
+
+    await givenConnection.close();
+    const whenReconnected = await givenConnector.connect();
+    const whenSession = await whenReconnected.openSession(IN_MEMORY_TEST_SCOPE);
+
+    const thenStored = await whenSession.bundles.get(IN_MEMORY_TEST_IDS.first);
+    expect(thenStored?.value.id).toBe(IN_MEMORY_TEST_IDS.first);
+    expect(givenConnector.manifest).toBe(
+      databaseV2.IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2,
+    );
+    await whenReconnected.close();
+  });
+
+  it("serializes conflicting commits across independent connections", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenFirstConnection = await givenConnector.connect();
+    const givenSecondConnection = await givenConnector.connect();
+    const givenFirst =
+      await givenFirstConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    const givenSecond =
+      await givenSecondConnection.openSession(IN_MEMORY_TEST_SCOPE);
+
+    const whenReceipts = await Promise.all([
+      givenFirst.applyChangeSet(
+        createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000110", [
+          createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first, "first"),
+        ]),
+      ),
+      givenSecond.applyChangeSet(
+        createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000111", [
+          createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first, "second"),
+        ]),
+      ),
+    ]);
+
+    const thenOutcomes = whenReceipts
+      .map((receipt) => receipt.outcome)
+      .toSorted();
+    expect(thenOutcomes).toEqual(["committed", "rejected"]);
+    expect((await givenFirst.bundles.page({ limit: 10 })).data).toHaveLength(1);
+    await Promise.all([
+      givenFirstConnection.close(),
+      givenSecondConnection.close(),
+    ]);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryConnector.testFixtures.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryConnector.testFixtures.ts
@@ -1,0 +1,68 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type { BundleChangeSetV2 } from "./bundles";
+
+export const IN_MEMORY_TEST_IDS = {
+  first: "018f12ab-1234-7abc-8def-000000000001",
+  second: "018f12ab-1234-7abc-8def-000000000002",
+  third: "018f12ab-1234-7abc-8def-000000000003",
+  fourth: "018f12ab-1234-7abc-8def-000000000004",
+} as const;
+
+export const IN_MEMORY_TEST_SCOPE = {
+  tenantId: "tenant-alpha",
+  principalId: "principal-alpha",
+  context: undefined,
+} as const;
+
+export const createInMemoryTestBundle = (
+  id: string,
+  channel = "production",
+): Bundle => ({
+  id,
+  platform: "ios",
+  shouldForceUpdate: false,
+  enabled: true,
+  fileHash: `hash-${id}`,
+  gitCommitHash: null,
+  message: `bundle-${id}`,
+  channel,
+  storageUri: `memory://${id}`,
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  metadata: { app_version: "1.0.0" },
+});
+
+export const createInMemoryPutChangeSet = (
+  id: string,
+  values: readonly Bundle[],
+): BundleChangeSetV2 => ({
+  id,
+  changes: values.map((value) => ({
+    type: "put",
+    value,
+    precondition: { state: "absent" },
+  })),
+});
+
+export const createInMemoryDeleteChangeSet = (
+  id: string,
+  bundleId: string,
+  revision: string,
+): BundleChangeSetV2 => ({
+  id,
+  changes: [
+    {
+      type: "delete",
+      id: bundleId,
+      precondition: { state: "revision", revision },
+    },
+  ],
+});
+
+export const expectInvalidInMemoryCursor = async (
+  operation: () => Promise<unknown>,
+): Promise<void> => {
+  const { expect } = await import("vitest");
+  await expect(operation()).rejects.toMatchObject({ code: "INVALID_CURSOR" });
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryConnector.testHarness.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryConnector.testHarness.ts
@@ -1,0 +1,131 @@
+import type {
+  DatabaseConnectorV2TestFaults,
+  DatabaseConnectorV2TestHarness,
+  DatabaseConnectorV2TestInstrumentation,
+  DatabaseConnectorV2TestSubject,
+} from "@hot-updater/test-utils";
+import type { DatabaseConnectorV2TestContext } from "@hot-updater/test-utils";
+
+import type {
+  DatabaseBackendCommitRequestV2,
+  DatabaseBackendV2,
+} from "./backend";
+import { createInMemoryDatabaseBackendV2 } from "./inMemoryBackend";
+import { createDatabaseConnectionRuntimeV2 } from "./sessionRuntime";
+
+type InterruptionStageV2 = "before-durability" | "after-durability";
+
+interface DeferredV2 {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+}
+
+const createDeferredV2 = (): DeferredV2 => {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+};
+
+const unknownReceipt = (request: DatabaseBackendCommitRequestV2) =>
+  Object.freeze({
+    changeSetId: request.changeSet.id,
+    scopeId: request.scope.scopeId,
+    canonicalPayloadHash: request.canonicalPayloadHash,
+    outcome: "unknown",
+    reason: "transport-unknown",
+    sessionState: "poisoned",
+    retry: "identical-scope-id-and-payload-only",
+  });
+
+class InstrumentedInMemoryBackendV2 implements DatabaseBackendV2 {
+  private operationAttempts = 0;
+  private commitAttempts = 0;
+  private mutations = 0;
+  private hold = false;
+  private held = createDeferredV2();
+  private release = createDeferredV2();
+  private interruption: InterruptionStageV2 | null = null;
+
+  constructor(private readonly backend: DatabaseBackendV2) {}
+
+  readonly instrumentation: DatabaseConnectorV2TestInstrumentation = {
+    backendOperationAttempts: () => this.operationAttempts,
+    backendCommitAttempts: () => this.commitAttempts,
+    domainMutationCount: () => this.mutations,
+  };
+
+  readonly faults: DatabaseConnectorV2TestFaults = {
+    holdNextCommit: () => {
+      this.hold = true;
+      this.held = createDeferredV2();
+      this.release = createDeferredV2();
+    },
+    waitForHeldCommit: async () => await this.held.promise,
+    releaseHeldCommit: () => this.release.resolve(),
+    interruptNextCommit: (stage) => {
+      this.interruption = stage;
+    },
+  };
+
+  async get(...parameters: Parameters<DatabaseBackendV2["get"]>) {
+    this.operationAttempts += 1;
+    return await this.backend.get(...parameters);
+  }
+
+  async page(...parameters: Parameters<DatabaseBackendV2["page"]>) {
+    this.operationAttempts += 1;
+    return await this.backend.page(...parameters);
+  }
+
+  async channels(...parameters: Parameters<DatabaseBackendV2["channels"]>) {
+    this.operationAttempts += 1;
+    return await this.backend.channels(...parameters);
+  }
+
+  async commit(request: DatabaseBackendCommitRequestV2): Promise<unknown> {
+    this.operationAttempts += 1;
+    this.commitAttempts += 1;
+    if (this.hold) {
+      this.hold = false;
+      this.held.resolve();
+      await this.release.promise;
+    }
+    const interruption = this.interruption;
+    this.interruption = null;
+    if (interruption === "before-durability") {
+      return unknownReceipt(request);
+    }
+    const receipt = await this.backend.commit(request);
+    if (
+      typeof receipt === "object" &&
+      receipt !== null &&
+      Reflect.get(receipt, "outcome") === "committed"
+    ) {
+      this.mutations += request.changeSet.changes.length;
+    }
+    return interruption === "after-durability"
+      ? unknownReceipt(request)
+      : receipt;
+  }
+}
+
+export const inMemoryConnectorV2TestHarness = {
+  createSubject: (): DatabaseConnectorV2TestSubject => {
+    const backend = new InstrumentedInMemoryBackendV2(
+      createInMemoryDatabaseBackendV2(),
+    );
+    return {
+      connector: {
+        connect: () =>
+          createDatabaseConnectionRuntimeV2<DatabaseConnectorV2TestContext>({
+            backend,
+            resource: { ownership: "borrowed" },
+          }),
+      },
+      instrumentation: backend.instrumentation,
+      faults: backend.faults,
+    };
+  },
+} satisfies DatabaseConnectorV2TestHarness;

--- a/plugins/plugin-core/src/database-v2/inMemoryConnector.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryConnector.ts
@@ -1,0 +1,20 @@
+import type { DatabaseConnectorV2 } from "./connector";
+import { createInMemoryDatabaseBackendV2 } from "./inMemoryBackend";
+import type { InMemoryDatabaseConnectorV2Options } from "./manifest";
+import { IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2 } from "./referenceManifest";
+import { createDatabaseConnectionRuntimeV2 } from "./sessionRuntime";
+
+export const createInMemoryDatabaseConnectorV2 = <TContext = unknown>(
+  options: InMemoryDatabaseConnectorV2Options = {},
+): DatabaseConnectorV2<TContext> => {
+  const backend = createInMemoryDatabaseBackendV2(options);
+  return Object.freeze({
+    manifest: IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2,
+    connect: () =>
+      createDatabaseConnectionRuntimeV2<TContext>({
+        backend,
+        resource: { ownership: "borrowed" },
+        ...(options.sha256 === undefined ? {} : { sha256: options.sha256 }),
+      }),
+  });
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryCursor.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryCursor.ts
@@ -1,0 +1,58 @@
+import {
+  createMapV2,
+  getMapValueV2,
+  setMapValueV2,
+} from "./collectionIntrinsics";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import type {
+  InMemoryCursorRecordV2,
+  InMemoryCursorRequestV2,
+} from "./inMemoryTypes";
+
+export interface InMemoryCursorScopeV2 {
+  readonly tenantId: string;
+  readonly principalId: string;
+}
+
+export interface InMemoryCursorCreationV2 extends InMemoryCursorScopeV2 {
+  readonly queryIdentity: string;
+  readonly direction: "after" | "before";
+  readonly anchorId: string;
+}
+
+export interface InMemoryCursorLookupV2 extends InMemoryCursorScopeV2 {
+  readonly queryIdentity: string;
+  readonly request: InMemoryCursorRequestV2;
+}
+
+const invalidCursor = (): never => {
+  throw new DatabaseConnectorErrorV2("INVALID_CURSOR", "invalid cursor");
+};
+
+export class InMemoryCursorRegistryV2 {
+  private readonly records = createMapV2<string, InMemoryCursorRecordV2>();
+  private sequence = 0;
+
+  create(input: InMemoryCursorCreationV2): string {
+    this.sequence += 1;
+    const token = `memory-cursor-v2:${this.sequence.toString(36)}`;
+    setMapValueV2(this.records, token, Object.freeze({ ...input }));
+    return token;
+  }
+
+  resolve(input: InMemoryCursorLookupV2): InMemoryCursorRecordV2 {
+    const record = getMapValueV2(this.records, input.request.token);
+    if (
+      record === undefined ||
+      record.tenantId !== input.tenantId ||
+      record.principalId !== input.principalId ||
+      record.queryIdentity !== input.queryIdentity ||
+      record.direction !== input.request.direction
+    ) {
+      return invalidCursor();
+    }
+    return record;
+  }
+}
+
+export const throwInvalidInMemoryCursorV2 = invalidCursor;

--- a/plugins/plugin-core/src/database-v2/inMemoryFilter.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryFilter.ts
@@ -1,0 +1,47 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type { BundleWhereV2 } from "./bundles";
+
+const compare = (value: string, expected: string | undefined): number =>
+  expected === undefined ? 0 : value < expected ? -1 : value > expected ? 1 : 0;
+
+export const bundleMatchesInMemoryWhereV2 = (
+  bundle: Bundle,
+  where: BundleWhereV2 | undefined,
+): boolean => {
+  if (where === undefined) return true;
+  if (where.channel !== undefined && bundle.channel !== where.channel)
+    return false;
+  if (where.platform !== undefined && bundle.platform !== where.platform)
+    return false;
+  if (where.enabled !== undefined && bundle.enabled !== where.enabled)
+    return false;
+  const id = where.id;
+  if (id?.in !== undefined && !id.in.includes(bundle.id)) return false;
+  if (id?.eq !== undefined && compare(bundle.id, id.eq) !== 0) return false;
+  if (id?.gt !== undefined && compare(bundle.id, id.gt) <= 0) return false;
+  if (id?.gte !== undefined && compare(bundle.id, id.gte) < 0) return false;
+  if (id?.lt !== undefined && compare(bundle.id, id.lt) >= 0) return false;
+  if (id?.lte !== undefined && compare(bundle.id, id.lte) > 0) return false;
+  if (
+    where.targetAppVersionNotNull === true &&
+    bundle.targetAppVersion === null
+  )
+    return false;
+  if (
+    where.targetAppVersion !== undefined &&
+    bundle.targetAppVersion !== where.targetAppVersion
+  )
+    return false;
+  if (
+    where.targetAppVersionIn !== undefined &&
+    !where.targetAppVersionIn.includes(bundle.targetAppVersion ?? "")
+  )
+    return false;
+  if (
+    where.fingerprintHash !== undefined &&
+    bundle.fingerprintHash !== where.fingerprintHash
+  )
+    return false;
+  return true;
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryFilters.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryFilters.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { DatabaseConnectorErrorV2 } from "./errors";
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+
+describe("in-memory database-v2 query filters", () => {
+  it("applies the complete bundle filter vocabulary before pagination", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    const first = createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first, "alpha");
+    first.targetAppVersion = null;
+    first.fingerprintHash = "fingerprint-a";
+    const second = createInMemoryTestBundle(IN_MEMORY_TEST_IDS.second, "beta");
+    second.platform = "android";
+    second.enabled = false;
+    second.targetAppVersion = "2.0.0";
+    const third = createInMemoryTestBundle(IN_MEMORY_TEST_IDS.third, "alpha");
+    third.targetAppVersion = "3.0.0";
+    await givenSession.applyChangeSet(
+      createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000112", [
+        first,
+        second,
+        third,
+      ]),
+    );
+
+    const whenChannel = await givenSession.bundles.page({
+      limit: 10,
+      where: { channel: "alpha" },
+    });
+    const whenPlatform = await givenSession.bundles.page({
+      limit: 10,
+      where: { platform: "android", enabled: false },
+    });
+    const whenIdRange = await givenSession.bundles.page({
+      limit: 10,
+      where: {
+        id: {
+          gt: IN_MEMORY_TEST_IDS.first,
+          gte: IN_MEMORY_TEST_IDS.second,
+          lt: IN_MEMORY_TEST_IDS.fourth,
+          lte: IN_MEMORY_TEST_IDS.third,
+          in: [IN_MEMORY_TEST_IDS.second, IN_MEMORY_TEST_IDS.third],
+        },
+      },
+    });
+    const whenNullable = await givenSession.bundles.page({
+      limit: 10,
+      where: {
+        targetAppVersion: null,
+        fingerprintHash: "fingerprint-a",
+      },
+    });
+    const whenNonNull = await givenSession.bundles.page({
+      limit: 10,
+      where: {
+        targetAppVersionNotNull: true,
+        targetAppVersionIn: ["2.0.0", "3.0.0"],
+      },
+    });
+
+    expect(whenChannel.data.map((row) => row.value.id).toSorted()).toEqual([
+      IN_MEMORY_TEST_IDS.first,
+      IN_MEMORY_TEST_IDS.third,
+    ]);
+    expect(whenPlatform.data.map((row) => row.value.id)).toEqual([
+      IN_MEMORY_TEST_IDS.second,
+    ]);
+    expect(whenIdRange.data.map((row) => row.value.id).toSorted()).toEqual([
+      IN_MEMORY_TEST_IDS.second,
+      IN_MEMORY_TEST_IDS.third,
+    ]);
+    expect(whenNullable.data.map((row) => row.value.id)).toEqual([
+      IN_MEMORY_TEST_IDS.first,
+    ]);
+    expect(whenNonNull.data.map((row) => row.value.id).toSorted()).toEqual([
+      IN_MEMORY_TEST_IDS.second,
+      IN_MEMORY_TEST_IDS.third,
+    ]);
+    expect(await givenSession.bundles.channels()).toEqual(["alpha", "beta"]);
+    await givenConnection.close();
+  });
+
+  it("rejects malformed page shapes with one indistinguishable code", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    const malformedQueries: readonly object[] = [
+      {},
+      { limit: 0 },
+      { limit: 1001 },
+      { limit: 1, cursor: { after: "a", before: "b" } },
+      { limit: 1, orderBy: { field: "createdAt", direction: "asc" } },
+      { limit: 1, where: { platform: "web" } },
+      { limit: 1, extra: true },
+    ];
+
+    const whenErrors = await Promise.all(
+      malformedQueries.map(async (query) => {
+        try {
+          await Reflect.apply(givenSession.bundles.page, givenSession.bundles, [
+            query,
+          ]);
+          return null;
+        } catch (error) {
+          if (error instanceof Error) return error;
+          throw error;
+        }
+      }),
+    );
+
+    expect(
+      whenErrors.every(
+        (error) =>
+          error instanceof DatabaseConnectorErrorV2 &&
+          error.code === "INVALID_CURSOR",
+      ),
+    ).toBe(true);
+    await givenConnection.close();
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryIntrinsicBoundary.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryIntrinsicBoundary.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { BundleChangeSetV2 } from "./bundles";
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+
+const requireMapSetDescriptor = (): PropertyDescriptor => {
+  const descriptor = Object.getOwnPropertyDescriptor(Map.prototype, "set");
+  if (descriptor === undefined) {
+    throw new TypeError("Map.prototype.set descriptor is unavailable");
+  }
+  return descriptor;
+};
+
+const suppressMapWritesDuringInspection = (
+  changeSet: BundleChangeSetV2,
+): BundleChangeSetV2 =>
+  new Proxy(changeSet, {
+    getPrototypeOf: (target) => {
+      Reflect.set(Map.prototype, "set", function suppressMapSet<
+        K,
+        V,
+      >(this: Map<K, V>): Map<K, V> {
+        return this;
+      });
+      return Reflect.getPrototypeOf(target);
+    },
+  });
+
+describe("in-memory database-v2 intrinsic boundary", () => {
+  it("persists and replays when input inspection mutates Map.prototype.set", async () => {
+    // Given a valid change set whose inspection suppresses later live Map writes
+    const connector = createInMemoryDatabaseConnectorV2();
+    const connection = await connector.connect();
+    const session = await connection.openSession(IN_MEMORY_TEST_SCOPE);
+    const changeSet = createInMemoryPutChangeSet(
+      "10000000-0000-4000-8000-000000000130",
+      [createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first)],
+    );
+    const originalMapSet = requireMapSetDescriptor();
+    let firstReceipt;
+
+    // When the proxy mutates the live intrinsic during canonical inspection
+    try {
+      firstReceipt = await session.applyChangeSet(
+        suppressMapWritesDuringInspection(changeSet),
+      );
+    } finally {
+      Object.defineProperty(Map.prototype, "set", originalMapSet);
+    }
+
+    // Then the committed row exists and an identical retry is a replay
+    expect(firstReceipt.outcome).toBe("committed");
+    await expect(
+      session.bundles.get(IN_MEMORY_TEST_IDS.first),
+    ).resolves.toMatchObject({ value: { id: IN_MEMORY_TEST_IDS.first } });
+    await expect(session.applyChangeSet(changeSet)).resolves.toMatchObject({
+      outcome: "replayed",
+    });
+    await connection.close();
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryIsolation.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryIsolation.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+
+describe("in-memory database-v2 value isolation", () => {
+  it("isolates stored rows from caller input and returned value mutation", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    const givenBundle = createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first);
+    const givenChangeSet = createInMemoryPutChangeSet(
+      "10000000-0000-4000-8000-000000000109",
+      [givenBundle],
+    );
+
+    const whenCommitting = givenSession.applyChangeSet(givenChangeSet);
+    givenBundle.channel = "mutated-input";
+    await whenCommitting;
+    const whenRead = await givenSession.bundles.get(IN_MEMORY_TEST_IDS.first);
+    if (whenRead !== null) whenRead.value.channel = "mutated-output";
+
+    const thenReadAgain = await givenSession.bundles.get(
+      IN_MEMORY_TEST_IDS.first,
+    );
+    expect(thenReadAgain?.value.channel).toBe("production");
+    expect(thenReadAgain?.value.metadata?.app_version).toBe("1.0.0");
+    await givenConnection.close();
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryLock.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryLock.ts
@@ -1,0 +1,17 @@
+export class InMemoryCommitLockV2 {
+  private tail: Promise<void> = Promise.resolve();
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    const predecessor = this.tail;
+    let release: () => void = () => undefined;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}

--- a/plugins/plugin-core/src/database-v2/inMemoryPagination.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryPagination.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryDeleteChangeSet,
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  expectInvalidInMemoryCursor,
+  IN_MEMORY_TEST_IDS,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+
+describe("in-memory database-v2 pagination", () => {
+  it("implements exact after and before pagination flags", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    await givenSession.applyChangeSet(
+      createInMemoryPutChangeSet(
+        "10000000-0000-4000-8000-000000000102",
+        Object.values(IN_MEMORY_TEST_IDS).map((id) =>
+          createInMemoryTestBundle(id),
+        ),
+      ),
+    );
+
+    const whenFirst = await givenSession.bundles.page({ limit: 2 });
+    const whenSecond = await givenSession.bundles.page({
+      limit: 2,
+      cursor: { after: whenFirst.pagination.nextCursor ?? "missing" },
+    });
+    const whenBack = await givenSession.bundles.page({
+      limit: 2,
+      cursor: { before: whenSecond.pagination.previousCursor ?? "missing" },
+    });
+
+    expect(whenFirst.data.map((row) => row.value.id)).toEqual([
+      IN_MEMORY_TEST_IDS.fourth,
+      IN_MEMORY_TEST_IDS.third,
+    ]);
+    expect(whenFirst.pagination).toMatchObject({
+      total: 4,
+      hasPreviousPage: false,
+      hasNextPage: true,
+      previousCursor: null,
+    });
+    expect(whenSecond.data.map((row) => row.value.id)).toEqual([
+      IN_MEMORY_TEST_IDS.second,
+      IN_MEMORY_TEST_IDS.first,
+    ]);
+    expect(whenSecond.pagination).toMatchObject({
+      total: 4,
+      hasPreviousPage: true,
+      hasNextPage: false,
+      nextCursor: null,
+    });
+    expect(whenBack.data.map((row) => row.value.id)).toEqual([
+      IN_MEMORY_TEST_IDS.fourth,
+      IN_MEMORY_TEST_IDS.third,
+    ]);
+    await givenConnection.close();
+  });
+
+  it("invalidates a cursor when its anchor is deleted", async () => {
+    const givenConnector = createInMemoryDatabaseConnectorV2();
+    const givenConnection = await givenConnector.connect();
+    const givenSession =
+      await givenConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    await givenSession.applyChangeSet(
+      createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000103", [
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first),
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.second),
+      ]),
+    );
+    const givenPage = await givenSession.bundles.page({
+      limit: 1,
+      orderBy: { field: "id", direction: "asc" },
+    });
+    const givenAnchor = await givenSession.bundles.get(
+      IN_MEMORY_TEST_IDS.first,
+    );
+    await givenSession.applyChangeSet(
+      createInMemoryDeleteChangeSet(
+        "10000000-0000-4000-8000-000000000104",
+        IN_MEMORY_TEST_IDS.first,
+        givenAnchor?.revision ?? "missing",
+      ),
+    );
+
+    const whenUsingDeletedAnchor = () =>
+      givenSession.bundles.page({
+        limit: 1,
+        orderBy: { field: "id", direction: "asc" },
+        cursor: { after: givenPage.pagination.nextCursor ?? "missing" },
+      });
+
+    await expectInvalidInMemoryCursor(whenUsingDeletedAnchor);
+    await givenConnection.close();
+  });
+
+  it("invalidates live-anchor after and before cursors that become empty", async () => {
+    const afterConnector = createInMemoryDatabaseConnectorV2();
+    const afterConnection = await afterConnector.connect();
+    const afterSession =
+      await afterConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    await afterSession.applyChangeSet(
+      createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000105", [
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first),
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.second),
+      ]),
+    );
+    const afterFirst = await afterSession.bundles.page({
+      limit: 1,
+      orderBy: { field: "id", direction: "asc" },
+    });
+    const second = await afterSession.bundles.get(IN_MEMORY_TEST_IDS.second);
+    await afterSession.applyChangeSet(
+      createInMemoryDeleteChangeSet(
+        "10000000-0000-4000-8000-000000000106",
+        IN_MEMORY_TEST_IDS.second,
+        second?.revision ?? "missing",
+      ),
+    );
+    await expectInvalidInMemoryCursor(() =>
+      afterSession.bundles.page({
+        limit: 1,
+        orderBy: { field: "id", direction: "asc" },
+        cursor: { after: afterFirst.pagination.nextCursor ?? "missing" },
+      }),
+    );
+
+    const beforeConnector = createInMemoryDatabaseConnectorV2();
+    const beforeConnection = await beforeConnector.connect();
+    const beforeSession =
+      await beforeConnection.openSession(IN_MEMORY_TEST_SCOPE);
+    await beforeSession.applyChangeSet(
+      createInMemoryPutChangeSet("10000000-0000-4000-8000-000000000107", [
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.first),
+        createInMemoryTestBundle(IN_MEMORY_TEST_IDS.second),
+      ]),
+    );
+    const beforeFirst = await beforeSession.bundles.page({
+      limit: 1,
+      orderBy: { field: "id", direction: "asc" },
+    });
+    const beforeSecond = await beforeSession.bundles.page({
+      limit: 1,
+      orderBy: { field: "id", direction: "asc" },
+      cursor: { after: beforeFirst.pagination.nextCursor ?? "missing" },
+    });
+    const first = await beforeSession.bundles.get(IN_MEMORY_TEST_IDS.first);
+    await beforeSession.applyChangeSet(
+      createInMemoryDeleteChangeSet(
+        "10000000-0000-4000-8000-000000000108",
+        IN_MEMORY_TEST_IDS.first,
+        first?.revision ?? "missing",
+      ),
+    );
+    await expectInvalidInMemoryCursor(() =>
+      beforeSession.bundles.page({
+        limit: 1,
+        orderBy: { field: "id", direction: "asc" },
+        cursor: {
+          before: beforeSecond.pagination.previousCursor ?? "missing",
+        },
+      }),
+    );
+    await Promise.all([afterConnection.close(), beforeConnection.close()]);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryPagination.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryPagination.ts
@@ -1,0 +1,111 @@
+import type { DatabaseBackendScopeV2 } from "./backend";
+import type { BundlePageV2 } from "./bundles";
+import { cloneInMemoryVersionedBundleV2 } from "./inMemoryClone";
+import {
+  InMemoryCursorRegistryV2,
+  throwInvalidInMemoryCursorV2,
+} from "./inMemoryCursor";
+import { bundleMatchesInMemoryWhereV2 } from "./inMemoryFilter";
+import type {
+  InMemoryPageRequestV2,
+  InMemoryStoredBundleV2,
+} from "./inMemoryTypes";
+
+interface InMemoryPaginationInputV2 {
+  readonly scope: DatabaseBackendScopeV2;
+  readonly request: InMemoryPageRequestV2;
+  readonly rows: readonly InMemoryStoredBundleV2[];
+  readonly cursors: InMemoryCursorRegistryV2;
+}
+
+const sortedMatches = (
+  rows: readonly InMemoryStoredBundleV2[],
+  request: InMemoryPageRequestV2,
+): readonly InMemoryStoredBundleV2[] => {
+  const direction = request.query.direction === "asc" ? 1 : -1;
+  return rows
+    .filter((row) =>
+      bundleMatchesInMemoryWhereV2(row.value, request.query.where),
+    )
+    .sort((left, right) =>
+      left.value.id < right.value.id
+        ? -direction
+        : left.value.id > right.value.id
+          ? direction
+          : 0,
+    );
+};
+
+const sliceBounds = (
+  input: InMemoryPaginationInputV2,
+  rows: readonly InMemoryStoredBundleV2[],
+): readonly [number, number] => {
+  if (input.request.cursor === null) {
+    return [0, Math.min(input.request.query.limit, rows.length)];
+  }
+  const cursor = input.cursors.resolve({
+    tenantId: input.scope.tenantId,
+    principalId: input.scope.principalId,
+    queryIdentity: input.request.identity,
+    request: input.request.cursor,
+  });
+  const anchorIndex = rows.findIndex((row) => row.value.id === cursor.anchorId);
+  if (anchorIndex < 0) {
+    return throwInvalidInMemoryCursorV2();
+  }
+  switch (cursor.direction) {
+    case "after": {
+      const start = anchorIndex + 1;
+      const end = Math.min(start + input.request.query.limit, rows.length);
+      if (start === end) return throwInvalidInMemoryCursorV2();
+      return [start, end];
+    }
+    case "before": {
+      const end = anchorIndex;
+      const start = Math.max(0, end - input.request.query.limit);
+      if (start === end) return throwInvalidInMemoryCursorV2();
+      return [start, end];
+    }
+  }
+};
+
+export const paginateInMemoryBundlesV2 = (
+  input: InMemoryPaginationInputV2,
+): BundlePageV2 => {
+  const rows = sortedMatches(input.rows, input.request);
+  const [start, end] = sliceBounds(input, rows);
+  const data = rows.slice(start, end).map(cloneInMemoryVersionedBundleV2);
+  const hasPreviousPage = start > 0;
+  const hasNextPage = end < rows.length;
+  const first = data[0];
+  const last = data.at(-1);
+  const cursorInput = {
+    tenantId: input.scope.tenantId,
+    principalId: input.scope.principalId,
+    queryIdentity: input.request.identity,
+  };
+  return Object.freeze({
+    data: Object.freeze(data),
+    pagination: Object.freeze({
+      total: rows.length,
+      hasNextPage,
+      hasPreviousPage,
+      nextCursor:
+        hasNextPage && last !== undefined
+          ? input.cursors.create({
+              ...cursorInput,
+              direction: "after",
+              anchorId: last.value.id,
+            })
+          : null,
+      previousCursor:
+        hasPreviousPage && first !== undefined
+          ? input.cursors.create({
+              ...cursorInput,
+              direction: "before",
+              anchorId: first.value.id,
+            })
+          : null,
+    }),
+  });
+};

--- a/plugins/plugin-core/src/database-v2/inMemoryQuery.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryQuery.ts
@@ -1,0 +1,210 @@
+import type { BundlePageQueryV2, BundleWhereV2 } from "./bundles";
+import {
+  canonicalizeDatabaseValueV1,
+  snapshotCanonicalDatabaseValueV1,
+} from "./canonicalIdentity";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import type {
+  InMemoryCursorQueryV2,
+  InMemoryCursorRequestV2,
+  InMemoryPageRequestV2,
+} from "./inMemoryTypes";
+
+const WHERE_KEYS = [
+  "channel",
+  "platform",
+  "enabled",
+  "id",
+  "targetAppVersion",
+  "targetAppVersionIn",
+  "targetAppVersionNotNull",
+  "fingerprintHash",
+] as const;
+const ID_KEYS = ["eq", "gt", "gte", "lt", "lte", "in"] as const;
+
+const invalidQuery = (message: string, cause?: unknown): never => {
+  throw new DatabaseConnectorErrorV2(
+    "INVALID_CURSOR",
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const record = (value: unknown, label: string): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    return invalidQuery(`${label} must be an object`);
+  }
+  return value;
+};
+
+const exactKeys = (
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void => {
+  if (Object.keys(value).some((key) => !allowed.includes(key))) {
+    invalidQuery(`${label} has an invalid shape`);
+  }
+};
+
+const optionalString = (value: unknown, label: string): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    return invalidQuery(`${label} must be a string`);
+  }
+  return value;
+};
+
+const stringArray = (value: unknown, label: string): readonly string[] => {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return invalidQuery(`${label} must be a string array`);
+  }
+  return [...value];
+};
+
+const parseIdFilter = (value: unknown): BundleWhereV2["id"] => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const candidate = record(value, "bundle ID filter");
+  exactKeys(candidate, ID_KEYS, "bundle ID filter");
+  const parsed = {
+    eq: optionalString(Reflect.get(candidate, "eq"), "ID eq"),
+    gt: optionalString(Reflect.get(candidate, "gt"), "ID gt"),
+    gte: optionalString(Reflect.get(candidate, "gte"), "ID gte"),
+    lt: optionalString(Reflect.get(candidate, "lt"), "ID lt"),
+    lte: optionalString(Reflect.get(candidate, "lte"), "ID lte"),
+    in:
+      Reflect.get(candidate, "in") === undefined
+        ? undefined
+        : stringArray(Reflect.get(candidate, "in"), "ID in"),
+  };
+  return Object.fromEntries(
+    Object.entries(parsed).filter((entry) => entry[1] !== undefined),
+  );
+};
+
+const parseWhere = (value: unknown): BundleWhereV2 | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const candidate = record(value, "bundle filter");
+  exactKeys(candidate, WHERE_KEYS, "bundle filter");
+  const channel = optionalString(Reflect.get(candidate, "channel"), "channel");
+  const platform = Reflect.get(candidate, "platform");
+  const enabled = Reflect.get(candidate, "enabled");
+  const target = Reflect.get(candidate, "targetAppVersion");
+  const targetNotNull = Reflect.get(candidate, "targetAppVersionNotNull");
+  const fingerprint = Reflect.get(candidate, "fingerprintHash");
+  if (platform !== undefined && platform !== "ios" && platform !== "android") {
+    return invalidQuery("platform must be ios or android");
+  }
+  if (enabled !== undefined && typeof enabled !== "boolean") {
+    return invalidQuery("enabled must be boolean");
+  }
+  if (target !== undefined && target !== null && typeof target !== "string") {
+    return invalidQuery("target app version must be string or null");
+  }
+  if (targetNotNull !== undefined && typeof targetNotNull !== "boolean") {
+    return invalidQuery("target app version non-null flag must be boolean");
+  }
+  if (
+    fingerprint !== undefined &&
+    fingerprint !== null &&
+    typeof fingerprint !== "string"
+  ) {
+    return invalidQuery("fingerprint hash must be string or null");
+  }
+  const parsed = {
+    channel,
+    platform,
+    enabled,
+    id: parseIdFilter(Reflect.get(candidate, "id")),
+    targetAppVersion: target,
+    targetAppVersionIn:
+      Reflect.get(candidate, "targetAppVersionIn") === undefined
+        ? undefined
+        : stringArray(
+            Reflect.get(candidate, "targetAppVersionIn"),
+            "target app version list",
+          ),
+    targetAppVersionNotNull: targetNotNull,
+    fingerprintHash: fingerprint,
+  };
+  const entries = Object.entries(parsed).filter(
+    (entry) => entry[1] !== undefined,
+  );
+  return entries.length === 0 ? undefined : Object.fromEntries(entries);
+};
+
+const parseCursor = (value: unknown): InMemoryCursorRequestV2 | null => {
+  if (value === undefined) {
+    return null;
+  }
+  const candidate = record(value, "cursor");
+  const keys = Object.keys(candidate);
+  if (keys.length !== 1 || (keys[0] !== "after" && keys[0] !== "before")) {
+    return invalidQuery("cursor must select exactly one direction");
+  }
+  const direction = keys[0];
+  const token = Reflect.get(candidate, direction);
+  if (typeof token !== "string" || token.length === 0) {
+    return invalidQuery("cursor token must be a non-empty string");
+  }
+  return { direction, token };
+};
+
+export const parseInMemoryPageQueryV2 = (
+  value: BundlePageQueryV2,
+): InMemoryPageRequestV2 => {
+  let snapshot: BundlePageQueryV2;
+  try {
+    snapshot = snapshotCanonicalDatabaseValueV1(value);
+  } catch (error) {
+    if (error instanceof Error) {
+      return invalidQuery("page query cannot be inspected safely");
+    }
+    return invalidQuery("page query inspection threw a non-error value");
+  }
+  const candidate = record(snapshot, "page query");
+  exactKeys(candidate, ["where", "limit", "cursor", "orderBy"], "page query");
+  const limit = Reflect.get(candidate, "limit");
+  if (
+    !Number.isInteger(limit) ||
+    typeof limit !== "number" ||
+    limit < 1 ||
+    limit > 1000
+  ) {
+    return invalidQuery("page limit must be an integer from 1 through 1000");
+  }
+  const orderValue = Reflect.get(candidate, "orderBy");
+  let direction: InMemoryCursorQueryV2["direction"] = "desc";
+  if (orderValue !== undefined) {
+    const order = record(orderValue, "page order");
+    exactKeys(order, ["field", "direction"], "page order");
+    if (Reflect.get(order, "field") !== "id") {
+      return invalidQuery("page order field must be id");
+    }
+    const parsedDirection = Reflect.get(order, "direction");
+    if (parsedDirection !== "asc" && parsedDirection !== "desc") {
+      return invalidQuery("page order direction is invalid");
+    }
+    direction = parsedDirection;
+  }
+  const where = parseWhere(Reflect.get(candidate, "where"));
+  const query: InMemoryCursorQueryV2 = {
+    ...(where === undefined ? {} : { where }),
+    limit,
+    direction,
+  };
+  return {
+    query,
+    cursor: parseCursor(Reflect.get(candidate, "cursor")),
+    identity: canonicalizeDatabaseValueV1(query),
+  };
+};

--- a/plugins/plugin-core/src/database-v2/inMemorySpecialIds.spec.ts
+++ b/plugins/plugin-core/src/database-v2/inMemorySpecialIds.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";
+import {
+  createInMemoryDeleteChangeSet,
+  createInMemoryPutChangeSet,
+  createInMemoryTestBundle,
+  IN_MEMORY_TEST_SCOPE,
+} from "./inMemoryConnector.testFixtures";
+
+describe("database-v2 special bundle IDs", () => {
+  it("preserves own revision keys through commit, replay, collision, and delete", async () => {
+    // Given bundle IDs that collide with ordinary object prototype names
+    const ids = ["__proto__", "constructor", "prototype"] as const;
+    const connector = createInMemoryDatabaseConnectorV2();
+    const connection = await connector.connect();
+    const session = await connection.openSession(IN_MEMORY_TEST_SCOPE);
+    const put = createInMemoryPutChangeSet(
+      "10000000-0000-4000-8000-000000000301",
+      ids.map((id) => createInMemoryTestBundle(id)),
+    );
+
+    // When values are committed, replayed, collided, and deleted
+    const committed = await session.applyChangeSet(put);
+    const replayed = await session.applyChangeSet(put);
+    const collision = await session.applyChangeSet({
+      ...put,
+      changes: [
+        {
+          type: "put",
+          value: createInMemoryTestBundle("other"),
+          precondition: { state: "absent" },
+        },
+      ],
+    });
+
+    // Then all revision keys are own data properties and collision is atomic
+    expect(committed.outcome).toBe("committed");
+    expect(replayed.outcome).toBe("replayed");
+    if (committed.outcome === "committed") {
+      for (const id of ids) {
+        expect(Object.hasOwn(committed.revisions, id)).toBe(true);
+      }
+    }
+    if (replayed.outcome === "replayed") {
+      for (const id of ids) {
+        expect(Object.hasOwn(replayed.revisions, id)).toBe(true);
+      }
+    }
+    expect(collision).toMatchObject({
+      outcome: "rejected",
+      reason: "conflict",
+    });
+    expect(await session.bundles.get("other")).toBeNull();
+
+    for (const [index, id] of ids.entries()) {
+      const row = await session.bundles.get(id);
+      expect(row).not.toBeNull();
+      if (row !== null) {
+        const deleted = await session.applyChangeSet(
+          createInMemoryDeleteChangeSet(
+            `10000000-0000-4000-8000-00000000031${index}`,
+            id,
+            row.revision,
+          ),
+        );
+        expect(deleted.outcome).toBe("committed");
+        if (deleted.outcome === "committed") {
+          expect(Object.hasOwn(deleted.revisions, id)).toBe(true);
+        }
+      }
+      expect(await session.bundles.get(id)).toBeNull();
+    }
+    await connection.close();
+  });
+});

--- a/plugins/plugin-core/src/database-v2/inMemoryTypes.ts
+++ b/plugins/plugin-core/src/database-v2/inMemoryTypes.ts
@@ -1,0 +1,33 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type { BundleWhereV2 } from "./bundles";
+
+export interface InMemoryStoredBundleV2 {
+  readonly value: Bundle;
+  readonly revision: string;
+}
+
+export interface InMemoryCursorQueryV2 {
+  readonly where?: BundleWhereV2;
+  readonly limit: number;
+  readonly direction: "asc" | "desc";
+}
+
+export interface InMemoryCursorRequestV2 {
+  readonly direction: "after" | "before";
+  readonly token: string;
+}
+
+export interface InMemoryPageRequestV2 {
+  readonly query: InMemoryCursorQueryV2;
+  readonly cursor: InMemoryCursorRequestV2 | null;
+  readonly identity: string;
+}
+
+export interface InMemoryCursorRecordV2 {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly queryIdentity: string;
+  readonly direction: "after" | "before";
+  readonly anchorId: string;
+}

--- a/plugins/plugin-core/src/database-v2/index.ts
+++ b/plugins/plugin-core/src/database-v2/index.ts
@@ -1,0 +1,37 @@
+export type {
+  BundleChangeSetV2,
+  BundleChangeV2,
+  BundlePageQueryV2,
+  BundlePageV2,
+  BundleRepositoryV2,
+  BundleWhereV2,
+} from "./bundles";
+export type {
+  AssertedDatabaseScope,
+  MaybePromise,
+  Sha256Digest,
+  Versioned,
+} from "./common";
+export { canonicalizeDatabaseValueV1 } from "./canonicalIdentity";
+export {
+  hashDatabaseChangeSetPayloadV1,
+  hashDatabaseManifestTupleV1,
+  hashDatabaseScopeV1,
+} from "./databaseIdentity";
+export type {
+  DatabaseConnectionV2,
+  DatabaseConnectorV2,
+  DatabaseSessionV2,
+} from "./connector";
+export {
+  DatabaseConnectorErrorV2,
+  type DatabaseConnectorErrorCodeV2,
+} from "./errors";
+export type {
+  DatabaseConnectorManifestV2,
+  DatabaseManifestTupleV2,
+  InMemoryDatabaseConnectorV2Options,
+} from "./manifest";
+export { IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2 } from "./referenceManifest";
+export type { CommitReceiptV2, ReceiptIdentityV2 } from "./receipts";
+export { createInMemoryDatabaseConnectorV2 } from "./inMemoryConnector";

--- a/plugins/plugin-core/src/database-v2/manifest.ts
+++ b/plugins/plugin-core/src/database-v2/manifest.ts
@@ -1,0 +1,74 @@
+import type { Sha256Digest } from "./common";
+
+export interface DatabaseConnectorManifestV2 {
+  readonly kind: "hot-updater.database-connector";
+  readonly apiVersion: 2;
+  readonly supportTier: "experimental-reference" | "preview" | "certified";
+  readonly connector: { readonly name: string; readonly version: string };
+  readonly adapter: {
+    readonly family: "kysely" | "drizzle" | "prisma" | "native";
+    readonly version: string;
+  };
+  readonly driver: { readonly name: string; readonly version: string };
+  readonly target: {
+    readonly product:
+      | "memory"
+      | "postgresql"
+      | "mysql"
+      | "sqlite"
+      | "d1"
+      | "firestore"
+      | "mongodb"
+      | "s3-object";
+    readonly transport: string;
+  };
+  readonly runtime: {
+    readonly family:
+      | "javascript"
+      | "node"
+      | "bun"
+      | "deno"
+      | "workerd"
+      | "react-native";
+    readonly version: string;
+    readonly constraints: readonly string[];
+  };
+  readonly certification: {
+    readonly tier: "reference" | "certified";
+    readonly id: string;
+    readonly tupleDigest: string;
+  };
+  readonly schema: { readonly readable: string; readonly writable: string };
+  readonly capabilities: {
+    readonly commit: {
+      readonly guarantee: "atomic" | "idempotent-best-effort" | "unsupported";
+      readonly primitive:
+        | "transaction"
+        | "batch"
+        | "single-statement"
+        | "document-transaction"
+        | "memory-atomic";
+      readonly interactiveTransaction: boolean;
+    };
+    readonly cursor: "opaque-keyset" | "offset" | "none";
+    readonly events: "idempotent-append" | "none";
+    readonly management: "separate" | "none";
+  };
+  readonly lifecycle: {
+    readonly clientOwnership: "owned" | "borrowed" | "internal";
+  };
+}
+
+export type DatabaseManifestTupleV2 = Omit<
+  DatabaseConnectorManifestV2,
+  "certification"
+> & {
+  readonly certification: Omit<
+    DatabaseConnectorManifestV2["certification"],
+    "tupleDigest"
+  >;
+};
+
+export interface InMemoryDatabaseConnectorV2Options {
+  readonly sha256?: Sha256Digest;
+}

--- a/plugins/plugin-core/src/database-v2/manifestBoundary.spec.ts
+++ b/plugins/plugin-core/src/database-v2/manifestBoundary.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DatabaseConnectorErrorV2,
+  hashDatabaseManifestTupleV1,
+  hashDatabaseScopeV1,
+  IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2,
+} from "./index";
+import type { DatabaseManifestTupleV2 } from "./manifest";
+
+const createValidTuple = (): DatabaseManifestTupleV2 => ({
+  ...IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2,
+  certification: {
+    tier: IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2.certification.tier,
+    id: IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2.certification.id,
+  },
+  runtime: {
+    ...IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2.runtime,
+    constraints: [
+      ...IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2.runtime.constraints,
+    ],
+  },
+});
+
+type ValidFutureTupleCase = {
+  readonly label: string;
+  readonly mutate: (tuple: DatabaseManifestTupleV2) => void;
+};
+
+const validFutureTupleCases: readonly ValidFutureTupleCase[] = [
+  {
+    label: "Kysely PostgreSQL on Node",
+    mutate: (tuple) => {
+      Reflect.set(tuple, "supportTier", "certified");
+      Reflect.set(tuple.adapter, "family", "kysely");
+      Reflect.set(tuple.target, "product", "postgresql");
+      Reflect.set(tuple.target, "transport", "tcp");
+      Reflect.set(tuple.runtime, "family", "node");
+      Reflect.set(tuple.runtime, "version", "24");
+      Reflect.set(tuple.runtime, "constraints", []);
+      Reflect.set(tuple.certification, "tier", "certified");
+      Reflect.set(tuple.capabilities.commit, "primitive", "transaction");
+      Reflect.set(tuple.capabilities, "cursor", "offset");
+      Reflect.set(tuple.capabilities, "events", "idempotent-append");
+      Reflect.set(tuple.capabilities, "management", "separate");
+      Reflect.set(tuple.lifecycle, "clientOwnership", "borrowed");
+    },
+  },
+  {
+    label: "Prisma D1 on workerd",
+    mutate: (tuple) => {
+      Reflect.set(tuple, "supportTier", "preview");
+      Reflect.set(tuple.adapter, "family", "prisma");
+      Reflect.set(tuple.target, "product", "d1");
+      Reflect.set(tuple.target, "transport", "binding");
+      Reflect.set(tuple.runtime, "family", "workerd");
+      Reflect.set(tuple.runtime, "version", "2026-07");
+      Reflect.set(tuple.runtime, "constraints", ["edge", "isolated"]);
+      Reflect.set(tuple.capabilities.commit, "guarantee", "unsupported");
+      Reflect.set(tuple.capabilities.commit, "primitive", "batch");
+      Reflect.set(tuple.capabilities, "cursor", "none");
+      Reflect.set(tuple.lifecycle, "clientOwnership", "owned");
+    },
+  },
+];
+
+const hashUnknownTuple = (tuple: unknown) =>
+  Reflect.apply(hashDatabaseManifestTupleV1, undefined, [tuple]);
+
+describe("DatabaseManifestTupleV2 canonical boundary", () => {
+  it("keeps the public scope digest exact when Number.prototype.toString is hostile", async () => {
+    // Given a public consumer provider that installs a hostile formatter
+    const originalToString = Number.prototype.toString;
+    let hookCalls = 0;
+
+    // When provider-time mutation precedes public-boundary formatting
+    let digest: string;
+    try {
+      digest = await hashDatabaseScopeV1(
+        {
+          principalId: "public-principal",
+          tenantId: "public-tenant",
+        },
+        async () => {
+          Object.defineProperty(Number.prototype, "toString", {
+            configurable: true,
+            writable: true,
+            value: function (radix?: number) {
+              if (radix === 16) {
+                hookCalls += 1;
+                return "number-hook";
+              }
+              return Reflect.apply(originalToString, this, [radix]);
+            },
+          });
+          return new Uint8Array(32);
+        },
+      );
+    } finally {
+      Object.defineProperty(Number.prototype, "toString", {
+        configurable: true,
+        writable: true,
+        value: originalToString,
+      });
+    }
+
+    // Then the public contract remains one exact lowercase SHA-256 digest
+    expect(digest).toBe(`sha256:${"00".repeat(32)}`);
+    expect(hookCalls).toBe(0);
+  });
+
+  it("keeps the public scope digest exact when String.prototype.padStart is hostile", async () => {
+    // Given a public consumer provider that installs a hostile formatter
+    const originalPadStart = String.prototype.padStart;
+    let hookCalls = 0;
+
+    // When provider-time mutation precedes public-boundary formatting
+    let digest: string;
+    try {
+      digest = await hashDatabaseScopeV1(
+        {
+          principalId: "public-principal",
+          tenantId: "public-tenant",
+        },
+        async () => {
+          Object.defineProperty(String.prototype, "padStart", {
+            configurable: true,
+            writable: true,
+            value: function (length: number, fill?: string) {
+              if (length === 2 && fill === "0") {
+                hookCalls += 1;
+                return "pad-hook";
+              }
+              return Reflect.apply(originalPadStart, this, [length, fill]);
+            },
+          });
+          return new Uint8Array(32);
+        },
+      );
+    } finally {
+      Object.defineProperty(String.prototype, "padStart", {
+        configurable: true,
+        writable: true,
+        value: originalPadStart,
+      });
+    }
+
+    // Then the public contract remains one exact lowercase SHA-256 digest
+    expect(digest).toBe(`sha256:${"00".repeat(32)}`);
+    expect(hookCalls).toBe(0);
+  });
+
+  it.each(validFutureTupleCases)(
+    "accepts valid future literal tuple $label without inferring combinations",
+    async ({ mutate }) => {
+      // Given a future tuple composed only from frozen public literal domains
+      const tuple = createValidTuple();
+      mutate(tuple);
+
+      // When it is hashed with a deterministic injected provider
+      const digest = await hashDatabaseManifestTupleV1(tuple, () =>
+        new Uint8Array(32).fill(0xab),
+      );
+
+      // Then validation accepts the grammar without certifying the combination
+      expect(digest).toBe(`sha256:${"ab".repeat(32)}`);
+    },
+  );
+
+  it.each([
+    {
+      label: "symbol key",
+      create: () => ({ ...createValidTuple(), [Symbol("hidden")]: true }),
+    },
+    {
+      label: "inherited prototype",
+      create: () => Object.create(createValidTuple()),
+    },
+    {
+      label: "accessor property",
+      create: () =>
+        Object.defineProperty(createValidTuple(), "kind", {
+          enumerable: true,
+          get: () => "hot-updater.database-connector",
+        }),
+    },
+  ])("preserves canonicalization errors for a $label", ({ create }) => {
+    // Given a structurally unsafe value rejected by canonical snapshotting
+    const tuple = create();
+
+    // When and Then the canonical boundary remains distinct from domain errors
+    expect(() => hashUnknownTuple(tuple)).toThrowError(
+      expect.objectContaining({
+        name: "DatabaseConnectorErrorV2",
+        code: "CANONICALIZATION_FAILED",
+      }),
+    );
+  });
+
+  it("preserves the cause of hostile descriptor inspection", () => {
+    // Given descriptor inspection that throws an attacker-controlled marker
+    const marker = new RangeError("manifest descriptor marker");
+    const tuple = new Proxy(createValidTuple(), {
+      getOwnPropertyDescriptor: () => {
+        throw marker;
+      },
+    });
+
+    // When the public boundary snapshots the tuple
+    const result = () => hashUnknownTuple(tuple);
+
+    // Then the canonical error remains synchronous and carries the cause
+    expect(result).toThrowError(DatabaseConnectorErrorV2);
+    expect(result).toThrowError(
+      expect.objectContaining({
+        code: "CANONICALIZATION_FAILED",
+        cause: marker,
+      }),
+    );
+  });
+});

--- a/plugins/plugin-core/src/database-v2/manifestGrammar.ts
+++ b/plugins/plugin-core/src/database-v2/manifestGrammar.ts
@@ -1,0 +1,46 @@
+export const SUPPORT_TIERS = [
+  "experimental-reference",
+  "preview",
+  "certified",
+] as const;
+export const ADAPTER_FAMILIES = [
+  "kysely",
+  "drizzle",
+  "prisma",
+  "native",
+] as const;
+export const TARGET_PRODUCTS = [
+  "memory",
+  "postgresql",
+  "mysql",
+  "sqlite",
+  "d1",
+  "firestore",
+  "mongodb",
+  "s3-object",
+] as const;
+export const RUNTIME_FAMILIES = [
+  "javascript",
+  "node",
+  "bun",
+  "deno",
+  "workerd",
+  "react-native",
+] as const;
+export const CERTIFICATION_TIERS = ["reference", "certified"] as const;
+export const COMMIT_GUARANTEES = [
+  "atomic",
+  "idempotent-best-effort",
+  "unsupported",
+] as const;
+export const COMMIT_PRIMITIVES = [
+  "transaction",
+  "batch",
+  "single-statement",
+  "document-transaction",
+  "memory-atomic",
+] as const;
+export const CURSOR_CAPABILITIES = ["opaque-keyset", "offset", "none"] as const;
+export const EVENT_CAPABILITIES = ["idempotent-append", "none"] as const;
+export const MANAGEMENT_CAPABILITIES = ["separate", "none"] as const;
+export const CLIENT_OWNERSHIP = ["owned", "borrowed", "internal"] as const;

--- a/plugins/plugin-core/src/database-v2/manifestValidation.spec.ts
+++ b/plugins/plugin-core/src/database-v2/manifestValidation.spec.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+
+import { hashDatabaseManifestTupleV1 } from "./index";
+import type { DatabaseManifestTupleV2 } from "./manifest";
+
+const createValidTuple = (): DatabaseManifestTupleV2 => ({
+  kind: "hot-updater.database-connector",
+  apiVersion: 2,
+  supportTier: "experimental-reference",
+  connector: { name: "hot-updater-memory-reference", version: "1" },
+  adapter: { family: "native", version: "1" },
+  driver: { name: "memory", version: "1" },
+  target: { product: "memory", transport: "process-local" },
+  runtime: {
+    family: "javascript",
+    version: "es2022",
+    constraints: ["sha256-required", "non-durable", "process-local"],
+  },
+  certification: {
+    tier: "reference",
+    id: "hot-updater.database.memory.reference-v1",
+  },
+  schema: {
+    readable: "reference-memory-v1",
+    writable: "reference-memory-v1",
+  },
+  capabilities: {
+    commit: {
+      guarantee: "atomic",
+      primitive: "memory-atomic",
+      interactiveTransaction: false,
+    },
+    cursor: "opaque-keyset",
+    events: "none",
+    management: "none",
+  },
+  lifecycle: { clientOwnership: "internal" },
+});
+
+type MalformedTupleCase = {
+  readonly label: string;
+  readonly mutate: (tuple: DatabaseManifestTupleV2) => void;
+};
+
+const malformedTupleCases: readonly MalformedTupleCase[] = [
+  {
+    label: "wrong kind",
+    mutate: (tuple) => void Reflect.set(tuple, "kind", "database"),
+  },
+  {
+    label: "wrong API version",
+    mutate: (tuple) => void Reflect.set(tuple, "apiVersion", 3),
+  },
+  {
+    label: "unknown support tier",
+    mutate: (tuple) => void Reflect.set(tuple, "supportTier", "stable"),
+  },
+  {
+    label: "empty connector name",
+    mutate: (tuple) => void Reflect.set(tuple.connector, "name", " "),
+  },
+  {
+    label: "non-string connector version",
+    mutate: (tuple) => void Reflect.set(tuple.connector, "version", 1),
+  },
+  {
+    label: "unknown adapter family",
+    mutate: (tuple) => void Reflect.set(tuple.adapter, "family", "orm"),
+  },
+  {
+    label: "empty driver name",
+    mutate: (tuple) => void Reflect.set(tuple.driver, "name", ""),
+  },
+  {
+    label: "unknown target product",
+    mutate: (tuple) => void Reflect.set(tuple.target, "product", "oracle"),
+  },
+  {
+    label: "empty transport",
+    mutate: (tuple) => void Reflect.set(tuple.target, "transport", ""),
+  },
+  {
+    label: "unknown runtime family",
+    mutate: (tuple) => void Reflect.set(tuple.runtime, "family", "browser"),
+  },
+  {
+    label: "non-array constraints",
+    mutate: (tuple) => void Reflect.set(tuple.runtime, "constraints", "local"),
+  },
+  {
+    label: "empty constraint",
+    mutate: (tuple) => void Reflect.set(tuple.runtime, "constraints", [""]),
+  },
+  {
+    label: "duplicate constraint",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.runtime, "constraints", ["local", "local"]),
+  },
+  {
+    label: "unknown certification tier",
+    mutate: (tuple) => void Reflect.set(tuple.certification, "tier", "preview"),
+  },
+  {
+    label: "empty certification ID",
+    mutate: (tuple) => void Reflect.set(tuple.certification, "id", ""),
+  },
+  {
+    label: "tuple digest present",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.certification, "tupleDigest", "sha256:00"),
+  },
+  {
+    label: "empty readable schema",
+    mutate: (tuple) => void Reflect.set(tuple.schema, "readable", " "),
+  },
+  {
+    label: "unknown commit guarantee",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.capabilities.commit, "guarantee", "eventual"),
+  },
+  {
+    label: "unknown commit primitive",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.capabilities.commit, "primitive", "lock"),
+  },
+  {
+    label: "non-boolean interactive flag",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.capabilities.commit, "interactiveTransaction", 0),
+  },
+  {
+    label: "unknown cursor capability",
+    mutate: (tuple) => void Reflect.set(tuple.capabilities, "cursor", "keyset"),
+  },
+  {
+    label: "unknown events capability",
+    mutate: (tuple) => void Reflect.set(tuple.capabilities, "events", "append"),
+  },
+  {
+    label: "unknown management capability",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.capabilities, "management", "inline"),
+  },
+  {
+    label: "unknown client ownership",
+    mutate: (tuple) =>
+      void Reflect.set(tuple.lifecycle, "clientOwnership", "shared"),
+  },
+  {
+    label: "missing root key",
+    mutate: (tuple) => void Reflect.deleteProperty(tuple, "connector"),
+  },
+  {
+    label: "missing nested key",
+    mutate: (tuple) =>
+      void Reflect.deleteProperty(tuple.capabilities.commit, "primitive"),
+  },
+  {
+    label: "extra root key",
+    mutate: (tuple) => void Reflect.set(tuple, "provider", "memory"),
+  },
+  {
+    label: "extra nested key",
+    mutate: (tuple) => void Reflect.set(tuple.runtime, "durable", false),
+  },
+];
+
+const hashUnknownTuple = (tuple: unknown, digest: () => Uint8Array) =>
+  Reflect.apply(hashDatabaseManifestTupleV1, undefined, [tuple, digest]);
+
+describe("DatabaseManifestTupleV2 validation", () => {
+  it.each(malformedTupleCases)(
+    "rejects $label before invoking the digest provider",
+    ({ mutate }) => {
+      // Given one detached but domain-invalid manifest tuple
+      const tuple = createValidTuple();
+      mutate(tuple);
+      let digestCalls = 0;
+
+      // When the tuple crosses the public manifest identity boundary
+      const hashTuple = () =>
+        hashUnknownTuple(tuple, () => {
+          digestCalls += 1;
+          return new Uint8Array(32);
+        });
+
+      // Then a stable typed manifest error wins before hashing
+      expect(hashTuple).toThrowError(
+        expect.objectContaining({
+          name: "DatabaseConnectorErrorV2",
+          code: "INVALID_MANIFEST",
+        }),
+      );
+      expect(digestCalls).toBe(0);
+    },
+  );
+});

--- a/plugins/plugin-core/src/database-v2/manifestValidation.ts
+++ b/plugins/plugin-core/src/database-v2/manifestValidation.ts
@@ -1,0 +1,211 @@
+import {
+  addSetValueV2,
+  createSetV2,
+  hasSetValueV2,
+} from "./collectionIntrinsics";
+import type { DatabaseManifestTupleV2 } from "./manifest";
+import {
+  ADAPTER_FAMILIES,
+  CERTIFICATION_TIERS,
+  CLIENT_OWNERSHIP,
+  COMMIT_GUARANTEES,
+  COMMIT_PRIMITIVES,
+  CURSOR_CAPABILITIES,
+  EVENT_CAPABILITIES,
+  MANAGEMENT_CAPABILITIES,
+  RUNTIME_FAMILIES,
+  SUPPORT_TIERS,
+  TARGET_PRODUCTS,
+} from "./manifestGrammar";
+import {
+  failManifest,
+  parseExactRecord,
+  parseLiteral,
+  parseNonEmptyString,
+} from "./manifestValidationPrimitives";
+
+const parseNamedVersion = (value: unknown, label: string) => {
+  const record = parseExactRecord(value, ["name", "version"], label);
+  return {
+    name: parseNonEmptyString(record["name"], `${label}.name`),
+    version: parseNonEmptyString(record["version"], `${label}.version`),
+  };
+};
+
+const parseConstraints = (value: unknown): readonly string[] => {
+  if (!Array.isArray(value)) {
+    return failManifest("runtime.constraints");
+  }
+  const constraints: string[] = [];
+  const seen = createSetV2<string>();
+  for (const candidate of value) {
+    const constraint = parseNonEmptyString(
+      candidate,
+      "runtime.constraints item",
+    );
+    if (hasSetValueV2(seen, constraint)) {
+      return failManifest("runtime.constraints duplicates");
+    }
+    addSetValueV2(seen, constraint);
+    constraints.push(constraint);
+  }
+  constraints.sort();
+  return constraints;
+};
+
+export const parseDatabaseManifestTupleV2 = (
+  value: unknown,
+): DatabaseManifestTupleV2 => {
+  const root = parseExactRecord(
+    value,
+    [
+      "kind",
+      "apiVersion",
+      "supportTier",
+      "connector",
+      "adapter",
+      "driver",
+      "target",
+      "runtime",
+      "certification",
+      "schema",
+      "capabilities",
+      "lifecycle",
+    ],
+    "tuple",
+  );
+  if (
+    root["kind"] !== "hot-updater.database-connector" ||
+    root["apiVersion"] !== 2
+  ) {
+    return failManifest("identity");
+  }
+  const adapter = parseExactRecord(
+    root["adapter"],
+    ["family", "version"],
+    "adapter",
+  );
+  const target = parseExactRecord(
+    root["target"],
+    ["product", "transport"],
+    "target",
+  );
+  const runtime = parseExactRecord(
+    root["runtime"],
+    ["family", "version", "constraints"],
+    "runtime",
+  );
+  const certification = parseExactRecord(
+    root["certification"],
+    ["tier", "id"],
+    "certification",
+  );
+  const schema = parseExactRecord(
+    root["schema"],
+    ["readable", "writable"],
+    "schema",
+  );
+  const capabilities = parseExactRecord(
+    root["capabilities"],
+    ["commit", "cursor", "events", "management"],
+    "capabilities",
+  );
+  const commit = parseExactRecord(
+    capabilities["commit"],
+    ["guarantee", "primitive", "interactiveTransaction"],
+    "capabilities.commit",
+  );
+  const lifecycle = parseExactRecord(
+    root["lifecycle"],
+    ["clientOwnership"],
+    "lifecycle",
+  );
+  if (typeof commit["interactiveTransaction"] !== "boolean") {
+    return failManifest("capabilities.commit.interactiveTransaction");
+  }
+  return {
+    kind: "hot-updater.database-connector",
+    apiVersion: 2,
+    supportTier: parseLiteral(
+      root["supportTier"],
+      SUPPORT_TIERS,
+      "supportTier",
+    ),
+    connector: parseNamedVersion(root["connector"], "connector"),
+    adapter: {
+      family: parseLiteral(
+        adapter["family"],
+        ADAPTER_FAMILIES,
+        "adapter.family",
+      ),
+      version: parseNonEmptyString(adapter["version"], "adapter.version"),
+    },
+    driver: parseNamedVersion(root["driver"], "driver"),
+    target: {
+      product: parseLiteral(
+        target["product"],
+        TARGET_PRODUCTS,
+        "target.product",
+      ),
+      transport: parseNonEmptyString(target["transport"], "target.transport"),
+    },
+    runtime: {
+      family: parseLiteral(
+        runtime["family"],
+        RUNTIME_FAMILIES,
+        "runtime.family",
+      ),
+      version: parseNonEmptyString(runtime["version"], "runtime.version"),
+      constraints: parseConstraints(runtime["constraints"]),
+    },
+    certification: {
+      tier: parseLiteral(
+        certification["tier"],
+        CERTIFICATION_TIERS,
+        "certification.tier",
+      ),
+      id: parseNonEmptyString(certification["id"], "certification.id"),
+    },
+    schema: {
+      readable: parseNonEmptyString(schema["readable"], "schema.readable"),
+      writable: parseNonEmptyString(schema["writable"], "schema.writable"),
+    },
+    capabilities: {
+      commit: {
+        guarantee: parseLiteral(
+          commit["guarantee"],
+          COMMIT_GUARANTEES,
+          "capabilities.commit.guarantee",
+        ),
+        primitive: parseLiteral(
+          commit["primitive"],
+          COMMIT_PRIMITIVES,
+          "capabilities.commit.primitive",
+        ),
+        interactiveTransaction: commit["interactiveTransaction"],
+      },
+      cursor: parseLiteral(
+        capabilities["cursor"],
+        CURSOR_CAPABILITIES,
+        "capabilities.cursor",
+      ),
+      events: parseLiteral(
+        capabilities["events"],
+        EVENT_CAPABILITIES,
+        "capabilities.events",
+      ),
+      management: parseLiteral(
+        capabilities["management"],
+        MANAGEMENT_CAPABILITIES,
+        "capabilities.management",
+      ),
+    },
+    lifecycle: {
+      clientOwnership: parseLiteral(
+        lifecycle["clientOwnership"],
+        CLIENT_OWNERSHIP,
+        "lifecycle.clientOwnership",
+      ),
+    },
+  };
+};

--- a/plugins/plugin-core/src/database-v2/manifestValidationPrimitives.ts
+++ b/plugins/plugin-core/src/database-v2/manifestValidationPrimitives.ts
@@ -1,0 +1,57 @@
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+type ManifestRecord = Readonly<Record<string, unknown>>;
+
+const isManifestRecord = (value: unknown): value is ManifestRecord =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype;
+
+export const failManifest = (label: string): never => {
+  throw new DatabaseConnectorErrorV2(
+    "INVALID_MANIFEST",
+    `manifest ${label} is invalid`,
+  );
+};
+
+export const parseExactRecord = (
+  value: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): ManifestRecord => {
+  if (!isManifestRecord(value)) {
+    return failManifest(label);
+  }
+  const keys = Object.keys(value);
+  if (
+    keys.length !== expectedKeys.length ||
+    expectedKeys.some((key) => !Object.hasOwn(value, key))
+  ) {
+    return failManifest(label);
+  }
+  return value;
+};
+
+export const parseNonEmptyString = (value: unknown, label: string): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return failManifest(label);
+  }
+  return value;
+};
+
+const isAllowedLiteral = <T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): value is T => allowed.some((candidate) => candidate === value);
+
+export const parseLiteral = <T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  label: string,
+): T => {
+  if (!isAllowedLiteral(value, allowed)) {
+    return failManifest(label);
+  }
+  return value;
+};

--- a/plugins/plugin-core/src/database-v2/receiptValidation.ts
+++ b/plugins/plugin-core/src/database-v2/receiptValidation.ts
@@ -1,0 +1,172 @@
+import type { BundleChangeSetV2, BundleChangeV2 } from "./bundles";
+import { snapshotCanonicalDatabaseValueV1 } from "./canonicalIdentity";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import type { CommitReceiptV2 } from "./receipts";
+
+interface ExpectedReceiptIdentityV2 {
+  readonly changeSetId: string;
+  readonly scopeId: string;
+  readonly canonicalPayloadHash: string;
+}
+
+const COMMON_KEYS = [
+  "changeSetId",
+  "scopeId",
+  "canonicalPayloadHash",
+  "outcome",
+] as const;
+
+const bundleIdOf = (change: BundleChangeV2): string => {
+  switch (change.type) {
+    case "put":
+      return change.value.id;
+    case "delete":
+      return change.id;
+  }
+};
+
+const protocolViolation = (message: string, cause?: unknown): never => {
+  throw new DatabaseConnectorErrorV2(
+    "CONNECTOR_PROTOCOL_VIOLATION",
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireRecord = (
+  value: unknown,
+  label: string,
+): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    return protocolViolation(`${label} must be an object`);
+  }
+  return value;
+};
+
+const requireExactKeys = (
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void => {
+  const actualKeys = Object.keys(value);
+  if (
+    actualKeys.length !== keys.length ||
+    actualKeys.some((key) => !keys.includes(key))
+  ) {
+    protocolViolation(`${label} has an invalid shape`);
+  }
+};
+
+const requireRevision = (value: unknown): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return protocolViolation(
+      "commit receipt revisions must be non-empty strings",
+    );
+  }
+  return value;
+};
+
+const validateIdentity = (
+  receipt: Record<string, unknown>,
+  expected: ExpectedReceiptIdentityV2,
+): void => {
+  if (
+    Reflect.get(receipt, "changeSetId") !== expected.changeSetId ||
+    Reflect.get(receipt, "scopeId") !== expected.scopeId ||
+    Reflect.get(receipt, "canonicalPayloadHash") !==
+      expected.canonicalPayloadHash
+  ) {
+    protocolViolation("commit receipt identity does not match the request");
+  }
+};
+
+const parseRevisions = (
+  value: unknown,
+  changeSet: BundleChangeSetV2,
+): Readonly<Record<string, string>> => {
+  const revisions = requireRecord(value, "commit receipt revisions");
+  const expectedIds = changeSet.changes.map(bundleIdOf).sort();
+  const revisionIds = Object.keys(revisions).sort();
+  if (
+    expectedIds.length !== revisionIds.length ||
+    expectedIds.some((id, index) => id !== revisionIds[index])
+  ) {
+    protocolViolation(
+      "commit receipt revision keys do not match the change set",
+    );
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      expectedIds.map((id) => [
+        id,
+        requireRevision(Reflect.get(revisions, id)),
+      ]),
+    ),
+  );
+};
+
+export const validateCommitReceiptV2 = (
+  receipt: unknown,
+  expected: ExpectedReceiptIdentityV2,
+  changeSet: BundleChangeSetV2,
+): CommitReceiptV2 => {
+  let snapshot: unknown;
+  try {
+    snapshot = snapshotCanonicalDatabaseValueV1(receipt);
+  } catch (error) {
+    if (error instanceof Error) {
+      return protocolViolation("commit receipt cannot be inspected safely");
+    }
+    return protocolViolation(
+      "commit receipt inspection threw a non-error value",
+    );
+  }
+  const candidate = requireRecord(snapshot, "commit receipt");
+  validateIdentity(candidate, expected);
+  const outcome = Reflect.get(candidate, "outcome");
+  if (outcome === "committed" || outcome === "replayed") {
+    requireExactKeys(
+      candidate,
+      [...COMMON_KEYS, "revisions"],
+      `${outcome} receipt`,
+    );
+    return Object.freeze({
+      ...expected,
+      outcome,
+      revisions: parseRevisions(Reflect.get(candidate, "revisions"), changeSet),
+    });
+  }
+  if (outcome === "rejected") {
+    requireExactKeys(candidate, [...COMMON_KEYS, "reason"], "rejected receipt");
+    const reason = Reflect.get(candidate, "reason");
+    if (reason !== "conflict" && reason !== "unsupported") {
+      return protocolViolation("rejected receipt has an invalid reason");
+    }
+    return Object.freeze({ ...expected, outcome, reason });
+  }
+  if (outcome === "unknown") {
+    requireExactKeys(
+      candidate,
+      [...COMMON_KEYS, "reason", "sessionState", "retry"],
+      "unknown receipt",
+    );
+    if (
+      Reflect.get(candidate, "reason") !== "transport-unknown" ||
+      Reflect.get(candidate, "sessionState") !== "poisoned" ||
+      Reflect.get(candidate, "retry") !== "identical-scope-id-and-payload-only"
+    ) {
+      return protocolViolation("unknown receipt has invalid recovery fields");
+    }
+    return Object.freeze({
+      ...expected,
+      outcome,
+      reason: "transport-unknown",
+      sessionState: "poisoned",
+      retry: "identical-scope-id-and-payload-only",
+    });
+  }
+  return protocolViolation("commit receipt has an invalid outcome");
+};

--- a/plugins/plugin-core/src/database-v2/receipts.ts
+++ b/plugins/plugin-core/src/database-v2/receipts.ts
@@ -1,0 +1,21 @@
+export interface ReceiptIdentityV2 {
+  readonly changeSetId: string;
+  readonly scopeId: string;
+  readonly canonicalPayloadHash: string;
+}
+
+export type CommitReceiptV2 =
+  | (ReceiptIdentityV2 & {
+      readonly outcome: "committed" | "replayed";
+      readonly revisions: Readonly<Record<string, string>>;
+    })
+  | (ReceiptIdentityV2 & {
+      readonly outcome: "rejected";
+      readonly reason: "conflict" | "unsupported";
+    })
+  | (ReceiptIdentityV2 & {
+      readonly outcome: "unknown";
+      readonly reason: "transport-unknown";
+      readonly sessionState: "poisoned";
+      readonly retry: "identical-scope-id-and-payload-only";
+    });

--- a/plugins/plugin-core/src/database-v2/referenceManifest.spec.ts
+++ b/plugins/plugin-core/src/database-v2/referenceManifest.spec.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DatabaseConnectorErrorV2,
+  hashDatabaseManifestTupleV1,
+  IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2,
+} from "./index";
+import type { DatabaseManifestTupleV2 } from "./manifest";
+
+const referenceTupleWithReorderedConstraints = {
+  kind: "hot-updater.database-connector",
+  apiVersion: 2,
+  supportTier: "experimental-reference",
+  connector: { name: "hot-updater-memory-reference", version: "1" },
+  adapter: { family: "native", version: "1" },
+  driver: { name: "memory", version: "1" },
+  target: { product: "memory", transport: "process-local" },
+  runtime: {
+    family: "javascript",
+    version: "es2022",
+    constraints: ["sha256-required", "non-durable", "process-local"],
+  },
+  certification: {
+    tier: "reference",
+    id: "hot-updater.database.memory.reference-v1",
+  },
+  schema: {
+    readable: "reference-memory-v1",
+    writable: "reference-memory-v1",
+  },
+  capabilities: {
+    commit: {
+      guarantee: "atomic",
+      primitive: "memory-atomic",
+      interactiveTransaction: false,
+    },
+    cursor: "opaque-keyset",
+    events: "none",
+    management: "none",
+  },
+  lifecycle: { clientOwnership: "internal" },
+} satisfies DatabaseManifestTupleV2;
+
+describe("IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2", () => {
+  it("publishes only the truthful process-local reference tuple", () => {
+    // Given the exported fixed reference manifest
+    // When its complete value is observed
+    // Then every identity and capability field matches the literal contract
+    expect(IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2).toEqual({
+      ...referenceTupleWithReorderedConstraints,
+      runtime: {
+        ...referenceTupleWithReorderedConstraints.runtime,
+        constraints: ["non-durable", "process-local", "sha256-required"],
+      },
+      certification: {
+        ...referenceTupleWithReorderedConstraints.certification,
+        tupleDigest:
+          "sha256:5d6872bfae8e5627b47a6bf90bba7729f93b4adc336cb50d8c36c2ce69137057",
+      },
+    });
+  });
+
+  it("is deeply frozen against caller mutation", () => {
+    // Given the public manifest and nested values
+    const manifest = IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2;
+
+    // When caller mutation is attempted without bypassing the type system
+    const rootMutation = Reflect.set(manifest, "supportTier", "certified");
+    const nestedMutation = Reflect.set(manifest.runtime, "version", "esnext");
+    const arrayMutation = Reflect.set(
+      manifest.runtime.constraints,
+      0,
+      "durable",
+    );
+
+    // Then every mutation is refused and the fixed value remains unchanged
+    expect(rootMutation).toBe(false);
+    expect(nestedMutation).toBe(false);
+    expect(arrayMutation).toBe(false);
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.runtime)).toBe(true);
+    expect(Object.isFrozen(manifest.runtime.constraints)).toBe(true);
+    expect(manifest.supportTier).toBe("experimental-reference");
+  });
+
+  it("recomputes its literal tuple digest independent of constraint order", async () => {
+    // Given the complete tuple with its unordered constraint set reversed
+    // When the manifest-domain digest is recomputed
+    const digest = await hashDatabaseManifestTupleV1(
+      referenceTupleWithReorderedConstraints,
+    );
+
+    // Then it matches the checked-in reference identity
+    expect(digest).toBe(
+      "sha256:5d6872bfae8e5627b47a6bf90bba7729f93b4adc336cb50d8c36c2ce69137057",
+    );
+    expect(digest).toBe(
+      IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2.certification.tupleDigest,
+    );
+  });
+
+  it("hashes one root descriptor snapshot without live Proxy reads", async () => {
+    // Given a manifest Proxy that mutates nested state on any live read
+    let getCalls = 0;
+    const mutableTuple = {
+      ...referenceTupleWithReorderedConstraints,
+      connector: { ...referenceTupleWithReorderedConstraints.connector },
+    } satisfies DatabaseManifestTupleV2;
+    const tuple = new Proxy(mutableTuple, {
+      get: () => {
+        getCalls += 1;
+        Reflect.set(mutableTuple.connector, "name", "mutated-after-validation");
+        throw new RangeError("manifest live read");
+      },
+    });
+
+    // When the public identity helper hashes the tuple
+    const digest = await hashDatabaseManifestTupleV1(tuple);
+
+    // Then identity comes from the validated snapshot and never invokes get
+    expect(digest).toBe(
+      "sha256:5d6872bfae8e5627b47a6bf90bba7729f93b4adc336cb50d8c36c2ce69137057",
+    );
+    expect(getCalls).toBe(0);
+    expect(mutableTuple.connector.name).toBe(
+      referenceTupleWithReorderedConstraints.connector.name,
+    );
+  });
+
+  it("hashes nested descriptor snapshots without live Proxy reads", async () => {
+    // Given nested object and array Proxies whose get traps throw
+    let connectorGets = 0;
+    let constraintGets = 0;
+    const connector = new Proxy(
+      referenceTupleWithReorderedConstraints.connector,
+      {
+        get: () => {
+          connectorGets += 1;
+          throw new RangeError("nested manifest live read");
+        },
+      },
+    );
+    const constraints = new Proxy(
+      [...referenceTupleWithReorderedConstraints.runtime.constraints],
+      {
+        get: () => {
+          constraintGets += 1;
+          throw new RangeError("constraint array live read");
+        },
+      },
+    );
+    const tuple = {
+      ...referenceTupleWithReorderedConstraints,
+      connector,
+      runtime: {
+        ...referenceTupleWithReorderedConstraints.runtime,
+        constraints,
+      },
+    } satisfies DatabaseManifestTupleV2;
+
+    // When the public identity helper hashes the tuple
+    const digest = await hashDatabaseManifestTupleV1(tuple);
+
+    // Then neither nested Proxy is read live and the frozen vector is stable
+    expect(digest).toBe(
+      "sha256:5d6872bfae8e5627b47a6bf90bba7729f93b4adc336cb50d8c36c2ce69137057",
+    );
+    expect(connectorGets).toBe(0);
+    expect(constraintGets).toBe(0);
+  });
+
+  it("reports hostile descriptor inspection through the typed error API", async () => {
+    // Given a manifest Proxy that refuses descriptor inspection
+    const tuple = new Proxy(referenceTupleWithReorderedConstraints, {
+      getOwnPropertyDescriptor: () => {
+        throw new RangeError("manifest descriptor inspection failed");
+      },
+    });
+
+    // When the tuple crosses the public identity boundary
+    const hashTuple = () => hashDatabaseManifestTupleV1(tuple);
+
+    // Then the stable typed code and original inspection cause are preserved
+    expect(hashTuple).toThrowError(DatabaseConnectorErrorV2);
+    expect(hashTuple).toThrowError(
+      expect.objectContaining({
+        name: "DatabaseConnectorErrorV2",
+        code: "CANONICALIZATION_FAILED",
+        cause: expect.any(RangeError),
+      }),
+    );
+  });
+});

--- a/plugins/plugin-core/src/database-v2/referenceManifest.ts
+++ b/plugins/plugin-core/src/database-v2/referenceManifest.ts
@@ -1,0 +1,48 @@
+import type { DatabaseConnectorManifestV2 } from "./manifest";
+
+const runtime = Object.freeze({
+  family: "javascript",
+  version: "es2022",
+  constraints: Object.freeze([
+    "non-durable",
+    "process-local",
+    "sha256-required",
+  ]),
+});
+
+const capabilities = Object.freeze({
+  commit: Object.freeze({
+    guarantee: "atomic",
+    primitive: "memory-atomic",
+    interactiveTransaction: false,
+  }),
+  cursor: "opaque-keyset",
+  events: "none",
+  management: "none",
+});
+
+export const IN_MEMORY_DATABASE_CONNECTOR_MANIFEST_V2 = Object.freeze({
+  kind: "hot-updater.database-connector",
+  apiVersion: 2,
+  supportTier: "experimental-reference",
+  connector: Object.freeze({
+    name: "hot-updater-memory-reference",
+    version: "1",
+  }),
+  adapter: Object.freeze({ family: "native", version: "1" }),
+  driver: Object.freeze({ name: "memory", version: "1" }),
+  target: Object.freeze({ product: "memory", transport: "process-local" }),
+  runtime,
+  certification: Object.freeze({
+    tier: "reference",
+    id: "hot-updater.database.memory.reference-v1",
+    tupleDigest:
+      "sha256:5d6872bfae8e5627b47a6bf90bba7729f93b4adc336cb50d8c36c2ce69137057",
+  }),
+  schema: Object.freeze({
+    readable: "reference-memory-v1",
+    writable: "reference-memory-v1",
+  }),
+  capabilities,
+  lifecycle: Object.freeze({ clientOwnership: "internal" }),
+} satisfies DatabaseConnectorManifestV2);

--- a/plugins/plugin-core/src/database-v2/scopeValidation.ts
+++ b/plugins/plugin-core/src/database-v2/scopeValidation.ts
@@ -1,0 +1,87 @@
+import { DatabaseConnectorErrorV2 } from "./errors";
+
+interface CapturedDatabaseScopeV2 {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly context: unknown;
+}
+
+const invalidScope = (message: string, cause?: unknown): never => {
+  throw new DatabaseConnectorErrorV2(
+    "INVALID_SCOPE",
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+};
+
+const requireDataDescriptor = (
+  descriptors: Record<string, PropertyDescriptor>,
+  key: string,
+): PropertyDescriptor => {
+  const descriptor = Reflect.get(descriptors, key);
+  if (
+    descriptor === undefined ||
+    descriptor.enumerable !== true ||
+    Object.hasOwn(descriptor, "get") ||
+    Object.hasOwn(descriptor, "set") ||
+    !Object.hasOwn(descriptor, "value")
+  ) {
+    return invalidScope(`scope ${key} must be an enumerable data property`);
+  }
+  return descriptor;
+};
+
+const requireIdentifier = (value: unknown, label: string): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return invalidScope(`${label} must be a non-empty asserted string`);
+  }
+  return value;
+};
+
+const captureScope = (scope: unknown): CapturedDatabaseScopeV2 => {
+  if (typeof scope !== "object" || scope === null || Array.isArray(scope)) {
+    return invalidScope("asserted scope must be a plain object");
+  }
+  if (Object.getPrototypeOf(scope) !== Object.prototype) {
+    return invalidScope("asserted scope must have a plain object prototype");
+  }
+  if (Object.getOwnPropertySymbols(scope).length > 0) {
+    return invalidScope("asserted scope must not contain symbol properties");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(scope);
+  const keys = Object.keys(descriptors);
+  const expectedKeys = ["tenantId", "principalId", "context"];
+  if (
+    keys.length !== expectedKeys.length ||
+    keys.some((key) => !expectedKeys.includes(key))
+  ) {
+    return invalidScope("asserted scope has an invalid shape");
+  }
+  const tenant = requireDataDescriptor(descriptors, "tenantId");
+  const principal = requireDataDescriptor(descriptors, "principalId");
+  const context = requireDataDescriptor(descriptors, "context");
+  return Object.freeze({
+    tenantId: requireIdentifier(tenant.value, "tenantId"),
+    principalId: requireIdentifier(principal.value, "principalId"),
+    context: context.value,
+  });
+};
+
+export const captureDatabaseScopeV2 = (
+  scope: unknown,
+): CapturedDatabaseScopeV2 => {
+  try {
+    return captureScope(scope);
+  } catch (error) {
+    if (error instanceof DatabaseConnectorErrorV2) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      return invalidScope(
+        "asserted scope could not be inspected safely",
+        error,
+      );
+    }
+    return invalidScope("scope inspection threw a non-error value", error);
+  }
+};

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.commit.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.commit.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeBundle,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+describe("database-v2 commit runtime", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("rejects malformed normalized changes before backend I/O", async () => {
+    // Given malformed IDs, empty changes, duplicates, and empty revisions
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const bundle = createRuntimeBundle("bundle-a");
+    const malformed = [
+      {
+        id: "not-a-uuid",
+        changes: [
+          { type: "put", value: bundle, precondition: { state: "absent" } },
+        ],
+      },
+      { id: CHANGE_SET_IDS.first, changes: [] },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          { type: "put", value: bundle, precondition: { state: "absent" } },
+          { type: "put", value: bundle, precondition: { state: "absent" } },
+        ],
+      },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          {
+            type: "put",
+            value: bundle,
+            precondition: { state: "revision", revision: "" },
+          },
+        ],
+      },
+    ] as const;
+
+    // When each malformed change set is submitted
+    for (const changeSet of malformed) {
+      await expectConnectorErrorCode(
+        () => session.applyChangeSet(changeSet),
+        "INVALID_CHANGE_SET",
+      );
+    }
+
+    // Then none reaches the backend commit seam
+    expect(backend.commitAttempts).toBe(0);
+  });
+
+  it("rejects concurrent commit B before a second backend call", async () => {
+    // Given commit A held after it enters the backend
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const entered = backend.holdNextCommit();
+    const commitA = session.applyChangeSet(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+    await entered;
+    const attemptsDuringA = backend.commitAttempts;
+
+    // When commit B is submitted on the same session
+    await expectConnectorErrorCode(
+      () =>
+        session.applyChangeSet(
+          createRuntimeChangeSet(
+            CHANGE_SET_IDS.second,
+            "018f12ab-1234-7abc-8def-000000000002",
+          ),
+        ),
+      "CONCURRENT_COMMIT",
+    );
+
+    // Then B causes zero backend I/O and A completes after release
+    expect(backend.commitAttempts).toBe(attemptsDuringA);
+    backend.releaseCommit();
+    await expect(commitA).resolves.toMatchObject({ outcome: "committed" });
+  });
+
+  it("snapshots an active change set before caller mutation", async () => {
+    // Given a mutable change set whose backend commit will be held
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const bundle = createRuntimeBundle("018f12ab-1234-7abc-8def-000000000001");
+    const changeSet = {
+      id: String(CHANGE_SET_IDS.first),
+      changes: [
+        {
+          type: "put" as const,
+          value: bundle,
+          precondition: { state: "absent" as const },
+        },
+      ],
+    };
+    const entered = backend.holdNextCommit();
+
+    // When commit starts and the caller immediately mutates its objects
+    const commit = session.applyChangeSet(changeSet);
+    changeSet.id = CHANGE_SET_IDS.second;
+    changeSet.changes[0].value.message = "mutated-after-call";
+    await entered;
+
+    // Then the backend sees only the immutable snapshot from call time
+    expect(backend.observedCommits[0]?.changeSet.id).toBe(CHANGE_SET_IDS.first);
+    expect(backend.observedCommits[0]?.changeSet.changes[0]).toMatchObject({
+      value: { message: "018f12ab-1234-7abc-8def-000000000001" },
+    });
+    backend.releaseCommit();
+    await expect(commit).resolves.toMatchObject({
+      changeSetId: CHANGE_SET_IDS.first,
+      outcome: "committed",
+    });
+  });
+
+  it("keeps an ordinary rejected conflict readable and unpoisoned", async () => {
+    // Given a backend that definitively rejects the next attempt
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    backend.enqueue({ kind: "rejected" });
+
+    // When the change set receives a definitive conflict
+    const receipt = await session.applyChangeSet(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+
+    // Then the rejection is returned and reads remain available
+    expect(receipt).toMatchObject({ outcome: "rejected", reason: "conflict" });
+    await expect(session.bundles.channels()).resolves.toEqual([]);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.input.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.input.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeBundle,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+const applyUntypedChangeSet = (
+  session: object,
+  changeSet: unknown,
+): Promise<unknown> =>
+  Reflect.apply(Reflect.get(session, "applyChangeSet"), session, [changeSet]);
+
+const descriptorCases = (): readonly {
+  readonly label: string;
+  readonly create: (observeGetter: () => void) => unknown;
+}[] => [
+  {
+    label: "an accessor on the root",
+    create: (observeGetter) => {
+      const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+      Object.defineProperty(changeSet, "id", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return CHANGE_SET_IDS.first;
+        },
+      });
+      return changeSet;
+    },
+  },
+  {
+    label: "a nested accessor",
+    create: (observeGetter) => {
+      const bundle = createRuntimeBundle("bundle-a");
+      Object.defineProperty(bundle, "message", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return "bundle-a";
+        },
+      });
+      return {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          { type: "put", value: bundle, precondition: { state: "absent" } },
+        ],
+      };
+    },
+  },
+  {
+    label: "a non-enumerable property",
+    create: () => {
+      const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+      Object.defineProperty(changeSet, "hidden", {
+        enumerable: false,
+        value: true,
+      });
+      return changeSet;
+    },
+  },
+  {
+    label: "a symbol property",
+    create: () => {
+      const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+      Reflect.set(changeSet, Symbol("hidden"), true);
+      return changeSet;
+    },
+  },
+  {
+    label: "an inherited shape",
+    create: () => Object.create(createRuntimeChangeSet(CHANGE_SET_IDS.first)),
+  },
+  {
+    label: "a sparse changes array",
+    create: () => {
+      const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+      Reflect.deleteProperty(changeSet.changes, "0");
+      return changeSet;
+    },
+  },
+  {
+    label: "a cycle",
+    create: () => {
+      const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+      Reflect.set(changeSet, "self", changeSet);
+      return changeSet;
+    },
+  },
+  {
+    label: "a present undefined value",
+    create: () => ({
+      ...createRuntimeChangeSet(CHANGE_SET_IDS.first),
+      unexpected: undefined,
+    }),
+  },
+];
+
+describe("database-v2 untyped change-set boundary", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("rejects malformed object shapes before backend I/O", async () => {
+    // Given values that violate the runtime change-set grammar
+    const malformed: readonly unknown[] = [
+      null,
+      7,
+      {},
+      { id: 7, changes: [] },
+      { id: CHANGE_SET_IDS.first, changes: null },
+      { id: CHANGE_SET_IDS.first, changes: [null] },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          {
+            type: "merge",
+            value: createRuntimeBundle("bundle-a"),
+            precondition: { state: "absent" },
+          },
+        ],
+      },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          { type: "put", value: null, precondition: { state: "absent" } },
+        ],
+      },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [{ type: "delete", id: "bundle-a", precondition: null }],
+      },
+      {
+        id: CHANGE_SET_IDS.first,
+        changes: [
+          {
+            type: "delete",
+            id: "bundle-a",
+            precondition: { state: "revision", revision: 3 },
+          },
+        ],
+      },
+    ];
+
+    // When each value crosses the public typed boundary at runtime
+    for (const value of malformed) {
+      const { backend, connection } =
+        createSubject<MutableScopeFixture["context"]>();
+      const session = await connection.openSession(createRuntimeScope());
+      await expectConnectorErrorCode(
+        () => applyUntypedChangeSet(session, value),
+        "INVALID_CHANGE_SET",
+      );
+
+      // Then the malformed value never reaches a backend
+      expect(backend.commitAttempts).toBe(0);
+    }
+  });
+
+  for (const descriptorCase of descriptorCases()) {
+    it(`rejects ${descriptorCase.label} without observing it`, async () => {
+      // Given a forbidden descriptor or graph shape
+      const { backend, connection } =
+        createSubject<MutableScopeFixture["context"]>();
+      const session = await connection.openSession(createRuntimeScope());
+      let getterCalls = 0;
+      const changeSet = descriptorCase.create(() => {
+        getterCalls += 1;
+      });
+
+      // When the value crosses the public typed boundary at runtime
+      await expectConnectorErrorCode(
+        () => applyUntypedChangeSet(session, changeSet),
+        "INVALID_CHANGE_SET",
+      );
+
+      // Then validation has no accessor or backend side effects
+      expect(getterCalls).toBe(0);
+      expect(backend.commitAttempts).toBe(0);
+    });
+  }
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.lifecycle.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.lifecycle.spec.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import { RuntimeDeferred } from "./sessionRuntime.testBackend";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+const invokeDuringPrototypeInspection = (
+  changeSet: ReturnType<typeof createRuntimeChangeSet>,
+  action: () => void,
+): ReturnType<typeof createRuntimeChangeSet> => {
+  let invoked = false;
+  return new Proxy(changeSet, {
+    getPrototypeOf: (target) => {
+      if (!invoked) {
+        invoked = true;
+        action();
+      }
+      return Reflect.getPrototypeOf(target);
+    },
+  });
+};
+
+describe("database-v2 connection and session lifecycle", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("waits for an active commit when closing only the session", async () => {
+    // Given an owned resource and a backend commit held in flight
+    let disposalCount = 0;
+    const { backend, connection } = createSubject<
+      MutableScopeFixture["context"]
+    >({
+      dispose: async () => {
+        disposalCount += 1;
+      },
+    });
+    const session = await connection.openSession(createRuntimeScope());
+    const entered = backend.holdNextCommit();
+    const commit = session.applyChangeSet(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+    await entered;
+
+    // When session close starts while the commit is active
+    const close = session.close();
+    const state = await Promise.race([
+      close.then(() => "closed" as const),
+      Promise.resolve("pending" as const),
+    ]);
+
+    // Then close waits, commit completes, and the connection resource remains alive
+    expect(state).toBe("pending");
+    expect(disposalCount).toBe(0);
+    backend.releaseCommit();
+    await expect(commit).resolves.toMatchObject({ outcome: "committed" });
+    await close;
+    expect(disposalCount).toBe(0);
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_CLOSED",
+    );
+  });
+
+  it("registers an active commit before a digest callback can close", async () => {
+    // Given a digest callback that reentrantly closes a session before commit I/O
+    let digestCalls = 0;
+    let closeSession = (): Promise<void> =>
+      Promise.reject(new TypeError("session has not opened"));
+    let reentrantClose: Promise<void> | undefined;
+    const order: string[] = [];
+    const { backend, connection } = createSubject<
+      MutableScopeFixture["context"]
+    >({
+      sha256: () => {
+        digestCalls += 1;
+        if (digestCalls === 2) {
+          reentrantClose = closeSession();
+        }
+        return new Uint8Array(32);
+      },
+    });
+    const session = await connection.openSession(createRuntimeScope());
+    closeSession = async () => await session.close();
+
+    // When change-set hashing invokes the reentrant close
+    const commit = session.applyChangeSet(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+    await Promise.resolve();
+    const close = reentrantClose;
+    if (close === undefined) {
+      throw new TypeError("digest callback did not close the session");
+    }
+    const observedClose = close.then(() => {
+      order.push("close");
+    });
+    const observedCommit = commit.then((receipt) => {
+      order.push("commit");
+      return receipt;
+    });
+
+    // Then close remains behind the registered commit until durability completes
+    await expect(observedCommit).resolves.toMatchObject({
+      outcome: "committed",
+    });
+    await expect(observedClose).resolves.toBeUndefined();
+    expect(order).toEqual(["commit", "close"]);
+    expect(backend.commitAttempts).toBe(1);
+  });
+
+  it("registers an active commit before input inspection can close", async () => {
+    // Given a transparent input proxy that closes during snapshot inspection
+    const order: string[] = [];
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    let reentrantClose: Promise<void> | undefined;
+    const changeSet = invokeDuringPrototypeInspection(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+      () => {
+        reentrantClose = session.close();
+      },
+    );
+
+    // When applying the change set enters caller-controlled inspection
+    const commit = session.applyChangeSet(changeSet).then((receipt) => {
+      order.push("commit");
+      return receipt;
+    });
+    const close = reentrantClose;
+    if (close === undefined) {
+      throw new TypeError("input inspection did not close the session");
+    }
+    const observedClose = close.then(() => {
+      order.push("close");
+    });
+
+    // Then close stays behind the reserved commit until durability completes
+    await expect(commit).resolves.toMatchObject({ outcome: "committed" });
+    await expect(observedClose).resolves.toBeUndefined();
+    expect(order).toEqual(["commit", "close"]);
+    expect(backend.commitAttempts).toBe(1);
+  });
+
+  it("rejects a reentrant commit during input inspection", async () => {
+    // Given a transparent input proxy that starts another commit during snapshot
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    let reentrantCommit: Promise<unknown> | undefined;
+    const outer = invokeDuringPrototypeInspection(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+      () => {
+        reentrantCommit = session.applyChangeSet(
+          createRuntimeChangeSet(CHANGE_SET_IDS.second),
+        );
+      },
+    );
+
+    // When the outer commit crosses its caller-controlled input boundary
+    const committed = session.applyChangeSet(outer);
+    const concurrent = reentrantCommit;
+    if (concurrent === undefined) {
+      throw new TypeError("input inspection did not attempt a second commit");
+    }
+
+    // Then the reserved slot rejects the nested commit and admits only the outer
+    await expectConnectorErrorCode(() => concurrent, "CONCURRENT_COMMIT");
+    await expect(committed).resolves.toMatchObject({ outcome: "committed" });
+    expect(backend.commitAttempts).toBe(1);
+    await connection.close();
+  });
+
+  it("automatically closes idle and poisoned children without hanging", async () => {
+    // Given one idle child and one poisoned child on a connection
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const idle = await connection.openSession(createRuntimeScope());
+    const poisoned = await connection.openSession(createRuntimeScope());
+    backend.enqueue({ kind: "unknown-before" });
+    await poisoned.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.first));
+
+    // When the connection closes without explicit child closes
+    await connection.close();
+
+    // Then both children are closed and repeated close is idempotent
+    await expectConnectorErrorCode(
+      () => idle.bundles.get("bundle-a"),
+      "SESSION_CLOSED",
+    );
+    await expectConnectorErrorCode(
+      () =>
+        poisoned.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.first)),
+      "SESSION_CLOSED",
+    );
+    await expect(connection.close()).resolves.toBeUndefined();
+  });
+
+  it("disposes owned resources once and borrowed resources never", async () => {
+    // Given owned and borrowed connections
+    let ownedDisposals = 0;
+    const owned = createSubject<MutableScopeFixture["context"]>({
+      dispose: async () => {
+        ownedDisposals += 1;
+      },
+    });
+    const borrowed = createSubject<MutableScopeFixture["context"]>();
+
+    // When each connection is closed repeatedly and concurrently
+    await Promise.all([
+      owned.connection.close(),
+      owned.connection.close(),
+      borrowed.connection.close(),
+      borrowed.connection.close(),
+    ]);
+
+    // Then ownership alone controls disposal count
+    expect(ownedDisposals).toBe(1);
+    await expectConnectorErrorCode(
+      () => owned.connection.openSession(createRuntimeScope()),
+      "CONNECTION_CLOSED",
+    );
+    await expectConnectorErrorCode(
+      () => borrowed.connection.openSession(createRuntimeScope()),
+      "CONNECTION_CLOSED",
+    );
+  });
+
+  it("makes close win new opens and commits while preserving active commit A", async () => {
+    // Given an active commit A and an owned disposer held in the closing phase
+    const disposalRelease = new RuntimeDeferred<void>();
+    const { backend, connection } = createSubject<
+      MutableScopeFixture["context"]
+    >({
+      dispose: async () => await disposalRelease.promise,
+    });
+    const session = await connection.openSession(createRuntimeScope());
+    const entered = backend.holdNextCommit();
+    const commitA = session.applyChangeSet(
+      createRuntimeChangeSet(CHANGE_SET_IDS.first),
+    );
+    await entered;
+
+    // When connection close races with open and commit B
+    const close = connection.close();
+    await expectConnectorErrorCode(
+      () => connection.openSession(createRuntimeScope()),
+      "CONNECTION_CLOSING",
+    );
+    await expectConnectorErrorCode(
+      () =>
+        session.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.second)),
+      "SESSION_CLOSING",
+    );
+
+    // Then A finishes, close waits for disposal, and all later use is closed
+    backend.releaseCommit();
+    await expect(commitA).resolves.toMatchObject({ outcome: "committed" });
+    disposalRelease.resolve();
+    await close;
+    await expectConnectorErrorCode(
+      () => connection.openSession(createRuntimeScope()),
+      "CONNECTION_CLOSED",
+    );
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_CLOSED",
+    );
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.protocol.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.protocol.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type {
+  MutableScopeFixture,
+  TestBackendCommitRequestV2,
+} from "./sessionRuntime.testTypes";
+
+const receiptIdentity = (request: TestBackendCommitRequestV2) => ({
+  changeSetId: request.changeSet.id,
+  scopeId: request.scope.scopeId,
+  canonicalPayloadHash: request.canonicalPayloadHash,
+});
+
+const receiptCases: readonly {
+  readonly label: string;
+  readonly create: (request: TestBackendCommitRequestV2) => unknown;
+}[] = [
+  { label: "null", create: () => null },
+  { label: "a primitive", create: () => 7 },
+  {
+    label: "an unknown outcome",
+    create: (request) => ({ ...receiptIdentity(request), outcome: "future" }),
+  },
+  {
+    label: "committed without revisions",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "committed",
+    }),
+  },
+  {
+    label: "committed with revision arrays",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "committed",
+      revisions: ["revision-1"],
+    }),
+  },
+  {
+    label: "committed with empty revisions",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "committed",
+      revisions: {
+        "018f12ab-1234-7abc-8def-000000000001": "",
+      },
+    }),
+  },
+  {
+    label: "committed with a contradictory reason",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "committed",
+      reason: "conflict",
+      revisions: {
+        "018f12ab-1234-7abc-8def-000000000001": "revision-1",
+      },
+    }),
+  },
+  {
+    label: "committed with an unsupported timestamp",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "committed",
+      committedAt: "2026-07-11T00:00:00.000Z",
+      revisions: {
+        "018f12ab-1234-7abc-8def-000000000001": "revision-1",
+      },
+    }),
+  },
+  {
+    label: "rejected with an unknown reason",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "rejected",
+      reason: "later",
+    }),
+  },
+  {
+    label: "rejected with contradictory revisions",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "rejected",
+      reason: "conflict",
+      revisions: {},
+    }),
+  },
+  {
+    label: "unknown with the wrong reason",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "unknown",
+      reason: "timeout",
+      sessionState: "poisoned",
+      retry: "identical-scope-id-and-payload-only",
+    }),
+  },
+  {
+    label: "unknown with the wrong state",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "unknown",
+      reason: "transport-unknown",
+      sessionState: "open",
+      retry: "identical-scope-id-and-payload-only",
+    }),
+  },
+  {
+    label: "unknown with the wrong retry rule",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "unknown",
+      reason: "transport-unknown",
+      sessionState: "poisoned",
+      retry: "always",
+    }),
+  },
+  {
+    label: "unknown with contradictory revisions",
+    create: (request) => ({
+      ...receiptIdentity(request),
+      outcome: "unknown",
+      reason: "transport-unknown",
+      sessionState: "poisoned",
+      retry: "identical-scope-id-and-payload-only",
+      revisions: {},
+    }),
+  },
+];
+
+describe("database-v2 backend receipt boundary", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  for (const receiptCase of receiptCases) {
+    it(`rejects ${receiptCase.label} as a protocol violation`, async () => {
+      // Given a backend returning a malformed runtime receipt
+      const { backend, connection } =
+        createSubject<MutableScopeFixture["context"]>();
+      const session = await connection.openSession(createRuntimeScope());
+      backend.queueReceiptDefect(receiptCase.create);
+
+      // When the receipt crosses the connector boundary
+      await expectConnectorErrorCode(
+        () =>
+          session.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.first)),
+        "CONNECTOR_PROTOCOL_VIOLATION",
+      );
+
+      // Then ambiguous backend activity poisons the session
+      await expectConnectorErrorCode(
+        () => session.bundles.channels(),
+        "SESSION_POISONED",
+      );
+    });
+  }
+
+  it("rejects receipt accessors without invoking them", async () => {
+    // Given a backend receipt with an accessor at its discriminant
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    let getterCalls = 0;
+    backend.queueReceiptDefect((request) => {
+      const receipt = {
+        ...receiptIdentity(request),
+        outcome: "unknown",
+        reason: "transport-unknown",
+        sessionState: "poisoned",
+        retry: "identical-scope-id-and-payload-only",
+      };
+      Object.defineProperty(receipt, "outcome", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          getterCalls += 1;
+          return "unknown";
+        },
+      });
+      return receipt;
+    });
+
+    // When the receipt crosses the connector boundary
+    await expectConnectorErrorCode(
+      () =>
+        session.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.first)),
+      "CONNECTOR_PROTOCOL_VIOLATION",
+    );
+
+    // Then inspection has no accessor side effects and poisons the session
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_POISONED",
+    );
+    expect(getterCalls).toBe(0);
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.recovery.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.recovery.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeChangeSet,
+  createRuntimeScope,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+describe("database-v2 unknown-outcome recovery", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("allows only exact retry after unknown and unpoisons on commit", async () => {
+    // Given an unknown-before-write result for one exact change identity
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    const unknown = await session.applyChangeSet(changeSet);
+
+    // When poisoned reads and a different commit are attempted
+    await expectConnectorErrorCode(
+      () => session.bundles.get("bundle-a"),
+      "SESSION_POISONED",
+    );
+    await expectConnectorErrorCode(
+      () =>
+        session.applyChangeSet(createRuntimeChangeSet(CHANGE_SET_IDS.second)),
+      "SESSION_POISONED",
+    );
+
+    // Then only the exact retry commits and restores reads
+    expect(unknown).toMatchObject({
+      outcome: "unknown",
+      sessionState: "poisoned",
+    });
+    await expect(session.applyChangeSet(changeSet)).resolves.toMatchObject({
+      outcome: "committed",
+    });
+    await expect(session.bundles.get("bundle-a")).resolves.toBeNull();
+  });
+
+  it("keeps repeated unknown poisoned until a definitive retry", async () => {
+    // Given two scripted unknown outcomes for the exact same retry
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    backend.enqueue({ kind: "unknown-repeated" });
+
+    // When both exact attempts return unknown
+    const first = await session.applyChangeSet(changeSet);
+    const second = await session.applyChangeSet(changeSet);
+
+    // Then the session remains poisoned until a third definitive attempt
+    expect(first.outcome).toBe("unknown");
+    expect(second.outcome).toBe("unknown");
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_POISONED",
+    );
+    await expect(session.applyChangeSet(changeSet)).resolves.toMatchObject({
+      outcome: "committed",
+    });
+    await expect(session.bundles.channels()).resolves.toEqual([]);
+  });
+
+  it("rejects a same-ID different-payload retry without backend I/O", async () => {
+    // Given an unknown change set and a retry that reuses only its ID
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const original = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    await session.applyChangeSet(original);
+    const attemptsAfterUnknown = backend.commitAttempts;
+    const mismatched = createRuntimeChangeSet(
+      CHANGE_SET_IDS.first,
+      "018f12ab-1234-7abc-8def-000000000002",
+    );
+
+    // When the same ID is retried with a different payload
+    await expectConnectorErrorCode(
+      () => session.applyChangeSet(mismatched),
+      "SESSION_POISONED",
+    );
+
+    // Then payload comparison fails closed before another backend attempt
+    expect(backend.commitAttempts).toBe(attemptsAfterUnknown);
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_POISONED",
+    );
+  });
+
+  it("unpoisons when an intervening tenant mutation makes recovery reject", async () => {
+    // Given unknown-before-write followed by a definitive backend conflict
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    await session.applyChangeSet(changeSet);
+    backend.mutateTenantBeforeRecovery();
+
+    // When the exact retry observes the intervening conflict
+    const recovered = await session.applyChangeSet(changeSet);
+
+    // Then the definitive rejection is returned and the session unpoisons
+    expect(recovered).toMatchObject({
+      outcome: "rejected",
+      reason: "conflict",
+    });
+    expect(backend.interveningTenantMutations).toBe(1);
+    await expect(session.bundles.channels()).resolves.toEqual([]);
+  });
+
+  it("discovers an after-durability receipt from a fresh session", async () => {
+    // Given a backend that durably commits but reports unknown
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-after" });
+
+    // When the poisoned session closes and a fresh session retries exactly
+    await expect(session.applyChangeSet(changeSet)).resolves.toMatchObject({
+      outcome: "unknown",
+    });
+    await session.close();
+    const fresh = await connection.openSession(createRuntimeScope());
+    const replay = await fresh.applyChangeSet(changeSet);
+
+    // Then the durable receipt is replayed without another domain write
+    expect(replay).toMatchObject({ outcome: "replayed" });
+    expect(backend.receipts).toHaveLength(1);
+  });
+
+  it("rejects mismatched recovery identity and remains poisoned", async () => {
+    // Given an unknown result followed by a backend identity mismatch
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    backend.enqueue({ kind: "protocol-identity" });
+    await session.applyChangeSet(changeSet);
+
+    // When the exact recovery returns a mismatched identity
+    await expectConnectorErrorCode(
+      () => session.applyChangeSet(changeSet),
+      "CONNECTOR_PROTOCOL_VIOLATION",
+    );
+
+    // Then the session remains poisoned
+    await expectConnectorErrorCode(
+      () => session.bundles.channels(),
+      "SESSION_POISONED",
+    );
+  });
+
+  it("rejects a mismatched recovery revision set and remains poisoned", async () => {
+    // Given an unknown result followed by a committed receipt without revisions
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const session = await connection.openSession(createRuntimeScope());
+    const changeSet = createRuntimeChangeSet(CHANGE_SET_IDS.first);
+    backend.enqueue({ kind: "unknown-before" });
+    backend.enqueue({ kind: "protocol-revisions" });
+    await session.applyChangeSet(changeSet);
+
+    // When exact recovery returns the incomplete revision set
+    await expectConnectorErrorCode(
+      () => session.applyChangeSet(changeSet),
+      "CONNECTOR_PROTOCOL_VIOLATION",
+    );
+
+    // Then poison is preserved
+    await expectConnectorErrorCode(
+      () => session.bundles.get("bundle-a"),
+      "SESSION_POISONED",
+    );
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.scope.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.scope.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import {
+  createRuntimeScope,
+  setupRuntimeSubject,
+} from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+describe("database-v2 asserted scope runtime", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  it("rejects empty asserted identifiers before backend I/O", async () => {
+    // Given a fresh connection and two malformed trusted-host assertions
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+
+    // When each assertion is opened
+    await expectConnectorErrorCode(
+      () =>
+        connection.openSession({
+          tenantId: "",
+          principalId: "principal-a",
+          context: { marker: "empty-tenant" },
+        }),
+      "INVALID_SCOPE",
+    );
+    await expectConnectorErrorCode(
+      () =>
+        connection.openSession({
+          tenantId: "tenant-a",
+          principalId: "   ",
+          context: { marker: "empty-principal" },
+        }),
+      "INVALID_SCOPE",
+    );
+
+    // Then no backend operation sees either assertion
+    expect(backend.readAttempts).toBe(0);
+    expect(backend.commitAttempts).toBe(0);
+    expect(backend.observedScopes).toEqual([]);
+  });
+
+  it("binds asserted IDs immutably and never trusts context lookalikes", async () => {
+    // Given a mutable assertion whose context contains spoof-like identifiers
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    const scope = createRuntimeScope();
+    const session = await connection.openSession(scope);
+
+    // When the caller mutates the source assertion after opening and reads
+    scope.tenantId = "mutated-tenant";
+    scope.principalId = "mutated-principal";
+    scope.context.tenantId = "mutated-context-tenant";
+    await session.bundles.get("bundle-a");
+
+    // Then only the original trusted assertion reaches the backend
+    expect(backend.observedScopes).toHaveLength(1);
+    expect(backend.observedScopes[0]).toMatchObject({
+      tenantId: "tenant-a",
+      principalId: "principal-a",
+    });
+    expect(backend.observedScopes[0]).not.toMatchObject({
+      tenantId: "context-tenant-must-not-win",
+      principalId: "context-principal-must-not-win",
+    });
+  });
+
+  it("fails a pending open when close begins before scope hashing completes", async () => {
+    // Given a scope digest and owned disposal held on deterministic gates
+    let digestEnteredResolve: (() => void) | undefined;
+    let digestReleaseResolve: (() => void) | undefined;
+    let disposeReleaseResolve: (() => void) | undefined;
+    const digestEntered = new Promise<void>((resolve) => {
+      digestEnteredResolve = resolve;
+    });
+    const digestRelease = new Promise<void>((resolve) => {
+      digestReleaseResolve = resolve;
+    });
+    const disposeRelease = new Promise<void>((resolve) => {
+      disposeReleaseResolve = resolve;
+    });
+    const subject = setupRuntimeSubject<MutableScopeFixture["context"]>(
+      await import("./sessionRuntime.testLoader").then((module) =>
+        module.loadConnectionRuntimeFactory(),
+      ),
+      {
+        sha256: async () => {
+          digestEnteredResolve?.();
+          await digestRelease;
+          return new Uint8Array(32);
+        },
+        dispose: async () => await disposeRelease,
+      },
+    );
+    const pendingOpen = subject.connection.openSession(createRuntimeScope());
+    await digestEntered;
+
+    // When connection close starts before the digest is released
+    const pendingClose = subject.connection.close();
+    digestReleaseResolve?.();
+
+    // Then the open observes the closing state and no backend I/O occurs
+    await expectConnectorErrorCode(() => pendingOpen, "CONNECTION_CLOSING");
+    expect(subject.backend.commitAttempts).toBe(0);
+    expect(subject.backend.readAttempts).toBe(0);
+    disposeReleaseResolve?.();
+    await pendingClose;
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.scopeBoundary.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.scopeBoundary.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { maliciousScopeCases } from "./sessionRuntime.scopeBoundaryCases";
+import { expectConnectorErrorCode } from "./sessionRuntime.testAssertions";
+import { createRuntimeScope } from "./sessionRuntime.testFixtures";
+import { setupRuntimeTestHarness } from "./sessionRuntime.testHarness";
+import type { MutableScopeFixture } from "./sessionRuntime.testTypes";
+
+const openUntypedSession = (
+  connection: object,
+  scope: unknown,
+): Promise<unknown> =>
+  Reflect.apply(Reflect.get(connection, "openSession"), connection, [scope]);
+
+describe("database-v2 untyped asserted-scope boundary", () => {
+  const createSubject = setupRuntimeTestHarness();
+
+  for (const maliciousCase of maliciousScopeCases()) {
+    it(`rejects ${maliciousCase.label} without observing it`, async () => {
+      // Given an untrusted runtime value and observable digest/backend seams
+      let digestCalls = 0;
+      let getterCalls = 0;
+      const { backend, connection } = createSubject<
+        MutableScopeFixture["context"]
+      >({
+        sha256: () => {
+          digestCalls += 1;
+          return new Uint8Array(32);
+        },
+      });
+      const scope = maliciousCase.create(() => {
+        getterCalls += 1;
+      });
+
+      // When the value crosses the typed openSession boundary
+      await expectConnectorErrorCode(
+        () => openUntypedSession(connection, scope),
+        "INVALID_SCOPE",
+      );
+
+      // Then parsing causes no getter, digest, or backend side effect
+      expect(getterCalls).toBe(0);
+      expect(digestCalls).toBe(0);
+      expect(backend.readAttempts).toBe(0);
+      expect(backend.commitAttempts).toBe(0);
+      expect(backend.observedScopes).toEqual([]);
+    });
+  }
+
+  it("captures asserted IDs once before asynchronous hashing", async () => {
+    // Given a valid mutable scope and a digest held after scope parsing
+    let digestEnteredResolve: (() => void) | undefined;
+    let digestReleaseResolve: (() => void) | undefined;
+    const digestEntered = new Promise<void>((resolve) => {
+      digestEnteredResolve = resolve;
+    });
+    const digestRelease = new Promise<void>((resolve) => {
+      digestReleaseResolve = resolve;
+    });
+    const { backend, connection } = createSubject<
+      MutableScopeFixture["context"]
+    >({
+      sha256: async () => {
+        digestEnteredResolve?.();
+        await digestRelease;
+        return new Uint8Array(32);
+      },
+    });
+    const scope = createRuntimeScope();
+
+    // When the source is mutated while hashing the captured identity
+    const pendingSession = connection.openSession(scope);
+    await digestEntered;
+    scope.tenantId = "mutated-tenant";
+    scope.principalId = "mutated-principal";
+    scope.context = { marker: "mutated-context" };
+    digestReleaseResolve?.();
+    const session = await pendingSession;
+    await session.bundles.get("bundle-a");
+
+    // Then the backend sees only the original data-descriptor values
+    expect(backend.observedScopes[0]).toMatchObject({
+      tenantId: "tenant-a",
+      principalId: "principal-a",
+    });
+  });
+
+  it("keeps nested context lookalikes opaque", async () => {
+    // Given context values whose own identifiers are accessor-backed lookalikes
+    const { backend, connection } =
+      createSubject<MutableScopeFixture["context"]>();
+    let contextGetterCalls = 0;
+    const context = { marker: "opaque-context" };
+    Object.defineProperties(context, {
+      tenantId: {
+        enumerable: true,
+        get: () => {
+          contextGetterCalls += 1;
+          return "spoofed-tenant";
+        },
+      },
+      principalId: {
+        enumerable: true,
+        get: () => {
+          contextGetterCalls += 1;
+          return "spoofed-principal";
+        },
+      },
+    });
+
+    // When a session opens and performs a backend read
+    const session = await connection.openSession({
+      tenantId: "tenant-a",
+      principalId: "principal-a",
+      context,
+    });
+    await session.bundles.get("bundle-a");
+
+    // Then context is not inspected and cannot override asserted IDs
+    expect(contextGetterCalls).toBe(0);
+    expect(backend.observedScopes[0]).toMatchObject({
+      tenantId: "tenant-a",
+      principalId: "principal-a",
+    });
+  });
+});

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.scopeBoundaryCases.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.scopeBoundaryCases.ts
@@ -1,0 +1,128 @@
+import { createRuntimeScope } from "./sessionRuntime.testFixtures";
+
+export const maliciousScopeCases = (): readonly {
+  readonly label: string;
+  readonly create: (observeGetter: () => void) => unknown;
+}[] => [
+  { label: "null", create: () => null },
+  { label: "a primitive", create: () => 7 },
+  { label: "an array", create: () => [] },
+  { label: "a date", create: () => new Date(0) },
+  {
+    label: "an inherited scope",
+    create: () => Object.create(createRuntimeScope()),
+  },
+  {
+    label: "a null-prototype scope",
+    create: () => {
+      const scope = Object.create(null);
+      Reflect.set(scope, "tenantId", "tenant-a");
+      Reflect.set(scope, "principalId", "principal-a");
+      Reflect.set(scope, "context", { marker: "null-prototype" });
+      return scope;
+    },
+  },
+  {
+    label: "a tenant accessor",
+    create: (observeGetter) => {
+      const scope = createRuntimeScope();
+      Object.defineProperty(scope, "tenantId", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return "tenant-a";
+        },
+      });
+      return scope;
+    },
+  },
+  {
+    label: "an alternating principal accessor",
+    create: (observeGetter) => {
+      const scope = createRuntimeScope();
+      let calls = 0;
+      Object.defineProperty(scope, "principalId", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          calls += 1;
+          return calls === 1 ? "principal-a" : "principal-b";
+        },
+      });
+      return scope;
+    },
+  },
+  {
+    label: "a context accessor",
+    create: (observeGetter) => {
+      const scope = createRuntimeScope();
+      Object.defineProperty(scope, "context", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          observeGetter();
+          return { marker: "accessor" };
+        },
+      });
+      return scope;
+    },
+  },
+  {
+    label: "a non-enumerable field",
+    create: () => {
+      const scope = createRuntimeScope();
+      Object.defineProperty(scope, "context", {
+        configurable: true,
+        enumerable: false,
+        value: scope.context,
+      });
+      return scope;
+    },
+  },
+  {
+    label: "a symbol field",
+    create: () => {
+      const scope = createRuntimeScope();
+      Reflect.set(scope, Symbol("scope"), true);
+      return scope;
+    },
+  },
+  {
+    label: "an extra field",
+    create: () => ({ ...createRuntimeScope(), unexpected: true }),
+  },
+  {
+    label: "a missing context",
+    create: () => ({ tenantId: "tenant-a", principalId: "principal-a" }),
+  },
+  {
+    label: "a missing tenant",
+    create: () => ({ principalId: "principal-a", context: {} }),
+  },
+  {
+    label: "a numeric principal",
+    create: () => ({
+      tenantId: "tenant-a",
+      principalId: 7,
+      context: {},
+    }),
+  },
+  {
+    label: "a whitespace tenant",
+    create: () => ({
+      tenantId: "   ",
+      principalId: "principal-a",
+      context: {},
+    }),
+  },
+  {
+    label: "a whitespace principal",
+    create: () => ({
+      tenantId: "tenant-a",
+      principalId: "\t",
+      context: {},
+    }),
+  },
+];

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.spec.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.spec.ts
@@ -1,0 +1,7 @@
+import "./sessionRuntime.commit.spec";
+import "./sessionRuntime.input.spec";
+import "./sessionRuntime.lifecycle.spec";
+import "./sessionRuntime.protocol.spec";
+import "./sessionRuntime.recovery.spec";
+import "./sessionRuntime.scope.spec";
+import "./sessionRuntime.scopeBoundary.spec";

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testAssertions.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testAssertions.ts
@@ -1,0 +1,20 @@
+import { expect } from "vitest";
+
+export const expectConnectorErrorCode = async (
+  action: () => Promise<unknown>,
+  code: string,
+): Promise<void> => {
+  const result = await action().then(
+    () => ({ kind: "fulfilled" }) as const,
+    (error: unknown) => ({ error, kind: "rejected" }) as const,
+  );
+  expect(result.kind).toBe("rejected");
+  if (result.kind === "fulfilled") {
+    return;
+  }
+  expect(
+    typeof result.error === "object" && result.error !== null
+      ? Reflect.get(result.error, "code")
+      : undefined,
+  ).toBe(code);
+};

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testBackend.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testBackend.ts
@@ -1,0 +1,217 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type { BundlePageV2 } from "./bundles";
+import type { Versioned } from "./common";
+import type { CommitReceiptV2 } from "./receipts";
+import type {
+  TestBackendCommitRequestV2,
+  TestBackendScopeV2,
+  TestDatabaseBackendV2,
+} from "./sessionRuntime.testTypes";
+
+export class RuntimeDeferred<T> {
+  readonly promise: Promise<T>;
+  private resolver: ((value: T) => void) | undefined;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  resolve(value: T): void {
+    const resolver = this.resolver;
+    if (resolver === undefined) {
+      throw new TypeError("runtime deferred was not initialized");
+    }
+    resolver(value);
+  }
+}
+
+type CommitScript =
+  | { readonly kind: "unknown-before" }
+  | { readonly kind: "unknown-after" }
+  | { readonly kind: "unknown-repeated" }
+  | { readonly kind: "rejected" }
+  | { readonly kind: "protocol-identity" }
+  | { readonly kind: "protocol-revisions" };
+
+type ReceiptDefect = (request: TestBackendCommitRequestV2) => unknown;
+
+const receiptKey = (request: TestBackendCommitRequestV2): string =>
+  `${request.scope.tenantId}\0${request.scope.principalId}\0${request.changeSet.id}`;
+
+const unknownReceipt = (
+  request: TestBackendCommitRequestV2,
+): CommitReceiptV2 => ({
+  changeSetId: request.changeSet.id,
+  scopeId: request.scope.scopeId,
+  canonicalPayloadHash: request.canonicalPayloadHash,
+  outcome: "unknown",
+  reason: "transport-unknown",
+  sessionState: "poisoned",
+  retry: "identical-scope-id-and-payload-only",
+});
+
+export class ScriptedRuntimeBackend implements TestDatabaseBackendV2 {
+  readonly observedScopes: TestBackendScopeV2[] = [];
+  readonly observedCommits: TestBackendCommitRequestV2[] = [];
+  readonly receipts = new Map<string, CommitReceiptV2>();
+  readonly rows = new Map<string, Versioned<Bundle>>();
+  commitAttempts = 0;
+  readAttempts = 0;
+  interveningTenantMutations = 0;
+  private revision = 0;
+  private receiptDefects: ReceiptDefect[] = [];
+  private scripts: CommitScript[] = [];
+  private held: RuntimeDeferred<void> | null = null;
+  private entered: RuntimeDeferred<void> | null = null;
+
+  enqueue(script: CommitScript): void {
+    this.scripts.push(script);
+  }
+
+  queueReceiptDefect(defect: ReceiptDefect): void {
+    this.receiptDefects.push(defect);
+  }
+
+  mutateTenantBeforeRecovery(): void {
+    this.interveningTenantMutations += 1;
+    this.scripts.push({ kind: "rejected" });
+  }
+
+  holdNextCommit(): Promise<void> {
+    this.held = new RuntimeDeferred<void>();
+    this.entered = new RuntimeDeferred<void>();
+    return this.entered.promise;
+  }
+
+  releaseCommit(): void {
+    const held = this.held;
+    if (held === null) {
+      throw new TypeError("no held commit");
+    }
+    held.resolve();
+    this.held = null;
+  }
+
+  releaseCommitIfHeld(): void {
+    if (this.held !== null) {
+      this.releaseCommit();
+    }
+  }
+
+  async get(
+    scope: TestBackendScopeV2,
+    id: string,
+  ): Promise<Versioned<Bundle> | null> {
+    this.readAttempts += 1;
+    this.observedScopes.push(scope);
+    return this.rows.get(`${scope.tenantId}\0${id}`) ?? null;
+  }
+
+  async page(scope: TestBackendScopeV2): Promise<BundlePageV2> {
+    this.readAttempts += 1;
+    this.observedScopes.push(scope);
+    return {
+      data: [],
+      pagination: {
+        total: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        nextCursor: null,
+        previousCursor: null,
+      },
+    };
+  }
+
+  async channels(scope: TestBackendScopeV2): Promise<readonly string[]> {
+    this.readAttempts += 1;
+    this.observedScopes.push(scope);
+    return [];
+  }
+
+  async commit(request: TestBackendCommitRequestV2): Promise<unknown> {
+    this.commitAttempts += 1;
+    this.observedCommits.push(request);
+    const entered = this.entered;
+    const held = this.held;
+    if (entered !== null && held !== null) {
+      entered.resolve();
+      this.entered = null;
+      await held.promise;
+    }
+    const receiptDefect = this.receiptDefects.shift();
+    if (receiptDefect !== undefined) {
+      return Reflect.apply(receiptDefect, undefined, [request]);
+    }
+    const existing = this.receipts.get(receiptKey(request));
+    if (existing?.outcome === "committed") {
+      return { ...existing, outcome: "replayed" };
+    }
+    if (existing !== undefined) {
+      return existing;
+    }
+    const script = this.scripts.shift();
+    if (
+      script?.kind === "unknown-before" ||
+      script?.kind === "unknown-repeated"
+    ) {
+      return unknownReceipt(request);
+    }
+    if (script?.kind === "rejected") {
+      const rejected = {
+        changeSetId: request.changeSet.id,
+        scopeId: request.scope.scopeId,
+        canonicalPayloadHash: request.canonicalPayloadHash,
+        outcome: "rejected",
+        reason: "conflict",
+      } as const;
+      this.receipts.set(receiptKey(request), rejected);
+      return rejected;
+    }
+    if (script?.kind === "protocol-identity") {
+      return { ...unknownReceipt(request), scopeId: "sha256:wrong" };
+    }
+    if (script?.kind === "protocol-revisions") {
+      return {
+        changeSetId: request.changeSet.id,
+        scopeId: request.scope.scopeId,
+        canonicalPayloadHash: request.canonicalPayloadHash,
+        outcome: "committed",
+        revisions: {},
+      };
+    }
+    const committed = this.commitRequest(request);
+    if (script?.kind === "unknown-after") {
+      return unknownReceipt(request);
+    }
+    return committed;
+  }
+
+  private commitRequest(request: TestBackendCommitRequestV2): CommitReceiptV2 {
+    this.revision += 1;
+    const revisions: Record<string, string> = {};
+    for (const change of request.changeSet.changes) {
+      const id = change.type === "put" ? change.value.id : change.id;
+      revisions[id] = `revision-${this.revision}`;
+      if (change.type === "put") {
+        this.rows.set(`${request.scope.tenantId}\0${id}`, {
+          value: change.value,
+          revision: revisions[id],
+        });
+      } else {
+        this.rows.delete(`${request.scope.tenantId}\0${id}`);
+      }
+    }
+    const committed = {
+      changeSetId: request.changeSet.id,
+      scopeId: request.scope.scopeId,
+      canonicalPayloadHash: request.canonicalPayloadHash,
+      outcome: "committed",
+      revisions,
+    } as const;
+    this.receipts.set(receiptKey(request), committed);
+    return committed;
+  }
+}

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testFixtures.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testFixtures.ts
@@ -1,0 +1,76 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type { BundleChangeSetV2 } from "./bundles";
+import type { Sha256Digest } from "./common";
+import { ScriptedRuntimeBackend } from "./sessionRuntime.testBackend";
+import type {
+  MutableScopeFixture,
+  TestConnectionRuntimeFactoryV2,
+} from "./sessionRuntime.testTypes";
+
+export const createRuntimeBundle = (
+  id: string,
+  channel = "production",
+): Bundle => ({
+  id,
+  channel,
+  platform: "ios",
+  enabled: true,
+  shouldForceUpdate: false,
+  fileHash: `hash-${id}`,
+  storageUri: `memory://${id}`,
+  gitCommitHash: null,
+  message: id,
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+});
+
+export const createRuntimeChangeSet = (
+  id: string,
+  bundleId = "018f12ab-1234-7abc-8def-000000000001",
+): BundleChangeSetV2 => ({
+  id,
+  changes: [
+    {
+      type: "put",
+      value: createRuntimeBundle(bundleId),
+      precondition: { state: "absent" },
+    },
+  ],
+});
+
+export const createRuntimeScope = (): MutableScopeFixture => ({
+  tenantId: "tenant-a",
+  principalId: "principal-a",
+  context: {
+    marker: "trusted-host",
+    tenantId: "context-tenant-must-not-win",
+    principalId: "context-principal-must-not-win",
+  },
+});
+
+export const CHANGE_SET_IDS = {
+  first: "10000000-0000-4000-8000-000000000001",
+  second: "10000000-0000-4000-8000-000000000002",
+  third: "10000000-0000-4000-8000-000000000003",
+} as const;
+
+export const setupRuntimeSubject = <TContext>(
+  factory: TestConnectionRuntimeFactoryV2,
+  options?: {
+    readonly dispose?: () => Promise<void>;
+    readonly sha256?: Sha256Digest;
+  },
+) => {
+  const backend = new ScriptedRuntimeBackend();
+  const resource =
+    options?.dispose === undefined
+      ? ({ ownership: "borrowed" } as const)
+      : ({ ownership: "owned", dispose: options.dispose } as const);
+  const connection = factory<TContext>({
+    backend,
+    resource,
+    ...(options?.sha256 === undefined ? {} : { sha256: options.sha256 }),
+  });
+  return { backend, connection };
+};

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testHarness.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testHarness.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeAll } from "vitest";
+
+import type { DatabaseConnectionV2 } from "./connector";
+import type { ScriptedRuntimeBackend } from "./sessionRuntime.testBackend";
+import { setupRuntimeSubject } from "./sessionRuntime.testFixtures";
+import { loadConnectionRuntimeFactory } from "./sessionRuntime.testLoader";
+import type {
+  TestConnectionRuntimeFactoryV2,
+  TestConnectionRuntimeOptionsV2,
+} from "./sessionRuntime.testTypes";
+
+const missingFactory: TestConnectionRuntimeFactoryV2 = () => {
+  throw new TypeError("database-v2 runtime factory has not loaded");
+};
+
+interface TrackedRuntimeSubject<TContext> {
+  readonly backend: ScriptedRuntimeBackend;
+  readonly connection: DatabaseConnectionV2<TContext>;
+}
+
+export const setupRuntimeTestHarness = () => {
+  let factory = missingFactory;
+  const subjects: TrackedRuntimeSubject<unknown>[] = [];
+
+  beforeAll(async () => {
+    factory = await loadConnectionRuntimeFactory();
+  });
+
+  afterEach(async () => {
+    for (const subject of subjects.splice(0)) {
+      subject.backend.releaseCommitIfHeld();
+      await subject.connection.close();
+    }
+  });
+
+  return <TContext>(
+    options?: Omit<TestConnectionRuntimeOptionsV2, "backend" | "resource"> & {
+      readonly dispose?: () => Promise<void>;
+    },
+  ): TrackedRuntimeSubject<TContext> => {
+    const subject = setupRuntimeSubject<TContext>(factory, options);
+    subjects.push(subject);
+    return subject;
+  };
+};

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testLoader.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testLoader.ts
@@ -1,0 +1,6 @@
+import { createDatabaseConnectionRuntimeV2 } from "./sessionRuntime";
+import type { TestConnectionRuntimeFactoryV2 } from "./sessionRuntime.testTypes";
+
+export const loadConnectionRuntimeFactory =
+  async (): Promise<TestConnectionRuntimeFactoryV2> =>
+    createDatabaseConnectionRuntimeV2;

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.testTypes.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.testTypes.ts
@@ -1,0 +1,58 @@
+import type { Bundle } from "@hot-updater/core";
+
+import type {
+  BundleChangeSetV2,
+  BundlePageQueryV2,
+  BundlePageV2,
+} from "./bundles";
+import type { AssertedDatabaseScope, Sha256Digest, Versioned } from "./common";
+import type { DatabaseConnectionV2 } from "./connector";
+
+export interface TestBackendScopeV2 {
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly scopeId: string;
+}
+
+export interface TestBackendCommitRequestV2 {
+  readonly scope: TestBackendScopeV2;
+  readonly changeSet: BundleChangeSetV2;
+  readonly canonicalPayloadHash: string;
+}
+
+export interface TestDatabaseBackendV2 {
+  get(scope: TestBackendScopeV2, id: string): Promise<Versioned<Bundle> | null>;
+  page(
+    scope: TestBackendScopeV2,
+    query: BundlePageQueryV2,
+  ): Promise<BundlePageV2>;
+  channels(scope: TestBackendScopeV2): Promise<readonly string[]>;
+  commit(request: TestBackendCommitRequestV2): Promise<unknown>;
+}
+
+export type TestDatabaseResourceV2 =
+  | { readonly ownership: "borrowed" }
+  | {
+      readonly ownership: "owned";
+      dispose(): Promise<void>;
+    };
+
+export interface TestConnectionRuntimeOptionsV2 {
+  readonly backend: TestDatabaseBackendV2;
+  readonly resource: TestDatabaseResourceV2;
+  readonly sha256?: Sha256Digest;
+}
+
+export type TestConnectionRuntimeFactoryV2 = <TContext>(
+  options: TestConnectionRuntimeOptionsV2,
+) => DatabaseConnectionV2<TContext>;
+
+export type MutableScopeFixture = {
+  tenantId: string;
+  principalId: string;
+  context: { tenantId?: string; principalId?: string; marker: string };
+};
+
+export type ScopeFixture = AssertedDatabaseScope<
+  MutableScopeFixture["context"]
+>;

--- a/plugins/plugin-core/src/database-v2/sessionRuntime.ts
+++ b/plugins/plugin-core/src/database-v2/sessionRuntime.ts
@@ -1,0 +1,109 @@
+import type {
+  DatabaseConnectionResourceV2,
+  DatabaseConnectionRuntimeV2Options,
+} from "./backend";
+import {
+  addSetValueV2,
+  createSetV2,
+  deleteSetValueV2,
+  setValuesV2,
+} from "./collectionIntrinsics";
+import type { AssertedDatabaseScope } from "./common";
+import type { DatabaseConnectionV2, DatabaseSessionV2 } from "./connector";
+import { hashDatabaseScopeV1 } from "./databaseIdentity";
+import { DatabaseSessionRuntimeV2 } from "./databaseSessionRuntime";
+import { DatabaseConnectorErrorV2 } from "./errors";
+import { captureDatabaseScopeV2 } from "./scopeValidation";
+
+type DatabaseConnectionStateV2 = "open" | "closing" | "closed";
+
+class DatabaseConnectionRuntimeV2<
+  TContext,
+> implements DatabaseConnectionV2<TContext> {
+  private state: DatabaseConnectionStateV2 = "open";
+  private closeCompletion: Promise<void> | null = null;
+  private readonly sessions = createSetV2<DatabaseSessionRuntimeV2>();
+
+  constructor(private readonly options: DatabaseConnectionRuntimeV2Options) {}
+
+  async openSession(
+    assertedScope: AssertedDatabaseScope<TContext>,
+  ): Promise<DatabaseSessionV2> {
+    this.assertOpen();
+    const captured = captureDatabaseScopeV2(assertedScope);
+    const scopeId = await hashDatabaseScopeV1(captured, this.options.sha256);
+    this.assertOpen();
+    const session = new DatabaseSessionRuntimeV2({
+      backend: this.options.backend,
+      scope: Object.freeze({
+        tenantId: captured.tenantId,
+        principalId: captured.principalId,
+        scopeId,
+      }),
+      ...(this.options.sha256 === undefined
+        ? {}
+        : { sha256: this.options.sha256 }),
+      onClosed: (closed) => {
+        deleteSetValueV2(this.sessions, closed);
+      },
+    });
+    addSetValueV2(this.sessions, session);
+    return session;
+  }
+
+  close(): Promise<void> {
+    if (this.closeCompletion !== null) {
+      return this.closeCompletion;
+    }
+    if (this.state === "closed") {
+      return Promise.resolve();
+    }
+    this.state = "closing";
+    this.closeCompletion = this.closeAll();
+    return this.closeCompletion;
+  }
+
+  private async closeAll(): Promise<void> {
+    await Promise.all(
+      setValuesV2(this.sessions).map(async (session) => session.close()),
+    );
+    try {
+      await disposeResource(this.options.resource);
+    } finally {
+      this.state = "closed";
+    }
+  }
+
+  private assertOpen(): void {
+    switch (this.state) {
+      case "open":
+        return;
+      case "closing":
+        throw new DatabaseConnectorErrorV2(
+          "CONNECTION_CLOSING",
+          "connection is closing",
+        );
+      case "closed":
+        throw new DatabaseConnectorErrorV2(
+          "CONNECTION_CLOSED",
+          "connection is closed",
+        );
+    }
+  }
+}
+
+const disposeResource = async (
+  resource: DatabaseConnectionResourceV2,
+): Promise<void> => {
+  switch (resource.ownership) {
+    case "borrowed":
+      return;
+    case "owned":
+      await resource.dispose();
+  }
+};
+
+export const createDatabaseConnectionRuntimeV2 = <TContext>(
+  options: DatabaseConnectionRuntimeV2Options,
+): DatabaseConnectionV2<TContext> =>
+  new DatabaseConnectionRuntimeV2<TContext>(options);

--- a/plugins/plugin-core/src/database-v2/sessionState.ts
+++ b/plugins/plugin-core/src/database-v2/sessionState.ts
@@ -1,0 +1,18 @@
+import type { BundleChangeSetV2 } from "./bundles";
+
+export type DatabaseSessionStateV2 =
+  | "open"
+  | "committing"
+  | "poisoned"
+  | "closing"
+  | "closed";
+
+export interface PoisonedCommitIdentityV2 {
+  readonly changeSetId: string;
+  readonly canonicalPayloadHash: string;
+}
+
+export interface PreparedCommitV2 {
+  readonly changeSet: BundleChangeSetV2;
+  readonly recovery: PoisonedCommitIdentityV2 | null;
+}

--- a/plugins/plugin-core/src/database-v2/trustBoundaryMatrix.spec.ts
+++ b/plugins/plugin-core/src/database-v2/trustBoundaryMatrix.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { snapshotDatabaseChangeSetV2 } from "./changeSetValidation";
+import { hashDatabaseScopeV1 } from "./databaseIdentity";
+import { parseInMemoryPageQueryV2 } from "./inMemoryQuery";
+import { validateCommitReceiptV2 } from "./receiptValidation";
+import {
+  CHANGE_SET_IDS,
+  createRuntimeChangeSet,
+} from "./sessionRuntime.testFixtures";
+
+const errorCode = (error: unknown): unknown =>
+  typeof error === "object" && error !== null
+    ? Reflect.get(error, "code")
+    : undefined;
+
+const errorCause = (error: unknown): unknown =>
+  typeof error === "object" && error !== null
+    ? Reflect.get(error, "cause")
+    : undefined;
+
+const callSnapshotChangeSet = (value: unknown): unknown =>
+  Reflect.apply(snapshotDatabaseChangeSetV2, undefined, [value]);
+
+const callParsePageQuery = (value: unknown): unknown =>
+  Reflect.apply(parseInMemoryPageQueryV2, undefined, [value]);
+
+const expectedReceipt = {
+  changeSetId: CHANGE_SET_IDS.first,
+  scopeId: "sha256:scope",
+  canonicalPayloadHash: "sha256:payload",
+} as const;
+
+describe("database-v2 hostile shape matrix", () => {
+  it("normalizes accessor, hidden, symbol, prototype, and proxy inputs", () => {
+    // Given every forbidden object inspection class
+    let getterCalls = 0;
+    class InheritedShape {
+      readonly value = true;
+    }
+    const factories: readonly (() => unknown)[] = [
+      () =>
+        Object.defineProperty({}, "value", {
+          enumerable: true,
+          get: () => {
+            getterCalls += 1;
+            return true;
+          },
+        }),
+      () => Object.defineProperty({}, "hidden", { value: true }),
+      () => ({ [Symbol("hidden")]: true }),
+      () => new InheritedShape(),
+      () =>
+        new Proxy(
+          {},
+          {
+            getPrototypeOf: () => {
+              throw new RangeError("prototype trap marker");
+            },
+          },
+        ),
+    ];
+
+    // When each shape crosses all three untyped runtime boundaries
+    for (const factory of factories) {
+      expect(() => callSnapshotChangeSet(factory())).toThrowError(
+        expect.objectContaining({ code: "INVALID_CHANGE_SET" }),
+      );
+      expect(() => callParsePageQuery(factory())).toThrowError(
+        expect.objectContaining({ code: "INVALID_CURSOR" }),
+      );
+      expect(() =>
+        validateCommitReceiptV2(
+          factory(),
+          expectedReceipt,
+          createRuntimeChangeSet(CHANGE_SET_IDS.first),
+        ),
+      ).toThrowError(
+        expect.objectContaining({ code: "CONNECTOR_PROTOCOL_VIOLATION" }),
+      );
+    }
+
+    // Then no accessor executes and no raw RangeError escapes
+    expect(getterCalls).toBe(0);
+  });
+});
+
+describe("hashDatabaseScopeV1 hostile shape matrix", () => {
+  it("rejects proxy, prototype, symbol, hidden, and non-string identifiers", async () => {
+    // Given malformed identity containers across orthogonal shape classes
+    class InheritedScope {
+      readonly tenantId = "tenant-a";
+      readonly principalId = "principal-a";
+    }
+    const hiddenTenant = { tenantId: "tenant-a", principalId: "principal-a" };
+    Object.defineProperty(hiddenTenant, "tenantId", { enumerable: false });
+    const cases: readonly unknown[] = [
+      new InheritedScope(),
+      { tenantId: "tenant-a", principalId: "principal-a", [Symbol()]: true },
+      hiddenTenant,
+      { tenantId: 7, principalId: "principal-a" },
+      new Proxy(
+        { tenantId: "tenant-a", principalId: "principal-a" },
+        {
+          ownKeys: () => {
+            throw new RangeError("scope ownKeys marker");
+          },
+        },
+      ),
+    ];
+
+    // When each scope reaches the versioned hash boundary
+    const results = await Promise.all(
+      cases.map(
+        async (scope) =>
+          await Reflect.apply(hashDatabaseScopeV1, undefined, [scope]).then(
+            () => ({ kind: "fulfilled" }) as const,
+            (error: unknown) => ({ error, kind: "rejected" }) as const,
+          ),
+      ),
+    );
+
+    // Then every failure is stable and strips hostile causes
+    for (const result of results) {
+      expect(result.kind).toBe("rejected");
+      if (result.kind === "rejected") {
+        expect(errorCode(result.error)).toBe("CANONICALIZATION_FAILED");
+        expect(errorCause(result.error)).toBeUndefined();
+      }
+    }
+  });
+});

--- a/plugins/plugin-core/src/database-v2/utf8.ts
+++ b/plugins/plugin-core/src/database-v2/utf8.ts
@@ -1,0 +1,32 @@
+const Uint8ArrayConstructor = Uint8Array;
+
+export const encodeUtf8V2 = (value: string): Uint8Array => {
+  const bytes: number[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    let codePoint = value.charCodeAt(index);
+    if (codePoint >= 0xd800 && codePoint <= 0xdbff) {
+      const low = value.charCodeAt(index + 1);
+      codePoint = 0x10000 + ((codePoint - 0xd800) << 10) + (low - 0xdc00);
+      index += 1;
+    }
+    if (codePoint <= 0x7f) {
+      bytes.push(codePoint);
+    } else if (codePoint <= 0x7ff) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint <= 0xffff) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    }
+  }
+  return new Uint8ArrayConstructor(bytes);
+};

--- a/plugins/plugin-core/tsdown.config.ts
+++ b/plugins/plugin-core/tsdown.config.ts
@@ -2,11 +2,24 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
   {
-    entry: ["./src/index.ts"],
+    entry: ["./src/index.ts", "./src/database-v2/index.ts"],
     format: ["esm", "cjs"],
     outDir: "dist",
     dts: true,
-    exports: true,
+    exports: {
+      customExports: {
+        "./database-v2": {
+          import: {
+            types: "./dist/database-v2/index.d.mts",
+            default: "./dist/database-v2/index.mjs",
+          },
+          require: {
+            types: "./dist/database-v2/index.d.cts",
+            default: "./dist/database-v2/index.cjs",
+          },
+        },
+      },
+    },
     unbundle: true,
     failOnWarn: true,
   },

--- a/plugins/plugin-core/type-tests/database-v2/contract-negative-mutation.ts
+++ b/plugins/plugin-core/type-tests/database-v2/contract-negative-mutation.ts
@@ -1,0 +1,9 @@
+import type { BundleChangeV2 } from "@hot-updater/plugin-core/database-v2";
+
+const change: BundleChangeV2 = {
+  type: "delete",
+  id: "bundle-id",
+  precondition: { state: "absent" },
+};
+
+void change;

--- a/plugins/plugin-core/type-tests/database-v2/contract-negative-omitted-scope.ts
+++ b/plugins/plugin-core/type-tests/database-v2/contract-negative-omitted-scope.ts
@@ -1,0 +1,5 @@
+import type { DatabaseConnectionV2 } from "@hot-updater/plugin-core/database-v2";
+
+declare const connection: DatabaseConnectionV2<unknown>;
+
+void connection.openSession();

--- a/plugins/plugin-core/type-tests/database-v2/contract-negative-optional-scope.ts
+++ b/plugins/plugin-core/type-tests/database-v2/contract-negative-optional-scope.ts
@@ -1,0 +1,12 @@
+import type { AssertedDatabaseScope } from "@hot-updater/plugin-core/database-v2";
+
+type OptionalScope = {
+  readonly tenantId?: string;
+  readonly principalId?: string;
+  readonly context: unknown;
+};
+
+declare const optionalScope: OptionalScope;
+const scope: AssertedDatabaseScope<unknown> = optionalScope;
+
+void scope;

--- a/plugins/plugin-core/type-tests/database-v2/contract-negative-outcome.ts
+++ b/plugins/plugin-core/type-tests/database-v2/contract-negative-outcome.ts
@@ -1,0 +1,11 @@
+import type { CommitReceiptV2 } from "@hot-updater/plugin-core/database-v2";
+
+const receipt: CommitReceiptV2 = {
+  outcome: "committed",
+  changeSetId: "change-set-id",
+  scopeId: "scope-id",
+  canonicalPayloadHash: "payload-hash",
+  reason: "conflict",
+};
+
+void receipt;

--- a/plugins/plugin-core/type-tests/database-v2/contract-positive.ts
+++ b/plugins/plugin-core/type-tests/database-v2/contract-positive.ts
@@ -1,0 +1,29 @@
+import {
+  DatabaseConnectorErrorV2,
+  type AssertedDatabaseScope,
+  type BundleChangeSetV2,
+  type CommitReceiptV2,
+  type DatabaseConnectorV2,
+} from "@hot-updater/plugin-core/database-v2";
+
+type AuthContext = {
+  readonly authenticated: true;
+};
+
+declare const connector: DatabaseConnectorV2<AuthContext>;
+declare const changeSet: BundleChangeSetV2;
+declare const receipt: CommitReceiptV2;
+
+const scope: AssertedDatabaseScope<AuthContext> = {
+  tenantId: "tenant-a",
+  principalId: "principal-a",
+  context: { authenticated: true },
+};
+
+const error = new DatabaseConnectorErrorV2("INVALID_SCOPE", "scope is invalid");
+
+void connector;
+void changeSet;
+void receipt;
+void scope;
+void error;

--- a/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-mutation.json
+++ b/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-mutation.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.positive.json",
+  "include": ["contract-negative-mutation.ts"]
+}

--- a/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-omitted-scope.json
+++ b/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-omitted-scope.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.positive.json",
+  "include": ["contract-negative-omitted-scope.ts"]
+}

--- a/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-optional-scope.json
+++ b/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-optional-scope.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.positive.json",
+  "include": ["contract-negative-optional-scope.ts"]
+}

--- a/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-outcome.json
+++ b/plugins/plugin-core/type-tests/database-v2/tsconfig.negative-outcome.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.positive.json",
+  "include": ["contract-negative-outcome.ts"]
+}

--- a/plugins/plugin-core/type-tests/database-v2/tsconfig.positive.json
+++ b/plugins/plugin-core/type-tests/database-v2/tsconfig.positive.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["contract-positive.ts"]
+}

--- a/scripts/database-v2-sdk-driver.mjs
+++ b/scripts/database-v2-sdk-driver.mjs
@@ -1,0 +1,166 @@
+import {
+  createInMemoryDatabaseConnectorV2,
+  DatabaseConnectorErrorV2,
+} from "@hot-updater/plugin-core/database-v2";
+
+const ensure = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const expectCode = async (code, operation) => {
+  try {
+    await operation();
+  } catch (error) {
+    ensure(error instanceof DatabaseConnectorErrorV2, `expected ${code} error`);
+    ensure(error.code === code, `expected ${code}, received ${error.code}`);
+    return;
+  }
+  throw new Error(`expected ${code} to reject`);
+};
+
+const createBundle = (id, channel) => ({
+  id,
+  platform: "ios",
+  shouldForceUpdate: false,
+  enabled: true,
+  fileHash: `hash-${id}`,
+  storageUri: `memory://${id}`,
+  gitCommitHash: null,
+  message: `bundle-${id}`,
+  channel,
+  targetAppVersion: "1.0.0",
+  fingerprintHash: null,
+  metadata: { app_version: "1.0.0" },
+});
+
+const connector = createInMemoryDatabaseConnectorV2();
+const connection = await connector.connect();
+const scope = {
+  tenantId: "sdk-tenant-a",
+  principalId: "sdk-principal-a",
+  context: { source: "checked-in-driver" },
+};
+
+await expectCode("INVALID_SCOPE", () =>
+  connection.openSession({ ...scope, tenantId: "" }),
+);
+
+const session = await connection.openSession(scope);
+const firstBundle = createBundle(
+  "018f12ab-1234-7abc-8def-000000000101",
+  "production",
+);
+const secondBundle = createBundle(
+  "018f12ab-1234-7abc-8def-000000000102",
+  "staging",
+);
+const atomicChangeSet = {
+  id: "10000000-0000-4000-8000-000000000601",
+  changes: [firstBundle, secondBundle].map((value) => ({
+    type: "put",
+    value,
+    precondition: { state: "absent" },
+  })),
+};
+
+const committed = await session.applyChangeSet(atomicChangeSet);
+ensure(committed.outcome === "committed", "atomic change set did not commit");
+ensure(
+  Object.keys(committed.revisions).length === 2,
+  "atomic receipt did not include two revisions",
+);
+ensure(
+  (await session.bundles.get(firstBundle.id))?.value.channel === "production",
+  "bundle read did not return the committed value",
+);
+
+const firstPage = await session.bundles.page({ limit: 1 });
+ensure(firstPage.data.length === 1, "first page did not contain one bundle");
+ensure(
+  firstPage.pagination.total === 2,
+  "page total did not include both rows",
+);
+ensure(
+  firstPage.pagination.nextCursor !== null,
+  "first page lacked next cursor",
+);
+
+const cursorSuffix = firstPage.pagination.nextCursor.endsWith("x") ? "y" : "x";
+const corruptedCursor = `${firstPage.pagination.nextCursor.slice(0, -1)}${cursorSuffix}`;
+await expectCode("INVALID_CURSOR", () =>
+  session.bundles.page({ limit: 1, cursor: { after: corruptedCursor } }),
+);
+
+const principalSession = await connection.openSession({
+  ...scope,
+  principalId: "sdk-principal-b",
+});
+await expectCode("INVALID_CURSOR", () =>
+  principalSession.bundles.page({
+    limit: 1,
+    cursor: { after: firstPage.pagination.nextCursor },
+  }),
+);
+ensure(
+  (await principalSession.bundles.get(firstBundle.id))?.value.id ===
+    firstBundle.id,
+  "same-tenant principal could not read tenant data",
+);
+
+const isolatedSession = await connection.openSession({
+  ...scope,
+  tenantId: "sdk-tenant-b",
+});
+ensure(
+  (await isolatedSession.bundles.page({ limit: 10 })).data.length === 0,
+  "other tenant observed committed rows",
+);
+
+await session.close();
+const replaySession = await connection.openSession(scope);
+const replayed = await replaySession.applyChangeSet(atomicChangeSet);
+ensure(replayed.outcome === "replayed", "fresh-session retry did not replay");
+ensure(
+  JSON.stringify(replayed.revisions) === JSON.stringify(committed.revisions),
+  "replay did not preserve committed revisions",
+);
+
+const conflicting = await replaySession.applyChangeSet({
+  ...atomicChangeSet,
+  changes: [
+    {
+      type: "put",
+      value: { ...firstBundle, channel: "conflicting" },
+      precondition: { state: "absent" },
+    },
+  ],
+});
+ensure(
+  conflicting.outcome === "rejected" && conflicting.reason === "conflict",
+  "same-id different-payload replay was not a typed conflict receipt",
+);
+
+await Promise.all([
+  replaySession.close(),
+  principalSession.close(),
+  isolatedSession.close(),
+]);
+await expectCode("SESSION_CLOSED", () =>
+  replaySession.bundles.page({ limit: 1 }),
+);
+await connection.close();
+await expectCode("CONNECTION_CLOSED", () => connection.openSession(scope));
+
+console.log(
+  JSON.stringify({
+    databaseV2SdkDriver: "passed",
+    committed: committed.outcome,
+    replayed: replayed.outcome,
+    conflicting: conflicting.outcome,
+    tenantIsolation: true,
+    principalCursorIsolation: true,
+    lifecycle: "closed",
+  }),
+);


### PR DESCRIPTION
## Summary

- add the Experimental `@hot-updater/plugin-core/database-v2` connector contract and deterministic identity model
- add an in-memory reference connector with atomic commit, replay/conflict receipts, tenant isolation, opaque keyset cursors, poison/recovery, and lifecycle guarantees
- add a structural second-party conformance suite in `@hot-updater/test-utils`
- publish ESM/CJS/NodeNext declarations from the dedicated `database-v2` subpath
- document the trust boundary, implementation tuple, and follow-up adapter/provider gates

## Scope

This is the contract bootstrap for the broader Database Plugin v2 migration. It intentionally does not yet migrate v1, server, Kysely/Drizzle/Prisma adapters, or managed providers. Those remain in the active follow-up goal.

## Verification

- database-v2 + conformance: 28 files, 283 tests passed
- full unit: 136 files, 1,994 tests passed
- plugin-core and test-utils strict TypeScript checks passed
- official format/lint globs passed with 0 warnings/errors
- plugin-core ESM/CJS/declaration build passed
- positive NodeNext type contract passed; four negative contracts failed as expected
- checked-in SDK driver passed commit/replay/conflict/isolation/cursor/lifecycle flows
- independent goal, integration, quality, security, and QA reviews passed for this Experimental scope

## Runtime note

The reference tuple is JavaScript ES2022 and no longer relies on `toSorted`, `structuredClone`, or host `TextEncoder`. Same-realm ambient-global mutation is explicitly outside the connector contract; untrusted code requiring that isolation must run in a separate realm or process.