### PR TITLE
fix(supabase): skip database migration prompt

### DIFF
--- a/.changeset/quiet-supabase-migrations.md
+++ b/.changeset/quiet-supabase-migrations.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/supabase": patch
+---
+
+Run Supabase database migrations non-interactively during initialization.

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -218,7 +218,7 @@ describe("Supabase database password failures", () => {
     expect(output).not.toContain("--password");
     expect(mockExeca).toHaveBeenCalledWith(
       "npx",
-      ["supabase", "db", "push", "--include-all"],
+      ["supabase", "db", "push", "--include-all", "--yes"],
       expect.objectContaining({
         env: { SUPABASE_DB_PASSWORD: secret },
         stderr: ["pipe", "inherit"],

--- a/plugins/supabase/iac/supabaseCli.spec.ts
+++ b/plugins/supabase/iac/supabaseCli.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExeca, mockSuccess } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+  mockSuccess: vi.fn(),
+}));
+
+vi.mock("@hot-updater/cli-tools", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@hot-updater/cli-tools")>();
+  return {
+    ...actual,
+    p: {
+      ...actual.p,
+      log: {
+        ...actual.p.log,
+        success: mockSuccess,
+      },
+    },
+  };
+});
+
+vi.mock("execa", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("execa")>();
+  return {
+    ...actual,
+    execa: mockExeca,
+  };
+});
+
+import { pushDB } from "./supabaseCli";
+
+describe("pushDB", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("answers migration confirmation prompts during init", async () => {
+    // Given
+    const workdir = "C:\\hot-updater-supabase-push";
+    mockExeca.mockResolvedValue({
+      stdout: "Finished supabase db push.",
+    });
+
+    // When
+    await pushDB(workdir, {});
+
+    // Then
+    expect(mockExeca).toHaveBeenCalledWith(
+      "npx",
+      ["supabase", "db", "push", "--include-all", "--yes"],
+      expect.objectContaining({ cwd: workdir }),
+    );
+    expect(mockSuccess).toHaveBeenCalledWith("DB pushed ✔");
+  });
+});

--- a/plugins/supabase/iac/supabaseCli.ts
+++ b/plugins/supabase/iac/supabaseCli.ts
@@ -96,7 +96,7 @@ export const pushDB = async (
   try {
     const dbPush = await execa(
       "npx",
-      ["supabase", "db", "push", "--include-all"],
+      ["supabase", "db", "push", "--include-all", "--yes"],
       {
         cwd: workdir,
         env: dbPassword ? { SUPABASE_DB_PASSWORD: dbPassword } : undefined,


### PR DESCRIPTION
## Summary

- pass Supabase CLI's global `--yes` flag to `db push` during `hot-updater init`
- add a regression test using a Windows-style working directory
- add a patch changeset for `@hot-updater/supabase`

## Root cause

When pending migrations exist, `supabase db push` opens its own `[Y/n]` confirmation prompt. Hot Updater launched that nested command interactively, so the Windows init flow remained waiting at the migration prompt instead of completing automatically.

## Validation

- `pnpm -w lint`
- `pnpm -w test` (130 files, 1,884 tests)
- `pnpm --filter @hot-updater/supabase test:type`
- `pnpm --filter @hot-updater/supabase build`
- `npx -y supabase db push --include-all --yes --help`

Closes #1101