### PR TITLE
fix(plugin-core): keep compression MIME detection edge-compatible

### DIFF
--- a/.changeset/edge-bundles-travel.md
+++ b/.changeset/edge-bundles-travel.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/plugin-core": patch
+---
+
+Keep bundle content type detection portable across runtimes.

--- a/plugins/plugin-core/src/compressionFormat.spec.ts
+++ b/plugins/plugin-core/src/compressionFormat.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getContentType } from "./compressionFormat";
+
+describe("getContentType", () => {
+  it("returns the compression MIME type for a bundle archive", () => {
+    expect(getContentType("build/bundle.tar.br")).toBe("application/x-tar");
+  });
+
+  it("supports Windows bundle paths", () => {
+    expect(getContentType("build\\bundle.tar.br")).toBe("application/x-tar");
+  });
+
+  it("ignores trailing path separators", () => {
+    expect(getContentType("build/bundle.tar.br/")).toBe("application/x-tar");
+    expect(getContentType("build\\bundle.tar.br\\")).toBe("application/x-tar");
+  });
+});

--- a/plugins/plugin-core/src/compressionFormat.ts
+++ b/plugins/plugin-core/src/compressionFormat.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 import mime from "mime";
 
 /**
@@ -70,11 +68,14 @@ export function getCompressionMimeType(filename: string): string | undefined {
  * @returns Content-Type string (never undefined, falls back to application/octet-stream)
  */
 export function getContentType(bundlePath: string): string {
-  const filename = path.basename(bundlePath);
+  const filename = bundlePath
+    .replace(/[\\/]+$/, "")
+    .split(/[\\/]/)
+    .pop();
 
   return (
     mime.getType(bundlePath) ??
-    getCompressionMimeType(filename) ??
+    getCompressionMimeType(filename ?? "") ??
     "application/octet-stream"
   );
 }


### PR DESCRIPTION
## Summary

- remove the `node:path` dependency from the published plugin-core compression helper so Worker and Edge runtimes can load it
- preserve archive MIME detection for POSIX paths, Windows paths, and trailing path separators

## Scope

This is the retained runtime-compatibility fix from the closed, unmerged #1103. It intentionally does not introduce Storage V2, a provider registry, config-shape changes, or source/import-policy tests.

## Verification

- plugin-core build and strict typecheck
- plugin-core unit suite: 9 files, 187 tests
- focused format and lint checks
- CJS and ESM built-artifact runtime checks across POSIX/Windows and trailing-separator paths
- built artifacts verified to contain no `node:path` import
- exact-SHA code, goal, security, context, manual-QA, and runtime-debugging reviews passed

Supersedes only the runtime portability residual from #1103.
