### PR TITLE
fix(android): ensure BsdiffPatch.apply runs on Dispatchers.IO to prevent ANR

### DIFF
--- a/.changeset/tricky-spiders-see.md
+++ b/.changeset/tricky-spiders-see.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+fix(android): ensure BsdiffPatch.apply runs on Dispatchers.IO to prevent ANR

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -429,7 +429,9 @@ class BundleFileStorageService(
                     if (!HashUtils.verifyHash(patchDownloadResult.file, patch.patchFileHash)) {
                         false
                     } else {
-                        BsdiffPatch.apply(sourceFile, patchDownloadResult.file, targetFile)
+                        withContext(Dispatchers.IO) {
+                            BsdiffPatch.apply(sourceFile, patchDownloadResult.file, targetFile)
+                        }
                         HashUtils.verifyHash(targetFile, expectedHash).also { patched ->
                             if (patched) {
                                 Log.d(


### PR DESCRIPTION
## Problem

`BsdiffPatch.apply` — which decompresses and applies a bsdiff OTA patch using BZip2 — was executing on the Android main thread, causing ANRs in production.

### Root cause

`applyPatchAssetIfPossible` is a `suspend fun` that wraps the download and patch application in `withContext(Dispatchers.IO)`. However, `downloadService.downloadFile()` suspends internally and resumes via a callback. When that callback fires, the coroutine continuation resumes on `Dispatchers.Main` — the dispatcher inherited from the calling context (`prepareLaunch()`, a regular non-suspend function running on the main thread). This silently escapes the outer `withContext(Dispatchers.IO)` block.

As a result, `BsdiffPatch.apply` — a blocking BZip2 decompression loop — runs on the main thread, blocking it for several seconds and triggering an ANR.

### Stack trace (from Firebase Crashlytics, app version 1.24.100)

```
main (native): tid=1 systid=3917
  libcore.io.Linux.readBytes (Native method)
  libcore.io.Linux.read (Linux.java:232)
  libcore.io.IoBridge.read (IoBridge.java:604)
  java.io.FileInputStream.read (FileInputStream.java:353)
  org.apache.commons.io.input.BoundedInputStream.read (BoundedInputStream.java:448)
  org.apache.commons.compress.utils.BitInputStream.ensureCache (BitInputStream.java:114)
  org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream.read (BZip2CompressorInputStream.java:654)
  com.hotupdater.BsdiffPatch.readExactly (BsdiffPatch.kt:190)
  com.hotupdater.BsdiffPatch.apply (BsdiffPatch.kt:120)
  com.hotupdater.BsdiffPatch.apply (BsdiffPatch.kt:41)
  com.hotupdater.BundleFileStorageService.applyPatchAssetIfPossible (BundleFileStorageService.kt:432)
  com.hotupdater.BundleFileStorageService.access$saveLaunchReport (BundleFileStorageService.kt:163)
  com.hotupdater.BundleFileStorageService.access$applyPatchAssetIfPossible (BundleFileStorageService.kt:163)
  com.hotupdater.BundleFileStorageService$applyPatchAssetIfPossible$1.invokeSuspend (BundleFileStorageService.kt:21)
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:101)
  android.os.Handler.handleCallback (Handler.java:959)
  android.os.Looper.loop (Looper.java:337)
  android.app.ActivityThread.main (ActivityThread.java:9469)
```

The `access$saveLaunchReport` synthetic accessor in the trace proves the lambda was compiled in the scope of `prepareLaunch()` — a regular (non-suspend) function on the main thread — which establishes `Dispatchers.Main` as the continuation context.

## Fix

Wrap `BsdiffPatch.apply` in its own explicit `withContext(Dispatchers.IO)` block at the call site (line 432). Both `Dispatchers` and `withContext` are already imported. This guarantees the blocking BZip2 decompression runs on an IO thread regardless of which dispatcher the enclosing coroutine resumed on.

```kotlin
// Before
BsdiffPatch.apply(sourceFile, patchDownloadResult.file, targetFile)

// After
withContext(Dispatchers.IO) {
    BsdiffPatch.apply(sourceFile, patchDownloadResult.file, targetFile)
}
```

`BsdiffPatch.apply` is pure file I/O with no shared state, UI interaction, or thread-local dependencies, so this change has no functional impact.

Closes #1089