### PR TITLE
fix(ios): fallback unresolved app version settings

### DIFF
--- a/.changeset/warm-dodos-wave.md
+++ b/.changeset/warm-dodos-wave.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+fix: fallback to project.pbxproj when Info.plist contains an unresolved build setting

--- a/packages/hot-updater/src/utils/version/getIOSVersion.ts
+++ b/packages/hot-updater/src/utils/version/getIOSVersion.ts
@@ -33,8 +33,13 @@ const getIOSVersionFromInfoPlist = async (): Promise<string | null> => {
 
     const fileBuffer = await fs.readFile(plistPath);
     const data = parsePlist(fileBuffer);
+    const appVersion = data["CFBundleShortVersionString"];
 
-    return data["CFBundleShortVersionString"] ?? null;
+    if (typeof appVersion !== "string" || appVersion.includes("$(")) {
+      return null;
+    }
+
+    return appVersion;
   } catch {
     return null;
   }

--- a/packages/hot-updater/src/utils/version/getNativeAppVersion.spec.ts
+++ b/packages/hot-updater/src/utils/version/getNativeAppVersion.spec.ts
@@ -173,6 +173,40 @@ describe("getNativeAppVersion", () => {
       expect(mockXcodeProjectOpen).not.toHaveBeenCalled();
     });
 
+    it("should fallback to xcodeproj when Info.plist contains an unresolved build setting", async () => {
+      // Arrange
+      const mockXcodeprojPath = "HotUpdaterExample.xcodeproj/project.pbxproj";
+      const mockPlistPath =
+        "/mock/project/root/ios/HotUpdaterExample/Info.plist";
+
+      mockGlobbySync.mockReturnValue([mockXcodeprojPath]);
+      mockFileExist([mockPlistPath]);
+      mockFsReadFile.mockResolvedValue(Buffer.from("mock plist"));
+      mockPlistParse.mockReturnValue({
+        CFBundleShortVersionString: "$(MARKETING_VERSION)",
+      });
+      mockXcodeProjectOpen.mockReturnValue({
+        toJSON: () => ({
+          objects: {
+            "13B07F941A680F5B00A75B9A": {
+              isa: "XCBuildConfiguration",
+              buildSettings: {
+                MARKETING_VERSION: "1.0",
+              },
+              name: "Release",
+            },
+          },
+        }),
+      });
+
+      // Act
+      const result = await getNativeAppVersion("ios");
+
+      // Assert
+      expect(result).toBe("1.0");
+      expect(mockXcodeProjectOpen).toHaveBeenCalledWith(mockXcodeprojPath);
+    });
+
     it("should return null when xcodeproj file does not exist", async () => {
       // Arrange
       mockGlobbySync.mockReturnValue([]); // 파일이 없음


### PR DESCRIPTION
## Summary

- treat unresolved Xcode build-setting references in `CFBundleShortVersionString` as unavailable
- fall back to the upgraded `project.pbxproj` parser merged in #1124
- add a regression test and patch changeset

Follow-up to #1124 for the `$(MARKETING_VERSION)` case described in #1123.

## Root cause

After #1124, Info.plist is checked first. When it contains `$(MARKETING_VERSION)`, the plist parser returns that placeholder as a non-empty string, so the parser chain stops before the xcodeproj fallback.

The fix rejects unresolved `$(` values at the Info.plist boundary. The existing xcodeproj parser then resolves `MARKETING_VERSION`; because #1124 also upgraded `@bacons/xcode`, this fallback uses the fast parser rather than the old multi-minute path.

## RED / GREEN

- RED: the new regression test returned `$(MARKETING_VERSION)` instead of `1.0`
- GREEN: the same test returns `1.0` and verifies `XcodeProject.open()` was called

## Validation

- `pnpm nx build hot-updater`
- `pnpm exec vitest run packages/hot-updater` (29 files, 291 tests)
- `pnpm --filter hot-updater test:type`
- `pnpm -w lint` (0 warnings, 0 errors)
- built CLI from `examples/v0.85.0`: `app-version --json` returned `{ "android": "1.0", "ios": "1.0" }`
