### PR TITLE
fix(firebase): support firebase-admin v14

### DIFF
--- a/.changeset/fix-firebase-admin-v14.md
+++ b/.changeset/fix-firebase-admin-v14.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/firebase": patch
+"@hot-updater/cli-tools": patch
+---
+
+Support firebase-admin v14 by using the modular Admin SDK APIs.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ export default defineConfig({
 ```tsx
 import { bare } from '@hot-updater/bare';
 import {firebaseStorage, firebaseDatabase} from '@hot-updater/firebase';
-import * as admin from 'firebase-admin';
+import { applicationDefault } from 'firebase-admin/app';
 import { config } from "dotenv";
 import { defineConfig } from "hot-updater";
 
@@ -166,7 +166,7 @@ config({ path: ".env.hotupdater" });
 // Check your .env file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   build: bare({

--- a/docs/content/docs/database-plugins/firestore.mdx
+++ b/docs/content/docs/database-plugins/firestore.mdx
@@ -26,9 +26,11 @@ For manual configuration, use the settings below.
 ## Configuration
 
 ```typescript
+import type { Credential } from 'firebase-admin/app';
+
 interface FirebaseDatabaseConfig {
   projectId: string;               // Firebase project ID
-  credential: admin.credential.Credential;  // Firebase credential
+  credential: Credential;          // Firebase credential
 }
 ```
 
@@ -46,14 +48,14 @@ FIREBASE_PROJECT_ID=your-project-id
 
 ```typescript
 import { firebaseDatabase } from '@hot-updater/firebase';
-import * as admin from 'firebase-admin';
+import { applicationDefault } from 'firebase-admin/app';
 import { defineConfig } from 'hot-updater';
 
 // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
 // Check your .env file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   database: firebaseDatabase({
@@ -70,10 +72,10 @@ Combined storage and database:
 
 ```typescript
 import { firebaseStorage, firebaseDatabase } from '@hot-updater/firebase';
-import * as admin from 'firebase-admin';
+import { applicationDefault } from 'firebase-admin/app';
 import { defineConfig } from 'hot-updater';
 
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   storage: firebaseStorage({

--- a/docs/content/docs/managed/firebase.mdx
+++ b/docs/content/docs/managed/firebase.mdx
@@ -87,7 +87,7 @@ GOOGLE_APPLICATION_CREDENTIALS=your-credentials.json
 ```ts title="hot-updater.config.ts"
 import { bare } from '@hot-updater/bare';
 import {firebaseStorage, firebaseDatabase} from '@hot-updater/firebase';
-import * as admin from 'firebase-admin';
+import { applicationDefault } from 'firebase-admin/app';
 import { defineConfig } from 'hot-updater';
 import 'dotenv/config';
 
@@ -95,7 +95,7 @@ import 'dotenv/config';
 // Check your .env file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   build: bare({

--- a/docs/content/docs/storage-plugins/firebase.mdx
+++ b/docs/content/docs/storage-plugins/firebase.mdx
@@ -25,10 +25,12 @@ For manual configuration, use the settings below.
 ## Configuration
 
 ```typescript
+import type { Credential } from 'firebase-admin/app';
+
 interface FirebaseStorageConfig {
   projectId: string;               // Firebase project ID
   storageBucket: string;           // Storage bucket name
-  credential: admin.credential.Credential;  // Firebase credential
+  credential: Credential;          // Firebase credential
   basePath?: string;               // Optional base path within bucket
 }
 ```
@@ -50,14 +52,14 @@ FIREBASE_STORAGE_BUCKET=your-bucket-name
 
 ```typescript
 import { firebaseStorage } from '@hot-updater/firebase';
-import * as admin from 'firebase-admin';
+import { applicationDefault } from 'firebase-admin/app';
 import { defineConfig } from 'hot-updater';
 
 // https://firebase.google.com/docs/admin/setup?hl=en#initialize_the_sdk_in_non-google_environments
 // Check your .env file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   storage: firebaseStorage({

--- a/packages/cli-tools/src/ConfigBuilder.spec.ts
+++ b/packages/cli-tools/src/ConfigBuilder.spec.ts
@@ -134,13 +134,13 @@ const getFirebaseConfigTemplate = (build: BuildType) => {
 // Check your .env.hotupdater file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();`.trim();
+const credential = applicationDefault();`.trim();
 
   return new ConfigBuilder()
     .setBuildType(build)
     .setStorage(storageConfig)
     .setDatabase(databaseConfig)
-    .addImport({ pkg: "firebase-admin", defaultOrNamespace: "admin" })
+    .addImport({ pkg: "firebase-admin/app", named: ["applicationDefault"] })
     .setIntermediateCode(intermediate)
     .getResult();
 };
@@ -313,8 +313,8 @@ export default defineConfig({
 
     const expectedConfig = `import { bare } from "@hot-updater/bare";
 import { firebaseDatabase, firebaseStorage } from "@hot-updater/firebase";
-import admin from "firebase-admin";
 import { config } from "dotenv";
+import { applicationDefault } from "firebase-admin/app";
 import { defineConfig } from "hot-updater";
 
 config({ path: ".env.hotupdater" });
@@ -323,7 +323,7 @@ config({ path: ".env.hotupdater" });
 // Check your .env.hotupdater file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();
+const credential = applicationDefault();
 
 export default defineConfig({
   build: bare({ enableHermes: true }),

--- a/packages/cli-tools/src/ConfigBuilder.ts
+++ b/packages/cli-tools/src/ConfigBuilder.ts
@@ -224,11 +224,11 @@ export class ConfigBuilder implements IConfigBuilder {
   setStorage(storageConfig: ProviderConfig): this {
     this.storageInfo = storageConfig;
     this.addImports(storageConfig.imports);
-    // Auto-add firebase-admin import if firebase is used
+    // Auto-add the modular firebase-admin credential import if firebase is used
     if (storageConfig.imports.some((imp) => imp.pkg.includes("firebase"))) {
       this.addImport({
-        pkg: "firebase-admin",
-        defaultOrNamespace: "admin",
+        pkg: "firebase-admin/app",
+        named: ["applicationDefault"],
       });
     }
     return this;
@@ -237,11 +237,11 @@ export class ConfigBuilder implements IConfigBuilder {
   setDatabase(databaseConfig: ProviderConfig): this {
     this.databaseInfo = databaseConfig;
     this.addImports(databaseConfig.imports);
-    // Auto-add firebase-admin import if firebase is used
+    // Auto-add the modular firebase-admin credential import if firebase is used
     if (databaseConfig.imports.some((imp) => imp.pkg.includes("firebase"))) {
       this.addImport({
-        pkg: "firebase-admin",
-        defaultOrNamespace: "admin",
+        pkg: "firebase-admin/app",
+        named: ["applicationDefault"],
       });
     }
     return this;

--- a/plugins/firebase/firebase/functions/index.ts
+++ b/plugins/firebase/firebase/functions/index.ts
@@ -1,5 +1,5 @@
 import { createHotUpdater } from "@hot-updater/server";
-import admin from "firebase-admin";
+import { getApps, initializeApp } from "firebase-admin/app";
 import { onRequest } from "firebase-functions/v2/https";
 import { Hono } from "hono";
 
@@ -14,11 +14,8 @@ declare global {
 
 export const HOT_UPDATER_BASE_PATH = "/api/check-update";
 
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
-const adminOptions = admin.app().options;
+const firebaseAdminApp = getApps()[0] ?? initializeApp();
+const adminOptions = firebaseAdminApp.options;
 const storageBucket = adminOptions.storageBucket;
 const cdnUrl = process.env.HOT_UPDATER_CDN_URL;
 

--- a/plugins/firebase/firebase/functions/runtime.emulator.integration.spec.ts
+++ b/plugins/firebase/firebase/functions/runtime.emulator.integration.spec.ts
@@ -20,7 +20,9 @@ import {
   setupBsdiffManifestUpdateInfoTestSuite,
   setupGetUpdateInfoTestSuite,
 } from "@hot-updater/test-utils";
-import admin from "firebase-admin";
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -228,9 +230,8 @@ exec node "${path.join(firebaseFunctionsPackagePath, "lib/bin/firebase-functions
       ),
     );
 
-    const firebaseAdminApp = admin.apps.length
-      ? admin.app()
-      : admin.initializeApp({ projectId, storageBucket });
+    const firebaseAdminApp =
+      getApps()[0] ?? initializeApp({ projectId, storageBucket });
     const adminOptions = {
       ...firebaseAdminApp.options,
       projectId,
@@ -513,13 +514,14 @@ exec node "${path.join(firebaseFunctionsPackagePath, "lib/bin/firebase-functions
 });
 
 const clearFirestoreCollection = async (collectionName: string) => {
-  const snapshot = await admin.firestore().collection(collectionName).get();
+  const firestore = getFirestore();
+  const snapshot = await firestore.collection(collectionName).get();
 
   if (snapshot.empty) {
     return;
   }
 
-  const batch = admin.firestore().batch();
+  const batch = firestore.batch();
   for (const doc of snapshot.docs) {
     batch.delete(doc.ref);
   }
@@ -527,7 +529,7 @@ const clearFirestoreCollection = async (collectionName: string) => {
 };
 
 const clearStorageBucket = async (storageBucket: string) => {
-  const [files] = await admin.storage().bucket(storageBucket).getFiles();
+  const [files] = await getStorage().bucket(storageBucket).getFiles();
 
   await Promise.all(
     files.map((file) =>
@@ -553,8 +555,7 @@ const seedStorageObject = async (
   body: string,
   contentType = "application/octet-stream",
 ) => {
-  await admin
-    .storage()
+  await getStorage()
     .bucket(storageBucket)
     .file(key.replace(/^\/+/, ""))
     .save(body, {

--- a/plugins/firebase/iac/select.ts
+++ b/plugins/firebase/iac/select.ts
@@ -46,7 +46,7 @@ const getConfigScaffold = (build: BuildType): HotUpdaterConfigScaffold => {
 // Check your .env file and add the credentials
 // Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to your credentials file path
 // Example: GOOGLE_APPLICATION_CREDENTIALS=./firebase-adminsdk-credentials.json
-const credential = admin.credential.applicationDefault();`.trim(),
+const credential = applicationDefault();`.trim(),
     },
   ];
 
@@ -54,7 +54,7 @@ const credential = admin.credential.applicationDefault();`.trim(),
     .setBuildType(build)
     .setStorage(storageConfig)
     .setDatabase(databaseConfig)
-    .addImport({ pkg: "firebase-admin", defaultOrNamespace: "admin" })
+    .addImport({ pkg: "firebase-admin/app", named: ["applicationDefault"] })
     .setIntermediateCode(
       helperStatements.map((statement) => statement.code.trim()).join("\n\n"),
     );

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -23,9 +23,19 @@ import {
   filterCompatibleAppVersions,
   resolveUpdateInfoFromBundles,
 } from "@hot-updater/plugin-core";
-import admin from "firebase-admin";
+import {
+  getApp,
+  getApps,
+  initializeApp,
+  type AppOptions,
+} from "firebase-admin/app";
+import {
+  getFirestore,
+  type DocumentData,
+  type Query,
+} from "firebase-admin/firestore";
 
-type FirestoreData = admin.firestore.DocumentData;
+type FirestoreData = DocumentData;
 
 const bundleMatchesQueryWhere = (
   bundle: Bundle,
@@ -84,7 +94,7 @@ const sortBundles = (
 };
 
 const applyFirestoreQueryableFilters = (
-  query: admin.firestore.Query<FirestoreData>,
+  query: Query<FirestoreData>,
   where: DatabaseBundleQueryWhere | undefined,
 ) => {
   let nextQuery = query;
@@ -206,17 +216,11 @@ const convertToBundle = (firestoreData: SnakeCaseBundle): Bundle => {
   };
 };
 
-export const firebaseDatabase = createDatabasePlugin<admin.AppOptions>({
+export const firebaseDatabase = createDatabasePlugin<AppOptions>({
   name: "firebaseDatabase",
   factory: (config) => {
-    let app: admin.app.App;
-    try {
-      app = admin.app();
-    } catch {
-      app = admin.initializeApp(config);
-    }
-
-    const db = admin.firestore(app);
+    const app = getApps().length ? getApp() : initializeApp(config);
+    const db = getFirestore(app);
     const bundlesCollection = db.collection("bundles");
     const targetAppVersionsCollection = db.collection("target_app_versions");
 

--- a/plugins/firebase/src/firebaseStorage.ts
+++ b/plugins/firebase/src/firebaseStorage.ts
@@ -7,9 +7,15 @@ import {
   getContentType,
   parseStorageUri,
 } from "@hot-updater/plugin-core";
-import admin from "firebase-admin";
+import {
+  getApp,
+  getApps,
+  initializeApp,
+  type AppOptions,
+} from "firebase-admin/app";
+import { getStorage } from "firebase-admin/storage";
 
-export interface FirebaseStorageConfig extends admin.AppOptions {
+export interface FirebaseStorageConfig extends AppOptions {
   storageBucket: string;
   /**
    * Base path where bundles will be stored in the bucket
@@ -22,13 +28,8 @@ export const firebaseStorage =
     name: "firebaseStorage",
     supportedProtocol: "gs",
     factory: (config) => {
-      let app: admin.app.App;
-      try {
-        app = admin.app();
-      } catch {
-        app = admin.initializeApp(config);
-      }
-      const bucket = app.storage().bucket(config.storageBucket);
+      const app = getApps().length ? getApp() : initializeApp(config);
+      const bucket = getStorage(app).bucket(config.storageBucket);
 
       const getStorageKey = createStorageKeyBuilder(config.basePath);
 

--- a/plugins/firebase/test-utils/createFirestoreMock.ts
+++ b/plugins/firebase/test-utils/createFirestoreMock.ts
@@ -1,13 +1,9 @@
-import admin from "firebase-admin";
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
 
 export function createFirestoreMock(projectId: string) {
-  if (!admin.apps.length) {
-    admin.initializeApp({
-      projectId,
-    });
-  }
-
-  const firestore = admin.firestore();
+  const app = getApps()[0] ?? initializeApp({ projectId });
+  const firestore = getFirestore(app);
   const bundlesCollection = firestore.collection("bundles");
   const targetAppVersionsCollection = firestore.collection(
     "target_app_versions",

--- a/plugins/firebase/vitest.global-setup.ts
+++ b/plugins/firebase/vitest.global-setup.ts
@@ -4,7 +4,8 @@ import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import admin from "firebase-admin";
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
 import fkill from "fkill";
 
 const PROJECT_ID_PREFIX = "hot-updater-test";
@@ -284,14 +285,8 @@ export async function setup() {
   process.env.FIREBASE_STORAGE_EMULATOR_HOST = storageHost;
   process.env.GCLOUD_PROJECT = projectId;
 
-  if (!admin.apps.length) {
-    admin.initializeApp({
-      projectId,
-      storageBucket,
-    });
-  }
-
-  const firestore = admin.firestore();
+  const app = getApps()[0] ?? initializeApp({ projectId, storageBucket });
+  const firestore = getFirestore(app);
   firestore.settings({
     host: emulatorHost,
     ssl: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ catalogs:
       version: 4.1.4
   firebase:
     firebase-admin:
-      specifier: 13.6.0
-      version: 13.6.0
+      specifier: 14.2.0
+      version: 14.2.0
   hono:
     '@hono/node-server':
       specifier: 1.19.11
@@ -555,7 +555,7 @@ importers:
         version: 9.5.2
       firebase-admin:
         specifier: catalog:firebase
-        version: 13.6.0
+        version: 14.2.0
       hono:
         specifier: catalog:hono
         version: 4.12.9
@@ -1276,7 +1276,7 @@ importers:
         version: 8.57.1
       firebase-admin:
         specifier: catalog:firebase
-        version: 13.6.0
+        version: 14.2.0
       firebase-tools:
         specifier: ^13.35.1
         version: 13.35.1(@types/node@25.9.3)
@@ -2147,13 +2147,13 @@ importers:
         version: 9.5.2
       firebase-admin:
         specifier: catalog:firebase
-        version: 13.6.0
+        version: 14.2.0
       firebase-functions:
         specifier: 6.3.2
-        version: 6.3.2(firebase-admin@13.6.0)
+        version: 6.3.2(firebase-admin@14.2.0)
       firebase-functions-test:
         specifier: ^3.5.0
-        version: 3.5.0(firebase-admin@13.6.0)(firebase-functions@6.3.2(firebase-admin@13.6.0))(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))
+        version: 3.5.0(firebase-admin@14.2.0)(firebase-functions@6.3.2(firebase-admin@14.2.0))(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))
       firebase-tools:
         specifier: ^13.32.0
         version: 13.35.1(@types/node@20.19.43)
@@ -4921,9 +4921,9 @@ packages:
     resolution: {integrity: sha512-pYFURu8H4Jr5O2KjrN0MdBLKkrChOPiQt+J/KT/DIRwa9cWhFVf2EB6MQxYYv3vQvkB5vEBpTi+TUp4DHZPi6Q==}
     engines: {node: '>=22'}
 
-  '@google-cloud/firestore@7.11.6':
-    resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
-    engines: {node: '>=14.0.0'}
+  '@google-cloud/firestore@8.7.1':
+    resolution: {integrity: sha512-Hp/WI8sH569ANitsko6RNvCUkzTCYudHoINOkQjiJq2FBG6kKnofBAW7PtS823cu6RMxHqK2RxRcspdjrRpUFA==}
+    engines: {node: '>=18'}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -12806,10 +12806,6 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
-  farmhash-modern@1.1.0:
-    resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
-    engines: {node: '>=18.0.0'}
-
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -13010,9 +13006,9 @@ packages:
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
-  firebase-admin@13.6.0:
-    resolution: {integrity: sha512-GdPA/t0+Cq8p1JnjFRBmxRxAGvF/kl2yfdhALl38PrRp325YxyQ5aNaHui0XmaKcKiGRFIJ/EgBNWFoDP0onjw==}
-    engines: {node: '>=18'}
+  firebase-admin@14.2.0:
+    resolution: {integrity: sha512-zfs5PdccEgjX479bbMmz95Rqc7ttQ4LV3qkGFlPiqOaOu/suBZc3fG52Qzn2hQjiSHkBM4NP2AZV5r2NvAt0TQ==}
+    engines: {node: '>=22'}
 
   firebase-functions-test@3.5.0:
     resolution: {integrity: sha512-Jg+f9GeWkWpgYRY9s+Oxst/b9kEnOJ6pU/XNFthOFYs2Ax2fU2Zxc7ckfTozYKEH/mzptSDxV5JYiPTvR+RhKA==}
@@ -13537,6 +13533,10 @@ packages:
   google-gax@4.6.1:
     resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
     engines: {node: '>=14'}
+
+  google-gax@5.0.8:
+    resolution: {integrity: sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==}
+    engines: {node: '>=18'}
 
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
@@ -14604,9 +14604,6 @@ packages:
   join-path@1.1.1:
     resolution: {integrity: sha512-jnt9OC34sLXMLJ6YfPQ2ZEKrR9mB5ZbSnQb4LPaOx1c5rTzxpR33L18jjp0r75mGGTJmsil3qwN1B5IBeTnSSA==}
 
-  jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
-
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -14755,9 +14752,9 @@ packages:
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
-  jwks-rsa@3.2.2:
-    resolution: {integrity: sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==}
-    engines: {node: '>=14'}
+  jwks-rsa@4.1.0:
+    resolution: {integrity: sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >= 23.0.0}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
@@ -15160,8 +15157,8 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lru-memoizer@2.3.0:
-    resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
+  lru-memoizer@3.0.0:
+    resolution: {integrity: sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==}
 
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
@@ -17154,6 +17151,10 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@7.6.3:
     resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
@@ -17784,6 +17785,10 @@ packages:
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
+
+  retry-request@8.0.4:
+    resolution: {integrity: sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==}
+    engines: {node: '>=18'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -18577,6 +18582,10 @@ packages:
   tcp-port-used@1.0.3:
     resolution: {integrity: sha512-4CEQ3qRJYo+mtEbJ+OoQu3dF4TDkwaO3RDVC4UzP5cpAOIUWwuwPjD7sdxDFFqsMUjsXVVYBMlg/boAaloThMA==}
 
+  teeny-request@10.1.4:
+    resolution: {integrity: sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==}
+    engines: {node: '>=18'}
+
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
@@ -19318,10 +19327,6 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@14.0.0:
@@ -23909,15 +23914,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6':
+  '@google-cloud/firestore@8.7.1':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
-      google-gax: 4.6.1
+      google-gax: 5.0.8
       protobufjs: 7.6.3
     transitivePeerDependencies:
-      - encoding
       - supports-color
     optional: true
 
@@ -33871,8 +33875,6 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
-  farmhash-modern@1.1.0: {}
-
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -34142,42 +34144,38 @@ snapshots:
     dependencies:
       micromatch: 4.0.8
 
-  firebase-admin@13.6.0:
+  firebase-admin@14.2.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.4
       '@firebase/database-types': 1.0.20
-      '@types/node': 22.19.21
-      farmhash-modern: 1.1.0
       fast-deep-equal: 3.1.3
-      google-auth-library: 9.15.1
+      google-auth-library: 10.7.0
       jsonwebtoken: 9.0.3
-      jwks-rsa: 3.2.2
-      node-forge: 1.4.0
-      uuid: 11.1.1
+      jwks-rsa: 4.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6
+      '@google-cloud/firestore': 8.7.1
       '@google-cloud/storage': 7.21.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  firebase-functions-test@3.5.0(firebase-admin@13.6.0)(firebase-functions@6.3.2(firebase-admin@13.6.0))(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)):
+  firebase-functions-test@3.5.0(firebase-admin@14.2.0)(firebase-functions@6.3.2(firebase-admin@14.2.0))(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)):
     dependencies:
       '@types/lodash': 4.17.24
-      firebase-admin: 13.6.0
-      firebase-functions: 6.3.2(firebase-admin@13.6.0)
+      firebase-admin: 14.2.0
+      firebase-functions: 6.3.2(firebase-admin@14.2.0)
       jest: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
       lodash: 4.18.1
       ts-deepmerge: 2.0.7
 
-  firebase-functions@6.3.2(firebase-admin@13.6.0):
+  firebase-functions@6.3.2(firebase-admin@14.2.0):
     dependencies:
       '@types/cors': 2.8.19
       '@types/express': 4.17.25
       cors: 2.8.6
       express: 4.22.2
-      firebase-admin: 13.6.0
+      firebase-admin: 14.2.0
       protobufjs: 7.6.3
     transitivePeerDependencies:
       - supports-color
@@ -34953,6 +34951,23 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  google-gax@5.0.8:
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
+      duplexify: 4.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.6.3
+      retry-request: 8.0.4
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   google-logging-utils@0.0.2: {}
 
@@ -36318,8 +36333,6 @@ snapshots:
       url-join: 0.0.1
       valid-url: 1.0.9
 
-  jose@4.15.9: {}
-
   jose@6.2.3: {}
 
   js-base64@3.7.8: {}
@@ -36525,13 +36538,14 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jwks-rsa@3.2.2:
+  jwks-rsa@4.1.0:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       debug: 4.4.3
-      jose: 4.15.9
+      jose: 6.2.3
       limiter: 1.1.5
-      lru-memoizer: 2.3.0
+      lru-cache: 11.5.1
+      lru-memoizer: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -36865,10 +36879,10 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lru-memoizer@2.3.0:
+  lru-memoizer@3.0.0:
     dependencies:
       lodash.clonedeep: 4.5.0
-      lru-cache: 6.0.0
+      lru-cache: 11.5.1
 
   lru.min@1.1.4: {}
 
@@ -40268,6 +40282,11 @@ snapshots:
     dependencies:
       protobufjs: 7.6.3
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.6.3
+    optional: true
+
   protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -41386,6 +41405,14 @@ snapshots:
       - encoding
       - supports-color
 
+  retry-request@8.0.4:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   retry@0.12.0: {}
 
   retry@0.13.1: {}
@@ -42420,6 +42447,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  teeny-request@10.1.4:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   teeny-request@9.0.0:
     dependencies:
       http-proxy-agent: 5.0.0
@@ -43074,8 +43111,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
-
-  uuid@11.1.1: {}
 
   uuid@14.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalogs:
     pg: 8.13.1
     prisma: 6.19.3
   firebase:
-    firebase-admin: 13.6.0
+    firebase-admin: 14.2.0
   hono:
     "@hono/node-server": 1.19.11
     hono: 4.12.9


### PR DESCRIPTION
## Summary

- upgrade the workspace `firebase-admin` development baseline from 13.6.0 to 14.2.0
- migrate Firebase database, storage, Functions, test setup, and generated config code from the removed legacy namespace API to the modular Admin SDK API
- update Firebase setup documentation and add patch changesets for `@hot-updater/firebase` and `@hot-updater/cli-tools`

## Root cause

`firebase-admin` v14 removed the legacy namespace exports used by `admin.app()`, `admin.firestore()`, `admin.storage()`, and `admin.credential`. Because the peer dependency allows v14, the failure surfaced only when the plugin factory ran.

The implementation now uses `firebase-admin/app`, `firebase-admin/firestore`, and `firebase-admin/storage`, which are available in both v13 and v14.

## Compatibility

The Firebase Functions deployment template remains on its existing v13 dependency set. The same source and emulator suite passed against both `firebase-admin@13.10.0` and `firebase-admin@14.2.0`.

## Validation

- reproduced the failure after the v14 bump: `admin.apps` was undefined before tests could run
- `pnpm --filter @hot-updater/firebase... build`
- `pnpm --filter @hot-updater/firebase test:run` — 278 tests on v14.2.0
- the same Firebase typecheck and 278-test suite on v13.10.0
- `pnpm -w test:type` — 33 projects
- `pnpm -w lint`
- `pnpm -w test` — 2,085 tests

Fixes #1133