### PR TITLE
fix(server): treat unknown built-in baseline bundle ids as nil baseline

### DIFF
--- a/.changeset/unknown-baseline-bundle-id.md
+++ b/.changeset/unknown-baseline-bundle-id.md
@@ -1,0 +1,7 @@
+---
+"@hot-updater/core": patch
+"@hot-updater/js": patch
+"@hot-updater/server": patch
+---
+
+Treat unknown build-time generated baseline bundle ids as the nil baseline during update checks so a fresh install still receives the latest compatible OTA instead of failing or rolling back.

--- a/packages/core/src/uuid.ts
+++ b/packages/core/src/uuid.ts
@@ -1,1 +1,19 @@
 export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Suffix shared by every build-time generated baseline bundle id
+ * (`generateMinBundleId()`): a UUIDv7 whose random bits are all zero.
+ *
+ * A fresh install that has never applied an OTA update reports this id as its
+ * current bundle id even though it is never stored as a deployed bundle.
+ */
+const BUILT_IN_BASELINE_BUNDLE_ID_SUFFIX = "-7000-8000-000000000000";
+
+/**
+ * Whether the given bundle id is a build-time generated built-in baseline id.
+ *
+ * Such ids identify the JS bundle embedded in the native app binary, not a
+ * deployed OTA bundle, so they never have a database record.
+ */
+export const isBuiltInBaselineBundleId = (bundleId: string): boolean =>
+  bundleId.endsWith(BUILT_IN_BASELINE_BUNDLE_ID_SUFFIX);

--- a/packages/server/src/db/pluginCore.spec.ts
+++ b/packages/server/src/db/pluginCore.spec.ts
@@ -422,6 +422,144 @@ describe("createPluginDatabaseCore", () => {
     expect(getBundleById).toHaveBeenCalledWith(targetBundle.id, undefined);
   });
 
+  it("skips database resolution for unknown built-in baseline bundle ids", async () => {
+    const baselineBundleId = "019e37fe-bd30-7000-8000-000000000000";
+    const targetBundle = {
+      ...baseBundle,
+      id: "019e3f00-90cc-70c9-bb2b-b7cf2acecf60",
+      fileHash: "hash-2",
+      manifestStorageUri: "s3://bucket/target/manifest.json",
+      manifestFileHash: "sig:target-manifest",
+      assetBaseStorageUri: "s3://bucket/target/files",
+    };
+    const manifests = new Map([
+      [
+        targetBundle.manifestStorageUri,
+        JSON.stringify({
+          bundleId: targetBundle.id,
+          assets: {
+            "index.ios.bundle": {
+              fileHash: "target-bundle-hash",
+            },
+          },
+        }),
+      ],
+    ]);
+    const getBundleById = vi.fn<DatabasePlugin<TestContext>["getBundleById"]>(
+      async (bundleId) => (bundleId === targetBundle.id ? targetBundle : null),
+    );
+    const getUpdateInfo = vi.fn<
+      NonNullable<DatabasePlugin<TestContext>["getUpdateInfo"]>
+    >(async () => ({
+      fileHash: targetBundle.fileHash,
+      id: targetBundle.id,
+      message: targetBundle.message,
+      shouldForceUpdate: targetBundle.shouldForceUpdate,
+      status: "UPDATE",
+      storageUri: targetBundle.storageUri,
+    }));
+
+    const plugin: DatabasePlugin<TestContext> = {
+      name: "baseline-id-plugin",
+      async appendBundle() {},
+      async commitBundle() {},
+      async deleteBundle() {},
+      getBundleById,
+      getUpdateInfo,
+      async getBundles() {
+        return {
+          data: [targetBundle],
+          pagination: {
+            currentPage: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            total: 1,
+            totalPages: 1,
+          },
+        };
+      },
+      async getChannels() {
+        return ["production"];
+      },
+      async updateBundle() {},
+    };
+
+    const core = createPluginDatabaseCore(
+      () => plugin,
+      async (storageUri) => {
+        if (!storageUri) return null;
+        const url = new URL(storageUri);
+        return `https://assets.example.com/${url.host}${url.pathname}`;
+      },
+      {
+        readStorageText: async (storageUri) =>
+          manifests.get(storageUri) ?? null,
+      },
+    );
+
+    const updateInfo = await core.api.getAppUpdateInfo({
+      ...updateArgs,
+      bundleId: baselineBundleId,
+    });
+
+    expect(updateInfo).toMatchObject({
+      id: targetBundle.id,
+      status: "UPDATE",
+    });
+    expect(getBundleById).toHaveBeenCalledOnce();
+    expect(getBundleById).toHaveBeenCalledWith(targetBundle.id, undefined);
+    expect(getBundleById).not.toHaveBeenCalledWith(baselineBundleId, undefined);
+  });
+
+  it("treats unknown built-in baseline bundle ids as the nil baseline when scanning", async () => {
+    const baselineBundleId = "019e37fe-bd30-7000-8000-000000000000";
+    const olderBundle = {
+      ...baseBundle,
+      id: "019e2f00-1111-7abc-8123-456789abcdef",
+    };
+
+    const plugin: DatabasePlugin<TestContext> = {
+      name: "scanning-plugin",
+      async appendBundle() {},
+      async commitBundle() {},
+      async deleteBundle() {},
+      async getBundleById(bundleId) {
+        return bundleId === olderBundle.id ? olderBundle : null;
+      },
+      async getBundles() {
+        return {
+          data: [olderBundle],
+          pagination: {
+            currentPage: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            total: 1,
+            totalPages: 1,
+          },
+        };
+      },
+      async getChannels() {
+        return ["production"];
+      },
+      async updateBundle() {},
+    };
+
+    const core = createPluginDatabaseCore(
+      () => plugin,
+      async () => null,
+    );
+
+    await expect(
+      core.api.getUpdateInfo({
+        ...updateArgs,
+        bundleId: baselineBundleId,
+      }),
+    ).resolves.toMatchObject({
+      id: olderBundle.id,
+      status: "UPDATE",
+    });
+  });
+
   it("seeds request bundle identity map from provider update lookups", async () => {
     const targetBundle = {
       ...baseBundle,

--- a/packages/server/src/db/pluginCore.ts
+++ b/packages/server/src/db/pluginCore.ts
@@ -7,7 +7,11 @@ import type {
   Platform,
   UpdateInfo,
 } from "@hot-updater/core";
-import { isCohortEligibleForUpdate, NIL_UUID } from "@hot-updater/core";
+import {
+  isBuiltInBaselineBundleId,
+  isCohortEligibleForUpdate,
+  NIL_UUID,
+} from "@hot-updater/core";
 import {
   type DatabaseBundleQueryOptions,
   type DatabaseBundleQueryOrder,
@@ -181,6 +185,13 @@ export function createPluginDatabaseCore<TContext = unknown>(
     isCandidate: (bundle: Bundle) => boolean;
     context?: HotUpdaterContext<TContext>;
   }): Promise<UpdateInfo | null> => {
+    // A build-time generated built-in baseline id never has a bundle record,
+    // so a fresh install reporting it must behave like the nil baseline
+    // instead of triggering rollback resolution against an id that cannot
+    // exist.
+    const requestBundleId = isBuiltInBaselineBundleId(args.bundleId)
+      ? NIL_UUID
+      : args.bundleId;
     let after: string | undefined;
 
     while (true) {
@@ -208,14 +219,14 @@ export function createPluginDatabaseCore<TContext = unknown>(
           continue;
         }
 
-        if (args.bundleId === NIL_UUID) {
+        if (requestBundleId === NIL_UUID) {
           if (isEligibleForUpdate(bundle, args.cohort)) {
             return makeResponse(bundle, "UPDATE");
           }
           continue;
         }
 
-        const compareResult = bundle.id.localeCompare(args.bundleId);
+        const compareResult = bundle.id.localeCompare(requestBundleId);
 
         if (compareResult > 0) {
           if (isEligibleForUpdate(bundle, args.cohort)) {
@@ -244,13 +255,13 @@ export function createPluginDatabaseCore<TContext = unknown>(
       }
     }
 
-    if (args.bundleId === NIL_UUID) {
+    if (requestBundleId === NIL_UUID) {
       return null;
     }
 
     if (
       args.minBundleId &&
-      args.bundleId.localeCompare(args.minBundleId) <= 0
+      requestBundleId.localeCompare(args.minBundleId) <= 0
     ) {
       return null;
     }
@@ -370,6 +381,13 @@ export function createPluginDatabaseCore<TContext = unknown>(
         const seededCurrentBundle = requestBundles.peek(args.bundleId);
         if (seededCurrentBundle || requestBundles.hasSeededBundles()) {
           return seededCurrentBundle;
+        }
+
+        if (isBuiltInBaselineBundleId(args.bundleId)) {
+          // A build-time generated built-in baseline id never has a bundle
+          // record, so skip database resolution instead of scanning for a
+          // record that cannot exist.
+          return null;
         }
 
         return requestBundles.getById(args.bundleId, () =>

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -444,6 +444,65 @@ describe("s3Database plugin", () => {
     ]);
   });
 
+  it("returns the latest OTA when a fresh install reports an unknown built-in baseline bundle id", async () => {
+    // Reproduces #1015: a fresh install reports the build-time generated
+    // baseline bundle id, which has no database record.
+    const baselineBundleId = "019e37fe-bd30-7000-8000-000000000000";
+    const otaBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.2.0",
+      "019e3f00-90cc-70c9-bb2b-b7cf2acecf60",
+    );
+
+    seedUpdateManifests([otaBundle]);
+    listedObjectPrefixes = [];
+    loadedObjectKeys = [];
+
+    await expect(
+      plugin.getUpdateInfo?.({
+        _updateStrategy: "appVersion",
+        appVersion: "1.2.0",
+        bundleId: baselineBundleId,
+        minBundleId: baselineBundleId,
+        platform: "ios",
+      }),
+    ).resolves.toMatchObject({
+      id: otaBundle.id,
+      status: "UPDATE",
+    });
+
+    expect(listedObjectPrefixes).toEqual([]);
+  });
+
+  it("treats an unknown built-in baseline bundle id as the nil baseline for stale bundles", async () => {
+    const baselineBundleId = "019e37fe-bd30-7000-8000-000000000000";
+    const staleOtaBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.2.0",
+      "019e2f00-1111-7abc-8123-456789abcdef",
+    );
+
+    seedUpdateManifests([staleOtaBundle]);
+    listedObjectPrefixes = [];
+    loadedObjectKeys = [];
+
+    await expect(
+      plugin.getUpdateInfo?.({
+        _updateStrategy: "appVersion",
+        appVersion: "1.2.0",
+        bundleId: baselineBundleId,
+        platform: "ios",
+      }),
+    ).resolves.toMatchObject({
+      id: staleOtaBundle.id,
+      status: "UPDATE",
+    });
+
+    expect(listedObjectPrefixes).toEqual([]);
+  });
+
   it("uses direct fingerprint manifests for update checks without listing S3 objects", async () => {
     const fingerprintBundle = createBundleJsonFingerprint(
       "production",

--- a/plugins/js/src/getUpdateInfo.spec.ts
+++ b/plugins/js/src/getUpdateInfo.spec.ts
@@ -1,10 +1,189 @@
+import { type Bundle, NIL_UUID } from "@hot-updater/core";
 import { setupGetUpdateInfoTestSuite } from "@hot-updater/test-utils";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { getUpdateInfo } from "./getUpdateInfo";
 
 describe("getUpdateInfo", () => {
   setupGetUpdateInfoTestSuite({
     getUpdateInfo,
+  });
+});
+
+describe("getUpdateInfo - unknown built-in baseline bundle id (#1015)", () => {
+  // Build-time generated baseline id reported by a fresh install (all random
+  // bits are zero), taken from the issue report.
+  const BASELINE_BUNDLE_ID = "019e37fe-bd30-7000-8000-000000000000";
+  const NEWER_OTA_BUNDLE_ID = "019e3f00-90cc-70c9-bb2b-b7cf2acecf60";
+  const OLDER_OTA_BUNDLE_ID = "019e2f00-1111-7abc-8123-456789abcdef";
+
+  const DEFAULT_BUNDLE = {
+    message: "hello",
+    platform: "ios",
+    gitCommitHash: null,
+    fileHash: "hash",
+    channel: "production",
+    storageUri: "storage://my-app/bundle.zip",
+    enabled: true,
+    shouldForceUpdate: false,
+  } as const;
+
+  it("returns the latest OTA when the unknown baseline id has a newer enabled bundle", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: "1.2.0",
+        fingerprintHash: null,
+        id: NEWER_OTA_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      appVersion: "1.2.0",
+      minBundleId: BASELINE_BUNDLE_ID,
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toMatchObject({
+      id: NEWER_OTA_BUNDLE_ID,
+      status: "UPDATE",
+    });
+  });
+
+  it("treats an unknown baseline id as the nil baseline instead of rolling back to an older bundle", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: "1.2.0",
+        fingerprintHash: null,
+        id: OLDER_OTA_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      appVersion: "1.2.0",
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toMatchObject({
+      id: OLDER_OTA_BUNDLE_ID,
+      status: "UPDATE",
+    });
+  });
+
+  it("returns null for an unknown baseline id when no bundles exist", async () => {
+    const update = await getUpdateInfo([], {
+      appVersion: "1.2.0",
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toBeNull();
+  });
+
+  it("keeps rollback semantics for unknown non-baseline bundle ids", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: "1.2.0",
+        fingerprintHash: null,
+        id: OLDER_OTA_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      appVersion: "1.2.0",
+      bundleId: "019e37fe-bd30-7abc-8123-456789abcdef", // deleted OTA bundle
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toMatchObject({
+      id: OLDER_OTA_BUNDLE_ID,
+      status: "ROLLBACK",
+    });
+  });
+
+  it("does not treat a baseline-shaped id as unknown when a bundle with that id exists", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: "1.2.0",
+        fingerprintHash: null,
+        id: BASELINE_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      appVersion: "1.2.0",
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toBeNull();
+  });
+
+  it("returns the latest OTA for an unknown baseline id with the fingerprint strategy", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: null,
+        fingerprintHash: "hash1",
+        id: NEWER_OTA_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      fingerprintHash: "hash1",
+      minBundleId: BASELINE_BUNDLE_ID,
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "fingerprint",
+    });
+
+    expect(update).toMatchObject({
+      id: NEWER_OTA_BUNDLE_ID,
+      status: "UPDATE",
+    });
+  });
+
+  it("treats an unknown baseline id as the nil baseline for the fingerprint strategy", async () => {
+    const bundles: Bundle[] = [
+      {
+        ...DEFAULT_BUNDLE,
+        targetAppVersion: null,
+        fingerprintHash: "hash1",
+        id: OLDER_OTA_BUNDLE_ID,
+      },
+    ];
+
+    const update = await getUpdateInfo(bundles, {
+      fingerprintHash: "hash1",
+      bundleId: BASELINE_BUNDLE_ID,
+      platform: "ios",
+      _updateStrategy: "fingerprint",
+    });
+
+    expect(update).toMatchObject({
+      id: OLDER_OTA_BUNDLE_ID,
+      status: "UPDATE",
+    });
+  });
+
+  it("keeps the nil baseline behavior unchanged", async () => {
+    const update = await getUpdateInfo([], {
+      appVersion: "1.2.0",
+      bundleId: NIL_UUID,
+      platform: "ios",
+      _updateStrategy: "appVersion",
+    });
+
+    expect(update).toBeNull();
   });
 });

--- a/plugins/js/src/getUpdateInfo.ts
+++ b/plugins/js/src/getUpdateInfo.ts
@@ -3,6 +3,7 @@ import {
   type Bundle,
   type FingerprintGetBundlesArgs,
   type GetBundlesArgs,
+  isBuiltInBaselineBundleId,
   isCohortEligibleForUpdate,
   NIL_UUID,
   type UpdateInfo,
@@ -61,15 +62,37 @@ const findLatestEligibleUpdateCandidate = (
   return updateCandidate;
 };
 
+const resolveRequestBundleId = (
+  bundles: Bundle[],
+  bundleId: string,
+): string => {
+  if (
+    isBuiltInBaselineBundleId(bundleId) &&
+    !bundles.some((bundle) => bundle.id === bundleId)
+  ) {
+    // A build-time generated built-in baseline id has no bundle record, so a
+    // fresh install reporting it must behave like the nil baseline instead of
+    // triggering rollback resolution against an id that cannot exist.
+    return NIL_UUID;
+  }
+  return bundleId;
+};
+
 export const getUpdateInfo = async (
   bundles: Bundle[],
   args: GetBundlesArgs,
 ): Promise<UpdateInfo | null> => {
   switch (args._updateStrategy) {
     case "appVersion":
-      return appVersionStrategy(bundles, args);
+      return appVersionStrategy(bundles, {
+        ...args,
+        bundleId: resolveRequestBundleId(bundles, args.bundleId),
+      });
     case "fingerprint":
-      return fingerprintStrategy(bundles, args);
+      return fingerprintStrategy(bundles, {
+        ...args,
+        bundleId: resolveRequestBundleId(bundles, args.bundleId),
+      });
     default:
       return null;
   }

--- a/plugins/plugin-core/src/generateMinBundleId.spec.ts
+++ b/plugins/plugin-core/src/generateMinBundleId.spec.ts
@@ -1,3 +1,4 @@
+import { isBuiltInBaselineBundleId, NIL_UUID } from "@hot-updater/core";
 import { describe, expect, it } from "vitest";
 
 import { generateMinBundleId } from "./generateMinBundleId";
@@ -39,5 +40,16 @@ describe("generateMinBundleId", () => {
 
     expect(timestamp).toBeGreaterThanOrEqual(startTime);
     expect(timestamp).toBeLessThanOrEqual(endTime);
+  });
+
+  it("should be detected as a built-in baseline bundle id", () => {
+    expect(isBuiltInBaselineBundleId(generateMinBundleId())).toBe(true);
+    expect(
+      isBuiltInBaselineBundleId("019e37fe-bd30-7000-8000-000000000000"),
+    ).toBe(true);
+    expect(isBuiltInBaselineBundleId(NIL_UUID)).toBe(false);
+    expect(
+      isBuiltInBaselineBundleId("019e3f00-90cc-70c9-bb2b-b7cf2acecf60"),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Root cause

Fixes #1015

A fresh install that has never applied an OTA update reports its **build-time generated built-in baseline bundle id** (from `generateMinBundleId()`, e.g. `019e37fe-bd30-7000-8000-000000000000`) as its current bundle id. That id is derived from the build timestamp with all UUIDv7 random bits zeroed, so it never exists as a deployed bundle record.

The update-check path still treated it like a regular installed bundle id:

- In the shared `getUpdateInfo` core (`@hot-updater/js`, used by the AWS Lambda runtime through `resolveUpdateInfoFromBundles`, and also by the Cloudflare/Firebase providers and the server DB adapters), an unknown baseline id could enter **rollback resolution** (`ROLLBACK` to an older bundle, or the forced nil-bundle `ROLLBACK`) instead of behaving like the nil baseline `00000000-0000-0000-0000-000000000000`.
- In `@hot-updater/server`'s `getAppUpdateInfo`, the unknown baseline id was **resolved against the database** (`getBundleById`) when no request-scoped seeds are available. On the AWS S3 database plugin that lookup cache-misses and falls back to a full bundle re-scan inside Lambda@Edge — the "request died while resolving the unknown current baseline bundle id" failure reported in the issue, surfacing as a CloudFront 503 before the available OTA could be returned.

## Fix

Applied in the shared core so every provider that funnels through it benefits (AWS, Cloudflare, Firebase, server DB adapters):

- `packages/core/src/uuid.ts`: add `isBuiltInBaselineBundleId()` — detects the `generateMinBundleId()` shape (`xxxxxxxx-xxxx-7000-8000-000000000000`).
- `plugins/js/src/getUpdateInfo.ts`: when the reported bundle id is a built-in baseline id **and has no bundle record**, evaluate the request with nil-baseline semantics. A fresh install therefore receives the latest compatible enabled OTA as `UPDATE` (never `ROLLBACK`), and gets `null`/`UP_TO_DATE` when nothing is available. Unknown ids that are not baseline-shaped keep the existing rollback semantics (deleted-bundle recovery is unchanged).
- `packages/server/src/db/pluginCore.ts`:
  - `getAppUpdateInfo` no longer resolves a built-in baseline id against the database — the record cannot exist, and on AWS the lookup is a full S3 re-scan inside Lambda@Edge.
  - `findUpdateInfoByScanning` (generic scanning fallback) applies the same nil-baseline semantics.

Request from the issue (`/ios/1.2.0/production/019e37fe-…/019e37fe-…/452` with enabled OTA `019e3f00-…`) now resolves to that OTA with `status: "UPDATE"`.

Note: the SQL-side implementations (Supabase RPC / self-hosted Postgres functions) evaluate update checks in SQL and are untouched here; they can be aligned in a follow-up if desired.

## Tests

- `plugins/js/src/getUpdateInfo.spec.ts` — 8 new tests, including the exact ids from the issue: unknown baseline id + newer enabled OTA → `UPDATE`; unknown baseline id with only stale bundles → treated as nil baseline (no bogus rollback); unknown **non**-baseline ids still roll back; baseline-shaped id that actually exists in the DB is left untouched; fingerprint-strategy variants.
- `packages/server/src/db/pluginCore.spec.ts` — verifies `getAppUpdateInfo` never issues a `getBundleById` for a built-in baseline id, and that the scanning fallback treats it as the nil baseline.
- `plugins/aws/src/s3Database.spec.ts` — reproduces the issue scenario against the S3 database plugin (unknown baseline id, enabled newer OTA for the same app version → `UPDATE`, with no S3 object listing).
- `plugins/plugin-core/src/generateMinBundleId.spec.ts` — asserts generated min-bundle ids always match `isBuiltInBaselineBundleId()` so the pattern cannot drift.

## Test evidence

- New js-core and pluginCore tests fail without the fix (3 + 2 failures) and pass with it
- `pnpm build` — all packages/plugins build
- `pnpm test` — full unit suite passes
- `pnpm test:type` — passes for all projects
- `pnpm lint` — oxfmt/oxlint clean on touched files
