### PR TITLE
fix(cli): render static progress in CI

### DIFF
--- a/.changeset/calm-ci-progress.md
+++ b/.changeset/calm-ci-progress.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/cli-tools": patch
+---
+
+Render spinner, progress, and task output statically in CI and non-interactive
+terminals.

--- a/.changeset/calm-ci-progress.md
+++ b/.changeset/calm-ci-progress.md
@@ -3,4 +3,4 @@
 ---
 
 Render spinner, progress, and task output statically in CI and non-interactive
-terminals.
+terminals, and update the embedded Clack runtime to 1.7.0.

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -71,8 +71,8 @@
   "inlinedDependencies": {
     "@babel/code-frame": "7.29.0",
     "@babel/helper-validator-identifier": "7.28.5",
-    "@clack/core": "1.0.1",
-    "@clack/prompts": "1.0.1",
+    "@clack/core": "1.4.3",
+    "@clack/prompts": "1.7.0",
     "@isaacs/fs-minipass": "4.0.1",
     "@nodelib/fs.scandir": "2.1.5",
     "@nodelib/fs.stat": "2.0.5",

--- a/packages/cli-tools/src/prompts.spec.ts
+++ b/packages/cli-tools/src/prompts.spec.ts
@@ -1,0 +1,74 @@
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { p } from "./prompts";
+
+const CURSOR_HIDE = "\u001B[?25l";
+const CURSOR_SHOW = "\u001B[?25h";
+
+const captureOutput = () => {
+  const output = new PassThrough();
+  let text = "";
+  output.on("data", (chunk) => {
+    text += chunk.toString();
+  });
+  return {
+    output,
+    read: () => text,
+  };
+};
+
+describe("prompts", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("renders tasks without terminal controls in CI", async () => {
+    // Given
+    vi.stubEnv("CI", "true");
+    const captured = captureOutput();
+
+    // When
+    await p.tasks(
+      [
+        {
+          title: "Uploading bundle",
+          task: () => "Upload complete",
+        },
+      ],
+      { output: captured.output },
+    );
+
+    // Then
+    expect(captured.read()).toContain("Uploading bundle");
+    expect(captured.read()).toContain("Upload complete");
+    expect(captured.read()).not.toContain(CURSOR_HIDE);
+    expect(captured.read()).not.toContain(CURSOR_SHOW);
+  });
+
+  it("omits transient progress messages when output is not a TTY", () => {
+    // Given
+    vi.useFakeTimers();
+    const captured = captureOutput();
+    const progress = p.progress({
+      delay: 5,
+      max: 100,
+      output: captured.output,
+    });
+
+    // When
+    progress.start("Uploading 0%");
+    progress.advance(50, "Uploading 50%");
+    vi.advanceTimersByTime(5);
+    progress.stop("Upload complete");
+
+    // Then
+    expect(captured.read()).toContain("Uploading 0%");
+    expect(captured.read()).toContain("Upload complete");
+    expect(captured.read()).not.toContain("Uploading 50%");
+    expect(captured.read()).not.toContain(CURSOR_HIDE);
+    expect(captured.read()).not.toContain(CURSOR_SHOW);
+  });
+});

--- a/packages/cli-tools/src/prompts.ts
+++ b/packages/cli-tools/src/prompts.ts
@@ -1,4 +1,90 @@
-import * as p from "@clack/prompts";
-export { p };
+import * as clack from "@clack/prompts";
+
+type SpinnerOptions = NonNullable<Parameters<typeof clack.spinner>[0]>;
+type Spinner = ReturnType<typeof clack.spinner>;
+
+const createStaticSpinner = ({
+  onCancel,
+  output = process.stdout,
+  withGuide,
+}: SpinnerOptions = {}): Spinner => {
+  let active = false;
+  let cancelled = false;
+  let latestMessage = "";
+  const logOptions = { output, withGuide };
+  const finish = (
+    message: string | undefined,
+    log: typeof clack.log.success,
+  ) => {
+    if (!active) return;
+    active = false;
+    const finalMessage = message || latestMessage;
+    if (finalMessage) log(finalMessage, logOptions);
+  };
+
+  return {
+    start: (message = "") => {
+      active = true;
+      latestMessage = message;
+      if (message) clack.log.step(message, logOptions);
+    },
+    stop: (message) => finish(message, clack.log.success),
+    cancel: (message) => {
+      const wasActive = active;
+      cancelled = wasActive;
+      finish(message, clack.log.warn);
+      if (wasActive) onCancel?.();
+    },
+    error: (message) => finish(message, clack.log.error),
+    message: (message = "") => {
+      latestMessage = message;
+    },
+    clear: () => {
+      active = false;
+    },
+    get isCancelled() {
+      return cancelled;
+    },
+  };
+};
+
+const spinner: typeof clack.spinner = (options = {}) => {
+  const output = options.output ?? process.stdout;
+  const isInteractive = clack.isTTY(output) && !clack.isCI();
+  return isInteractive ? clack.spinner(options) : createStaticSpinner(options);
+};
+
+const progress: typeof clack.progress = (options = {}) => {
+  const output = options.output ?? process.stdout;
+  const isInteractive = clack.isTTY(output) && !clack.isCI();
+  if (isInteractive) return clack.progress(options);
+
+  const staticSpinner = createStaticSpinner(options);
+  return {
+    ...staticSpinner,
+    advance: (_step, message) => staticSpinner.message(message),
+    get isCancelled() {
+      return staticSpinner.isCancelled;
+    },
+  };
+};
+
+const tasks: typeof clack.tasks = async (taskList, options) => {
+  for (const task of taskList) {
+    if (task.enabled === false) continue;
+    const taskSpinner = spinner(options);
+    taskSpinner.start(task.title);
+    const result = await task.task(taskSpinner.message);
+    taskSpinner.stop(result || task.title);
+  }
+};
+
+export const p: typeof clack = {
+  ...clack,
+  progress,
+  spinner,
+  tasks,
+};
+
 export type PromptProgress = ReturnType<typeof p.progress>;
 export type PromptSpinner = ReturnType<typeof p.spinner>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ catalogs:
       version: 2.76.1
   tools:
     '@clack/prompts':
-      specifier: 1.0.1
-      version: 1.0.1
+      specifier: 1.7.0
+      version: 1.7.0
     execa:
       specifier: 9.5.2
       version: 9.5.2
@@ -1360,7 +1360,7 @@ importers:
     devDependencies:
       '@clack/prompts':
         specifier: catalog:tools
-        version: 1.0.1
+        version: 1.7.0
       '@hot-updater/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -3484,14 +3484,16 @@ packages:
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
-  '@clack/core@1.0.1':
-    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
-  '@clack/prompts@1.0.1':
-    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -22102,9 +22104,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/core@1.0.1':
+  '@clack/core@1.4.3':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@clack/prompts@0.11.0':
@@ -22113,10 +22115,11 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.0.1':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 1.0.1
-      picocolors: 1.1.1
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.4.2': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalogs:
   supabase:
     "@supabase/supabase-js": 2.76.1
   tools:
-    "@clack/prompts": 1.0.1
+    "@clack/prompts": 1.7.0
     "execa": 9.5.2
     tsdown: 0.21.6
 


### PR DESCRIPTION
## Summary

- render spinner, progress, and task output statically in CI and non-TTY
  environments
- preserve Clack's dynamic renderer for interactive terminals
- upgrade the embedded Clack runtime from `@clack/prompts` 1.0.1 to the current
  latest 1.7.0 (`@clack/core` 1.4.3)
- add regressions for cursor control sequences and transient progress updates
- add a patch changeset for `@hot-updater/cli-tools`

## Root cause

Clack's spinner renderer emits cursor hide/show control sequences. Some CI log
renderers strip the escape introducer but leave visible `25l` and `25h`
fragments, while transient progress redraws become repeated log lines.

Upgrading Clack alone does not resolve this. Direct `@clack/prompts` 1.7.0
still emitted cursor hide/show sequences with `CI=true` when the selected
stream reported TTY, while the Hot Updater adapter emitted stable static
output under the same conditions.

## Validation

- `pnpm -w lint`: passed
- `pnpm -w build`: 25 projects passed
- `pnpm -w test`: 129 files, 1,883 tests passed
- `vitest run packages/cli-tools/src`: 12 files, 46 tests passed
- `vitest run packages/hot-updater/src/commands/deploy.spec.ts`: 30 tests passed
- TypeScript checks passed for `packages/cli-tools` and
  `packages/hot-updater`
- `git diff --check origin/main...HEAD`: passed
- built public API runtime audit under `CI=true`: no ESC bytes, `25l`/`25h`
  fragments, or transient progress lines
