### PR TITLE
fix(android): run manifest-driven installs on Dispatchers.IO

### DIFF
--- a/.changeset/calm-crabs-wait.md
+++ b/.changeset/calm-crabs-wait.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+fix(android): run manifest-driven bundle installation on the I/O dispatcher

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -1211,15 +1211,17 @@ class BundleFileStorageService(
 
         if (hasManifestDrivenArtifacts && canUseManifestDrivenInstall()) {
             try {
-                updateBundleFromManifest(
-                    bundleId = bundleId,
-                    manifestUrl = manifestUrl!!,
-                    manifestFileHash = manifestFileHash!!,
-                    changedAssets = changedAssets!!,
-                    bundleStoreDir = bundleStoreDir,
-                    finalBundleDir = finalBundleDir,
-                    progressCallback = progressCallback,
-                )
+                withContext(Dispatchers.IO) {
+                    updateBundleFromManifest(
+                        bundleId = bundleId,
+                        manifestUrl = manifestUrl!!,
+                        manifestFileHash = manifestFileHash!!,
+                        changedAssets = changedAssets!!,
+                        bundleStoreDir = bundleStoreDir,
+                        finalBundleDir = finalBundleDir,
+                        progressCallback = progressCallback,
+                    )
+                }
                 return
             } catch (e: Exception) {
                 if (fileUrl.isNullOrEmpty()) {

--- a/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
@@ -1,6 +1,8 @@
 package com.hotupdater
 
 import android.content.ContextWrapper
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -12,6 +14,8 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.net.URL
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -270,6 +274,47 @@ class BundleFileStorageServiceTest {
     }
 
     @Test
+    fun `manifest driven install moves blocking work off caller dispatcher`() {
+        val rootDir = temporaryFolder.newFolder("manifest-install-dispatcher")
+        val preferences = InMemoryPreferencesService()
+        val downloadService = RecordingFailedDownloadService()
+        val service = createService(rootDir, preferences, downloadService)
+        val activeDir = createBundleDir(rootDir, "active-bundle")
+        val activeBundleFile = writeFile(activeDir, "index.android.bundle")
+        writeManifest(activeDir, listOf("index.android.bundle"))
+
+        preferences.setItem("HotUpdaterBundleURL", activeBundleFile.absolutePath)
+
+        Executors
+            .newSingleThreadExecutor { runnable -> Thread(runnable, "manifest-caller") }
+            .asCoroutineDispatcher()
+            .use { callerDispatcher ->
+                runBlocking(callerDispatcher) {
+                    val result =
+                        runCatching {
+                            service.updateBundle(
+                                bundleId = "target-bundle",
+                                fileUrl = "https://example.com/bundle.zip",
+                                fileHash = null,
+                                manifestUrl = "https://example.com/manifest.json",
+                                manifestFileHash = "manifest-hash",
+                                changedAssets = emptyMap(),
+                                progressCallback = {},
+                            )
+                        }
+                    assertTrue(result.exceptionOrNull() is HotUpdaterException)
+                }
+            }
+
+        val manifestCall = downloadService.calls.first()
+        assertEquals("https://example.com/manifest.json", manifestCall.first)
+        assertFalse(
+            "Manifest install ran on the caller dispatcher: ${manifestCall.second}",
+            manifestCall.second.contains("manifest-caller"),
+        )
+    }
+
+    @Test
     fun `zip decompression does not write sibling prefix traversal entries`() {
         val rootDir = temporaryFolder.newFolder("zip-sibling-prefix")
         val zipFile = File(rootDir, "bundle.zip")
@@ -293,11 +338,12 @@ class BundleFileStorageServiceTest {
     private fun createService(
         rootDir: File,
         preferences: InMemoryPreferencesService = InMemoryPreferencesService(),
+        downloadService: DownloadService = UnusedDownloadService,
     ): BundleFileStorageService =
         BundleFileStorageService(
             ContextWrapper(null),
             TestFileSystemService(rootDir),
-            UnusedDownloadService,
+            downloadService,
             DecompressService(),
             preferences,
             TEST_ISOLATION_KEY,
@@ -445,6 +491,20 @@ class BundleFileStorageServiceTest {
             fileSizeCallback: ((Long) -> Unit)?,
             progressCallback: (DownloadProgress) -> Unit,
         ): DownloadResult = error("downloadFile should not be called in these tests")
+    }
+
+    private class RecordingFailedDownloadService : DownloadService {
+        val calls = CopyOnWriteArrayList<Pair<String, String>>()
+
+        override suspend fun downloadFile(
+            fileUrl: URL,
+            destination: File,
+            fileSizeCallback: ((Long) -> Unit)?,
+            progressCallback: (DownloadProgress) -> Unit,
+        ): DownloadResult {
+            calls += fileUrl.toString() to Thread.currentThread().name
+            return DownloadResult.Error(IllegalStateException("expected download failure"))
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Summary

- run the complete Android manifest-driven install on `Dispatchers.IO`
- cover the dispatcher boundary with a failing-first regression test
- add a patch changeset for `@hot-updater/react-native`

## Root cause

Both Android module variants start `updateBundle` from a `Dispatchers.Main`
scope. `OkHttpDownloadService.downloadFile` temporarily switches to
`Dispatchers.IO`, but returns to the caller context when the download finishes.
The manifest-driven installer therefore continued hash verification, file
copying, decompression, patching, and finalization on the main thread.

PR #1090 moved only `BsdiffPatch.apply` to the I/O dispatcher. This follow-up
places the I/O boundary around the complete manifest-driven installation while
keeping progress events marshalled to Main by the native modules. The nested
bsdiff boundary remains as a safe local guard and does not add another dispatch
when the caller is already on `Dispatchers.IO`.

## Verification

- failing-first dispatcher regression test: red on `main`, green with this fix,
  red again when only the boundary was reverted
- `./.agents/skills/fix-ci/scripts/run_fixci.sh all`
  - build and typecheck passed
  - lint passed
  - 1,881 unit tests passed
  - 1,454 integration tests passed
- Android `BundleFileStorageServiceTest` suite passed (17/17)
- GitHub Android Integration passed
  - Kotlin lint
  - old-architecture build
  - new-architecture build
- Android device E2E passed: 14/14 Detox scenarios
  - job `job-20260721050835-nwmrev`
  - profile `standalone-s3`
  - commit `411a055329072556a8ea4615db3a5d6931a116cb`

Follow-up to #1090 and #1089.
