### PR TITLE
feat: platform-scoped fingerprint.extraSources (ios / android)

### DIFF
--- a/.changeset/platform-scoped-fingerprint-extra-sources.md
+++ b/.changeset/platform-scoped-fingerprint-extra-sources.md
@@ -1,0 +1,16 @@
+---
+"@hot-updater/plugin-core": patch
+"@hot-updater/cli-tools": patch
+"hot-updater": patch
+---
+
+feat: support platform-scoped `fingerprint.extraSources`
+
+`fingerprint.extraSources` now accepts `{ ios?: string[], android?: string[] }`
+in addition to `string[]`. An array keeps the existing behavior (shared by both
+platforms); the object form only feeds the fingerprint of the platform it is
+scoped to, so an iOS-only native input no longer moves the Android fingerprint
+(and vice versa).
+
+The default config no longer sets `extraSources: []`, which the config deep
+merge would otherwise use to clobber a user-supplied object.

--- a/docs/content/docs/guides/update-strategies/fingerprint.mdx
+++ b/docs/content/docs/guides/update-strategies/fingerprint.mdx
@@ -47,6 +47,24 @@ export default defineConfig({
 });
 ```
 
+An array is shared: every entry is hashed into both the iOS and the Android
+fingerprint. When the native inputs differ per platform, use the object form so
+that an iOS-only change does not move the Android fingerprint (and vice versa):
+
+```typescript title="hot-updater.config.ts"
+import { defineConfig } from "hot-updater";
+
+export default defineConfig({
+  updateStrategy: "fingerprint",
+  fingerprint: {
+    extraSources: {
+      ios: ["ios/.env"],
+      android: ["android/local.properties"],
+    },
+  },
+});
+```
+
 ## Workflow
 
 ### Before App Store Submission

--- a/packages/cli-tools/src/loadConfig.spec.ts
+++ b/packages/cli-tools/src/loadConfig.spec.ts
@@ -176,4 +176,31 @@ describe("loadConfig", () => {
       "ios/HotUpdaterExample/Info.plist",
     ]);
   });
+
+  it("keeps platform-scoped fingerprint extraSources intact", async () => {
+    await writeProjectFile(
+      projectRoot,
+      "hot-updater.config.ts",
+      [
+        "export default {",
+        "  updateStrategy: 'fingerprint',",
+        "  fingerprint: {",
+        "    extraSources: {",
+        "      ios: ['ios/.env'],",
+        "      android: ['android/local.properties'],",
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const { loadConfig } = await import("./loadConfig");
+    const config = await loadConfig(null);
+
+    expect(config.fingerprint.extraSources).toEqual({
+      ios: ["ios/.env"],
+      android: ["android/local.properties"],
+    });
+  });
 });

--- a/packages/cli-tools/src/loadConfig.ts
+++ b/packages/cli-tools/src/loadConfig.ts
@@ -97,9 +97,9 @@ const getDefaultConfig = (): ConfigInput => {
     releaseChannel: "production",
     updateStrategy: "appVersion",
     compressStrategy: "zip",
-    fingerprint: {
-      extraSources: [],
-    },
+    // `extraSources` is intentionally absent: the deep merge would let this
+    // default array clobber a user-supplied platform-scoped object.
+    fingerprint: {},
     patch: {
       enabled: true,
       maxBaseBundles: 3,

--- a/packages/hot-updater/src/utils/fingerprint/common.spec.ts
+++ b/packages/hot-updater/src/utils/fingerprint/common.spec.ts
@@ -1,0 +1,54 @@
+import { getCwd } from "@hot-updater/cli-tools";
+import { describe, expect, it } from "vitest";
+
+import { getOtaFingerprintOptions } from "./common";
+
+const SHARED_SOURCE =
+  "packages/hot-updater/src/utils/fingerprint/processExtraSources.ts";
+const IOS_ONLY_SOURCE = "packages/hot-updater/src/utils/fingerprint/common.ts";
+
+const getExtraSourceIds = async (
+  platform: "ios" | "android",
+  extraSources: Parameters<typeof getOtaFingerprintOptions>[2]["extraSources"],
+) => {
+  const cwd = getCwd();
+  const { extraSources: processed } = await getOtaFingerprintOptions(
+    platform,
+    cwd,
+    { platform, extraSources },
+  );
+  return processed.map((source) =>
+    source.type === "dir" ? source.filePath : source.id,
+  );
+};
+
+describe("getOtaFingerprintOptions", () => {
+  it("applies array extraSources to both platforms", async () => {
+    await expect(getExtraSourceIds("ios", [SHARED_SOURCE])).resolves.toEqual([
+      SHARED_SOURCE,
+    ]);
+    await expect(
+      getExtraSourceIds("android", [SHARED_SOURCE]),
+    ).resolves.toEqual([SHARED_SOURCE]);
+  });
+
+  it("keeps platform-scoped extraSources out of the other platform", async () => {
+    const extraSources = {
+      ios: [IOS_ONLY_SOURCE],
+      android: [SHARED_SOURCE],
+    };
+
+    await expect(getExtraSourceIds("ios", extraSources)).resolves.toEqual([
+      IOS_ONLY_SOURCE,
+    ]);
+    await expect(getExtraSourceIds("android", extraSources)).resolves.toEqual([
+      SHARED_SOURCE,
+    ]);
+  });
+
+  it("adds no extra sources for a platform without entries", async () => {
+    await expect(
+      getExtraSourceIds("android", { ios: [IOS_ONLY_SOURCE] }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/packages/hot-updater/src/utils/fingerprint/common.ts
+++ b/packages/hot-updater/src/utils/fingerprint/common.ts
@@ -1,8 +1,12 @@
 import { loadConfig, p } from "@hot-updater/cli-tools";
+import type { FingerprintExtraSources } from "@hot-updater/plugin-core";
 
 import { isExpo } from "../expoDetection";
 import { loadExpoFingerprint } from "./dependency";
-import { processExtraSources } from "./processExtraSources";
+import {
+  processExtraSources,
+  resolveExtraSources,
+} from "./processExtraSources";
 
 export const ensureFingerprintConfig = async () => {
   const config = await loadConfig(null);
@@ -100,7 +104,10 @@ export async function getOtaFingerprintOptions(
       SourceSkips.ExpoConfigExtraSection |
       SourceSkips.ExpoConfigEASProject |
       SourceSkips.ExpoConfigSchemes,
-    extraSources: processExtraSources(options.extraSources ?? [], path),
+    extraSources: processExtraSources(
+      resolveExtraSources(options.extraSources, platform),
+      path,
+    ),
     debug: options.debug,
   };
 }
@@ -129,7 +136,7 @@ export type FingerprintSource =
 
 export type FingerprintOptions = {
   platform: "ios" | "android";
-  extraSources?: string[];
+  extraSources?: FingerprintExtraSources;
   ignorePaths?: string[];
   debug?: boolean;
 };

--- a/packages/hot-updater/src/utils/fingerprint/processExtraSources.spec.ts
+++ b/packages/hot-updater/src/utils/fingerprint/processExtraSources.spec.ts
@@ -4,7 +4,10 @@ import { createFingerprintAsync } from "@expo/fingerprint";
 import { getCwd } from "@hot-updater/cli-tools";
 import { describe, expect, it } from "vitest";
 
-import { processExtraSources } from "./processExtraSources";
+import {
+  processExtraSources,
+  resolveExtraSources,
+} from "./processExtraSources";
 
 describe("processExtraSources", () => {
   it("should return relative paths, not absolute paths", () => {
@@ -75,5 +78,36 @@ describe("processExtraSources", () => {
 
     expect(result).toBeDefined();
     expect(result.hash).toBeDefined();
+  });
+});
+
+describe("resolveExtraSources", () => {
+  it("should apply an array to both platforms", () => {
+    const extraSources = ["resources/**", ".gitignore"];
+
+    expect(resolveExtraSources(extraSources, "ios")).toEqual(extraSources);
+    expect(resolveExtraSources(extraSources, "android")).toEqual(extraSources);
+  });
+
+  it("should scope the object form to the requested platform", () => {
+    const extraSources = {
+      ios: ["ios/.env"],
+      android: ["android/local.properties"],
+    };
+
+    expect(resolveExtraSources(extraSources, "ios")).toEqual(["ios/.env"]);
+    expect(resolveExtraSources(extraSources, "android")).toEqual([
+      "android/local.properties",
+    ]);
+  });
+
+  it("should return an empty array for a platform without entries", () => {
+    expect(resolveExtraSources({ ios: ["ios/.env"] }, "android")).toEqual([]);
+    expect(resolveExtraSources({}, "ios")).toEqual([]);
+  });
+
+  it("should handle undefined", () => {
+    expect(resolveExtraSources(undefined, "ios")).toEqual([]);
+    expect(resolveExtraSources(undefined, "android")).toEqual([]);
   });
 });

--- a/packages/hot-updater/src/utils/fingerprint/processExtraSources.ts
+++ b/packages/hot-updater/src/utils/fingerprint/processExtraSources.ts
@@ -3,6 +3,7 @@
 import fs from "fs";
 import path from "path";
 
+import type { FingerprintExtraSources } from "@hot-updater/plugin-core";
 import fg from "fast-glob";
 
 type HashSourceDir = {
@@ -17,6 +18,28 @@ type HashSourceContents = {
   contents: string | Buffer;
   reasons: string[];
 };
+
+/**
+ * Resolves the extra sources that apply to a single platform.
+ *
+ * An array is shared by both platforms; the object form only contributes the
+ * entries scoped to the requested platform.
+ * @param extraSources Shared array or platform-scoped object
+ * @param platform Platform the fingerprint is computed for
+ * @returns Array of file paths, directory paths, or glob patterns
+ */
+export function resolveExtraSources(
+  extraSources: FingerprintExtraSources | undefined,
+  platform: "ios" | "android",
+): string[] {
+  if (!extraSources) {
+    return [];
+  }
+  if (Array.isArray(extraSources)) {
+    return extraSources;
+  }
+  return extraSources[platform] ?? [];
+}
 
 /**
  * Processes extra source files and directories for fingerprinting.

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -493,6 +493,20 @@ export type SigningConfig =
       privateKeyPath: string;
     };
 
+/**
+ * Extra fingerprint sources.
+ *
+ * - `string[]`: shared, applied to both the iOS and Android fingerprint.
+ * - object: scoped per platform, so a change to one platform's native inputs
+ *   leaves the other platform's fingerprint untouched.
+ */
+export type FingerprintExtraSources =
+  | string[]
+  | {
+      ios?: string[];
+      android?: string[];
+    };
+
 export type ConfigInput = {
   /**
    * @hidden
@@ -537,9 +551,15 @@ export type ConfigInput = {
   fingerprint?: {
     /**
      * The extra sources to be included in the fingerprint.
+     *
+     * An array applies the sources to both platforms. Use the object form when
+     * the native inputs differ per platform, so that an iOS-only change does
+     * not move the Android fingerprint (and vice versa).
+     *
      * @example ["resources/**", ".gitignore"]
+     * @example { ios: ["ios/.env"], android: ["android/local.properties"] }
      */
-    extraSources?: string[];
+    extraSources?: FingerprintExtraSources;
     /**
      * The paths to be ignored in the fingerprint.
      */


### PR DESCRIPTION
Closes #1112 — implements the shape you suggested in the issue.

## Summary

`fingerprint.extraSources` now accepts an object in addition to `string[]`:

```ts
extraSources: ["resources/**"]            // shared, both platforms (unchanged)
extraSources: { ios: ["ios/.env"] }       // iOS fingerprint only
```

When a platform fingerprint is computed, only the entries for that platform are
processed, so an iOS-only native input no longer moves the Android fingerprint
and vice versa. This matters for brownfield / replace-in-place hosts where iOS
and Android native inputs are different trees and ship on separate native
release lines — cross-platform contamination there forces unrelated native
rebuilds and blocks OTA on the platform that didn't change.

Fully backward compatible: the array form behaves exactly as before.

## Changes

- `plugin-core`: new exported `FingerprintExtraSources` type (`string[] | { ios?, android? }`), used by `ConfigInput["fingerprint"]["extraSources"]`.
- `hot-updater`: `resolveExtraSources(extraSources, platform)` in `processExtraSources.ts`; `getOtaFingerprintOptions` resolves per platform before processing.
- `cli-tools`: the default config no longer sets `fingerprint.extraSources: []`. `merge` (es-toolkit) would otherwise let that default array clobber a user-supplied object — verified: `merge({ extraSources: [] }, { extraSources: { ios: [...] } })` yields `[]`.
- docs: object form documented in the fingerprint strategy guide.
- changeset: patch for `hot-updater`, `@hot-updater/cli-tools`, `@hot-updater/plugin-core`.

## Test plan

- New `resolveExtraSources` unit tests (array shared / object scoped / missing platform / undefined).
- New `getOtaFingerprintOptions` tests asserting the processed `extraSources` per platform, including that a platform with no entries gets none.
- New `loadConfig` test proving the object form survives the config deep merge.
- `pnpm -w test` (157 files / 2081 tests), `pnpm -w lint`, `pnpm -w test:type` all pass.

Made with [Cursor](https://cursor.com)