### PR TITLE
fix(android): preserve brotli decoder when Android minification is actived

### DIFF
--- a/.changeset/quick-meals-sit.md
+++ b/.changeset/quick-meals-sit.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Preserve brotli decoder when Android minification is actived

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -15,3 +15,10 @@
 -keepclassmembers class * implements com.facebook.react.runtime.ReactHostDelegate {
     ** jsBundleLoader;
 }
+
+# Preserve the Brotli decoder and its embedded static dictionary
+# (DictionaryData). R8 otherwise strips the dictionary's static init, causing OTA
+# .tar.br extraction to fail at runtime with:
+#   java.io.IOException: Brotli stream decoding failed
+#   Caused by: brotli dictionary is not set
+-keep class com.hotupdater.vendor.brotli.** { *; }


### PR DESCRIPTION
## Summary

When Android minification (R8) is enabled in release builds, R8 strips the static initializer of the bundled Brotli decoder's embedded dictionary (DictionaryData). This causes OTA `.tar.br` bundle extraction to fail at runtime with:

```
java.io.IOException: Brotli stream decoding failed
Caused by: brotli dictionary is not set
```

## Changes

Add a ProGuard/R8 -keep rule for com.hotupdater.vendor.brotli.** in proguard-rules.pro, preventing R8 from removing the Brotli decoder and its static dictionary so OTA bundle decompression continues to work in minified release builds.

## Impact

- Fixes OTA updates failing to apply on minified Android release builds.
- No effect on debug or non-minified builds.