### PR TITLE
fix: prefer Info.plist over project.pbxproj when resolving the iOS app version

### DIFF
--- a/.changeset/hip-moons-invite.md
+++ b/.changeset/hip-moons-invite.md
@@ -1,0 +1,15 @@
+---
+"hot-updater": patch
+---
+
+fix: read the iOS app version from Info.plist before project.pbxproj
+
+`getNativeAppVersion("ios")` tried the `xcodeproj` parser first and only fell back
+to `info-plist`. Parsing project.pbxproj is synchronous, so on a large project it
+blocks the event loop for the whole parse, and `deploy` does this after the bundle
+has already been uploaded, just to fill in `metadata.app_version`. On a 12.5MB
+pbxproj that was ~5 minutes locally and ~16 minutes on CI.
+
+Info.plist is read first now. `CFBundleShortVersionString` is also closer to what
+the built app actually reports than `MARKETING_VERSION` (#84). The xcodeproj parser
+is still there as a fallback when Info.plist has no version.

--- a/.changeset/olive-pugs-attack.md
+++ b/.changeset/olive-pugs-attack.md
@@ -1,0 +1,15 @@
+---
+"hot-updater": patch
+---
+
+fix: bump the bundled `@bacons/xcode` to 1.0.0-alpha.33
+
+alpha.24 was published in December 2024 and still uses the old Chevrotain-based
+pbxproj parser. alpha.31 picked up the single-pass rewrite from
+EvanBacon/xcode#37, which is 42x faster on their benchmarks and considerably more
+than that on large files.
+
+On a 12.5MB `project.pbxproj`, `XcodeProject.open()` goes from 286s and 1.8GB of
+peak RSS down to 0.2s and 285MB, returning the same 48,670 objects. The only API
+used here is `XcodeProject.open().toJSON()` in `getIOSVersion`, which is unchanged
+between the two versions.

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -59,7 +59,7 @@
     "jiti": "2.6.1"
   },
   "devDependencies": {
-    "@bacons/xcode": "1.0.0-alpha.24",
+    "@bacons/xcode": "1.0.0-alpha.33",
     "@commander-js/extra-typings": "^14.0.0",
     "@expo/fingerprint": "^0.15.4",
     "@hot-updater/aws": "workspace:*",
@@ -115,7 +115,7 @@
     }
   },
   "inlinedDependencies": {
-    "@bacons/xcode": "1.0.0-alpha.24",
+    "@bacons/xcode": "1.0.0-alpha.33",
     "@commander-js/extra-typings": "14.0.0",
     "@expo/plist": "0.0.18",
     "@nodable/entities": "2.1.1",

--- a/packages/hot-updater/src/utils/version/getNativeAppVersion.spec.ts
+++ b/packages/hot-updater/src/utils/version/getNativeAppVersion.spec.ts
@@ -79,12 +79,13 @@ describe("getNativeAppVersion", () => {
   });
 
   describe("iOS platform", () => {
-    it("should return app version when xcodeproj file exists and has MARKETING_VERSION", async () => {
+    it("should fallback to xcodeproj MARKETING_VERSION when Info.plist has no version", async () => {
       // Arrange
       const mockXcodeprojPath =
         "/mock/project/root/ios/HotUpdaterExample.xcodeproj/project.pbxproj";
 
       mockGlobbySync.mockReturnValue([mockXcodeprojPath]);
+      mockFileExistFailure(); // no Info.plist
 
       const mockProject = {
         objects: {
@@ -117,7 +118,7 @@ describe("getNativeAppVersion", () => {
       );
     });
 
-    it("should fallback to plist when xcodeproj has no MARKETING_VERSION", async () => {
+    it("should prefer Info.plist over xcodeproj and never parse project.pbxproj", async () => {
       // Arrange
       const mockXcodeprojPath = "HotUpdaterExample.xcodeproj/project.pbxproj";
       const mockPlistPath =
@@ -125,13 +126,13 @@ describe("getNativeAppVersion", () => {
 
       mockGlobbySync.mockReturnValue([mockXcodeprojPath]);
 
-      // xcodeproj에 MARKETING_VERSION이 없는 경우
+      // xcodeproj also has a MARKETING_VERSION, but Info.plist wins
       const mockProject = {
         objects: {
           "13B07F941A680F5B00A75B9A": {
             isa: "XCBuildConfiguration",
             buildSettings: {
-              // MARKETING_VERSION이 없음
+              MARKETING_VERSION: "1.0",
             },
             name: "Release",
           },
@@ -167,6 +168,9 @@ describe("getNativeAppVersion", () => {
       expect(result).toBe("2.0");
       expect(mockFsReadFile).toHaveBeenCalledWith(mockPlistPath);
       expect(mockPlistParse).toHaveBeenCalledWith(mockPlistContent);
+      // Parsing project.pbxproj is synchronous and blocks the event loop, so
+      // it must not be opened at all once Info.plist has answered.
+      expect(mockXcodeProjectOpen).not.toHaveBeenCalled();
     });
 
     it("should return null when xcodeproj file does not exist", async () => {

--- a/packages/hot-updater/src/utils/version/getNativeAppVersion.ts
+++ b/packages/hot-updater/src/utils/version/getNativeAppVersion.ts
@@ -8,7 +8,16 @@ export const getNativeAppVersion = async (
 ): Promise<string | null> => {
   switch (platform) {
     case "ios":
-      return getIOSVersion({ parser: ["xcodeproj", "info-plist"] });
+      // Info.plist first, project.pbxproj as a fallback.
+      //
+      // CFBundleShortVersionString is the version the built app actually
+      // reports, so it is the more correct source (#84). It is also far cheaper:
+      // reading Info.plist is a small file read, whereas the pbxproj parser is
+      // synchronous and blocks the event loop for the length of the parse. On a
+      // large project.pbxproj that can take minutes, and `deploy` calls this
+      // after the bundle is already uploaded, purely to fill the informational
+      // `metadata.app_version` field on the bundle record.
+      return getIOSVersion({ parser: ["info-plist", "xcodeproj"] });
     case "android":
       return getAndroidVersion({ parser: "app-build-gradle" });
     default:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1640,8 +1640,8 @@ importers:
         version: 2.6.1
     devDependencies:
       '@bacons/xcode':
-        specifier: 1.0.0-alpha.24
-        version: 1.0.0-alpha.24
+        specifier: 1.0.0-alpha.33
+        version: 1.0.0-alpha.33
       '@commander-js/extra-typings':
         specifier: ^14.0.0
         version: 14.0.0(commander@14.0.3)
@@ -3432,8 +3432,8 @@ packages:
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@bacons/xcode@1.0.0-alpha.24':
-    resolution: {integrity: sha512-RaYUNsGBJVp0t2vgXaT4L668WIvbhtdl1JFJHedPkebIPR6h/+E2Kq32O49t+8f4LUPW9UF4CfXBrDc+XdXUUQ==}
+  '@bacons/xcode@1.0.0-alpha.33':
+    resolution: {integrity: sha512-+vwXK3mLnW8NOYSHNpCa7sAYR7qWmIHM3xBbBkLailN81F1CdSVsJBH1TAnTMHb+rDEh5ehsZ8AQRNVxvhWR/Q==}
 
   '@base-ui/react@1.5.0':
     resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
@@ -22128,7 +22128,7 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.3
 
-  '@bacons/xcode@1.0.0-alpha.24':
+  '@bacons/xcode@1.0.0-alpha.33':
     dependencies:
       '@expo/plist': 0.0.18
       debug: 4.4.3
@@ -24589,7 +24589,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -40293,7 +40293,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -41933,7 +41933,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
`getNativeAppVersion("ios")` runs the `xcodeproj` parser first, so every `deploy`
synchronously parses project.pbxproj just to fill in `metadata.app_version`. On our
project that's a 12.5MB pbxproj and it blocks the event loop for ~16 minutes on CI,
after the bundle has already finished uploading. Full trace in #1123.

Two commits, independent of each other, drop either if you disagree.

**Info.plist first.** Flips the order to `["info-plist", "xcodeproj"]`. Reading
Info.plist is a small file read, and `CFBundleShortVersionString` is closer to what the
built app actually reports than `MARKETING_VERSION`, which is what #84 was asking for on
correctness grounds. xcodeproj stays as the fallback, so anything that resolves today
still resolves.

**@bacons/xcode 1.0.0-alpha.24 -> 1.0.0-alpha.33.** alpha.24 is from December 2024;
alpha.31 picked up EvanBacon/xcode#37, the single-pass parser rewrite. This matters even
with the reorder, because everything else still goes through the xcodeproj path: the
`app-version` command, `getDefaultTargetAppVersion`, and the fallback above for projects
whose Info.plist uses `$(MARKETING_VERSION)`. The only API this repo uses is
`XcodeProject.open().toJSON()` in `getIOSVersion`, and it's unchanged across those
versions. I checked by building the CLI from this branch, reverting just the parser order
so it took the xcodeproj path, and running `app-version` against our 12.5MB pbxproj:
0.37s, same output as before. Same call on alpha.24 takes 286s.

On the tests: the existing xcodeproj test is now the fallback path, so I renamed it and
made it mock Info.plist away explicitly rather than relying on it happening to fail. The
second test now asserts Info.plist wins and that `XcodeProject.open` is never called.
That last assertion is the one actually protecting the fix, and it fails on main.

`pnpm -w lint` is clean, `pnpm -w build` succeeds, and `tsc --noEmit` in
packages/hot-updater is clean after a build. `pnpm -w test` has 72 failing files on main
from unbuilt workspace packages; the counts are identical with and without these changes
(72 failed / 85 passed, 46 / 596 / 1).
