### PR TITLE
feat(storage): reduce S3 scans and add reference-aware pruning

### DIFF
--- a/.changeset/fix-s3-management-listing.md
+++ b/.changeset/fix-s3-management-listing.md
@@ -1,0 +1,8 @@
+---
+"@hot-updater/aws": patch
+"@hot-updater/plugin-core": patch
+"@hot-updater/console": patch
+"hot-updater": patch
+---
+
+Reduce S3 management query work by excluding bundle artifact prefixes, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits.

--- a/.changeset/fix-s3-management-listing.md
+++ b/.changeset/fix-s3-management-listing.md
@@ -7,4 +7,4 @@
 "hot-updater": minor
 ---
 
-Reduce S3 management query work by excluding storage artifact prefixes, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>`, while preserving reads and cleanup for the legacy root layout. Add `hot-updater storage prune` to find orphaned bundle objects and unreferenced shared assets, with dry-run and minimum-age safeguards.
+Reduce S3 management query work by skipping legacy UUIDv7 artifact traversal, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>` while preserving legacy reads, and add exact target app version filters to the CLI and Console. Add an exclusive-maintenance `hot-updater storage prune` command for orphaned bundle objects and unreferenced shared assets, with dry-run, minimum-age, and fail-closed reference validation safeguards.

--- a/.changeset/fix-s3-management-listing.md
+++ b/.changeset/fix-s3-management-listing.md
@@ -7,4 +7,4 @@
 "hot-updater": minor
 ---
 
-Reduce S3 management query work by skipping legacy UUIDv7 artifact traversal, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>` while preserving legacy reads, and add exact target app version filters to the CLI and Console. Add an exclusive-maintenance `hot-updater storage prune` command for orphaned bundle objects and unreferenced shared assets, with dry-run, minimum-age, and fail-closed reference validation safeguards.
+Reduce S3 management query work by skipping legacy UUIDv7 artifact traversal, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>` while preserving legacy reads, and add exact target app version filters to the CLI and Console. Add an exclusive-maintenance `hot-updater storage prune` command for orphaned bundle objects and unreferenced shared assets, with explicit `--dry-run`, minimum-age, and fail-closed reference validation safeguards.

--- a/.changeset/fix-s3-management-listing.md
+++ b/.changeset/fix-s3-management-listing.md
@@ -1,8 +1,10 @@
 ---
 "@hot-updater/aws": patch
+"@hot-updater/cli-tools": patch
 "@hot-updater/plugin-core": patch
 "@hot-updater/console": patch
-"hot-updater": patch
+"@hot-updater/server": patch
+"hot-updater": minor
 ---
 
-Reduce S3 management query work by excluding bundle artifact prefixes, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits.
+Reduce S3 management query work by excluding storage artifact prefixes, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>`, while preserving reads and cleanup for the legacy root layout. Add `hot-updater storage prune` to find orphaned bundle objects and unreferenced shared assets, with dry-run and minimum-age safeguards.

--- a/packages/cli-tools/src/promoteBundle.spec.ts
+++ b/packages/cli-tools/src/promoteBundle.spec.ts
@@ -293,12 +293,13 @@ describe("createCopiedBundleArchive", () => {
         expect(copiedBundle.id).toBe("bundle-copy-id");
         expect(copiedBundle.channel).toBe("beta");
         expect(copiedBundle.storageUri).toBe(
-          `s3://bucket/bundle-copy-id/bundle.${format}`,
+          `s3://bucket/bundles/bundle-copy-id/bundle.${format}`,
         );
         expect(copiedBundle.fileHash).not.toBe(baseBundle.fileHash);
         expect(copiedBundle).toMatchObject({
-          assetBaseStorageUri: "s3://bucket/bundle-copy-id/files",
-          manifestStorageUri: "s3://bucket/bundle-copy-id/manifest.json",
+          assetBaseStorageUri: "s3://bucket/assets",
+          manifestStorageUri:
+            "s3://bucket/bundles/bundle-copy-id/manifest.json",
           patchBaseBundleId: null,
           patchStorageUri: null,
         });
@@ -308,22 +309,23 @@ describe("createCopiedBundleArchive", () => {
         );
         expect(uploadedStorageUris).toEqual(
           expect.arrayContaining([
-            `s3://bucket/bundle-copy-id/bundle.${format}`,
-            "s3://bucket/bundle-copy-id/manifest.json",
-            "s3://bucket/bundle-copy-id/files/assets/logo.png",
-            "s3://bucket/bundle-copy-id/files/index.js",
+            `s3://bucket/bundles/bundle-copy-id/bundle.${format}`,
+            "s3://bucket/bundles/bundle-copy-id/manifest.json",
           ]),
         );
+        expect(uploadedStorageUris).toHaveLength(2);
+        expect(uploadedFiles.has("assets/sha256/lo/logo-hash.png")).toBe(true);
+        expect(uploadedFiles.has("assets/sha256/as/asset-hash.js")).toBe(true);
 
         const uploadedArchivePath = uploadedFiles.get(
-          path.posix.join("bundle-copy-id", `bundle.${format}`),
+          path.posix.join("bundles", "bundle-copy-id", `bundle.${format}`),
         );
         expect(uploadedArchivePath).toBeDefined();
 
         const manifest = await readManifest(uploadedArchivePath as string);
         expect(manifest.bundleId).toBe("bundle-copy-id");
         const uploadedManifestPath = uploadedFiles.get(
-          "bundle-copy-id/manifest.json",
+          "bundles/bundle-copy-id/manifest.json",
         );
         expect(uploadedManifestPath).toBeDefined();
         expect(
@@ -450,16 +452,16 @@ describe("createCopiedBundleArchive", () => {
 
       expect(uploadedStorageUris).toEqual(
         expect.arrayContaining([
-          "s3://bucket/bundle-copy-id/files/assets/logo.png",
-          "s3://bucket/bundle-copy-id/files/main.ios.bundle.br",
+          "s3://bucket/bundles/bundle-copy-id/bundle.zip",
+          "s3://bucket/bundles/bundle-copy-id/manifest.json",
         ]),
       );
       expect(uploadedStorageUris).not.toContain(
-        "s3://bucket/bundle-copy-id/files/main.ios.bundle",
+        "s3://bucket/assets/sha256/bu/bundle-hash.br",
       );
 
       const uploadedBundlePath = uploadedFiles.get(
-        "bundle-copy-id/files/main.ios.bundle.br",
+        "assets/sha256/bu/bundle-hash.br",
       );
       expect(uploadedBundlePath).toBeDefined();
       expect(
@@ -547,17 +549,12 @@ describe("createCopiedBundleArchive", () => {
       ).rejects.toThrow("append failed");
 
       expect(deleteFromStorage).toHaveBeenCalledWith(
-        "s3://bucket/bundle-copy-id/bundle.zip",
+        "s3://bucket/bundles/bundle-copy-id/bundle.zip",
       );
       expect(deleteFromStorage).toHaveBeenCalledWith(
-        "s3://bucket/bundle-copy-id/manifest.json",
+        "s3://bucket/bundles/bundle-copy-id/manifest.json",
       );
-      expect(deleteFromStorage).toHaveBeenCalledWith(
-        "s3://bucket/bundle-copy-id/files/assets/logo.png",
-      );
-      expect(deleteFromStorage).toHaveBeenCalledWith(
-        "s3://bucket/bundle-copy-id/files/index.js",
-      );
+      expect(deleteFromStorage).toHaveBeenCalledTimes(2);
     } finally {
       await cleanup();
     }

--- a/packages/cli-tools/src/promoteBundle.spec.ts
+++ b/packages/cli-tools/src/promoteBundle.spec.ts
@@ -383,14 +383,14 @@ describe("createCopiedBundleArchive", () => {
   it("uploads copied Hermes bundle assets with the brotli artifact name", async () => {
     const { archivePath, cleanup } = await createSourceArchive("zip", {
       "assets/logo.png": "logo",
-      "main.ios.bundle": "hermes bytecode",
+      "index.ios.bundle": "hermes bytecode",
       "manifest.json": JSON.stringify({
         bundleId: baseBundle.id,
         assets: {
           "assets/logo.png": {
             fileHash: "logo-hash",
           },
-          "main.ios.bundle": {
+          "index.ios.bundle": {
             fileHash: "bundle-hash",
           },
         },

--- a/packages/cli-tools/src/promoteBundle.ts
+++ b/packages/cli-tools/src/promoteBundle.ts
@@ -16,8 +16,12 @@ import type {
   NodeStoragePlugin,
 } from "@hot-updater/plugin-core";
 import {
+  createBundleStorageKey,
+  createStorageRootUriWithPath,
   createUUIDv7,
   detectCompressionFormat,
+  getContentAddressedAssetStoragePath,
+  resolveManifestAssetStorageUri,
 } from "@hot-updater/plugin-core";
 import JSZip from "jszip";
 import * as tar from "tar";
@@ -126,16 +130,30 @@ async function prepareManifestAssetUploadFile({
   return uploadPath;
 }
 
-const replaceStorageUriLeaf = (storageUri: string, nextLeaf: string) => {
-  const storageUrl = new URL(storageUri);
-  const normalizedPath = storageUrl.pathname.replace(/\/+$/, "");
-  const lastSlashIndex = normalizedPath.lastIndexOf("/");
-  const parentPath =
-    lastSlashIndex >= 0 ? normalizedPath.slice(0, lastSlashIndex) : "";
+async function prepareContentAddressedUploadFile({
+  sourcePath,
+  storagePath,
+  workDir,
+}: {
+  sourcePath: string;
+  storagePath: string;
+  workDir: string;
+}) {
+  const filename = path.posix.basename(storagePath);
+  if (path.basename(sourcePath) === filename) {
+    return sourcePath;
+  }
 
-  storageUrl.pathname = `${parentPath}/${nextLeaf}`;
-  return storageUrl.toString();
-};
+  const uploadPath = path.join(
+    workDir,
+    "upload-artifacts",
+    "content-addressed",
+    filename,
+  );
+  await fs.mkdir(path.dirname(uploadPath), { recursive: true });
+  await fs.copyFile(sourcePath, uploadPath);
+  return uploadPath;
+}
 
 function resolveExtractedPath(rootDir: string, entryName: string) {
   const normalizedEntryName = entryName.replaceAll("\\", "/");
@@ -381,42 +399,64 @@ export async function createCopiedBundleArchive({
       : manifestHash;
 
     const archiveUpload = await storagePlugin.profiles.node.upload(
-      nextBundleId,
+      createBundleStorageKey(nextBundleId),
       outputArchivePath,
     );
     uploadedStorageUris.push(archiveUpload.storageUri);
     const manifestUpload = await storagePlugin.profiles.node.upload(
-      nextBundleId,
+      createBundleStorageKey(nextBundleId),
       manifestPath,
     );
     uploadedStorageUris.push(manifestUpload.storageUri);
+    const assetBaseStorageUri = createStorageRootUriWithPath(
+      manifestUpload.storageUri,
+      nextBundleId,
+      "assets",
+    );
 
     const assetPaths = Object.keys(manifest.assets ?? {}).sort((left, right) =>
       left.localeCompare(right),
     );
 
     for (const assetPath of assetPaths) {
-      const relativeDir = getRelativeStorageDir(assetPath);
-      const uploadKey = [nextBundleId, "files", relativeDir]
-        .filter(Boolean)
-        .join("/");
+      const asset = manifest.assets?.[assetPath];
+      if (!asset?.fileHash) {
+        throw new Error(`Manifest file hash not found for ${assetPath}`);
+      }
       const sourcePath = path.join(extractDir, assetPath);
       const uploadPath = await prepareManifestAssetUploadFile({
         assetPath,
         sourcePath,
         workDir,
       });
-      const assetUpload = await storagePlugin.profiles.node.upload(
-        uploadKey,
-        uploadPath,
-      );
-      uploadedStorageUris.push(assetUpload.storageUri);
-    }
+      const uploadName = isBundleAsset(assetPath)
+        ? `${assetPath}.br`
+        : assetPath;
+      const storagePath = getContentAddressedAssetStoragePath({
+        assetPath: uploadName,
+        fileHash: asset.fileHash,
+      });
+      const storageUri = resolveManifestAssetStorageUri({
+        assetBaseStorageUri,
+        assetPath: uploadName,
+        fileHash: asset.fileHash,
+      });
 
-    const assetBaseStorageUri = replaceStorageUriLeaf(
-      manifestUpload.storageUri,
-      "files",
-    );
+      if (!(await storagePlugin.profiles.node.exists(storageUri))) {
+        const contentAddressedUploadPath =
+          await prepareContentAddressedUploadFile({
+            sourcePath: uploadPath,
+            storagePath,
+            workDir,
+          });
+        await storagePlugin.profiles.node.upload(
+          getRelativeStorageDir(storagePath)
+            ? `assets/${getRelativeStorageDir(storagePath)}`
+            : "assets",
+          contentAddressedUploadPath,
+        );
+      }
+    }
 
     return {
       bundle: {

--- a/packages/cli-tools/src/promoteBundle.ts
+++ b/packages/cli-tools/src/promoteBundle.ts
@@ -21,6 +21,7 @@ import {
   createUUIDv7,
   detectCompressionFormat,
   getContentAddressedAssetStoragePath,
+  getManifestAssetDownloadPath,
   resolveManifestAssetStorageUri,
 } from "@hot-updater/plugin-core";
 import JSZip from "jszip";
@@ -84,9 +85,6 @@ const getRelativeStorageDir = (relativePath: string) => {
   return dirname === "." ? "" : dirname;
 };
 
-const isBundleAsset = (relativePath: string) =>
-  /(^|\/)[^/]+\.(ios|android)\.bundle$/.test(relativePath.replace(/\\/g, "/"));
-
 function resolvePreparedUploadPath(rootDir: string, assetPath: string) {
   const normalizedAssetPath = assetPath.replaceAll("\\", "/");
   const outputPath = path.resolve(
@@ -116,7 +114,7 @@ async function prepareManifestAssetUploadFile({
   sourcePath: string;
   workDir: string;
 }) {
-  if (!isBundleAsset(assetPath)) {
+  if (getManifestAssetDownloadPath(assetPath) === assetPath) {
     return sourcePath;
   }
 
@@ -429,9 +427,7 @@ export async function createCopiedBundleArchive({
         sourcePath,
         workDir,
       });
-      const uploadName = isBundleAsset(assetPath)
-        ? `${assetPath}.br`
-        : assetPath;
+      const uploadName = getManifestAssetDownloadPath(assetPath);
       const storagePath = getContentAddressedAssetStoragePath({
         assetPath: uploadName,
         fileHash: asset.fileHash,

--- a/packages/console/src/components/AppSidebar.tsx
+++ b/packages/console/src/components/AppSidebar.tsx
@@ -31,6 +31,7 @@ export function AppSidebar() {
           search={{
             channel: undefined,
             platform: undefined,
+            targetAppVersion: undefined,
             page: undefined,
             after: undefined,
             before: undefined,
@@ -67,6 +68,7 @@ export function AppSidebar() {
                     search={{
                       channel: undefined,
                       platform: undefined,
+                      targetAppVersion: undefined,
                       page: undefined,
                       after: undefined,
                       before: undefined,

--- a/packages/console/src/components/NotFoundPage.tsx
+++ b/packages/console/src/components/NotFoundPage.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 const homeSearch = {
   channel: undefined,
   platform: undefined,
+  targetAppVersion: undefined,
   page: undefined,
   after: undefined,
   before: undefined,

--- a/packages/console/src/components/features/bundles/FilterToolbar.tsx
+++ b/packages/console/src/components/features/bundles/FilterToolbar.tsx
@@ -1,6 +1,8 @@
 import { Filter, X } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -15,8 +17,20 @@ import { useChannelsQuery } from "@/lib/api";
 export function FilterToolbar() {
   const { filters, setFilters, resetFilters } = useFilterParams();
   const { data: channels = [] } = useChannelsQuery();
+  const [targetAppVersion, setTargetAppVersion] = useState(
+    filters.targetAppVersion ?? "",
+  );
 
-  const hasActiveFilters = filters.channel || filters.platform;
+  useEffect(() => {
+    setTargetAppVersion(filters.targetAppVersion ?? "");
+  }, [filters.targetAppVersion]);
+
+  const hasActiveFilters =
+    filters.channel || filters.platform || filters.targetAppVersion;
+  const applyTargetAppVersion = () => {
+    const value = targetAppVersion.trim();
+    setFilters({ targetAppVersion: value || undefined });
+  };
 
   return (
     <header className="sticky top-0 z-10 flex shrink-0 flex-wrap items-center gap-2 border-b bg-background px-3 py-3 sm:h-12 sm:flex-nowrap sm:bg-card/70 sm:px-4 sm:py-0 sm:backdrop-blur-sm">
@@ -45,6 +59,20 @@ export function FilterToolbar() {
           <SelectItem value="android">Android</SelectItem>
         </SelectContent>
       </Select>
+
+      <Input
+        aria-label="Target app version"
+        className="h-8 w-full min-w-[132px] text-xs sm:w-[160px]"
+        placeholder="Target version"
+        value={targetAppVersion}
+        onBlur={applyTargetAppVersion}
+        onChange={(event) => setTargetAppVersion(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            applyTargetAppVersion();
+          }
+        }}
+      />
 
       <Select
         value={filters.channel || "all"}

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -126,7 +126,10 @@ describe("SelectedBundlesDeleteDialog", () => {
   });
 
   it("deletes all selected bundles in one batch", async () => {
-    const deletion = createDeferred<void>();
+    const deletion = createDeferred<{
+      deletedBundleIds: string[];
+      missingBundleIds: string[];
+    }>();
     mockDeleteBundlesMutation.mutateAsync.mockReturnValue(deletion.promise);
 
     render(
@@ -155,7 +158,10 @@ describe("SelectedBundlesDeleteDialog", () => {
     expect(screen.queryByRole("img", { name: "Queued" })).toBeNull();
     expect(screen.getAllByLabelText("Deleting")).toHaveLength(2);
 
-    deletion.resolve(undefined);
+    deletion.resolve({
+      deletedBundleIds: [firstBundle.id, secondBundle.id],
+      missingBundleIds: [],
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
@@ -176,7 +182,10 @@ describe("SelectedBundlesDeleteDialog", () => {
   it("keeps a failed batch actionable and retries it", async () => {
     mockDeleteBundlesMutation.mutateAsync
       .mockRejectedValueOnce(new Error("storage timeout"))
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce({
+        deletedBundleIds: [firstBundle.id, secondBundle.id],
+        missingBundleIds: [],
+      });
 
     render(
       <SelectedBundlesDeleteDialog

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.spec.tsx
@@ -11,9 +11,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SelectedBundlesDeleteDialog } from "./SelectedBundlesDeleteDialog";
 
-const { mockDeleteBundleMutation, mockToastSuccess, mockToastError } =
+const { mockDeleteBundlesMutation, mockToastSuccess, mockToastError } =
   vi.hoisted(() => ({
-    mockDeleteBundleMutation: {
+    mockDeleteBundlesMutation: {
       mutateAsync: vi.fn(),
     },
     mockToastSuccess: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/lib/api", () => ({
-  useDeleteBundleMutation: () => mockDeleteBundleMutation,
+  useDeleteBundlesMutation: () => mockDeleteBundlesMutation,
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
@@ -114,7 +114,7 @@ describe("SelectedBundlesDeleteDialog", () => {
   const mockOnComplete = vi.fn();
 
   beforeEach(() => {
-    mockDeleteBundleMutation.mutateAsync.mockReset();
+    mockDeleteBundlesMutation.mutateAsync.mockReset();
     mockToastSuccess.mockReset();
     mockToastError.mockReset();
     mockOnOpenChange.mockReset();
@@ -125,16 +125,9 @@ describe("SelectedBundlesDeleteDialog", () => {
     cleanup();
   });
 
-  it("shows each selected bundle moving from queued to deleted", async () => {
-    const firstDelete = createDeferred<void>();
-    const secondDelete = createDeferred<void>();
-
-    mockDeleteBundleMutation.mutateAsync.mockImplementation(
-      ({ bundleId }: { readonly bundleId: string }) =>
-        bundleId === firstBundle.id
-          ? firstDelete.promise
-          : secondDelete.promise,
-    );
+  it("deletes all selected bundles in one batch", async () => {
+    const deletion = createDeferred<void>();
+    mockDeleteBundlesMutation.mutateAsync.mockReturnValue(deletion.promise);
 
     render(
       <SelectedBundlesDeleteDialog
@@ -150,29 +143,19 @@ describe("SelectedBundlesDeleteDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {
-      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledWith({
-        bundleId: firstBundle.id,
+      expect(mockDeleteBundlesMutation.mutateAsync).toHaveBeenCalledWith({
+        bundleIds: [firstBundle.id, secondBundle.id],
       });
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Dismiss dialog" }));
     expect(mockOnOpenChange).not.toHaveBeenCalled();
 
-    firstDelete.resolve(undefined);
-
-    await waitFor(() => {
-      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledWith({
-        bundleId: secondBundle.id,
-      });
-    });
-
     expect(screen.getByRole("columnheader", { name: "Status" })).toBeTruthy();
     expect(screen.queryByRole("img", { name: "Queued" })).toBeNull();
-    expect(screen.getByText("1 of 2 delete requests finished.")).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Deleted" })).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Deleting" })).toBeTruthy();
+    expect(screen.getAllByLabelText("Deleting")).toHaveLength(2);
 
-    secondDelete.resolve(undefined);
+    deletion.resolve(undefined);
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
@@ -190,10 +173,9 @@ describe("SelectedBundlesDeleteDialog", () => {
     );
   });
 
-  it("keeps failed bundles actionable and retries only those ids", async () => {
-    mockDeleteBundleMutation.mutateAsync
+  it("keeps a failed batch actionable and retries it", async () => {
+    mockDeleteBundlesMutation.mutateAsync
       .mockRejectedValueOnce(new Error("storage timeout"))
-      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
 
     render(
@@ -211,24 +193,24 @@ describe("SelectedBundlesDeleteDialog", () => {
       expect(screen.getByRole("button", { name: "Retry failed" })).toBeTruthy();
     });
 
-    expect(screen.getByText("storage timeout")).toBeTruthy();
+    expect(screen.getAllByText("storage timeout")).toHaveLength(2);
     expect(mockOnComplete).toHaveBeenCalledWith({
-      deletedBundleIds: [secondBundle.id],
-      failedBundleIds: [firstBundle.id],
+      deletedBundleIds: [],
+      failedBundleIds: [firstBundle.id, secondBundle.id],
     });
-    expect(mockToastError).toHaveBeenCalledWith("1 deleted, 1 failed");
+    expect(mockToastError).toHaveBeenCalledWith("0 deleted, 2 failed");
 
     fireEvent.click(screen.getByRole("button", { name: "Retry failed" }));
 
     await waitFor(() => {
-      expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenCalledTimes(3);
+      expect(mockDeleteBundlesMutation.mutateAsync).toHaveBeenCalledTimes(2);
     });
 
-    expect(mockDeleteBundleMutation.mutateAsync).toHaveBeenLastCalledWith({
-      bundleId: firstBundle.id,
+    expect(mockDeleteBundlesMutation.mutateAsync).toHaveBeenLastCalledWith({
+      bundleIds: [firstBundle.id, secondBundle.id],
     });
     expect(mockOnComplete).toHaveBeenLastCalledWith({
-      deletedBundleIds: [firstBundle.id],
+      deletedBundleIds: [firstBundle.id, secondBundle.id],
       failedBundleIds: [],
     });
   });

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
@@ -133,7 +133,7 @@ export function SelectedBundlesDeleteDialog({
     phase === "confirming" ? "Delete selected bundles?" : "Deleting bundles";
   const description =
     phase === "confirming"
-      ? `This action cannot be undone. This will permanently delete ${bundles.length} bundles and remove them from storage.`
+      ? `This action cannot be undone. This deletes ${bundles.length} bundle records and schedules artifact cleanup; shared assets are reclaimed by storage prune.`
       : phase === "deleting"
         ? `Deleting ${totalCount} bundles in one batch.`
         : `${activeCount} of ${totalCount} delete requests finished.`;
@@ -175,7 +175,9 @@ export function SelectedBundlesDeleteDialog({
     );
 
     try {
-      await deleteBundlesMutation.mutateAsync({ bundleIds: [...bundleIds] });
+      const result = await deleteBundlesMutation.mutateAsync({
+        bundleIds: [...bundleIds],
+      });
       setItems((currentItems) =>
         currentItems.map((item) =>
           bundleIdSet.has(item.bundle.id)
@@ -185,7 +187,11 @@ export function SelectedBundlesDeleteDialog({
       );
       setPhase("complete");
       onComplete({ deletedBundleIds: bundleIds, failedBundleIds: [] });
-      toast.success(`${bundleIds.length} bundles deleted successfully`);
+      toast.success(
+        result.missingBundleIds.length > 0
+          ? `${result.deletedBundleIds.length} deleted, ${result.missingBundleIds.length} already absent`
+          : `${bundleIds.length} bundles deleted successfully`,
+      );
     } catch (error) {
       setItems((currentItems) =>
         currentItems.map((item) =>

--- a/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
+++ b/packages/console/src/components/features/bundles/SelectedBundlesDeleteDialog.tsx
@@ -7,7 +7,7 @@ import {
   Trash2,
   XCircle,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -33,7 +33,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useDeleteBundleMutation } from "@/lib/api";
+import { useDeleteBundlesMutation } from "@/lib/api";
 
 interface SelectedBundlesDeleteDialogProps {
   readonly bundles: readonly Bundle[];
@@ -115,7 +115,7 @@ export function SelectedBundlesDeleteDialog({
   onOpenChange,
   onComplete,
 }: SelectedBundlesDeleteDialogProps) {
-  const deleteBundleMutation = useDeleteBundleMutation();
+  const deleteBundlesMutation = useDeleteBundlesMutation();
   const [phase, setPhase] = useState<DeletePhase>("confirming");
   const [items, setItems] = useState<DeleteItem[]>(() =>
     createDeleteItems(bundles),
@@ -134,16 +134,10 @@ export function SelectedBundlesDeleteDialog({
   const description =
     phase === "confirming"
       ? `This action cannot be undone. This will permanently delete ${bundles.length} bundles and remove them from storage.`
-      : `${activeCount} of ${totalCount} delete requests finished.`;
-  const deleteButtonLabel = useMemo(() => {
-    if (!isDeleting) {
-      return "Delete";
-    }
-
-    const progressIndex = Math.min(activeCount + 1, totalCount);
-
-    return `Deleting ${progressIndex}/${totalCount}`;
-  }, [activeCount, isDeleting, totalCount]);
+      : phase === "deleting"
+        ? `Deleting ${totalCount} bundles in one batch.`
+        : `${activeCount} of ${totalCount} delete requests finished.`;
+  const deleteButtonLabel = isDeleting ? "Deleting..." : "Delete";
 
   useEffect(() => {
     if (open && phase === "confirming") {
@@ -170,64 +164,44 @@ export function SelectedBundlesDeleteDialog({
     }
 
     const bundleIdSet = new Set(bundleIds);
-    const deletedBundleIds: string[] = [];
-    const nextFailedBundleIds: string[] = [];
 
     setPhase("deleting");
     setItems((currentItems) =>
       currentItems.map((item) =>
         bundleIdSet.has(item.bundle.id)
-          ? { bundle: item.bundle, status: "queued" }
+          ? { bundle: item.bundle, status: "deleting" }
           : item,
       ),
     );
 
-    for (const bundleId of bundleIds) {
+    try {
+      await deleteBundlesMutation.mutateAsync({ bundleIds: [...bundleIds] });
       setItems((currentItems) =>
         currentItems.map((item) =>
-          item.bundle.id === bundleId
-            ? { bundle: item.bundle, status: "deleting" }
+          bundleIdSet.has(item.bundle.id)
+            ? { bundle: item.bundle, status: "deleted" }
             : item,
         ),
       );
-
-      try {
-        await deleteBundleMutation.mutateAsync({ bundleId });
-        deletedBundleIds.push(bundleId);
-        setItems((currentItems) =>
-          currentItems.map((item) =>
-            item.bundle.id === bundleId
-              ? { bundle: item.bundle, status: "deleted" }
-              : item,
-          ),
-        );
-      } catch (error) {
-        nextFailedBundleIds.push(bundleId);
-        setItems((currentItems) =>
-          currentItems.map((item) =>
-            item.bundle.id === bundleId
-              ? {
-                  bundle: item.bundle,
-                  message: getDeleteErrorMessage(error),
-                  status: "failed",
-                }
-              : item,
-          ),
-        );
-      }
-    }
-
-    setPhase("complete");
-    onComplete({ deletedBundleIds, failedBundleIds: nextFailedBundleIds });
-
-    if (nextFailedBundleIds.length > 0) {
-      toast.error(
-        `${deletedBundleIds.length} deleted, ${nextFailedBundleIds.length} failed`,
+      setPhase("complete");
+      onComplete({ deletedBundleIds: bundleIds, failedBundleIds: [] });
+      toast.success(`${bundleIds.length} bundles deleted successfully`);
+    } catch (error) {
+      setItems((currentItems) =>
+        currentItems.map((item) =>
+          bundleIdSet.has(item.bundle.id)
+            ? {
+                bundle: item.bundle,
+                message: getDeleteErrorMessage(error),
+                status: "failed",
+              }
+            : item,
+        ),
       );
-      return;
+      setPhase("complete");
+      onComplete({ deletedBundleIds: [], failedBundleIds: bundleIds });
+      toast.error(`0 deleted, ${bundleIds.length} failed`);
     }
-
-    toast.success(`${deletedBundleIds.length} bundles deleted successfully`);
   };
 
   const handleDelete = () => {

--- a/packages/console/src/hooks/useFilterParams.spec.tsx
+++ b/packages/console/src/hooks/useFilterParams.spec.tsx
@@ -39,10 +39,12 @@ describe("useFilterParams", () => {
       search: {
         channel: undefined,
         platform: "ios",
+        targetAppVersion: undefined,
         page: undefined,
         after: undefined,
         before: undefined,
         bundleId: undefined,
+        expandedBundleId: undefined,
       },
     });
   });
@@ -67,10 +69,12 @@ describe("useFilterParams", () => {
       search: {
         channel: "stable",
         platform: "android",
+        targetAppVersion: undefined,
         page: 4,
         after: undefined,
         before: undefined,
         bundleId: undefined,
+        expandedBundleId: undefined,
       },
     });
   });
@@ -96,6 +100,7 @@ describe("useFilterParams", () => {
       search: {
         channel: "beta",
         platform: "ios",
+        targetAppVersion: undefined,
         page: undefined,
         after: undefined,
         before: undefined,
@@ -131,10 +136,43 @@ describe("useFilterParams", () => {
       search: {
         channel: "stable",
         platform: "ios",
+        targetAppVersion: undefined,
         page: undefined,
         after: undefined,
         before: "bundle-020",
         bundleId: undefined,
+        expandedBundleId: undefined,
+      },
+    });
+  });
+
+  it("sets the target app version and resets pagination", () => {
+    mockUseSearch.mockReturnValue({
+      channel: "stable",
+      platform: "ios",
+      targetAppVersion: undefined,
+      page: 3,
+      after: "bundle-020",
+      before: undefined,
+    });
+
+    const { result } = renderHook(() => useFilterParams());
+
+    act(() => {
+      result.current.setFilters({ targetAppVersion: "1.2.3" });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/",
+      search: {
+        channel: "stable",
+        platform: "ios",
+        targetAppVersion: "1.2.3",
+        page: undefined,
+        after: undefined,
+        before: undefined,
+        bundleId: undefined,
+        expandedBundleId: undefined,
       },
     });
   });

--- a/packages/console/src/hooks/useFilterParams.ts
+++ b/packages/console/src/hooks/useFilterParams.ts
@@ -3,6 +3,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 export interface BundleFilters {
   channel?: string;
   platform?: "ios" | "android";
+  targetAppVersion?: string;
   page?: number;
   after?: string;
   before?: string;
@@ -11,6 +12,7 @@ export interface BundleFilters {
 interface BundleSearchParams {
   channel: string | undefined;
   platform: "ios" | "android" | undefined;
+  targetAppVersion: string | undefined;
   page: number | undefined;
   after: string | undefined;
   before: string | undefined;
@@ -25,6 +27,7 @@ export function useFilterParams() {
   const filters: BundleFilters = {
     channel: search.channel as string | undefined,
     platform: search.platform as "ios" | "android" | undefined,
+    targetAppVersion: search.targetAppVersion as string | undefined,
     page: search.page as number | undefined,
     after: search.after as string | undefined,
     before: search.before as string | undefined,
@@ -46,10 +49,12 @@ export function useFilterParams() {
   const getNextFilters = (newFilters: Partial<BundleFilters>) => {
     const hasChannel = Object.hasOwn(newFilters, "channel");
     const hasPlatform = Object.hasOwn(newFilters, "platform");
+    const hasTargetAppVersion = Object.hasOwn(newFilters, "targetAppVersion");
     const hasPage = Object.hasOwn(newFilters, "page");
     const hasAfter = Object.hasOwn(newFilters, "after");
     const hasBefore = Object.hasOwn(newFilters, "before");
-    const shouldResetPagination = hasChannel || hasPlatform;
+    const shouldResetPagination =
+      hasChannel || hasPlatform || hasTargetAppVersion;
     const nextPage =
       hasPage && newFilters.page !== undefined && newFilters.page > 1
         ? newFilters.page
@@ -58,6 +63,9 @@ export function useFilterParams() {
     return {
       channel: hasChannel ? newFilters.channel : filters.channel,
       platform: hasPlatform ? newFilters.platform : filters.platform,
+      targetAppVersion: hasTargetAppVersion
+        ? newFilters.targetAppVersion
+        : filters.targetAppVersion,
       page: shouldResetPagination
         ? undefined
         : hasPage
@@ -120,6 +128,7 @@ export function useFilterParams() {
     navigateWithSearch({
       channel: undefined,
       platform: undefined,
+      targetAppVersion: undefined,
       page: undefined,
       after: undefined,
       before: undefined,

--- a/packages/console/src/lib/api-rpc.ts
+++ b/packages/console/src/lib/api-rpc.ts
@@ -44,6 +44,10 @@ type DeleteBundleInput = {
   bundleId: string;
 };
 
+type DeleteBundlesInput = {
+  bundleIds: string[];
+};
+
 const assertRemoteDownloadUrl = (fileUrl: string) => {
   try {
     const protocol = new URL(fileUrl).protocol.replace(":", "");
@@ -326,6 +330,28 @@ export const deleteBundle = createServerFn({ method: "POST" })
       const { databasePlugin, storagePlugin } = await prepareConfig();
 
       await deleteBundleWithStorage(data, {
+        databasePlugin,
+        storagePlugin,
+        waitForStorageCleanup: false,
+      });
+
+      return { success: true };
+    } catch (error) {
+      console.error("Error during bundle deletion:", error);
+      throw error;
+    }
+  });
+
+export const deleteBundles = createServerFn({ method: "POST" })
+  .inputValidator((input: DeleteBundlesInput) => input)
+  .handler(async ({ data }) => {
+    try {
+      const { prepareConfig } = await import("./server/config.server");
+      const { deleteBundles: deleteBundlesWithStorage } =
+        await import("./server/deleteBundle");
+      const { databasePlugin, storagePlugin } = await prepareConfig();
+
+      await deleteBundlesWithStorage(data, {
         databasePlugin,
         storagePlugin,
         waitForStorageCleanup: false,

--- a/packages/console/src/lib/api-rpc.ts
+++ b/packages/console/src/lib/api-rpc.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PAGE_LIMIT } from "./constants";
 type GetBundlesInput = {
   channel?: string;
   platform?: "ios" | "android";
+  targetAppVersion?: string;
   page?: number;
   limit?: string;
   after?: string;
@@ -109,6 +110,7 @@ export const getBundles = createServerFn({ method: "GET" })
       const query = {
         channel: data?.channel ?? undefined,
         platform: data?.platform ?? undefined,
+        targetAppVersion: data?.targetAppVersion ?? undefined,
         page:
           typeof data?.page === "number" &&
           Number.isInteger(data.page) &&
@@ -125,6 +127,7 @@ export const getBundles = createServerFn({ method: "GET" })
         where: {
           channel: query.channel,
           platform: query.platform,
+          targetAppVersion: query.targetAppVersion,
         },
         limit: query.limit,
         page: query.page,
@@ -351,13 +354,13 @@ export const deleteBundles = createServerFn({ method: "POST" })
         await import("./server/deleteBundle");
       const { databasePlugin, storagePlugin } = await prepareConfig();
 
-      await deleteBundlesWithStorage(data, {
+      const result = await deleteBundlesWithStorage(data, {
         databasePlugin,
         storagePlugin,
         waitForStorageCleanup: false,
       });
 
-      return { success: true };
+      return { success: true, ...result };
     } catch (error) {
       console.error("Error during bundle deletion:", error);
       throw error;

--- a/packages/console/src/lib/api.spec.tsx
+++ b/packages/console/src/lib/api.spec.tsx
@@ -269,7 +269,11 @@ describe("useDeleteBundleMutation", () => {
 
 describe("useDeleteBundlesMutation", () => {
   it("removes a batch from cached lists and invalidates once", async () => {
-    vi.mocked(deleteBundlesApi).mockResolvedValue({ success: true });
+    vi.mocked(deleteBundlesApi).mockResolvedValue({
+      success: true,
+      deletedBundleIds: [bundle.id, otherBundle.id],
+      missingBundleIds: [],
+    });
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
@@ -280,7 +284,8 @@ describe("useDeleteBundlesMutation", () => {
       .spyOn(queryClient, "invalidateQueries")
       .mockResolvedValue();
 
-    queryClient.setQueryData(queryKeys.bundles.list({}), {
+    const filters = { channel: "development", limit: "2000" };
+    queryClient.setQueryData(queryKeys.bundles.list(filters), {
       data: [bundle, otherBundle],
       pagination: {
         total: 2,
@@ -304,7 +309,7 @@ describe("useDeleteBundlesMutation", () => {
       });
     });
 
-    expect(queryClient.getQueryData(queryKeys.bundles.list({}))).toEqual({
+    expect(queryClient.getQueryData(queryKeys.bundles.list(filters))).toEqual({
       data: [],
       pagination: {
         total: 2,

--- a/packages/console/src/lib/api.spec.tsx
+++ b/packages/console/src/lib/api.spec.tsx
@@ -7,16 +7,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   queryKeys,
   useDeleteBundleMutation,
+  useDeleteBundlesMutation,
   useUpdateBundleMutation,
 } from "./api";
 import {
   deleteBundle as deleteBundleApi,
+  deleteBundles as deleteBundlesApi,
   updateBundle as updateBundleApi,
 } from "./api-rpc";
 
 vi.mock("./api-rpc", () => ({
   createBundle: vi.fn(),
   deleteBundle: vi.fn(),
+  deleteBundles: vi.fn(),
   getBundle: vi.fn(),
   getBundleChildCounts: vi.fn(),
   getBundleChildren: vi.fn(),
@@ -252,6 +255,57 @@ describe("useDeleteBundleMutation", () => {
     ).toBeUndefined();
     expect(queryClient.getQueryData(queryKeys.bundles.list({}))).toEqual({
       data: [otherBundle],
+      pagination: {
+        total: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        currentPage: 1,
+        totalPages: 1,
+      },
+    });
+    expect(invalidateQueries).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("useDeleteBundlesMutation", () => {
+  it("removes a batch from cached lists and invalidates once", async () => {
+    vi.mocked(deleteBundlesApi).mockResolvedValue({ success: true });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue();
+
+    queryClient.setQueryData(queryKeys.bundles.list({}), {
+      data: [bundle, otherBundle],
+      pagination: {
+        total: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        currentPage: 1,
+        totalPages: 1,
+      },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDeleteBundlesMutation(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        bundleIds: [bundle.id, otherBundle.id],
+      });
+    });
+
+    expect(queryClient.getQueryData(queryKeys.bundles.list({}))).toEqual({
+      data: [],
       pagination: {
         total: 2,
         hasNextPage: false,

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -26,6 +26,7 @@ import {
 type BundleFilters = {
   channel?: string;
   platform?: "ios" | "android";
+  targetAppVersion?: string;
   page?: number;
   limit?: string;
   after?: string;

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -10,6 +10,7 @@ import {
 import {
   createBundle as createBundleApi,
   deleteBundle as deleteBundleApi,
+  deleteBundles as deleteBundlesApi,
   getBundle,
   getBundleChildCounts,
   getBundleChildren,
@@ -80,6 +81,21 @@ function removeBundleFromQueryData(
   return {
     ...data,
     data: data.data.filter((bundle) => bundle.id !== bundleId),
+  };
+}
+
+function removeBundlesFromQueryData(
+  data: BundlesQueryData | undefined,
+  bundleIds: readonly string[],
+) {
+  if (!data) {
+    return data;
+  }
+
+  const bundleIdSet = new Set(bundleIds);
+  return {
+    ...data,
+    data: data.data.filter((bundle) => !bundleIdSet.has(bundle.id)),
   };
 }
 
@@ -254,6 +270,29 @@ export function useDeleteBundleMutation() {
         { queryKey: queryKeys.bundles.all },
         (data: BundlesQueryData | undefined) =>
           removeBundleFromQueryData(data, vars.bundleId),
+      );
+
+      invalidateInBackground(queryClient, queryKeys.bundles.all);
+      invalidateInBackground(queryClient, queryKeys.bundleChildren.all);
+      invalidateInBackground(queryClient, queryKeys.channels);
+    },
+  });
+}
+
+export function useDeleteBundlesMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { bundleIds: string[] }) =>
+      deleteBundlesApi({ data: params }),
+    onSuccess: (_, vars) => {
+      for (const bundleId of vars.bundleIds) {
+        queryClient.removeQueries({ queryKey: queryKeys.bundle(bundleId) });
+      }
+      queryClient.setQueriesData(
+        { queryKey: queryKeys.bundles.all },
+        (data: BundlesQueryData | undefined) =>
+          removeBundlesFromQueryData(data, vars.bundleIds),
       );
 
       invalidateInBackground(queryClient, queryKeys.bundles.all);

--- a/packages/console/src/lib/server/deleteBundle.spec.ts
+++ b/packages/console/src/lib/server/deleteBundle.spec.ts
@@ -11,7 +11,7 @@ import type {
 } from "@hot-updater/plugin-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { deleteBundle } from "./deleteBundle";
+import { deleteBundle, deleteBundles } from "./deleteBundle";
 
 const baseBundle: Bundle = {
   id: "0195a408-8f13-7d9b-8df4-123456789abc",
@@ -33,7 +33,7 @@ function createDatabasePlugin(bundle: Bundle | null = baseBundle) {
   return {
     name: "mockDatabase",
     getChannels: vi.fn(),
-    getBundleById: vi.fn(async () => bundle),
+    getBundleById: vi.fn(async (_bundleId: string) => bundle),
     getBundles: vi.fn(),
     updateBundle: vi.fn(),
     appendBundle: vi.fn(),
@@ -111,6 +111,59 @@ describe("deleteBundle", () => {
     expect(
       databasePlugin.commitBundle.mock.invocationCallOrder[0],
     ).toBeLessThan(deleteFromStorage.mock.invocationCallOrder[0]);
+  });
+
+  it("deletes multiple bundles with one database commit", async () => {
+    const secondBundle = {
+      ...baseBundle,
+      id: "0195a408-8f13-7d9b-8df4-123456789abd",
+      storageUri: "s3://bucket/second-bundle.zip",
+    };
+    const databasePlugin = createDatabasePlugin();
+    databasePlugin.getBundleById.mockImplementation(async (bundleId) =>
+      bundleId === baseBundle.id ? baseBundle : secondBundle,
+    );
+    const deleteFromStorage = vi.fn();
+    const storagePlugin = createStoragePlugin("s3", {
+      delete: deleteFromStorage,
+    });
+
+    await deleteBundles(
+      { bundleIds: [baseBundle.id, secondBundle.id] },
+      { databasePlugin, storagePlugin },
+    );
+
+    expect(databasePlugin.getBundleById).toHaveBeenNthCalledWith(
+      1,
+      baseBundle.id,
+    );
+    expect(databasePlugin.getBundleById).toHaveBeenNthCalledWith(
+      2,
+      secondBundle.id,
+    );
+    expect(databasePlugin.deleteBundle).toHaveBeenCalledTimes(2);
+    expect(databasePlugin.commitBundle).toHaveBeenCalledOnce();
+    expect(deleteFromStorage).toHaveBeenCalledWith(baseBundle.storageUri);
+    expect(deleteFromStorage).toHaveBeenCalledWith(secondBundle.storageUri);
+  });
+
+  it("validates every bundle before starting a batch deletion", async () => {
+    const databasePlugin = createDatabasePlugin();
+    databasePlugin.getBundleById
+      .mockResolvedValueOnce(baseBundle)
+      .mockResolvedValueOnce(null);
+    const storagePlugin = createStoragePlugin();
+
+    await expect(
+      deleteBundles(
+        { bundleIds: [baseBundle.id, "missing-bundle"] },
+        { databasePlugin, storagePlugin },
+      ),
+    ).rejects.toThrow("Bundle not found: missing-bundle");
+
+    expect(databasePlugin.deleteBundle).not.toHaveBeenCalled();
+    expect(databasePlugin.commitBundle).not.toHaveBeenCalled();
+    expect(storagePlugin.profiles.node.delete).not.toHaveBeenCalled();
   });
 
   it("skips storage deletion for http urls", async () => {

--- a/packages/console/src/lib/server/deleteBundle.spec.ts
+++ b/packages/console/src/lib/server/deleteBundle.spec.ts
@@ -30,11 +30,21 @@ const baseBundle: Bundle = {
 };
 
 function createDatabasePlugin(bundle: Bundle | null = baseBundle) {
+  const bundles = bundle ? [bundle] : [];
   return {
     name: "mockDatabase",
     getChannels: vi.fn(),
     getBundleById: vi.fn(async (_bundleId: string) => bundle),
-    getBundles: vi.fn(),
+    getBundles: vi.fn(async () => ({
+      data: bundles,
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: bundles.length,
+        totalPages: 1,
+      },
+    })),
     updateBundle: vi.fn(),
     appendBundle: vi.fn(),
     commitBundle: vi.fn(),
@@ -100,7 +110,10 @@ describe("deleteBundle", () => {
       { databasePlugin, storagePlugin },
     );
 
-    expect(databasePlugin.getBundleById).toHaveBeenCalledWith(baseBundle.id);
+    expect(databasePlugin.getBundles).toHaveBeenCalledWith({
+      where: { id: { in: [baseBundle.id] } },
+      limit: 1,
+    });
     expect(databasePlugin.deleteBundle).toHaveBeenCalledWith(baseBundle);
     expect(databasePlugin.commitBundle).toHaveBeenCalledOnce();
     expect(deleteFromStorage).toHaveBeenCalledWith(baseBundle.storageUri);
@@ -120,9 +133,16 @@ describe("deleteBundle", () => {
       storageUri: "s3://bucket/second-bundle.zip",
     };
     const databasePlugin = createDatabasePlugin();
-    databasePlugin.getBundleById.mockImplementation(async (bundleId) =>
-      bundleId === baseBundle.id ? baseBundle : secondBundle,
-    );
+    databasePlugin.getBundles.mockResolvedValue({
+      data: [baseBundle, secondBundle],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: 2,
+        totalPages: 1,
+      },
+    });
     const deleteFromStorage = vi.fn();
     const storagePlugin = createStoragePlugin("s3", {
       delete: deleteFromStorage,
@@ -133,25 +153,15 @@ describe("deleteBundle", () => {
       { databasePlugin, storagePlugin },
     );
 
-    expect(databasePlugin.getBundleById).toHaveBeenNthCalledWith(
-      1,
-      baseBundle.id,
-    );
-    expect(databasePlugin.getBundleById).toHaveBeenNthCalledWith(
-      2,
-      secondBundle.id,
-    );
+    expect(databasePlugin.getBundles).toHaveBeenCalledOnce();
     expect(databasePlugin.deleteBundle).toHaveBeenCalledTimes(2);
     expect(databasePlugin.commitBundle).toHaveBeenCalledOnce();
     expect(deleteFromStorage).toHaveBeenCalledWith(baseBundle.storageUri);
     expect(deleteFromStorage).toHaveBeenCalledWith(secondBundle.storageUri);
   });
 
-  it("validates every bundle before starting a batch deletion", async () => {
+  it("deletes found bundles and reports stale ids in the same batch", async () => {
     const databasePlugin = createDatabasePlugin();
-    databasePlugin.getBundleById
-      .mockResolvedValueOnce(baseBundle)
-      .mockResolvedValueOnce(null);
     const storagePlugin = createStoragePlugin();
 
     await expect(
@@ -159,11 +169,31 @@ describe("deleteBundle", () => {
         { bundleIds: [baseBundle.id, "missing-bundle"] },
         { databasePlugin, storagePlugin },
       ),
-    ).rejects.toThrow("Bundle not found: missing-bundle");
+    ).resolves.toEqual({
+      deletedBundleIds: [baseBundle.id],
+      missingBundleIds: ["missing-bundle"],
+    });
 
-    expect(databasePlugin.deleteBundle).not.toHaveBeenCalled();
-    expect(databasePlugin.commitBundle).not.toHaveBeenCalled();
-    expect(storagePlugin.profiles.node.delete).not.toHaveBeenCalled();
+    expect(databasePlugin.deleteBundle).toHaveBeenCalledWith(baseBundle);
+    expect(databasePlugin.commitBundle).toHaveBeenCalledOnce();
+    expect(storagePlugin.profiles.node.delete).toHaveBeenCalledWith(
+      baseBundle.storageUri,
+    );
+  });
+
+  it("deduplicates ids before database and storage deletion", async () => {
+    const databasePlugin = createDatabasePlugin();
+    const storagePlugin = createStoragePlugin();
+
+    await deleteBundles(
+      { bundleIds: [baseBundle.id, baseBundle.id] },
+      { databasePlugin, storagePlugin },
+    );
+
+    expect(databasePlugin.getBundles).toHaveBeenCalledOnce();
+    expect(databasePlugin.deleteBundle).toHaveBeenCalledOnce();
+    expect(databasePlugin.commitBundle).toHaveBeenCalledOnce();
+    expect(storagePlugin.profiles.node.delete).toHaveBeenCalledOnce();
   });
 
   it("skips storage deletion for http urls", async () => {
@@ -326,7 +356,7 @@ describe("deleteBundle", () => {
       { databasePlugin, storagePlugin },
     );
 
-    expect(databasePlugin.getBundles).not.toHaveBeenCalled();
+    expect(databasePlugin.getBundles).toHaveBeenCalledOnce();
     expect(fetchManifest).not.toHaveBeenCalled();
     expect(deleteFromStorage).toHaveBeenCalledTimes(2);
     expect(deleteFromStorage).toHaveBeenCalledWith(

--- a/packages/console/src/lib/server/deleteBundle.ts
+++ b/packages/console/src/lib/server/deleteBundle.ts
@@ -188,14 +188,21 @@ export async function deleteBundles(
     waitForStorageCleanup = true,
   }: DeleteBundleDependencies,
 ) {
-  const bundles: Bundle[] = [];
-  for (const bundleId of bundleIds) {
-    const bundle = await databasePlugin.getBundleById(bundleId);
-    if (!bundle) {
-      throw new Error(`Bundle not found: ${bundleId}`);
-    }
-    bundles.push(bundle);
-  }
+  const uniqueBundleIds = [...new Set(bundleIds)];
+  const { data: matchedBundles } = await databasePlugin.getBundles({
+    where: { id: { in: uniqueBundleIds } },
+    limit: uniqueBundleIds.length,
+  });
+  const matchedById = new Map(
+    matchedBundles.map((bundle) => [bundle.id, bundle]),
+  );
+  const bundles = uniqueBundleIds.flatMap((bundleId) => {
+    const bundle = matchedById.get(bundleId);
+    return bundle ? [bundle] : [];
+  });
+  const missingBundleIds = uniqueBundleIds.filter(
+    (bundleId) => !matchedById.has(bundleId),
+  );
 
   for (const bundle of bundles) {
     const cleanupCandidates = [
@@ -211,10 +218,12 @@ export async function deleteBundles(
     }
   }
 
-  for (const bundle of bundles) {
-    await databasePlugin.deleteBundle(bundle);
+  if (bundles.length > 0) {
+    for (const bundle of bundles) {
+      await databasePlugin.deleteBundle(bundle);
+    }
+    await databasePlugin.commitBundle();
   }
-  await databasePlugin.commitBundle();
 
   const cleanupStorage = async () => {
     for (const bundle of bundles) {
@@ -224,17 +233,27 @@ export async function deleteBundles(
 
   if (waitForStorageCleanup) {
     await cleanupStorage();
-    return;
+    return {
+      deletedBundleIds: bundles.map((bundle) => bundle.id),
+      missingBundleIds,
+    };
   }
 
   void cleanupStorage().catch((error) => {
     console.error("Failed to clean up bundle storage:", error);
   });
+  return {
+    deletedBundleIds: bundles.map((bundle) => bundle.id),
+    missingBundleIds,
+  };
 }
 
 export async function deleteBundle(
   { bundleId }: DeleteBundleInput,
   dependencies: DeleteBundleDependencies,
 ) {
-  await deleteBundles({ bundleIds: [bundleId] }, dependencies);
+  const result = await deleteBundles({ bundleIds: [bundleId] }, dependencies);
+  if (result.missingBundleIds.length > 0) {
+    throw new Error(`Bundle not found: ${bundleId}`);
+  }
 }

--- a/packages/console/src/lib/server/deleteBundle.ts
+++ b/packages/console/src/lib/server/deleteBundle.ts
@@ -9,6 +9,7 @@ import {
   getPatchStorageUri,
 } from "@hot-updater/core";
 import type {
+  Bundle,
   DatabasePlugin,
   NodeStoragePlugin,
 } from "@hot-updater/plugin-core";
@@ -18,6 +19,10 @@ import { getLegacyBundleAssetCleanupUris } from "./legacyBundleAssetCleanup";
 
 interface DeleteBundleInput {
   bundleId: string;
+}
+
+interface DeleteBundlesInput {
+  bundleIds: readonly string[];
 }
 
 interface DeleteBundleDependencies {
@@ -98,105 +103,122 @@ async function loadBundleManifest(
   return JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest;
 }
 
-export async function deleteBundle(
-  { bundleId }: DeleteBundleInput,
+async function cleanupBundleStorage(
+  bundle: Bundle,
+  storagePlugin: NodeStoragePlugin,
+) {
+  const cleanupUris = new Set<string>();
+  const addCleanupUri = (storageUri: string | undefined) => {
+    if (!storageUri) {
+      return;
+    }
+
+    const resolvedStorageUri = resolveStorageUriForDeletion(
+      storageUri,
+      storagePlugin,
+    );
+    if (resolvedStorageUri) {
+      cleanupUris.add(resolvedStorageUri);
+    }
+  };
+
+  addCleanupUri(bundle.storageUri);
+  addCleanupUri(getManifestStorageUri(bundle) ?? undefined);
+  addCleanupUri(getPatchStorageUri(bundle) ?? undefined);
+  for (const patch of getBundlePatches(bundle)) {
+    addCleanupUri(patch.patchStorageUri);
+  }
+
+  const manifestStorageUri = getManifestStorageUri(bundle);
+  const assetBaseStorageUri = getAssetBaseStorageUri(bundle);
+
+  if (assetBaseStorageUri) {
+    if (!manifestStorageUri) {
+      if (!isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
+        addCleanupUri(assetBaseStorageUri);
+      }
+    } else if (isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
+      // New deploys store manifest assets under a shared content-addressed
+      // /assets root. Deleting individual shared objects here would require
+      // either reference metadata or a storage/DB scan, so bundle deletion
+      // leaves them in place and only removes per-bundle archive/manifest data.
+    } else {
+      try {
+        const manifest = await loadBundleManifest(
+          manifestStorageUri,
+          storagePlugin,
+        );
+
+        for (const storageUri of getLegacyBundleAssetCleanupUris({
+          assetBaseStorageUri,
+          manifest,
+        })) {
+          addCleanupUri(storageUri);
+        }
+      } catch (error) {
+        console.error(
+          "Failed to load bundle manifest for storage cleanup:",
+          error,
+        );
+        if (!isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
+          addCleanupUri(assetBaseStorageUri);
+        }
+      }
+    }
+  }
+
+  if (cleanupUris.size === 0) {
+    return;
+  }
+
+  for (const storageUri of cleanupUris) {
+    try {
+      await storagePlugin.profiles.node.delete(storageUri);
+    } catch (error) {
+      console.error("Failed to delete bundle from storage:", error);
+    }
+  }
+}
+
+export async function deleteBundles(
+  { bundleIds }: DeleteBundlesInput,
   {
     databasePlugin,
     storagePlugin,
     waitForStorageCleanup = true,
   }: DeleteBundleDependencies,
 ) {
-  const bundle = await databasePlugin.getBundleById(bundleId);
-  if (!bundle) {
-    throw new Error("Bundle not found");
+  const bundles: Bundle[] = [];
+  for (const bundleId of bundleIds) {
+    const bundle = await databasePlugin.getBundleById(bundleId);
+    if (!bundle) {
+      throw new Error(`Bundle not found: ${bundleId}`);
+    }
+    bundles.push(bundle);
   }
 
-  const cleanupCandidates = [
-    bundle.storageUri,
-    getManifestStorageUri(bundle),
-    getAssetBaseStorageUri(bundle),
-    getPatchStorageUri(bundle),
-    ...getBundlePatches(bundle).map((patch) => patch.patchStorageUri),
-  ].filter((value): value is string => Boolean(value));
+  for (const bundle of bundles) {
+    const cleanupCandidates = [
+      bundle.storageUri,
+      getManifestStorageUri(bundle),
+      getAssetBaseStorageUri(bundle),
+      getPatchStorageUri(bundle),
+      ...getBundlePatches(bundle).map((patch) => patch.patchStorageUri),
+    ].filter((value): value is string => Boolean(value));
 
-  for (const candidate of cleanupCandidates) {
-    resolveStorageUriForDeletion(candidate, storagePlugin);
+    for (const candidate of cleanupCandidates) {
+      resolveStorageUriForDeletion(candidate, storagePlugin);
+    }
   }
 
-  await databasePlugin.deleteBundle(bundle);
+  for (const bundle of bundles) {
+    await databasePlugin.deleteBundle(bundle);
+  }
   await databasePlugin.commitBundle();
 
   const cleanupStorage = async () => {
-    const cleanupUris = new Set<string>();
-    const addCleanupUri = (storageUri: string | undefined) => {
-      if (!storageUri) {
-        return;
-      }
-
-      const resolvedStorageUri = resolveStorageUriForDeletion(
-        storageUri,
-        storagePlugin,
-      );
-      if (resolvedStorageUri) {
-        cleanupUris.add(resolvedStorageUri);
-      }
-    };
-
-    addCleanupUri(bundle.storageUri);
-    addCleanupUri(getManifestStorageUri(bundle) ?? undefined);
-    addCleanupUri(getPatchStorageUri(bundle) ?? undefined);
-    for (const patch of getBundlePatches(bundle)) {
-      addCleanupUri(patch.patchStorageUri);
-    }
-
-    const manifestStorageUri = getManifestStorageUri(bundle);
-    const assetBaseStorageUri = getAssetBaseStorageUri(bundle);
-
-    if (assetBaseStorageUri) {
-      if (!manifestStorageUri) {
-        if (!isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
-          addCleanupUri(assetBaseStorageUri);
-        }
-      } else if (isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
-        // New deploys store manifest assets under a shared content-addressed
-        // /assets root. Deleting individual shared objects here would require
-        // either reference metadata or a storage/DB scan, so bundle deletion
-        // leaves them in place and only removes per-bundle archive/manifest data.
-      } else {
-        try {
-          const manifest = await loadBundleManifest(
-            manifestStorageUri,
-            storagePlugin,
-          );
-
-          for (const storageUri of getLegacyBundleAssetCleanupUris({
-            assetBaseStorageUri,
-            manifest,
-          })) {
-            addCleanupUri(storageUri);
-          }
-        } catch (error) {
-          console.error(
-            "Failed to load bundle manifest for storage cleanup:",
-            error,
-          );
-          if (!isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)) {
-            addCleanupUri(assetBaseStorageUri);
-          }
-        }
-      }
-    }
-
-    if (cleanupUris.size === 0) {
-      return;
-    }
-
-    for (const storageUri of cleanupUris) {
-      try {
-        await storagePlugin.profiles.node.delete(storageUri);
-      } catch (error) {
-        console.error("Failed to delete bundle from storage:", error);
-      }
+    for (const bundle of bundles) {
+      await cleanupBundleStorage(bundle, storagePlugin);
     }
   };
 
@@ -208,4 +230,11 @@ export async function deleteBundle(
   void cleanupStorage().catch((error) => {
     console.error("Failed to clean up bundle storage:", error);
   });
+}
+
+export async function deleteBundle(
+  { bundleId }: DeleteBundleInput,
+  dependencies: DeleteBundleDependencies,
+) {
+  await deleteBundles({ bundleIds: [bundleId] }, dependencies);
 }

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -22,6 +22,7 @@ export const Route = createFileRoute("/")({
     return {
       channel: search.channel as string | undefined,
       platform: search.platform as "ios" | "android" | undefined,
+      targetAppVersion: search.targetAppVersion as string | undefined,
       page:
         parsedPage !== undefined &&
         Number.isInteger(parsedPage) &&
@@ -46,6 +47,7 @@ function BundlesPage() {
   const { data: bundlesData, isLoading } = useBundlesQuery({
     channel: filters.channel,
     platform: filters.platform,
+    targetAppVersion: filters.targetAppVersion,
     page: filters.page,
     after: filters.after,
     before: filters.before,

--- a/packages/hot-updater/src/commands/bundle.spec.ts
+++ b/packages/hot-updater/src/commands/bundle.spec.ts
@@ -456,6 +456,34 @@ describe("handleBundleDelete", () => {
     );
   });
 
+  it("resolves multiple ids sequentially to avoid overlapping provider scans", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const b1 = buildBundle({ id: "B1" });
+    const b2 = buildBundle({ id: "B2" });
+    let resolveFirst: ((bundle: Bundle) => void) | undefined;
+    const firstLookup = new Promise<Bundle>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    mockDatabasePlugin.getBundleById
+      .mockImplementationOnce(() => firstLookup)
+      .mockResolvedValueOnce(b2)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const { handleBundleDelete } = await import("./bundle");
+    const deletion = handleBundleDelete(["B1", "B2"], { yes: true });
+
+    await vi.waitFor(() => {
+      expect(mockDatabasePlugin.getBundleById).toHaveBeenCalledTimes(1);
+    });
+    resolveFirst?.(b1);
+    await deletion;
+
+    expect(mockDatabasePlugin.getBundleById).toHaveBeenNthCalledWith(1, "B1");
+    expect(mockDatabasePlugin.getBundleById).toHaveBeenNthCalledWith(2, "B2");
+  });
+
   it("exits 1 when no ids are provided", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     const { exitSpy } = expectExit(1);

--- a/packages/hot-updater/src/commands/bundle.spec.ts
+++ b/packages/hot-updater/src/commands/bundle.spec.ts
@@ -95,7 +95,11 @@ describe("handleBundleList", () => {
     await handleBundleList({});
 
     expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
-      where: { channel: undefined, platform: undefined },
+      where: {
+        channel: undefined,
+        platform: undefined,
+        targetAppVersion: undefined,
+      },
       limit: 20,
     });
     const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
@@ -142,9 +146,18 @@ describe("handleBundleList", () => {
       pagination: { total: 0 },
     });
     const { handleBundleList } = await import("./bundle");
-    await handleBundleList({ channel: "beta", platform: "android", limit: 5 });
+    await handleBundleList({
+      channel: "beta",
+      platform: "android",
+      limit: 5,
+      targetAppVersion: "1.2.3",
+    });
     expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
-      where: { channel: "beta", platform: "android" },
+      where: {
+        channel: "beta",
+        platform: "android",
+        targetAppVersion: "1.2.3",
+      },
       limit: 5,
     });
   });
@@ -394,9 +407,11 @@ describe("handleBundleDelete", () => {
   it("deletes an existing bundle record with -y and verifies it is gone", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     const bundle = buildBundle({ id: "B1" });
-    mockDatabasePlugin.getBundleById
-      .mockResolvedValueOnce(bundle)
-      .mockResolvedValueOnce(null);
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [bundle],
+      pagination: { total: 1 },
+    });
+    mockDatabasePlugin.getBundleById.mockResolvedValueOnce(null);
 
     const { handleBundleDelete } = await import("./bundle");
     await handleBundleDelete(["B1"], { yes: true });
@@ -412,8 +427,11 @@ describe("handleBundleDelete", () => {
     vi.useFakeTimers();
     vi.spyOn(console, "log").mockImplementation(() => {});
     const bundle = buildBundle({ id: "B1" });
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [bundle],
+      pagination: { total: 1 },
+    });
     mockDatabasePlugin.getBundleById
-      .mockResolvedValueOnce(bundle)
       .mockResolvedValueOnce(bundle)
       .mockResolvedValueOnce(null);
 
@@ -437,11 +455,13 @@ describe("handleBundleDelete", () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     const b1 = buildBundle({ id: "B1" });
     const b2 = buildBundle({ id: "B2" });
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [b1, b2],
+      pagination: { total: 2 },
+    });
     mockDatabasePlugin.getBundleById
-      .mockResolvedValueOnce(b1) // resolve B1
-      .mockResolvedValueOnce(b2) // resolve B2
-      .mockResolvedValueOnce(null) // verify B1 gone
-      .mockResolvedValueOnce(null); // verify B2 gone
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
 
     const { handleBundleDelete } = await import("./bundle");
     await handleBundleDelete(["B1", "B2"], { yes: true });
@@ -456,32 +476,31 @@ describe("handleBundleDelete", () => {
     );
   });
 
-  it("resolves multiple ids sequentially to avoid overlapping provider scans", async () => {
+  it("resolves multiple and missing ids from one management snapshot", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     const b1 = buildBundle({ id: "B1" });
     const b2 = buildBundle({ id: "B2" });
-    let resolveFirst: ((bundle: Bundle) => void) | undefined;
-    const firstLookup = new Promise<Bundle>((resolve) => {
-      resolveFirst = resolve;
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [b1, b2],
+      pagination: { total: 2 },
     });
-
     mockDatabasePlugin.getBundleById
-      .mockImplementationOnce(() => firstLookup)
-      .mockResolvedValueOnce(b2)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
     const { handleBundleDelete } = await import("./bundle");
-    const deletion = handleBundleDelete(["B1", "B2"], { yes: true });
+    await handleBundleDelete(["B1", "missing", "B2", "B1"], { yes: true });
 
-    await vi.waitFor(() => {
-      expect(mockDatabasePlugin.getBundleById).toHaveBeenCalledTimes(1);
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledOnce();
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledWith({
+      where: { id: { in: ["B1", "missing", "B2"] } },
+      limit: 3,
     });
-    resolveFirst?.(b1);
-    await deletion;
-
-    expect(mockDatabasePlugin.getBundleById).toHaveBeenNthCalledWith(1, "B1");
-    expect(mockDatabasePlugin.getBundleById).toHaveBeenNthCalledWith(2, "B2");
+    expect(mockDatabasePlugin.deleteBundle).toHaveBeenCalledTimes(2);
+    expect(mockDatabasePlugin.commitBundle).toHaveBeenCalledOnce();
+    expect(mockCli.p.log.info).toHaveBeenCalledWith(
+      "No bundle with id missing. Skipping.",
+    );
   });
 
   it("exits 1 when no ids are provided", async () => {

--- a/packages/hot-updater/src/commands/bundle.ts
+++ b/packages/hot-updater/src/commands/bundle.ts
@@ -54,6 +54,7 @@ export interface BundleListOptions {
   json?: boolean;
   platform?: Platform;
   limit?: number;
+  targetAppVersion?: string;
 }
 
 export interface BundleMutationOptions {
@@ -164,6 +165,7 @@ export const handleBundleList = async (options: BundleListOptions = {}) => {
       where: {
         channel: options.channel,
         platform: options.platform,
+        targetAppVersion: options.targetAppVersion,
       },
       limit,
     });
@@ -346,7 +348,7 @@ export const handleBundleDelete = async (
 ) => {
   printBanner();
 
-  const ids = bundleIds ?? [];
+  const ids = [...new Set(bundleIds ?? [])];
   if (ids.length === 0) {
     p.log.error("Provide at least one bundle id.");
     process.exit(1);
@@ -355,16 +357,23 @@ export const handleBundleDelete = async (
   const config = await loadConfig(null);
   const databasePlugin: DatabasePlugin = await config.database();
   try {
-    // Resolve the target set from the given ids.
-    const targets: Bundle[] = [];
-    for (const id of ids) {
-      const bundle = await databasePlugin.getBundleById(id);
-      if (bundle) {
-        targets.push(bundle);
-      } else {
+    // Resolve the complete target set from one management snapshot. Blob-backed
+    // databases otherwise rescan storage once for every missing ID.
+    const { data: matchedBundles } = await databasePlugin.getBundles({
+      where: { id: { in: ids } },
+      limit: ids.length,
+    });
+    const matchedById = new Map(
+      matchedBundles.map((bundle) => [bundle.id, bundle]),
+    );
+    const targets = ids.flatMap((id) => {
+      const bundle = matchedById.get(id);
+      if (!bundle) {
         p.log.info(`No bundle with id ${id}. Skipping.`);
+        return [];
       }
-    }
+      return [bundle];
+    });
     if (targets.length === 0) {
       p.log.info("No matching bundle records. No changes.");
       return;

--- a/packages/hot-updater/src/commands/bundle.ts
+++ b/packages/hot-updater/src/commands/bundle.ts
@@ -356,17 +356,15 @@ export const handleBundleDelete = async (
   const databasePlugin: DatabasePlugin = await config.database();
   try {
     // Resolve the target set from the given ids.
-    const fetched = await Promise.all(
-      ids.map((id) => databasePlugin.getBundleById(id)),
-    );
     const targets: Bundle[] = [];
-    fetched.forEach((bundle, index) => {
+    for (const id of ids) {
+      const bundle = await databasePlugin.getBundleById(id);
       if (bundle) {
         targets.push(bundle);
       } else {
-        p.log.info(`No bundle with id ${ids[index]}. Skipping.`);
+        p.log.info(`No bundle with id ${id}. Skipping.`);
       }
-    });
+    }
     if (targets.length === 0) {
       p.log.info("No matching bundle records. No changes.");
       return;

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -677,7 +677,7 @@ describe("deploy rollout wiring", () => {
       expect.objectContaining({
         assetBaseStorageUri: "s3://bundles/assets",
         manifestFileHash: "file-hash",
-        manifestStorageUri: "s3://bundles/bundle-123/manifest.json",
+        manifestStorageUri: "s3://bundles/bundles/bundle-123/manifest.json",
         metadata: expect.objectContaining({
           app_version: "1.0",
         }),

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -581,6 +581,9 @@ describe("deploy rollout wiring", () => {
       bundleId: platform === "ios" ? "bundle-ios" : "bundle-android",
       stdout: null,
     }));
+    mockStoragePlugin.profiles.node.upload.mockImplementation(async (key) => ({
+      storageUri: `s3://bundles/${key}/bundle.tar.br`,
+    }));
 
     await deploy({
       channel: "production",

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -19,7 +19,11 @@ import type {
   Platform,
 } from "@hot-updater/plugin-core";
 import { assertNodeStoragePlugin } from "@hot-updater/plugin-core";
-import { getContentAddressedAssetStoragePath } from "@hot-updater/plugin-core";
+import {
+  createBundleStorageKey,
+  createStorageRootUriWithPath,
+  getContentAddressedAssetStoragePath,
+} from "@hot-updater/plugin-core";
 import { createBundleDiff } from "@hot-updater/server/db";
 import isPortReachable from "is-port-reachable";
 import open from "open";
@@ -323,24 +327,6 @@ const getManifestAssetUploadName = (relativePath: string) =>
   isBrotliManifestBundleAsset(relativePath)
     ? `${relativePath}.br`
     : relativePath;
-
-const replaceBundleStorageUriPath = (
-  storageUri: string,
-  bundleId: string,
-  nextPath: string,
-) => {
-  const storageUrl = new URL(storageUri);
-  const segments = storageUrl.pathname.split("/").filter(Boolean);
-  const bundleIndex = segments.lastIndexOf(bundleId);
-  const parentSegments =
-    bundleIndex >= 0 ? segments.slice(0, bundleIndex) : segments.slice(0, -2);
-
-  storageUrl.pathname = `/${[...parentSegments, nextPath]
-    .filter(Boolean)
-    .map((segment) => encodeURIComponent(segment))
-    .join("/")}`;
-  return storageUrl.toString();
-};
 
 const createStorageUriWithRelativePath = (
   baseStorageUri: string,
@@ -934,7 +920,7 @@ const deployPlatform = async ({
 
             updateUploadProgress();
             const { storageUri } = await storagePlugin.profiles.node.upload(
-              bundleId,
+              createBundleStorageKey(bundleId),
               bundlePath,
             );
             taskRef.storageUri = storageUri;
@@ -946,7 +932,7 @@ const deployPlatform = async ({
             // from manifest fileHash values. LEGACY: existing /files bundles
             // still resolve through the server fallback until that layout is
             // intentionally removed.
-            taskRef.assetBaseStorageUri = replaceBundleStorageUriPath(
+            taskRef.assetBaseStorageUri = createStorageRootUriWithPath(
               storageUri,
               bundleId,
               "assets",
@@ -985,7 +971,7 @@ const deployPlatform = async ({
             );
 
             const manifestUpload = await storagePlugin.profiles.node.upload(
-              bundleId,
+              createBundleStorageKey(bundleId),
               taskRef.manifestPath,
             );
             taskRef.manifestStorageUri = manifestUpload.storageUri;

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -23,6 +23,7 @@ import {
   createBundleStorageKey,
   createStorageRootUriWithPath,
   getContentAddressedAssetStoragePath,
+  getManifestAssetDownloadPath,
 } from "@hot-updater/plugin-core";
 import { createBundleDiff } from "@hot-updater/server/db";
 import isPortReachable from "is-port-reachable";
@@ -320,14 +321,6 @@ const getRelativeStorageDir = (relativePath: string) => {
   return dirname === "." ? "" : dirname;
 };
 
-const isBrotliManifestBundleAsset = (relativePath: string) =>
-  /(^|\/)index\.[^/]+\.bundle$/.test(relativePath.replace(/\\/g, "/"));
-
-const getManifestAssetUploadName = (relativePath: string) =>
-  isBrotliManifestBundleAsset(relativePath)
-    ? `${relativePath}.br`
-    : relativePath;
-
 const createStorageUriWithRelativePath = (
   baseStorageUri: string,
   relativePath: string,
@@ -354,7 +347,7 @@ const ensureUploadSourcePath = async ({
   targetFile: { path: string; name: string };
   uploadFilename?: string;
 }) => {
-  const uploadName = getManifestAssetUploadName(targetFile.name);
+  const uploadName = getManifestAssetDownloadPath(targetFile.name);
   const expectedFilename = uploadFilename ?? path.posix.basename(uploadName);
   const actualFilename = path.basename(targetFile.path);
 
@@ -408,7 +401,7 @@ const getUniqueContentAddressedAssetUploadTargets = ({
     }
 
     const storagePath = getContentAddressedAssetStoragePath({
-      assetPath: getManifestAssetUploadName(targetFile.name),
+      assetPath: getManifestAssetDownloadPath(targetFile.name),
       fileHash: manifestAsset.fileHash,
     });
 

--- a/packages/hot-updater/src/commands/storage.spec.ts
+++ b/packages/hot-updater/src/commands/storage.spec.ts
@@ -149,6 +149,7 @@ describe("handleStoragePrune", () => {
         await fs.writeFile(
           filePath,
           JSON.stringify({
+            bundleId: LIVE_BUNDLE_ID,
             assets: {
               "images/logo.png": { fileHash: IMAGE_HASH },
               "index.ios.bundle": { fileHash: BUNDLE_HASH },
@@ -181,6 +182,7 @@ describe("handleStoragePrune", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("deletes only old unreferenced assets and orphaned bundle storage", async () => {
@@ -190,13 +192,19 @@ describe("handleStoragePrune", () => {
 
     expect(mockStorageNode.deleteObjects).toHaveBeenCalledOnce();
     expect(mockStorageNode.deleteObjects).toHaveBeenCalledWith([
-      `s3://bucket/assets/sha256/${ORPHAN_HASH.slice(0, 2)}/${ORPHAN_HASH}.png`,
-      `s3://bucket/${DEAD_BUNDLE_ID}/bundle.zip`,
-      `s3://bucket/${DEAD_BUNDLE_ID}/files/logo.png`,
-      `s3://bucket/bundles/${DEAD_BUNDLE_ID}/manifest.json`,
+      `assets/sha256/${ORPHAN_HASH.slice(0, 2)}/${ORPHAN_HASH}.png`,
+      `${DEAD_BUNDLE_ID}/bundle.zip`,
+      `${DEAD_BUNDLE_ID}/files/logo.png`,
+      `bundles/${DEAD_BUNDLE_ID}/manifest.json`,
     ]);
     expect(mockCli.p.log.success).toHaveBeenCalledWith(
       "Pruned 4 objects (140 B).",
+    );
+    expect(mockCli.p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("requires exclusive access"),
+    );
+    expect(mockCli.p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("separate storage basePath"),
     );
     expect(mockDatabasePlugin.onUnmount).toHaveBeenCalledOnce();
   });
@@ -220,6 +228,7 @@ describe("handleStoragePrune", () => {
         await fs.writeFile(
           filePath,
           JSON.stringify({
+            bundleId: LIVE_BUNDLE_ID,
             assets: {
               "images/logo.png": { fileHash: IMAGE_HASH },
               "index.ios.bundle": { fileHash: BUNDLE_HASH },
@@ -236,10 +245,219 @@ describe("handleStoragePrune", () => {
     await handleStoragePrune({ yes: true });
 
     expect(mockStorageNode.deleteObjects).toHaveBeenCalledWith([
-      `s3://bucket/${DEAD_BUNDLE_ID}/bundle.zip`,
-      `s3://bucket/${DEAD_BUNDLE_ID}/files/logo.png`,
-      `s3://bucket/bundles/${DEAD_BUNDLE_ID}/manifest.json`,
+      `${DEAD_BUNDLE_ID}/bundle.zip`,
+      `${DEAD_BUNDLE_ID}/files/logo.png`,
+      `bundles/${DEAD_BUNDLE_ID}/manifest.json`,
     ]);
+  });
+
+  it("does not delete when the final reference scan fails", async () => {
+    let manifestReadCount = 0;
+    mockStorageNode.downloadFile.mockImplementation(
+      async (_storageUri: string, filePath: string) => {
+        manifestReadCount += 1;
+        if (manifestReadCount > 1) {
+          throw new Error("manifest unavailable");
+        }
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            bundleId: LIVE_BUNDLE_ID,
+            assets: {
+              "images/logo.png": { fileHash: IMAGE_HASH },
+              "index.ios.bundle": { fileHash: BUNDLE_HASH },
+            },
+          }),
+        );
+      },
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      `failed to read manifest for bundle ${LIVE_BUNDLE_ID}`,
+    );
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("protects metadata stored below a UUID-shaped channel", async () => {
+    const uuidChannelMetadata = `${DEAD_BUNDLE_ID}/ios/1.0.0/update.json`;
+    mockStorageNode.listObjects.mockResolvedValue([
+      object(uuidChannelMetadata, old),
+      object(`${DEAD_BUNDLE_ID}/bundle.zip`, old),
+    ]);
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ yes: true });
+
+    expect(mockStorageNode.deleteObjects).toHaveBeenCalledWith([
+      `${DEAD_BUNDLE_ID}/bundle.zip`,
+    ]);
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalledWith(
+      expect.arrayContaining([uuidChannelMetadata]),
+    );
+  });
+
+  it("fails closed when the asset base uses another storage protocol", async () => {
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [
+        {
+          ...liveBundle,
+          assetBaseStorageUri: "https://cdn.example.com/assets",
+        },
+      ],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      "uses https asset storage",
+    );
+    expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("allows an HTTP manifest when shared assets use the configured storage", async () => {
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [
+        {
+          ...liveBundle,
+          manifestStorageUri: "https://cdn.example.com/manifest.json",
+        },
+      ],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            bundleId: LIVE_BUNDLE_ID,
+            assets: {
+              "images/logo.png": { fileHash: IMAGE_HASH },
+              "index.ios.bundle": { fileHash: BUNDLE_HASH },
+            },
+          }),
+      })),
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ yes: true });
+
+    expect(fetch).toHaveBeenCalledWith("https://cdn.example.com/manifest.json");
+    expect(mockStorageNode.deleteObjects).toHaveBeenCalled();
+  });
+
+  it("fails closed when a manifest belongs to another bundle", async () => {
+    mockStorageNode.downloadFile.mockImplementation(
+      async (_storageUri: string, filePath: string) => {
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            bundleId: DEAD_BUNDLE_ID,
+            assets: {
+              "images/logo.png": { fileHash: IMAGE_HASH },
+            },
+          }),
+        );
+      },
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      `invalid manifest for bundle ${LIVE_BUNDLE_ID}`,
+    );
+    expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a manifest contains a malformed asset hash", async () => {
+    mockStorageNode.downloadFile.mockImplementation(
+      async (_storageUri: string, filePath: string) => {
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            bundleId: LIVE_BUNDLE_ID,
+            assets: {
+              "images/logo.png": { fileHash: "not-a-sha256" },
+            },
+          }),
+        );
+      },
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      `invalid manifest for bundle ${LIVE_BUNDLE_ID}`,
+    );
+    expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the database omits a required next cursor", async () => {
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [liveBundle],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: true,
+        hasPreviousPage: false,
+        nextCursor: null,
+        total: 10_001,
+        totalPages: 2,
+      },
+    });
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      "cannot provide safe cursor pagination",
+    );
+    expect(mockStorageNode.downloadFile).not.toHaveBeenCalled();
+    expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("protects exact and legacy-prefix URIs referenced by live bundles", async () => {
+    const referencedLegacyId = DEAD_BUNDLE_ID;
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [
+        {
+          ...liveBundle,
+          assetBaseStorageUri: `s3://bucket/${referencedLegacyId}/files`,
+          manifestStorageUri: `s3://bucket/${referencedLegacyId}/manifest.json`,
+          storageUri: `s3://bucket/${referencedLegacyId}/bundle.zip`,
+        },
+      ],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+    mockStorageNode.listObjects.mockResolvedValue([
+      object(`${referencedLegacyId}/bundle.zip`, old),
+      object(`${referencedLegacyId}/manifest.json`, old),
+      object(`${referencedLegacyId}/files/logo.png`, old),
+    ]);
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ yes: true });
+
+    expect(mockStorageNode.downloadFile).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
   });
 
   it("aborts before listing or deletion when a live manifest cannot be read", async () => {

--- a/packages/hot-updater/src/commands/storage.spec.ts
+++ b/packages/hot-updater/src/commands/storage.spec.ts
@@ -209,15 +209,28 @@ describe("handleStoragePrune", () => {
     expect(mockDatabasePlugin.onUnmount).toHaveBeenCalledOnce();
   });
 
-  it("reports candidates without deleting when --yes is omitted", async () => {
+  it.each([
+    { label: "by default", options: {} },
+    { label: "with --dry-run", options: { dryRun: true } },
+  ])("reports candidates without deleting $label", async ({ options }) => {
     const { handleStoragePrune } = await import("./storage");
 
-    await handleStoragePrune();
+    await handleStoragePrune(options);
 
     expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
     expect(mockCli.p.log.info).toHaveBeenCalledWith(
       expect.stringContaining("Dry run only"),
     );
+  });
+
+  it("rejects conflicting dry-run and deletion options before loading config", async () => {
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(
+      handleStoragePrune({ dryRun: true, yes: true }),
+    ).rejects.toThrow("--dry-run cannot be used with --yes");
+    expect(mockCli.loadConfig).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
   });
 
   it("rechecks manifest references before deleting", async () => {

--- a/packages/hot-updater/src/commands/storage.spec.ts
+++ b/packages/hot-updater/src/commands/storage.spec.ts
@@ -1,0 +1,284 @@
+import fs from "node:fs/promises";
+
+import type { Bundle, StorageObject } from "@hot-updater/plugin-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCli,
+  mockDatabasePlugin,
+  mockPrintBanner,
+  mockStorageNode,
+  mockStoragePlugin,
+} = vi.hoisted(() => {
+  const mockDatabasePlugin = {
+    appendBundle: vi.fn(),
+    commitBundle: vi.fn(),
+    deleteBundle: vi.fn(),
+    getBundleById: vi.fn(),
+    getBundles: vi.fn(),
+    getChannels: vi.fn(),
+    name: "mock-database",
+    onUnmount: vi.fn(),
+    updateBundle: vi.fn(),
+  };
+  const mockStorageNode = {
+    delete: vi.fn(),
+    deleteObjects: vi.fn(),
+    downloadFile: vi.fn(),
+    exists: vi.fn(),
+    listObjects: vi.fn(),
+    upload: vi.fn(),
+  };
+  const mockStoragePlugin = {
+    name: "s3Storage",
+    profiles: { node: mockStorageNode },
+    supportedProtocol: "s3",
+  };
+  const mockCli = {
+    loadConfig: vi.fn(),
+    p: {
+      log: {
+        error: vi.fn(),
+        info: vi.fn(),
+        message: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  };
+
+  return {
+    mockCli,
+    mockDatabasePlugin,
+    mockPrintBanner: vi.fn(),
+    mockStorageNode,
+    mockStoragePlugin,
+  };
+});
+
+vi.mock("@hot-updater/cli-tools", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@hot-updater/cli-tools")>();
+  return {
+    ...actual,
+    loadConfig: mockCli.loadConfig,
+    p: mockCli.p,
+  };
+});
+
+vi.mock("@/utils/printBanner", () => ({
+  printBanner: mockPrintBanner,
+}));
+
+const LIVE_BUNDLE_ID = "0195a408-8f13-7d9b-8df4-123456789abc";
+const DEAD_BUNDLE_ID = "0195a408-8f13-7d9b-8df4-123456789abd";
+const IMAGE_HASH = "a".repeat(64);
+const BUNDLE_HASH = "b".repeat(64);
+const ORPHAN_HASH = "c".repeat(64);
+const YOUNG_ORPHAN_HASH = "d".repeat(64);
+
+const liveBundle: Bundle = {
+  assetBaseStorageUri: "s3://bucket/assets",
+  channel: "production",
+  enabled: true,
+  fileHash: "archive-hash",
+  fingerprintHash: null,
+  gitCommitHash: null,
+  id: LIVE_BUNDLE_ID,
+  manifestStorageUri: `s3://bucket/${LIVE_BUNDLE_ID}/manifest.json`,
+  message: null,
+  platform: "ios",
+  rolloutCohortCount: 1000,
+  shouldForceUpdate: false,
+  storageUri: `s3://bucket/${LIVE_BUNDLE_ID}/bundle.zip`,
+  targetAppVersion: "1.0.0",
+  targetCohorts: null,
+};
+
+const object = (
+  key: string,
+  lastModifiedAt: Date,
+  size = 10,
+): StorageObject => ({
+  key,
+  lastModifiedAt,
+  size,
+  storageUri: `s3://bucket/${key}`,
+});
+
+describe("parseStoragePruneMinAge", () => {
+  it("parses minute, hour, day, and week durations", async () => {
+    const { parseStoragePruneMinAge } = await import("./storage");
+
+    expect(parseStoragePruneMinAge("30m")).toBe(30 * 60 * 1000);
+    expect(parseStoragePruneMinAge("24h")).toBe(24 * 60 * 60 * 1000);
+    expect(parseStoragePruneMinAge("7d")).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(parseStoragePruneMinAge("2w")).toBe(14 * 24 * 60 * 60 * 1000);
+    expect(() => parseStoragePruneMinAge("tomorrow")).toThrow(
+      "must use a duration",
+    );
+  });
+});
+
+describe("handleStoragePrune", () => {
+  const now = new Date("2026-08-13T00:00:00.000Z");
+  const old = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+  const young = new Date(now.getTime() - 60 * 60 * 1000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
+
+    mockCli.loadConfig.mockResolvedValue({
+      database: vi.fn().mockResolvedValue(mockDatabasePlugin),
+      storage: vi.fn().mockResolvedValue(mockStoragePlugin),
+    });
+    mockDatabasePlugin.getBundles.mockResolvedValue({
+      data: [liveBundle],
+      pagination: {
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+    mockStorageNode.downloadFile.mockImplementation(
+      async (_storageUri: string, filePath: string) => {
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            assets: {
+              "images/logo.png": { fileHash: IMAGE_HASH },
+              "index.ios.bundle": { fileHash: BUNDLE_HASH },
+            },
+          }),
+        );
+      },
+    );
+    mockStorageNode.listObjects.mockResolvedValue([
+      object(`assets/sha256/${IMAGE_HASH.slice(0, 2)}/${IMAGE_HASH}.png`, old),
+      object(`assets/sha256/${BUNDLE_HASH.slice(0, 2)}/${BUNDLE_HASH}.br`, old),
+      object(
+        `assets/sha256/${ORPHAN_HASH.slice(0, 2)}/${ORPHAN_HASH}.png`,
+        old,
+        30,
+      ),
+      object(
+        `assets/sha256/${YOUNG_ORPHAN_HASH.slice(0, 2)}/${YOUNG_ORPHAN_HASH}.png`,
+        young,
+      ),
+      object(`${LIVE_BUNDLE_ID}/bundle.zip`, old),
+      object(`${DEAD_BUNDLE_ID}/bundle.zip`, old, 40),
+      object(`${DEAD_BUNDLE_ID}/files/logo.png`, old, 20),
+      object(`bundles/${LIVE_BUNDLE_ID}/manifest.json`, old),
+      object(`bundles/${DEAD_BUNDLE_ID}/manifest.json`, old, 50),
+      object("production/ios/1.0.0/update.json", old),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("deletes only old unreferenced assets and orphaned bundle storage", async () => {
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ yes: true });
+
+    expect(mockStorageNode.deleteObjects).toHaveBeenCalledOnce();
+    expect(mockStorageNode.deleteObjects).toHaveBeenCalledWith([
+      `s3://bucket/assets/sha256/${ORPHAN_HASH.slice(0, 2)}/${ORPHAN_HASH}.png`,
+      `s3://bucket/${DEAD_BUNDLE_ID}/bundle.zip`,
+      `s3://bucket/${DEAD_BUNDLE_ID}/files/logo.png`,
+      `s3://bucket/bundles/${DEAD_BUNDLE_ID}/manifest.json`,
+    ]);
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      "Pruned 4 objects (140 B).",
+    );
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalledOnce();
+  });
+
+  it("reports candidates without deleting when --yes is omitted", async () => {
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune();
+
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+    expect(mockCli.p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Dry run only"),
+    );
+  });
+
+  it("rechecks manifest references before deleting", async () => {
+    let manifestReadCount = 0;
+    mockStorageNode.downloadFile.mockImplementation(
+      async (_storageUri: string, filePath: string) => {
+        manifestReadCount += 1;
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            assets: {
+              "images/logo.png": { fileHash: IMAGE_HASH },
+              "index.ios.bundle": { fileHash: BUNDLE_HASH },
+              ...(manifestReadCount > 1
+                ? { "images/restored.png": { fileHash: ORPHAN_HASH } }
+                : {}),
+            },
+          }),
+        );
+      },
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ yes: true });
+
+    expect(mockStorageNode.deleteObjects).toHaveBeenCalledWith([
+      `s3://bucket/${DEAD_BUNDLE_ID}/bundle.zip`,
+      `s3://bucket/${DEAD_BUNDLE_ID}/files/logo.png`,
+      `s3://bucket/bundles/${DEAD_BUNDLE_ID}/manifest.json`,
+    ]);
+  });
+
+  it("aborts before listing or deletion when a live manifest cannot be read", async () => {
+    mockStorageNode.downloadFile.mockRejectedValueOnce(
+      new Error("manifest missing"),
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune({ yes: true })).rejects.toThrow(
+      `failed to read manifest for bundle ${LIVE_BUNDLE_ID}`,
+    );
+
+    expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalledOnce();
+  });
+
+  it("reports when the configured storage plugin cannot enumerate objects", async () => {
+    mockCli.loadConfig.mockResolvedValue({
+      database: vi.fn().mockResolvedValue(mockDatabasePlugin),
+      storage: vi.fn().mockResolvedValue({
+        ...mockStoragePlugin,
+        name: "unsupportedStorage",
+        profiles: {
+          node: {
+            ...mockStorageNode,
+            listObjects: undefined,
+          },
+        },
+      }),
+    });
+    const { handleStoragePrune } = await import("./storage");
+
+    await expect(handleStoragePrune()).rejects.toThrow(
+      'Storage plugin "unsupportedStorage" does not support storage prune.',
+    );
+
+    expect(mockStorageNode.downloadFile).not.toHaveBeenCalled();
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+    expect(mockDatabasePlugin.onUnmount).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/hot-updater/src/commands/storage.ts
+++ b/packages/hot-updater/src/commands/storage.ts
@@ -1,0 +1,463 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { loadConfig, p } from "@hot-updater/cli-tools";
+import {
+  getAssetBaseStorageUri,
+  getManifestStorageUri,
+} from "@hot-updater/core";
+import type {
+  Bundle,
+  DatabasePlugin,
+  NodeStoragePlugin,
+  StorageObject,
+} from "@hot-updater/plugin-core";
+import {
+  assertNodeStoragePlugin,
+  BUNDLE_STORAGE_PREFIX,
+  isContentAddressedAssetBaseStorageUri,
+  resolveManifestAssetStorageUri,
+} from "@hot-updater/plugin-core";
+
+import { printBanner } from "@/utils/printBanner";
+
+import { ui } from "../utils/cli-ui";
+
+const BUNDLE_PAGE_SIZE = 10_000;
+const MANIFEST_READ_CONCURRENCY = 4;
+const UUID_V7_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CONTENT_ADDRESSED_ASSET_KEY_RE =
+  /^assets\/sha256\/[0-9a-f]{2}\/[0-9a-f]{64}(?:\.[^/]+)?$/i;
+const BROTLI_BUNDLE_ASSET_RE = /(^|\/)index\.[^/]+\.bundle$/;
+
+export const DEFAULT_STORAGE_PRUNE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
+export interface StoragePruneOptions {
+  minAge?: number;
+  yes?: boolean;
+}
+
+interface BundleManifest {
+  assets: Record<string, { fileHash: string }>;
+}
+
+interface PruneCandidate extends StorageObject {
+  reason: "asset" | "bundle";
+}
+
+export function parseStoragePruneMinAge(value: string): number {
+  const match = value.trim().match(/^(\d+)(m|h|d|w)$/i);
+  if (!match) {
+    throw new Error("must use a duration such as 30m, 24h, or 7d");
+  }
+
+  const amount = Number.parseInt(match[1]!, 10);
+  const unit = match[2]!.toLowerCase();
+  const multiplier =
+    unit === "m"
+      ? 60 * 1000
+      : unit === "h"
+        ? 60 * 60 * 1000
+        : unit === "d"
+          ? 24 * 60 * 60 * 1000
+          : 7 * 24 * 60 * 60 * 1000;
+
+  return amount * multiplier;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = value / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(size >= 10 ? 1 : 2)} ${units[unitIndex]}`;
+}
+
+function formatDuration(value: number): string {
+  const hour = 60 * 60 * 1000;
+  const day = 24 * hour;
+  if (value % day === 0) {
+    return `${value / day}d`;
+  }
+  if (value % hour === 0) {
+    return `${value / hour}h`;
+  }
+  return `${value / (60 * 1000)}m`;
+}
+
+function normalizeStorageUri(storageUri: string): string {
+  return new URL(storageUri).toString();
+}
+
+function getBundleIdFromStorageKey(key: string): string | null {
+  const segments = key.split("/");
+  const bundleId =
+    segments[0] === BUNDLE_STORAGE_PREFIX ? segments[1] : segments[0];
+  return bundleId && UUID_V7_RE.test(bundleId) ? bundleId.toLowerCase() : null;
+}
+
+function isBundleManifest(value: unknown): value is BundleManifest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const assets = (value as { assets?: unknown }).assets;
+  if (!assets || typeof assets !== "object" || Array.isArray(assets)) {
+    return false;
+  }
+
+  return Object.values(assets as Record<string, unknown>).every((asset) => {
+    return (
+      asset !== null &&
+      typeof asset === "object" &&
+      !Array.isArray(asset) &&
+      typeof (asset as { fileHash?: unknown }).fileHash === "string"
+    );
+  });
+}
+
+async function forEachWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  callback: (value: T, index: number) => Promise<void>,
+) {
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        const value = values[index];
+        if (value === undefined) {
+          return;
+        }
+        await callback(value, index);
+      }
+    },
+  );
+
+  const results = await Promise.allSettled(workers);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) {
+    throw failure.reason;
+  }
+}
+
+async function loadAllBundles(databasePlugin: DatabasePlugin) {
+  const bundles: Bundle[] = [];
+  const seenCursors = new Set<string>();
+  let after: string | undefined;
+
+  while (true) {
+    const { data, pagination } = await databasePlugin.getBundles({
+      cursor: after ? { after } : undefined,
+      limit: BUNDLE_PAGE_SIZE,
+      orderBy: { direction: "desc", field: "id" },
+    });
+    bundles.push(...data);
+
+    const nextCursor = pagination.nextCursor ?? undefined;
+    if (!nextCursor) {
+      return bundles;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(`Database returned a repeated cursor: ${nextCursor}`);
+    }
+
+    seenCursors.add(nextCursor);
+    after = nextCursor;
+  }
+}
+
+async function readManifest(
+  bundle: Bundle,
+  storagePlugin: NodeStoragePlugin,
+  workDir: string,
+  index: number,
+): Promise<BundleManifest> {
+  const manifestStorageUri = getManifestStorageUri(bundle);
+  if (!manifestStorageUri) {
+    throw new Error(
+      `Cannot prune shared assets: bundle ${bundle.id} has no manifest URI.`,
+    );
+  }
+
+  const protocol = new URL(manifestStorageUri).protocol.replace(":", "");
+  let manifestText: string;
+  if (protocol === "http" || protocol === "https") {
+    const response = await fetch(manifestStorageUri);
+    if (!response.ok) {
+      throw new Error(
+        `Cannot prune shared assets: failed to read manifest for bundle ${bundle.id}.`,
+      );
+    }
+    manifestText = await response.text();
+  } else {
+    if (protocol !== storagePlugin.supportedProtocol) {
+      throw new Error(`No storage plugin for protocol: ${protocol}`);
+    }
+
+    const manifestPath = path.join(workDir, `${index}.json`);
+    try {
+      await storagePlugin.profiles.node.downloadFile(
+        manifestStorageUri,
+        manifestPath,
+      );
+      manifestText = await fs.readFile(manifestPath, "utf8");
+    } catch (error) {
+      throw new Error(
+        `Cannot prune shared assets: failed to read manifest for bundle ${bundle.id}.`,
+        { cause: error },
+      );
+    }
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(manifestText) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Cannot prune shared assets: invalid manifest for bundle ${bundle.id}.`,
+      { cause: error },
+    );
+  }
+
+  if (!isBundleManifest(manifest)) {
+    throw new Error(
+      `Cannot prune shared assets: invalid manifest for bundle ${bundle.id}.`,
+    );
+  }
+
+  return manifest;
+}
+
+async function collectReferencedAssetUris(
+  bundles: readonly Bundle[],
+  storagePlugin: NodeStoragePlugin,
+) {
+  const bundlesWithSharedAssets = bundles.filter((bundle) => {
+    const assetBaseStorageUri = getAssetBaseStorageUri(bundle);
+    return (
+      assetBaseStorageUri !== null &&
+      isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)
+    );
+  });
+  const referencedUris = new Set<string>();
+
+  if (bundlesWithSharedAssets.length === 0) {
+    return { manifestCount: 0, referencedUris };
+  }
+
+  const workDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "hot-updater-storage-prune-"),
+  );
+  try {
+    await forEachWithConcurrency(
+      bundlesWithSharedAssets,
+      MANIFEST_READ_CONCURRENCY,
+      async (bundle, index) => {
+        const assetBaseStorageUri = getAssetBaseStorageUri(bundle)!;
+        const manifest = await readManifest(
+          bundle,
+          storagePlugin,
+          workDir,
+          index,
+        );
+
+        for (const [assetPath, asset] of Object.entries(manifest.assets)) {
+          const downloadPath = BROTLI_BUNDLE_ASSET_RE.test(assetPath)
+            ? `${assetPath}.br`
+            : assetPath;
+          referencedUris.add(
+            normalizeStorageUri(
+              resolveManifestAssetStorageUri({
+                assetBaseStorageUri,
+                assetPath: downloadPath,
+                fileHash: asset.fileHash,
+              }),
+            ),
+          );
+        }
+      },
+    );
+  } finally {
+    await fs.rm(workDir, { force: true, recursive: true });
+  }
+
+  return {
+    manifestCount: bundlesWithSharedAssets.length,
+    referencedUris,
+  };
+}
+
+function getPruneCandidates({
+  objects,
+  liveBundleIds,
+  referencedAssetUris,
+}: {
+  objects: readonly StorageObject[];
+  liveBundleIds: ReadonlySet<string>;
+  referencedAssetUris: ReadonlySet<string>;
+}): PruneCandidate[] {
+  const candidates: PruneCandidate[] = [];
+
+  for (const object of objects) {
+    const bundleId = getBundleIdFromStorageKey(object.key);
+    if (bundleId && !liveBundleIds.has(bundleId)) {
+      candidates.push({ ...object, reason: "bundle" });
+      continue;
+    }
+
+    if (
+      CONTENT_ADDRESSED_ASSET_KEY_RE.test(object.key) &&
+      !referencedAssetUris.has(normalizeStorageUri(object.storageUri))
+    ) {
+      candidates.push({ ...object, reason: "asset" });
+    }
+  }
+
+  return candidates;
+}
+
+async function safeOnUnmount(databasePlugin: DatabasePlugin) {
+  try {
+    await databasePlugin.onUnmount?.();
+  } catch (error) {
+    p.log.warn(
+      `Database plugin onUnmount failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function handleStoragePrune(options: StoragePruneOptions = {}) {
+  printBanner();
+
+  const minAge = options.minAge ?? DEFAULT_STORAGE_PRUNE_MIN_AGE_MS;
+  if (!Number.isFinite(minAge) || minAge < 0) {
+    throw new Error("Storage prune min age must be a non-negative duration.");
+  }
+
+  const config = await loadConfig(null);
+  const [databasePlugin, loadedStoragePlugin] = await Promise.all([
+    config.database(),
+    config.storage(),
+  ]);
+  assertNodeStoragePlugin(loadedStoragePlugin);
+  const storagePlugin = loadedStoragePlugin;
+
+  try {
+    const listObjects = storagePlugin.profiles.node.listObjects;
+    if (!listObjects) {
+      throw new Error(
+        `Storage plugin "${storagePlugin.name}" does not support storage prune.`,
+      );
+    }
+    const deleteObjects = storagePlugin.profiles.node.deleteObjects;
+    if (options.yes && !deleteObjects) {
+      throw new Error(
+        `Storage plugin "${storagePlugin.name}" does not support exact object deletion.`,
+      );
+    }
+    if (options.yes) {
+      p.log.warn(
+        "Do not deploy or promote bundles while storage prune is running.",
+      );
+    }
+
+    const bundles = await loadAllBundles(databasePlugin);
+    const liveBundleIds = new Set(
+      bundles.map((bundle) => bundle.id.toLowerCase()),
+    );
+    const { manifestCount, referencedUris } = await collectReferencedAssetUris(
+      bundles,
+      storagePlugin,
+    );
+    const objects = await listObjects();
+    const unreferenced = getPruneCandidates({
+      liveBundleIds,
+      objects,
+      referencedAssetUris: referencedUris,
+    });
+
+    const cutoff = Date.now() - minAge;
+    let candidates = unreferenced.filter((object) => {
+      const modifiedAt = object.lastModifiedAt?.getTime();
+      return modifiedAt !== undefined && modifiedAt <= cutoff;
+    });
+    if (options.yes && candidates.length > 0) {
+      const refreshedBundles = await loadAllBundles(databasePlugin);
+      const refreshedBundleIds = new Set(
+        refreshedBundles.map((bundle) => bundle.id.toLowerCase()),
+      );
+      const { referencedUris: refreshedReferencedUris } =
+        await collectReferencedAssetUris(refreshedBundles, storagePlugin);
+      candidates = getPruneCandidates({
+        liveBundleIds: refreshedBundleIds,
+        objects: candidates,
+        referencedAssetUris: refreshedReferencedUris,
+      });
+    }
+    const protectedCount = unreferenced.length - candidates.length;
+    const bundleObjects = candidates.filter(
+      (candidate) => candidate.reason === "bundle",
+    );
+    const assetObjects = candidates.filter(
+      (candidate) => candidate.reason === "asset",
+    );
+    const candidateBytes = candidates.reduce(
+      (total, candidate) => total + candidate.size,
+      0,
+    );
+
+    p.log.message(
+      ui.block(
+        "Storage prune",
+        [
+          ui.kv("Storage", storagePlugin.name),
+          ui.kv("Bundles", bundles.length),
+          ui.kv("Manifests", manifestCount),
+          ui.kv("Objects", objects.length),
+          ui.kv("Min age", formatDuration(minAge)),
+          ui.kv("Bundle data", bundleObjects.length),
+          ui.kv("Shared assets", assetObjects.length),
+          ui.kv("Reclaimable", formatBytes(candidateBytes)),
+          protectedCount > 0
+            ? ui.kv("Protected", `${protectedCount} newer/undated objects`)
+            : null,
+        ].filter((line): line is string => line !== null),
+      ),
+    );
+
+    if (candidates.length === 0) {
+      p.log.success("No objects are eligible for pruning.");
+      return;
+    }
+
+    if (!options.yes) {
+      p.log.info(
+        `Dry run only. Delete with ${ui.command("hot-updater storage prune --yes")}.`,
+      );
+      return;
+    }
+
+    await deleteObjects!(candidates.map((candidate) => candidate.storageUri));
+    p.log.success(
+      `Pruned ${candidates.length} objects (${formatBytes(candidateBytes)}).`,
+    );
+  } finally {
+    await safeOnUnmount(databasePlugin);
+  }
+}

--- a/packages/hot-updater/src/commands/storage.ts
+++ b/packages/hot-updater/src/commands/storage.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import { loadConfig, p } from "@hot-updater/cli-tools";
 import {
   getAssetBaseStorageUri,
+  getBundlePatches,
   getManifestStorageUri,
+  getPatchStorageUri,
 } from "@hot-updater/core";
 import type {
   Bundle,
@@ -16,6 +18,7 @@ import type {
 import {
   assertNodeStoragePlugin,
   BUNDLE_STORAGE_PREFIX,
+  getManifestAssetDownloadPath,
   isContentAddressedAssetBaseStorageUri,
   resolveManifestAssetStorageUri,
 } from "@hot-updater/plugin-core";
@@ -30,7 +33,6 @@ const UUID_V7_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const CONTENT_ADDRESSED_ASSET_KEY_RE =
   /^assets\/sha256\/[0-9a-f]{2}\/[0-9a-f]{64}(?:\.[^/]+)?$/i;
-const BROTLI_BUNDLE_ASSET_RE = /(^|\/)index\.[^/]+\.bundle$/;
 
 export const DEFAULT_STORAGE_PRUNE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
@@ -40,7 +42,13 @@ export interface StoragePruneOptions {
 }
 
 interface BundleManifest {
+  bundleId: string;
   assets: Record<string, { fileHash: string }>;
+}
+
+interface BundleStorageReferences {
+  exactUris: ReadonlySet<string>;
+  prefixUris: readonly string[];
 }
 
 interface PruneCandidate extends StorageObject {
@@ -99,19 +107,47 @@ function normalizeStorageUri(storageUri: string): string {
   return new URL(storageUri).toString();
 }
 
-function getBundleIdFromStorageKey(key: string): string | null {
-  const segments = key.split("/");
-  const bundleId =
-    segments[0] === BUNDLE_STORAGE_PREFIX ? segments[1] : segments[0];
-  return bundleId && UUID_V7_RE.test(bundleId) ? bundleId.toLowerCase() : null;
+function isLegacyBundleArtifactPath(segments: readonly string[]) {
+  const [firstSegment] = segments;
+  return (
+    firstSegment === "manifest.json" ||
+    firstSegment === "files" ||
+    firstSegment === "patches" ||
+    (firstSegment !== undefined && /^bundle(?:\..+)?$/.test(firstSegment))
+  );
 }
 
-function isBundleManifest(value: unknown): value is BundleManifest {
+function getBundleIdFromStorageKey(key: string): string | null {
+  const segments = key.split("/").filter(Boolean);
+  if (segments[0] === BUNDLE_STORAGE_PREFIX) {
+    const bundleId = segments[1];
+    return bundleId && UUID_V7_RE.test(bundleId)
+      ? bundleId.toLowerCase()
+      : null;
+  }
+
+  const bundleId = segments[0];
+  return bundleId &&
+    UUID_V7_RE.test(bundleId) &&
+    isLegacyBundleArtifactPath(segments.slice(1))
+    ? bundleId.toLowerCase()
+    : null;
+}
+
+function isBundleManifest(
+  value: unknown,
+  bundleId: string,
+): value is BundleManifest {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
 
-  const assets = (value as { assets?: unknown }).assets;
+  const candidate = value as { assets?: unknown; bundleId?: unknown };
+  if (candidate.bundleId !== bundleId) {
+    return false;
+  }
+
+  const assets = candidate.assets;
   if (!assets || typeof assets !== "object" || Array.isArray(assets)) {
     return false;
   }
@@ -121,7 +157,8 @@ function isBundleManifest(value: unknown): value is BundleManifest {
       asset !== null &&
       typeof asset === "object" &&
       !Array.isArray(asset) &&
-      typeof (asset as { fileHash?: unknown }).fileHash === "string"
+      typeof (asset as { fileHash?: unknown }).fileHash === "string" &&
+      /^[0-9a-f]{64}$/i.test((asset as { fileHash: string }).fileHash)
     );
   });
 }
@@ -170,6 +207,11 @@ async function loadAllBundles(databasePlugin: DatabasePlugin) {
     bundles.push(...data);
 
     const nextCursor = pagination.nextCursor ?? undefined;
+    if (pagination.hasNextPage && !nextCursor) {
+      throw new Error(
+        "Database cannot provide safe cursor pagination for storage prune.",
+      );
+    }
     if (!nextCursor) {
       return bundles;
     }
@@ -235,7 +277,7 @@ async function readManifest(
     );
   }
 
-  if (!isBundleManifest(manifest)) {
+  if (!isBundleManifest(manifest, bundle.id)) {
     throw new Error(
       `Cannot prune shared assets: invalid manifest for bundle ${bundle.id}.`,
     );
@@ -250,10 +292,20 @@ async function collectReferencedAssetUris(
 ) {
   const bundlesWithSharedAssets = bundles.filter((bundle) => {
     const assetBaseStorageUri = getAssetBaseStorageUri(bundle);
-    return (
-      assetBaseStorageUri !== null &&
-      isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)
-    );
+    if (
+      assetBaseStorageUri === null ||
+      !isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)
+    ) {
+      return false;
+    }
+
+    const protocol = new URL(assetBaseStorageUri).protocol.replace(":", "");
+    if (protocol !== storagePlugin.supportedProtocol) {
+      throw new Error(
+        `Cannot prune shared assets: bundle ${bundle.id} uses ${protocol} asset storage, but the configured storage plugin uses ${storagePlugin.supportedProtocol}.`,
+      );
+    }
+    return true;
   });
   const referencedUris = new Set<string>();
 
@@ -278,9 +330,7 @@ async function collectReferencedAssetUris(
         );
 
         for (const [assetPath, asset] of Object.entries(manifest.assets)) {
-          const downloadPath = BROTLI_BUNDLE_ASSET_RE.test(assetPath)
-            ? `${assetPath}.br`
-            : assetPath;
+          const downloadPath = getManifestAssetDownloadPath(assetPath);
           referencedUris.add(
             normalizeStorageUri(
               resolveManifestAssetStorageUri({
@@ -303,11 +353,46 @@ async function collectReferencedAssetUris(
   };
 }
 
+function collectBundleStorageReferences(
+  bundles: readonly Bundle[],
+): BundleStorageReferences {
+  const exactUris = new Set<string>();
+  const prefixUris = new Set<string>();
+  const addExactUri = (storageUri: string | null | undefined) => {
+    if (storageUri) {
+      exactUris.add(normalizeStorageUri(storageUri));
+    }
+  };
+
+  for (const bundle of bundles) {
+    addExactUri(bundle.storageUri);
+    addExactUri(getManifestStorageUri(bundle));
+    addExactUri(getPatchStorageUri(bundle));
+    for (const patch of getBundlePatches(bundle)) {
+      addExactUri(patch.patchStorageUri);
+    }
+
+    const assetBaseStorageUri = getAssetBaseStorageUri(bundle);
+    if (
+      assetBaseStorageUri &&
+      !isContentAddressedAssetBaseStorageUri(assetBaseStorageUri)
+    ) {
+      prefixUris.add(
+        `${normalizeStorageUri(assetBaseStorageUri).replace(/\/+$/, "")}/`,
+      );
+    }
+  }
+
+  return { exactUris, prefixUris: [...prefixUris] };
+}
+
 function getPruneCandidates({
+  bundleStorageReferences,
   objects,
   liveBundleIds,
   referencedAssetUris,
 }: {
+  bundleStorageReferences: BundleStorageReferences;
   objects: readonly StorageObject[];
   liveBundleIds: ReadonlySet<string>;
   referencedAssetUris: ReadonlySet<string>;
@@ -315,6 +400,16 @@ function getPruneCandidates({
   const candidates: PruneCandidate[] = [];
 
   for (const object of objects) {
+    const normalizedStorageUri = normalizeStorageUri(object.storageUri);
+    if (
+      bundleStorageReferences.exactUris.has(normalizedStorageUri) ||
+      bundleStorageReferences.prefixUris.some((prefix) =>
+        normalizedStorageUri.startsWith(prefix),
+      )
+    ) {
+      continue;
+    }
+
     const bundleId = getBundleIdFromStorageKey(object.key);
     if (bundleId && !liveBundleIds.has(bundleId)) {
       candidates.push({ ...object, reason: "bundle" });
@@ -323,7 +418,7 @@ function getPruneCandidates({
 
     if (
       CONTENT_ADDRESSED_ASSET_KEY_RE.test(object.key) &&
-      !referencedAssetUris.has(normalizeStorageUri(object.storageUri))
+      !referencedAssetUris.has(normalizedStorageUri)
     ) {
       candidates.push({ ...object, reason: "asset" });
     }
@@ -373,7 +468,10 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
     }
     if (options.yes) {
       p.log.warn(
-        "Do not deploy or promote bundles while storage prune is running.",
+        "Storage prune requires exclusive access. Stop deploy and promote operations first.",
+      );
+      p.log.warn(
+        "The current database must own every object under this storage prefix. Use a separate storage basePath for each database or environment.",
       );
     }
 
@@ -381,12 +479,14 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
     const liveBundleIds = new Set(
       bundles.map((bundle) => bundle.id.toLowerCase()),
     );
+    const bundleStorageReferences = collectBundleStorageReferences(bundles);
     const { manifestCount, referencedUris } = await collectReferencedAssetUris(
       bundles,
       storagePlugin,
     );
     const objects = await listObjects();
     const unreferenced = getPruneCandidates({
+      bundleStorageReferences,
       liveBundleIds,
       objects,
       referencedAssetUris: referencedUris,
@@ -402,9 +502,12 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
       const refreshedBundleIds = new Set(
         refreshedBundles.map((bundle) => bundle.id.toLowerCase()),
       );
+      const refreshedBundleStorageReferences =
+        collectBundleStorageReferences(refreshedBundles);
       const { referencedUris: refreshedReferencedUris } =
         await collectReferencedAssetUris(refreshedBundles, storagePlugin);
       candidates = getPruneCandidates({
+        bundleStorageReferences: refreshedBundleStorageReferences,
         liveBundleIds: refreshedBundleIds,
         objects: candidates,
         referencedAssetUris: refreshedReferencedUris,
@@ -453,7 +556,7 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
       return;
     }
 
-    await deleteObjects!(candidates.map((candidate) => candidate.storageUri));
+    await deleteObjects!(candidates.map((candidate) => candidate.key));
     p.log.success(
       `Pruned ${candidates.length} objects (${formatBytes(candidateBytes)}).`,
     );

--- a/packages/hot-updater/src/commands/storage.ts
+++ b/packages/hot-updater/src/commands/storage.ts
@@ -37,6 +37,7 @@ const CONTENT_ADDRESSED_ASSET_KEY_RE =
 export const DEFAULT_STORAGE_PRUNE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 export interface StoragePruneOptions {
+  dryRun?: boolean;
   minAge?: number;
   yes?: boolean;
 }
@@ -439,6 +440,10 @@ async function safeOnUnmount(databasePlugin: DatabasePlugin) {
 
 export async function handleStoragePrune(options: StoragePruneOptions = {}) {
   printBanner();
+
+  if (options.dryRun && options.yes) {
+    throw new Error("Storage prune --dry-run cannot be used with --yes.");
+  }
 
   const minAge = options.minAge ?? DEFAULT_STORAGE_PRUNE_MIN_AGE_MS;
   if (!Number.isFinite(minAge) || minAge < 0) {

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -273,8 +273,19 @@ storageCommand
       })
       .default(DEFAULT_STORAGE_PRUNE_MIN_AGE_MS, "24h"),
   )
-  .option("-y, --yes", "delete candidates; otherwise run a dry run")
-  .action((options: { minAge: number; yes?: boolean }) =>
+  .addOption(
+    new Option(
+      "--dry-run",
+      "list eligible objects without deleting them (default)",
+    ).conflicts("yes"),
+  )
+  .addOption(
+    new Option(
+      "-y, --yes",
+      "delete eligible objects after reference validation",
+    ).conflicts("dryRun"),
+  )
+  .action((options: { dryRun?: boolean; minAge: number; yes?: boolean }) =>
     handleStoragePrune(options),
   );
 

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -147,6 +147,10 @@ bundleCommand
   .command("list")
   .description("List bundles, most recent first")
   .option("-c, --channel <channel>", "filter by channel")
+  .option(
+    "--target-app-version <targetAppVersion>",
+    "filter by exact target app version",
+  )
   .option("--json", "output raw bundle data as JSON")
   .addOption(platformCommandOption)
   .option(
@@ -250,7 +254,9 @@ const storageCommand = program
 
 storageCommand
   .command("prune")
-  .description("Find and delete unreferenced storage objects")
+  .description(
+    "Find and delete unreferenced objects (requires exclusive storage access)",
+  )
   .addOption(
     new Option(
       "--min-age <duration>",

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -54,6 +54,11 @@ import { keysExportPublic, keysGenerate, keysRemove } from "./commands/keys";
 import { migrate } from "./commands/migrate";
 import { handlePromote } from "./commands/promote";
 import { handleRollback } from "./commands/rollback";
+import {
+  DEFAULT_STORAGE_PRUNE_MIN_AGE_MS,
+  handleStoragePrune,
+  parseStoragePruneMinAge,
+} from "./commands/storage";
 
 const DEFAULT_CHANNEL = "production";
 const parseBooleanOption = (value: string) => {
@@ -237,6 +242,34 @@ bundleCommand
         yes?: boolean;
       },
     ) => handlePromote(bundleId, options),
+  );
+
+const storageCommand = program
+  .command("storage")
+  .description("Manage stored bundle artifacts");
+
+storageCommand
+  .command("prune")
+  .description("Find and delete unreferenced storage objects")
+  .addOption(
+    new Option(
+      "--min-age <duration>",
+      "only prune objects older than this duration (for example 24h or 7d)",
+    )
+      .argParser((value) => {
+        try {
+          return parseStoragePruneMinAge(value);
+        } catch (error) {
+          throw new InvalidArgumentError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      })
+      .default(DEFAULT_STORAGE_PRUNE_MIN_AGE_MS, "24h"),
+  )
+  .option("-y, --yes", "delete candidates; otherwise run a dry run")
+  .action((options: { minAge: number; yes?: boolean }) =>
+    handleStoragePrune(options),
   );
 
 const keysCommand = program

--- a/packages/server/src/db/createBundleDiff.spec.ts
+++ b/packages/server/src/db/createBundleDiff.spec.ts
@@ -193,7 +193,7 @@ describe("createBundleDiff", () => {
       });
       expect(updatedBundle.patchFileHash).toMatch(/[a-f0-9]{64}/);
       expect(updatedBundle.patchStorageUri).toContain(
-        `${targetBundle.id}/patches/${baseBundle.id}`,
+        `bundles/${targetBundle.id}/patches/${baseBundle.id}`,
       );
       expect(updatedBundle.patches).toEqual([
         {
@@ -394,7 +394,7 @@ describe("createBundleDiff", () => {
           baseFileHash: "hash-secondary-old",
           patchFileHash: expect.any(String),
           patchStorageUri: expect.stringContaining(
-            `${targetBundle.id}/patches/${secondaryBaseBundle.id}`,
+            `bundles/${targetBundle.id}/patches/${secondaryBaseBundle.id}`,
           ),
         },
       ]);

--- a/packages/server/src/db/createBundleDiff.ts
+++ b/packages/server/src/db/createBundleDiff.ts
@@ -17,7 +17,10 @@ import type {
   DatabasePlugin,
   NodeStoragePlugin,
 } from "@hot-updater/plugin-core";
-import { resolveManifestAssetStorageUri } from "@hot-updater/plugin-core";
+import {
+  createBundleStorageKey,
+  resolveManifestAssetStorageUri,
+} from "@hot-updater/plugin-core";
 
 type BundleManifest = {
   bundleId: string;
@@ -321,14 +324,12 @@ export async function createBundleDiff(
   try {
     await fs.writeFile(patchPath, patchBytes);
 
-    const uploadKey = [
+    const uploadKey = createBundleStorageKey(
       targetBundle.id,
       "patches",
       baseBundle.id,
       getRelativeStorageDir(targetAssetPath),
-    ]
-      .filter(Boolean)
-      .join("/");
+    );
     const patchUpload = await deps.storagePlugin.profiles.node.upload(
       uploadKey,
       patchPath,

--- a/packages/server/src/db/createBundleDiff.ts
+++ b/packages/server/src/db/createBundleDiff.ts
@@ -19,6 +19,7 @@ import type {
 } from "@hot-updater/plugin-core";
 import {
   createBundleStorageKey,
+  getManifestAssetDownloadPath,
   resolveManifestAssetStorageUri,
 } from "@hot-updater/plugin-core";
 
@@ -42,7 +43,6 @@ export interface CreateBundleDiffOptions {
 }
 
 const HBC_ASSET_PATH_RE = /\.bundle$/;
-const BR_COMPRESSED_ASSET_PATH_RE = /(^|\/)index\.[^/]+\.bundle$/;
 const HOT_UPDATER_DOWNLOAD_DIR_PREFIX = "downloads-";
 const decompressBrotli = promisify(brotliDecompress);
 
@@ -189,10 +189,11 @@ async function fetchAssetBytes(
     throw new Error(`Asset ${assetPath} is missing from manifest`);
   }
 
-  if (BR_COMPRESSED_ASSET_PATH_RE.test(assetPath)) {
+  const downloadPath = getManifestAssetDownloadPath(assetPath);
+  if (downloadPath !== assetPath) {
     const compressedAssetStorageUri = resolveManifestAssetStorageUri({
       assetBaseStorageUri,
-      assetPath: `${assetPath}.br`,
+      assetPath: downloadPath,
       fileHash: asset.fileHash,
     });
 

--- a/packages/server/src/db/updateArtifacts.ts
+++ b/packages/server/src/db/updateArtifacts.ts
@@ -9,6 +9,7 @@ import {
   type ChangedAsset,
 } from "@hot-updater/core";
 import {
+  getManifestAssetDownloadPath,
   resolveManifestAssetStorageUri,
   type HotUpdaterContext,
 } from "@hot-updater/plugin-core";
@@ -29,7 +30,6 @@ type ReadStorageText<TContext> = (
 ) => Promise<string | null>;
 
 const HBC_ASSET_PATH_RE = /\.bundle$/;
-const BR_COMPRESSED_ASSET_PATH_RE = /(^|\/)index\.[^/]+\.bundle$/;
 
 const resolveUniqueHbcAssetPath = (manifest: BundleManifest) => {
   const candidates = Object.keys(manifest.assets)
@@ -199,8 +199,8 @@ async function resolveChangedAssets<TContext>({
         return null;
       }
 
-      const usesBrotliAsset = BR_COMPRESSED_ASSET_PATH_RE.test(assetPath);
-      const downloadPath = usesBrotliAsset ? `${assetPath}.br` : assetPath;
+      const downloadPath = getManifestAssetDownloadPath(assetPath);
+      const usesBrotliAsset = downloadPath !== assetPath;
       const storageUri = resolveManifestAssetStorageUri({
         assetBaseStorageUri,
         assetPath: downloadPath,

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -200,6 +200,10 @@ beforeEach(() => {
         const keys = Object.keys(fakeStore).filter((key) =>
           key.startsWith(prefix),
         );
+        const pageOffset = command.input.ContinuationToken
+          ? Number(command.input.ContinuationToken)
+          : 0;
+        const pageSize = 1000;
 
         if (typeof delimiter === "string") {
           const directKeys: string[] = [];
@@ -220,12 +224,28 @@ beforeEach(() => {
               );
             }
 
-            return {
-              CommonPrefixes: Array.from(commonPrefixes).map((Prefix) => ({
-                Prefix,
+            const entries = [
+              ...directKeys.map((Key) => ({
+                type: "key" as const,
+                value: Key,
               })),
-              Contents: directKeys.map((Key) => ({ Key })),
-              NextContinuationToken: undefined,
+              ...Array.from(commonPrefixes).map((value) => ({
+                type: "prefix" as const,
+                value,
+              })),
+            ].sort((left, right) => left.value.localeCompare(right.value));
+            const page = entries.slice(pageOffset, pageOffset + pageSize);
+            const nextOffset = pageOffset + page.length;
+
+            return {
+              CommonPrefixes: page
+                .filter((entry) => entry.type === "prefix")
+                .map(({ value: Prefix }) => ({ Prefix })),
+              Contents: page
+                .filter((entry) => entry.type === "key")
+                .map(({ value: Key }) => ({ Key })),
+              NextContinuationToken:
+                nextOffset < entries.length ? String(nextOffset) : undefined,
             };
           } finally {
             activeListObjectRequests -= 1;
@@ -233,9 +253,14 @@ beforeEach(() => {
         }
 
         try {
+          const page = keys
+            .sort((left, right) => left.localeCompare(right))
+            .slice(pageOffset, pageOffset + pageSize);
+          const nextOffset = pageOffset + page.length;
           return {
-            Contents: keys.map((key) => ({ Key: key })),
-            NextContinuationToken: undefined,
+            Contents: page.map((key) => ({ Key: key })),
+            NextContinuationToken:
+              nextOffset < keys.length ? String(nextOffset) : undefined,
           };
         } finally {
           activeListObjectRequests -= 1;
@@ -575,12 +600,128 @@ describe("s3Database plugin", () => {
 
     expect(listedObjectPrefixes).toEqual([
       "",
+      "bundles/",
       "production/",
       "production/ios/",
     ]);
   });
 
-  it("limits recursive S3 manifest listing concurrency", async () => {
+  it("preserves assets and bundles as channel names", async () => {
+    const assetsChannelBundle = createBundleJson(
+      "assets",
+      "ios",
+      "1.0.0",
+      "assets-channel-bundle",
+    );
+    const bundlesChannelBundle = createBundleJson(
+      "bundles",
+      "android",
+      "1.0.0",
+      "bundles-channel-bundle",
+    );
+    seedUpdateManifests([assetsChannelBundle, bundlesChannelBundle]);
+    fakeStore["assets/sha256/aa/asset.png"] = "asset";
+    fakeStore["bundles/0198a408-8f13-7d9b-8df4-123456789abc/bundle.zip"] =
+      "zip";
+
+    plugin = createPlugin();
+    listedObjectPrefixes = [];
+
+    await expect(plugin.getChannels()).resolves.toEqual(["assets", "bundles"]);
+    expect(listedObjectPrefixes).toEqual([
+      "",
+      "assets/",
+      "bundles/",
+      "assets/ios/",
+      "bundles/android/",
+    ]);
+    expect(listedObjectPrefixes).not.toContain("assets/sha256/");
+    expect(
+      listedObjectPrefixes.some((prefix) =>
+        prefix.startsWith("bundles/0198a408-"),
+      ),
+    ).toBe(false);
+  });
+
+  it("reads only the requested target app version when scope is exact", async () => {
+    const requestedBundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "requested-version-bundle",
+    );
+    const otherBundle = createBundleJson(
+      "production",
+      "ios",
+      "2.0.0",
+      "other-version-bundle",
+    );
+    seedUpdateManifests([requestedBundle, otherBundle]);
+    listedObjectPrefixes = [];
+    loadedObjectKeys = [];
+
+    await expect(
+      plugin.getBundles({
+        where: {
+          channel: "production",
+          platform: "ios",
+          targetAppVersion: "1.0.0",
+        },
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({ data: [requestedBundle] });
+    expect(listedObjectPrefixes).toEqual(["production/ios/1.0.0/"]);
+    expect(loadedObjectKeys).toEqual(["production/ios/1.0.0/update.json"]);
+  });
+
+  it("rejects new UUIDv7 channel names that collide with legacy bundle storage", async () => {
+    const bundle = createBundleJson(
+      "0198a408-8f13-7d9b-8df4-123456789abc",
+      "ios",
+      "1.0.0",
+      "uuid-channel-bundle",
+    );
+
+    await plugin.appendBundle(bundle);
+
+    await expect(plugin.commitBundle()).rejects.toThrow(
+      "S3 database channel cannot use a UUIDv7 name",
+    );
+    expect(putObjectKeys).toEqual([]);
+  });
+
+  it("paginates more than 1000 legacy root prefixes without traversing them", async () => {
+    const bundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "pagination-bundle",
+    );
+    seedUpdateManifests([bundle]);
+    for (let index = 0; index < 1680; index += 1) {
+      const bundleId = `0198a408-8f13-7d9b-8df4-${String(index).padStart(12, "0")}`;
+      fakeStore[`${bundleId}/bundle.zip`] = "zip";
+    }
+
+    plugin = createPlugin();
+    listedObjectPrefixes = [];
+
+    await expect(plugin.getBundles({ limit: 20 })).resolves.toMatchObject({
+      data: [bundle],
+    });
+    expect(listedObjectPrefixes.filter((prefix) => prefix === "")).toHaveLength(
+      2,
+    );
+    expect(
+      listedObjectPrefixes.some((prefix) =>
+        prefix.startsWith("0198a408-8f13-7d9b-8df4-"),
+      ),
+    ).toBe(false);
+    expect(listedObjectPrefixes).toContain("production/");
+    expect(listedObjectPrefixes).toContain("production/ios/");
+  });
+
+  it("limits one recursive channel-listing batch to four requests", async () => {
     const channelCount = 12;
     const bundles = Array.from({ length: channelCount }, (_, index) =>
       createBundleJson(

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -549,6 +549,35 @@ describe("s3Database plugin", () => {
     expect(loadedObjectKeys).toEqual(["production/ios/1.0.0/update.json"]);
   });
 
+  it("skips bundle artifact prefixes while discovering manifests", async () => {
+    const bundle = createBundleJson(
+      "production",
+      "ios",
+      "1.0.0",
+      "0198a408-8f13-7d9b-8df4-123456789abc",
+    );
+
+    seedUpdateManifests([bundle]);
+    for (let index = 0; index < 100; index += 1) {
+      const bundleId = `0198a408-8f13-7d9b-8df4-${String(index).padStart(12, "0")}`;
+      fakeStore[`${bundleId}/bundle.zip`] = "zip";
+      fakeStore[`${bundleId}/manifest.json`] = "{}";
+    }
+
+    plugin = createPlugin();
+    listedObjectPrefixes = [];
+
+    await expect(plugin.getBundles({ limit: 20 })).resolves.toMatchObject({
+      data: [bundle],
+    });
+
+    expect(listedObjectPrefixes).toEqual([
+      "",
+      "production/",
+      "production/ios/",
+    ]);
+  });
+
   it("limits recursive S3 manifest listing concurrency", async () => {
     const channelCount = 12;
     const bundles = Array.from({ length: channelCount }, (_, index) =>
@@ -708,14 +737,7 @@ describe("s3Database plugin", () => {
     ]);
 
     expect(listedObjectPrefixes).toContain("");
-    expect(loadedObjectKeys.slice().sort()).toEqual(
-      [
-        "production/ios/1.0.0/update.json",
-        "production/ios/1.0.1/update.json",
-        "staging/android/1.0.0/update.json",
-        "staging/android/1.0.1/update.json",
-      ].sort(),
-    );
+    expect(loadedObjectKeys).toEqual([]);
   });
 
   it("reads bundle detail from canonical manifests", async () => {
@@ -799,7 +821,7 @@ describe("s3Database plugin", () => {
     await expect(plugin.getChannels()).resolves.toEqual(["production"]);
 
     expect(listedObjectPrefixes).toContain("");
-    expect(loadedObjectKeys).toEqual(["production/ios/1.0.0/update.json"]);
+    expect(loadedObjectKeys).toEqual([]);
   });
 
   it("serves console-style reads from canonical manifests after deleting bundles", async () => {
@@ -845,7 +867,7 @@ describe("s3Database plugin", () => {
     await expect(plugin.getChannels()).resolves.toEqual(["production"]);
 
     expect(listedObjectPrefixes).toContain("");
-    expect(loadedObjectKeys).toEqual(["production/ios/1.0.0/update.json"]);
+    expect(loadedObjectKeys).toEqual([]);
 
     plugin = createPlugin();
 

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -562,6 +562,8 @@ describe("s3Database plugin", () => {
       const bundleId = `0198a408-8f13-7d9b-8df4-${String(index).padStart(12, "0")}`;
       fakeStore[`${bundleId}/bundle.zip`] = "zip";
       fakeStore[`${bundleId}/manifest.json`] = "{}";
+      fakeStore[`bundles/${bundleId}/bundle.zip`] = "zip";
+      fakeStore[`bundles/${bundleId}/manifest.json`] = "{}";
     }
 
     plugin = createPlugin();

--- a/plugins/aws/src/s3Database.ts
+++ b/plugins/aws/src/s3Database.ts
@@ -12,7 +12,11 @@ import {
   S3Client,
   type S3ClientConfig,
 } from "@aws-sdk/client-s3";
-import { createBlobDatabasePlugin } from "@hot-updater/plugin-core";
+import {
+  BUNDLE_STORAGE_PREFIX,
+  CONTENT_ADDRESSED_ASSET_PREFIX,
+  createBlobDatabasePlugin,
+} from "@hot-updater/plugin-core";
 import mime from "mime";
 
 import { applyS3RuntimeAwsConfig } from "./runtimeAwsConfig";
@@ -146,10 +150,12 @@ function isPlatformDirectoryPrefix(prefix: string) {
 function isBundleStorageDirectoryPrefix(prefix: string) {
   const lastSegment = getLastDirectorySegment(prefix);
   return (
-    lastSegment !== undefined &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      lastSegment,
-    )
+    lastSegment === BUNDLE_STORAGE_PREFIX ||
+    lastSegment === CONTENT_ADDRESSED_ASSET_PREFIX ||
+    (lastSegment !== undefined &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        lastSegment,
+      ))
   );
 }
 

--- a/plugins/aws/src/s3Database.ts
+++ b/plugins/aws/src/s3Database.ts
@@ -143,6 +143,16 @@ function isPlatformDirectoryPrefix(prefix: string) {
   return lastSegment === "ios" || lastSegment === "android";
 }
 
+function isBundleStorageDirectoryPrefix(prefix: string) {
+  const lastSegment = getLastDirectorySegment(prefix);
+  return (
+    lastSegment !== undefined &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      lastSegment,
+    )
+  );
+}
+
 function isUpdateJsonKey(key: string) {
   return key.endsWith(`${S3_DIRECTORY_DELIMITER}update.json`);
 }
@@ -278,9 +288,13 @@ async function listObjectsInS3(
     }
 
     const nextPrefixes =
-      depth === 1
-        ? commonPrefixes.filter(isPlatformDirectoryPrefix)
-        : commonPrefixes;
+      depth === 0
+        ? commonPrefixes.filter(
+            (commonPrefix) => !isBundleStorageDirectoryPrefix(commonPrefix),
+          )
+        : depth === 1
+          ? commonPrefixes.filter(isPlatformDirectoryPrefix)
+          : commonPrefixes;
     const nestedKeys = await mapWithConcurrency(
       nextPrefixes,
       S3_LIST_OBJECTS_CONCURRENCY,

--- a/plugins/aws/src/s3Database.ts
+++ b/plugins/aws/src/s3Database.ts
@@ -12,11 +12,7 @@ import {
   S3Client,
   type S3ClientConfig,
 } from "@aws-sdk/client-s3";
-import {
-  BUNDLE_STORAGE_PREFIX,
-  CONTENT_ADDRESSED_ASSET_PREFIX,
-  createBlobDatabasePlugin,
-} from "@hot-updater/plugin-core";
+import { createBlobDatabasePlugin } from "@hot-updater/plugin-core";
 import mime from "mime";
 
 import { applyS3RuntimeAwsConfig } from "./runtimeAwsConfig";
@@ -147,16 +143,20 @@ function isPlatformDirectoryPrefix(prefix: string) {
   return lastSegment === "ios" || lastSegment === "android";
 }
 
-function isBundleStorageDirectoryPrefix(prefix: string) {
+function isLegacyBundleStorageDirectoryPrefix(prefix: string) {
   const lastSegment = getLastDirectorySegment(prefix);
   return (
-    lastSegment === BUNDLE_STORAGE_PREFIX ||
-    lastSegment === CONTENT_ADDRESSED_ASSET_PREFIX ||
-    (lastSegment !== undefined &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-        lastSegment,
-      ))
+    lastSegment !== undefined &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      lastSegment,
+    )
   );
+}
+
+function validateS3Channel(channel: string) {
+  if (isLegacyBundleStorageDirectoryPrefix(channel)) {
+    throw new Error(`S3 database channel cannot use a UUIDv7 name: ${channel}`);
+  }
 }
 
 function isUpdateJsonKey(key: string) {
@@ -296,7 +296,8 @@ async function listObjectsInS3(
     const nextPrefixes =
       depth === 0
         ? commonPrefixes.filter(
-            (commonPrefix) => !isBundleStorageDirectoryPrefix(commonPrefix),
+            (commonPrefix) =>
+              !isLegacyBundleStorageDirectoryPrefix(commonPrefix),
           )
         : depth === 1
           ? commonPrefixes.filter(isPlatformDirectoryPrefix)
@@ -449,6 +450,7 @@ export const s3Database = createBlobDatabasePlugin<S3DatabaseConfig>({
         deleteObjectInS3(client, bucketName, toStorageKey(key)),
       shouldSkipLoadObjectError: (error) =>
         error instanceof Error && error.name === "S3ArchivedObjectError",
+      validateChannel: validateS3Channel,
       invalidatePaths: (pathsToInvalidate: string[]) => {
         if (
           cloudfrontClient &&

--- a/plugins/aws/src/s3Storage.spec.ts
+++ b/plugins/aws/src/s3Storage.spec.ts
@@ -69,7 +69,7 @@ describe("s3Storage object management", () => {
     );
   });
 
-  it("deletes exact object URIs in S3 batches", async () => {
+  it("deletes exact relative object keys in S3 batches", async () => {
     const deletedBatches: string[][] = [];
     vi.spyOn(S3Client.prototype, "send").mockImplementation(
       async (command: unknown) => {
@@ -84,28 +84,13 @@ describe("s3Storage object management", () => {
       },
     );
     const storage = s3Storage({ bucketName: "bucket" })();
-    const storageUris = Array.from(
-      { length: 1001 },
-      (_, index) => `s3://bucket/assets/${index}`,
-    );
+    const keys = Array.from({ length: 1001 }, (_, index) => `assets/${index}`);
 
-    await storage.profiles.node.deleteObjects?.(storageUris);
+    await storage.profiles.node.deleteObjects?.(keys);
 
     expect(deletedBatches).toHaveLength(2);
     expect(deletedBatches[0]).toHaveLength(1000);
     expect(deletedBatches[1]).toEqual(["assets/1000"]);
-  });
-
-  it("rejects exact deletion outside the configured bucket", async () => {
-    const send = vi.spyOn(S3Client.prototype, "send");
-    const storage = s3Storage({ bucketName: "bucket" })();
-
-    await expect(
-      storage.profiles.node.deleteObjects?.([
-        "s3://another-bucket/assets/orphan.png",
-      ]),
-    ).rejects.toThrow("Bucket name mismatch");
-    expect(send).not.toHaveBeenCalled();
   });
 
   it("reports partial S3 batch deletion failures", async () => {
@@ -115,7 +100,36 @@ describe("s3Storage object management", () => {
     const storage = s3Storage({ bucketName: "bucket" })();
 
     await expect(
-      storage.profiles.node.deleteObjects?.(["s3://bucket/assets/orphan.png"]),
+      storage.profiles.node.deleteObjects?.(["assets/orphan.png"]),
     ).rejects.toThrow("Failed to delete 1 S3 object");
+  });
+
+  it("preserves special characters in exact deletion keys", async () => {
+    const deletedKeys: string[] = [];
+    vi.spyOn(S3Client.prototype, "send").mockImplementation(
+      async (command: unknown) => {
+        if (!(command instanceof DeleteObjectsCommand)) {
+          throw new Error("Unexpected command");
+        }
+        deletedKeys.push(
+          ...(command.input.Delete?.Objects?.map(({ Key }) => Key ?? "") ?? []),
+        );
+        return {};
+      },
+    );
+    const storage = s3Storage({
+      basePath: "/releases/",
+      bucketName: "bucket",
+    })();
+
+    await storage.profiles.node.deleteObjects?.([
+      "legacy/files/logo#dark?.png",
+      "legacy/files/한글 100%.png",
+    ]);
+
+    expect(deletedKeys).toEqual([
+      "releases/legacy/files/logo#dark?.png",
+      "releases/legacy/files/한글 100%.png",
+    ]);
   });
 });

--- a/plugins/aws/src/s3Storage.spec.ts
+++ b/plugins/aws/src/s3Storage.spec.ts
@@ -1,0 +1,121 @@
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { s3Storage } from "./s3Storage";
+
+describe("s3Storage object management", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists every object relative to basePath across S3 pages", async () => {
+    const send = vi
+      .spyOn(S3Client.prototype, "send")
+      .mockImplementation(async (command: unknown) => {
+        if (!(command instanceof ListObjectsV2Command)) {
+          throw new Error("Unexpected command");
+        }
+
+        if (!command.input.ContinuationToken) {
+          return {
+            Contents: [
+              {
+                Key: "releases/assets/sha256/aa/asset.png",
+                LastModified: new Date("2026-08-01T00:00:00.000Z"),
+                Size: 12,
+              },
+            ],
+            NextContinuationToken: "page-2",
+          };
+        }
+
+        return {
+          Contents: [
+            {
+              Key: "releases/bundles/bundle-id/bundle.zip",
+              Size: 34,
+            },
+          ],
+        };
+      });
+    const storage = s3Storage({
+      basePath: "/releases/",
+      bucketName: "bucket",
+    })();
+
+    await expect(storage.profiles.node.listObjects?.()).resolves.toEqual([
+      {
+        key: "assets/sha256/aa/asset.png",
+        lastModifiedAt: new Date("2026-08-01T00:00:00.000Z"),
+        size: 12,
+        storageUri: "s3://bucket/releases/assets/sha256/aa/asset.png",
+      },
+      {
+        key: "bundles/bundle-id/bundle.zip",
+        lastModifiedAt: undefined,
+        size: 34,
+        storageUri: "s3://bucket/releases/bundles/bundle-id/bundle.zip",
+      },
+    ]);
+    expect(send).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        input: expect.objectContaining({ Prefix: "releases/" }),
+      }),
+    );
+  });
+
+  it("deletes exact object URIs in S3 batches", async () => {
+    const deletedBatches: string[][] = [];
+    vi.spyOn(S3Client.prototype, "send").mockImplementation(
+      async (command: unknown) => {
+        if (!(command instanceof DeleteObjectsCommand)) {
+          throw new Error("Unexpected command");
+        }
+        deletedBatches.push(
+          command.input.Delete?.Objects?.map((object) => object.Key ?? "") ??
+            [],
+        );
+        return {};
+      },
+    );
+    const storage = s3Storage({ bucketName: "bucket" })();
+    const storageUris = Array.from(
+      { length: 1001 },
+      (_, index) => `s3://bucket/assets/${index}`,
+    );
+
+    await storage.profiles.node.deleteObjects?.(storageUris);
+
+    expect(deletedBatches).toHaveLength(2);
+    expect(deletedBatches[0]).toHaveLength(1000);
+    expect(deletedBatches[1]).toEqual(["assets/1000"]);
+  });
+
+  it("rejects exact deletion outside the configured bucket", async () => {
+    const send = vi.spyOn(S3Client.prototype, "send");
+    const storage = s3Storage({ bucketName: "bucket" })();
+
+    await expect(
+      storage.profiles.node.deleteObjects?.([
+        "s3://another-bucket/assets/orphan.png",
+      ]),
+    ).rejects.toThrow("Bucket name mismatch");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("reports partial S3 batch deletion failures", async () => {
+    vi.spyOn(S3Client.prototype, "send").mockResolvedValue({
+      Errors: [{ Code: "AccessDenied", Key: "assets/orphan.png" }],
+    } as never);
+    const storage = s3Storage({ bucketName: "bucket" })();
+
+    await expect(
+      storage.profiles.node.deleteObjects?.(["s3://bucket/assets/orphan.png"]),
+    ).rejects.toThrow("Failed to delete 1 S3 object");
+  });
+});

--- a/plugins/aws/src/s3Storage.ts
+++ b/plugins/aws/src/s3Storage.ts
@@ -35,8 +35,8 @@ export const s3Storage = createUniversalStoragePlugin<S3StorageConfig>({
   factory: (config) => {
     const { bucketName, ...s3Config } = config;
     const client = new S3Client(applyS3RuntimeAwsConfig(s3Config));
-    const getStorageKey = createStorageKeyBuilder(config.basePath);
     const normalizedBasePath = config.basePath?.replace(/^\/+|\/+$/g, "") ?? "";
+    const getStorageKey = createStorageKeyBuilder(normalizedBasePath);
 
     const getListPrefix = (prefix = "") => {
       const normalizedPrefix = prefix.replace(/^\/+|\/+$/g, "");
@@ -88,16 +88,8 @@ export const s3Storage = createUniversalStoragePlugin<S3StorageConfig>({
 
           return objects;
         },
-        async deleteObjects(storageUris) {
-          const keys = storageUris.map((storageUri) => {
-            const { bucket, key } = parseStorageUri(storageUri, "s3");
-            if (bucket !== bucketName) {
-              throw new Error(
-                `Bucket name mismatch: expected "${bucketName}", but found "${bucket}".`,
-              );
-            }
-            return key;
-          });
+        async deleteObjects(relativeKeys) {
+          const keys = relativeKeys.map((key) => getStorageKey(key));
 
           for (let offset = 0; offset < keys.length; offset += 1000) {
             const batch = keys.slice(offset, offset + 1000);

--- a/plugins/aws/src/s3Storage.ts
+++ b/plugins/aws/src/s3Storage.ts
@@ -16,6 +16,7 @@ import {
   createUniversalStoragePlugin,
   getContentType,
   parseStorageUri,
+  type StorageObject,
 } from "@hot-updater/plugin-core";
 
 import { applyS3RuntimeAwsConfig } from "./runtimeAwsConfig";
@@ -35,9 +36,91 @@ export const s3Storage = createUniversalStoragePlugin<S3StorageConfig>({
     const { bucketName, ...s3Config } = config;
     const client = new S3Client(applyS3RuntimeAwsConfig(s3Config));
     const getStorageKey = createStorageKeyBuilder(config.basePath);
+    const normalizedBasePath = config.basePath?.replace(/^\/+|\/+$/g, "") ?? "";
+
+    const getListPrefix = (prefix = "") => {
+      const normalizedPrefix = prefix.replace(/^\/+|\/+$/g, "");
+      const value = [normalizedBasePath, normalizedPrefix]
+        .filter(Boolean)
+        .join("/");
+      return value ? `${value}/` : "";
+    };
+
+    const getRelativeKey = (key: string) => {
+      if (!normalizedBasePath) {
+        return key;
+      }
+
+      const basePrefix = `${normalizedBasePath}/`;
+      return key.startsWith(basePrefix) ? key.slice(basePrefix.length) : key;
+    };
 
     return {
       node: {
+        async listObjects(prefix) {
+          const objects: StorageObject[] = [];
+          let continuationToken: string | undefined;
+
+          do {
+            const response = await client.send(
+              new ListObjectsV2Command({
+                Bucket: bucketName,
+                ContinuationToken: continuationToken,
+                Prefix: getListPrefix(prefix),
+              }),
+            );
+
+            for (const object of response.Contents ?? []) {
+              if (!object.Key) {
+                continue;
+              }
+
+              objects.push({
+                key: getRelativeKey(object.Key),
+                lastModifiedAt: object.LastModified,
+                size: object.Size ?? 0,
+                storageUri: `s3://${bucketName}/${object.Key}`,
+              });
+            }
+
+            continuationToken = response.NextContinuationToken;
+          } while (continuationToken);
+
+          return objects;
+        },
+        async deleteObjects(storageUris) {
+          const keys = storageUris.map((storageUri) => {
+            const { bucket, key } = parseStorageUri(storageUri, "s3");
+            if (bucket !== bucketName) {
+              throw new Error(
+                `Bucket name mismatch: expected "${bucketName}", but found "${bucket}".`,
+              );
+            }
+            return key;
+          });
+
+          for (let offset = 0; offset < keys.length; offset += 1000) {
+            const batch = keys.slice(offset, offset + 1000);
+            if (batch.length === 0) {
+              continue;
+            }
+
+            const response = await client.send(
+              new DeleteObjectsCommand({
+                Bucket: bucketName,
+                Delete: {
+                  Objects: batch.map((Key) => ({ Key })),
+                  Quiet: true,
+                },
+              }),
+            );
+            if (response.Errors && response.Errors.length > 0) {
+              throw new Error(
+                `Failed to delete ${response.Errors.length} S3 object(s).`,
+              );
+            }
+          }
+        },
         async delete(storageUri) {
           const { bucket, key } = parseStorageUri(storageUri, "s3");
           if (bucket !== bucketName) {

--- a/plugins/plugin-core/src/assetStorageLayout.spec.ts
+++ b/plugins/plugin-core/src/assetStorageLayout.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   createStorageUriWithRelativePath,
   getAssetStorageLayout,
+  getManifestAssetDownloadPath,
   getManifestAssetStoragePath,
   resolveManifestAssetStorageUri,
 } from "./assetStorageLayout";
@@ -60,5 +61,17 @@ describe("assetStorageLayout", () => {
         fileHash: "abcdef",
       }),
     ).toBe("s3://bucket/assets/sha256/ab/abcdef.png");
+  });
+
+  it("uses one physical download-name rule for bundle assets", () => {
+    expect(getManifestAssetDownloadPath("index.ios.bundle")).toBe(
+      "index.ios.bundle.br",
+    );
+    expect(getManifestAssetDownloadPath("nested/index.android.bundle")).toBe(
+      "nested/index.android.bundle.br",
+    );
+    expect(getManifestAssetDownloadPath("main.ios.bundle")).toBe(
+      "main.ios.bundle",
+    );
   });
 });

--- a/plugins/plugin-core/src/assetStorageLayout.ts
+++ b/plugins/plugin-core/src/assetStorageLayout.ts
@@ -3,6 +3,12 @@ import { getLegacyManifestAssetStoragePath } from "./legacyAssetStorageLayout";
 
 export type AssetStorageLayout = "content-addressed" | "legacy-files";
 
+export const isBrotliManifestAssetPath = (assetPath: string) =>
+  /(^|\/)index\.[^/]+\.bundle$/.test(assetPath.replace(/\\/g, "/"));
+
+export const getManifestAssetDownloadPath = (assetPath: string) =>
+  isBrotliManifestAssetPath(assetPath) ? `${assetPath}.br` : assetPath;
+
 export const createStorageUriWithRelativePath = ({
   baseStorageUri,
   relativePath,

--- a/plugins/plugin-core/src/bundleStorageLayout.spec.ts
+++ b/plugins/plugin-core/src/bundleStorageLayout.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBundleStorageKey,
+  createStorageRootUriWithPath,
+} from "./bundleStorageLayout";
+
+describe("bundle storage layout", () => {
+  it("stores new bundle artifacts below the bundles namespace", () => {
+    expect(createBundleStorageKey("bundle-id")).toBe("bundles/bundle-id");
+    expect(createBundleStorageKey("bundle-id", "patches", "base-id")).toBe(
+      "bundles/bundle-id/patches/base-id",
+    );
+  });
+
+  it("derives the shared storage root from new and legacy bundle URIs", () => {
+    expect(
+      createStorageRootUriWithPath(
+        "s3://bucket/releases/bundles/bundle-id/manifest.json",
+        "bundle-id",
+        "assets",
+      ),
+    ).toBe("s3://bucket/releases/assets");
+    expect(
+      createStorageRootUriWithPath(
+        "s3://bucket/releases/bundle-id/manifest.json",
+        "bundle-id",
+        "assets",
+      ),
+    ).toBe("s3://bucket/releases/assets");
+  });
+
+  it("preserves encoded storage root segments", () => {
+    expect(
+      createStorageRootUriWithPath(
+        "s3://bucket/release%20files/bundles/bundle-id/manifest.json",
+        "bundle-id",
+        "assets/sha256",
+      ),
+    ).toBe("s3://bucket/release%20files/assets/sha256");
+  });
+});

--- a/plugins/plugin-core/src/bundleStorageLayout.spec.ts
+++ b/plugins/plugin-core/src/bundleStorageLayout.spec.ts
@@ -30,6 +30,16 @@ describe("bundle storage layout", () => {
     ).toBe("s3://bucket/releases/assets");
   });
 
+  it("rejects storage URIs that do not contain the bundle id", () => {
+    expect(() =>
+      createStorageRootUriWithPath(
+        "https://uploads.example.com/object",
+        "bundle-id",
+        "assets",
+      ),
+    ).toThrow("Storage URI does not contain bundle id: bundle-id");
+  });
+
   it("preserves encoded storage root segments", () => {
     expect(
       createStorageRootUriWithPath(

--- a/plugins/plugin-core/src/bundleStorageLayout.ts
+++ b/plugins/plugin-core/src/bundleStorageLayout.ts
@@ -14,8 +14,10 @@ export const createStorageRootUriWithPath = (
   const storageUrl = new URL(storageUri);
   const segments = storageUrl.pathname.split("/").filter(Boolean);
   const bundleIndex = segments.lastIndexOf(bundleId);
-  const rootSegments =
-    bundleIndex >= 0 ? segments.slice(0, bundleIndex) : segments.slice(0, -2);
+  if (bundleIndex < 0) {
+    throw new Error(`Storage URI does not contain bundle id: ${bundleId}`);
+  }
+  const rootSegments = segments.slice(0, bundleIndex);
   if (rootSegments.at(-1) === BUNDLE_STORAGE_PREFIX) {
     rootSegments.pop();
   }

--- a/plugins/plugin-core/src/bundleStorageLayout.ts
+++ b/plugins/plugin-core/src/bundleStorageLayout.ts
@@ -1,0 +1,29 @@
+export const BUNDLE_STORAGE_PREFIX = "bundles";
+
+export const createBundleStorageKey = (
+  bundleId: string,
+  ...relativePaths: string[]
+) =>
+  [BUNDLE_STORAGE_PREFIX, bundleId, ...relativePaths].filter(Boolean).join("/");
+
+export const createStorageRootUriWithPath = (
+  storageUri: string,
+  bundleId: string,
+  relativePath: string,
+) => {
+  const storageUrl = new URL(storageUri);
+  const segments = storageUrl.pathname.split("/").filter(Boolean);
+  const bundleIndex = segments.lastIndexOf(bundleId);
+  const rootSegments =
+    bundleIndex >= 0 ? segments.slice(0, bundleIndex) : segments.slice(0, -2);
+  if (rootSegments.at(-1) === BUNDLE_STORAGE_PREFIX) {
+    rootSegments.pop();
+  }
+
+  const relativeSegments = relativePath
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment));
+  storageUrl.pathname = `/${[...rootSegments, ...relativeSegments].join("/")}`;
+  return storageUrl.toString();
+};

--- a/plugins/plugin-core/src/contentAddressedAssets.ts
+++ b/plugins/plugin-core/src/contentAddressedAssets.ts
@@ -1,3 +1,5 @@
+export const CONTENT_ADDRESSED_ASSET_PREFIX = "assets";
+
 export const getContentAddressedAssetStoragePath = ({
   assetPath,
   fileHash,

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -1163,7 +1163,7 @@ describe("blobDatabase plugin", () => {
     await expect(plugin.getChannels()).resolves.toEqual(["production"]);
 
     expect(listObjectCalls).toEqual([""]);
-    expect(loadObjectCalls).toEqual(["production/ios/1.0.0/update.json"]);
+    expect(loadObjectCalls).toEqual([]);
   });
 
   it("serves console-style reads from canonical manifests after deleting bundles", async () => {
@@ -1209,7 +1209,7 @@ describe("blobDatabase plugin", () => {
     await expect(plugin.getChannels()).resolves.toEqual(["production"]);
 
     expect(listObjectCalls).toEqual([""]);
-    expect(loadObjectCalls).toEqual(["production/ios/1.0.0/update.json"]);
+    expect(loadObjectCalls).toEqual([]);
   });
 
   it("supports cursor pagination from canonical manifests", async () => {

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -227,6 +227,12 @@ function getManagementListPrefixes(
   return [""];
 }
 
+function getChannelFromUpdateJsonKey(key: string): string | null {
+  return (
+    key.match(/^([^/]+)\/(?:ios|android)\/[^/]+\/update\.json$/)?.[1] ?? null
+  );
+}
+
 const DEFAULT_DESC_ORDER = { field: "id", direction: "desc" } as const;
 
 function sortManagedBundles(
@@ -585,13 +591,11 @@ export const createBlobDatabasePlugin = <TConfig>({
         },
 
         async getChannels() {
-          return [
-            ...new Set(
-              (await loadAllBundlesForManagementFallback()).map(
-                (bundle) => bundle.channel,
-              ),
-            ),
-          ].sort();
+          const channels = (await listObjects(""))
+            .map(getChannelFromUpdateJsonKey)
+            .filter((channel): channel is string => channel !== null);
+
+          return [...new Set(channels)].sort();
         },
 
         async commitBundle({ changedSets }) {

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.ts
@@ -216,6 +216,17 @@ function addTargetVersionRemoval(
 function getManagementListPrefixes(
   where: DatabaseBundleQueryWhere | undefined,
 ): string[] {
+  if (
+    where?.channel &&
+    where.platform &&
+    typeof where.targetAppVersion === "string"
+  ) {
+    const targetAppVersion = normalizeTargetAppVersion(where.targetAppVersion);
+    if (targetAppVersion) {
+      return [`${where.channel}/${where.platform}/${targetAppVersion}/`];
+    }
+  }
+
   if (where?.channel && where.platform) {
     return [`${where.channel}/${where.platform}/`];
   }
@@ -248,6 +259,7 @@ export interface BlobOperations {
   uploadObject: <T>(key: string, data: T) => Promise<void>;
   deleteObject: (key: string) => Promise<void>;
   shouldSkipLoadObjectError?: (error: unknown, key: string) => boolean;
+  validateChannel?: (channel: string) => void;
   invalidatePaths: (paths: string[]) => Promise<void>;
   apiBasePath: string;
 }
@@ -273,6 +285,7 @@ export const createBlobDatabasePlugin = <TConfig>({
       uploadObject,
       deleteObject,
       shouldSkipLoadObjectError,
+      validateChannel,
       invalidatePaths,
       apiBasePath,
     } = factory(config);
@@ -600,6 +613,15 @@ export const createBlobDatabasePlugin = <TConfig>({
 
         async commitBundle({ changedSets }) {
           if (changedSets.length === 0) return;
+
+          for (const { operation, data } of changedSets) {
+            if (
+              operation === "insert" ||
+              (operation === "update" && data.channel !== undefined)
+            ) {
+              validateChannel?.(data.channel);
+            }
+          }
 
           const changedBundlesByKey: Record<string, Bundle[]> = {};
           const removalsByKey: Record<string, string[]> = {};

--- a/plugins/plugin-core/src/createStoragePlugin.ts
+++ b/plugins/plugin-core/src/createStoragePlugin.ts
@@ -155,7 +155,7 @@ const createProfiledStoragePlugin = <TContext>(
   const profiles = {} as StoragePluginProfiles<TContext>;
 
   if (profileShape?.node) {
-    profiles.node = {
+    const nodeProfile: NodeStorageProfile = {
       async delete(storageUri) {
         return requireNodeProfile().delete(storageUri);
       },
@@ -169,6 +169,29 @@ const createProfiledStoragePlugin = <TContext>(
         return requireNodeProfile().upload(key, filePath);
       },
     };
+
+    Object.defineProperties(nodeProfile, {
+      deleteObjects: {
+        enumerable: true,
+        get: () => {
+          const deleteObjects = requireNodeProfile().deleteObjects;
+          return deleteObjects
+            ? (storageUris: readonly string[]) => deleteObjects(storageUris)
+            : undefined;
+        },
+      },
+      listObjects: {
+        enumerable: true,
+        get: () => {
+          const listObjects = requireNodeProfile().listObjects;
+          return listObjects
+            ? (prefix?: string) => listObjects(prefix)
+            : undefined;
+        },
+      },
+    });
+
+    profiles.node = nodeProfile;
   } else if (profileShape?.node !== false) {
     Object.defineProperty(profiles, "node", {
       enumerable: true,

--- a/plugins/plugin-core/src/createStoragePlugin.ts
+++ b/plugins/plugin-core/src/createStoragePlugin.ts
@@ -176,7 +176,7 @@ const createProfiledStoragePlugin = <TContext>(
         get: () => {
           const deleteObjects = requireNodeProfile().deleteObjects;
           return deleteObjects
-            ? (storageUris: readonly string[]) => deleteObjects(storageUris)
+            ? (keys: readonly string[]) => deleteObjects(keys)
             : undefined;
         },
       },

--- a/plugins/plugin-core/src/index.ts
+++ b/plugins/plugin-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./calculatePagination";
+export * from "./bundleStorageLayout";
 export * from "./compressionFormat";
 export * from "./assetStorageLayout";
 export * from "./contentAddressedAssets";

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -390,10 +390,11 @@ export interface NodeStorageProfile {
 
   /**
    * Optional management capabilities used by storage garbage collection.
-   * `deleteObjects` must delete only the exact object URIs it receives.
+   * Object keys are relative to the configured storage base path.
+   * `deleteObjects` must delete only the exact keys it receives.
    */
   listObjects?: (prefix?: string) => Promise<StorageObject[]>;
-  deleteObjects?: (storageUris: readonly string[]) => Promise<void>;
+  deleteObjects?: (keys: readonly string[]) => Promise<void>;
 }
 
 export interface RuntimeStorageProfile<TContext = unknown> {

--- a/plugins/plugin-core/src/types/index.ts
+++ b/plugins/plugin-core/src/types/index.ts
@@ -361,6 +361,14 @@ export type HotUpdaterContext<TContext = unknown> = TContext;
 export type StorageResolveContext<TContext = unknown> =
   HotUpdaterContext<TContext>;
 
+export interface StorageObject {
+  /** Object key relative to the storage plugin's configured base path. */
+  key: string;
+  storageUri: string;
+  size: number;
+  lastModifiedAt?: Date;
+}
+
 export interface NodeStorageProfile {
   upload: (
     key: string,
@@ -379,6 +387,13 @@ export interface NodeStorageProfile {
   delete: (storageUri: string) => Promise<void>;
 
   downloadFile: (storageUri: string, filePath: string) => Promise<void>;
+
+  /**
+   * Optional management capabilities used by storage garbage collection.
+   * `deleteObjects` must delete only the exact object URIs it receives.
+   */
+  listObjects?: (prefix?: string) => Promise<StorageObject[]>;
+  deleteObjects?: (storageUris: readonly string[]) => Promise<void>;
 }
 
 export interface RuntimeStorageProfile<TContext = unknown> {


### PR DESCRIPTION
## Root cause

S3 management discovery treated every root-level legacy UUIDv7 bundle artifact directory as a possible metadata prefix. With about 1,680 legacy bundle directories, one unfiltered management query produced about 1,680 avoidable recursive `ListObjectsV2` calls. Repeated Console refetches then multiplied that work and saturated the AWS SDK socket pool.

The shared `assets/` directory was not the bundle-count-dependent cause: it adds one root traversal. The fan-out came from legacy `<bundle-id>/...` directories.

After this change, management discovery performs root pagination, channel/platform traversal, and canonical `update.json` reads. It no longer performs one recursive LIST per artifact directory. Root pages and metadata partitions still scale; this PR does not claim mathematically constant S3 metadata queries.

## What changed

- skip only legacy root UUIDv7 artifact prefixes during unfiltered S3 metadata discovery
- preserve valid `assets` and `bundles` channel names while avoiding traversal below their non-platform storage children
- cover the reported scale with a paginated 1,680-prefix regression test
- derive channels from canonical `update.json` keys without downloading every manifest
- store new archives, manifests, and patches below `bundles/<bundle-id>/...`
- continue reading and cleaning existing root `<bundle-id>/...` storage URIs without migration
- keep shared content-addressed assets below `assets/sha256/...`
- reject new UUIDv7 S3 channel names because they are indistinguishable from legacy artifact roots during unfiltered discovery
- resolve CLI and Console multi-delete targets from one management snapshot and commit once per batch
- tolerate duplicate and already-absent IDs in Console batch deletion
- add exact target app version filters to `bundle list` and the Console; an exact channel/platform/version scope reads only that metadata partition
- use one shared physical-name rule for deploy, promote, server artifact resolution, diff generation, and prune

## Storage pruning

AWS S3 storage supports paginated object listing and exact raw-key batch deletion:

```bash
# Explicit dry run; protects objects newer than 24h by default\npnpm hot-updater storage prune --dry-run

# Delete eligible objects after reviewing the dry run
pnpm hot-updater storage prune --min-age 7d --yes
```

The command finds:

- orphaned legacy `<bundle-id>/...` objects
- orphaned `bundles/<bundle-id>/...` objects
- unreferenced `assets/sha256/...` objects

Individual bundle deletion intentionally leaves shared content-addressed assets for prune. Console wording now distinguishes metadata deletion, best-effort per-bundle artifact cleanup, and shared-asset reclamation.

### Safety contract

- dry-run by default, with an explicit `--dry-run` flag for automation
- 24h minimum age by default; young and undated objects are protected
- loads every database page and aborts on missing or repeated cursors
- validates live manifest `bundleId` and SHA-256 asset hashes before listing or deleting
- aborts when a live content-addressed asset base uses a different protocol from the active storage plugin
- protects exact archive, manifest, and patch references plus legacy asset prefixes
- narrows legacy UUID matching to known artifact shapes so UUID-shaped metadata is not pruned
- deletes raw relative S3 keys, preserving `#`, `?`, `%`, spaces, and Unicode exactly
- reloads references before deletion, but does not claim atomic online GC

`storage prune --yes` is an exclusive maintenance operation: stop deploy and promote while it runs. The current database must own every object under the configured storage prefix. If databases or environments are separate, configure a separate storage `basePath` for each before pruning.

## Compatibility decisions

Kept because they represent real published layouts:

- legacy root `<bundle-id>/...` reads and cleanup
- legacy per-bundle `files/` assets
- optional storage-management capabilities for non-S3 providers

Removed because they were unsafe guesses rather than valid compatibility contracts:

- guessing a storage root when an upload URI does not contain the bundle ID
- treating arbitrary `main.<platform>.bundle` files as Brotli objects when runtime resolution only supports `index.<platform>.bundle`
- comparing CDN and S3 URI strings as if they proved object identity

## Long-term boundary

Future artifacts are grouped below one `bundles/` root, so artifact growth no longer increases root prefix cardinality. Unfiltered blob metadata management still reads canonical metadata partitions; a DynamoDB/index migration remains a separate long-term scalability option rather than a prerequisite for this fix.

Closes #1131

## Verification

- `pnpm -w lint`
- `pnpm -w test:type` — 34 projects
- `pnpm -w build` — 26 projects
- `pnpm -w test` — 162 files, 2,125 tests
- `pnpm -w test:integration` — 15 files, 1,454 tests
- built CLI help verified for `storage prune --dry-run`, its conflict with `--yes`, and `bundle list --target-app-version`
