### PR TITLE
fix(supabase): batch signed URL generation

### DIFF
--- a/.changeset/batch-supabase-signed-urls.md
+++ b/.changeset/batch-supabase-signed-urls.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/supabase": patch
+---
+
+Batch concurrent Supabase signed URL generation to avoid per-asset Storage API and database fan-out during update checks.

--- a/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
+++ b/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
@@ -2,19 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { supabaseEdgeFunctionStorage } from "./supabaseEdgeFunctionStorage";
 
-const { bucket, createClient } = vi.hoisted(() => {
+const { bucket, createClient, from } = vi.hoisted(() => {
   const bucket = {
-    createSignedUrl: vi.fn(),
+    createSignedUrls: vi.fn(),
     download: vi.fn(),
   };
+  const from = vi.fn(() => bucket);
 
   return {
     bucket,
     createClient: vi.fn(() => ({
       storage: {
-        from: vi.fn(() => bucket),
+        from,
       },
     })),
+    from,
   };
 });
 
@@ -24,13 +26,133 @@ vi.mock("@supabase/supabase-js", () => ({
 
 describe("supabaseEdgeFunctionStorage", () => {
   beforeEach(() => {
-    bucket.createSignedUrl.mockReset();
+    bucket.createSignedUrls.mockReset();
     bucket.download.mockReset();
     createClient.mockClear();
+    from.mockClear();
+  });
+
+  it("batches concurrent signed URL requests for a bucket", async () => {
+    bucket.createSignedUrls.mockImplementation(
+      async (paths: string[], expiresIn: number) => ({
+        data: paths.map((path) => ({
+          error: null,
+          path,
+          signedUrl: `https://example.supabase.co/${expiresIn}/${path}`,
+        })),
+        error: null,
+      }),
+    );
+
+    const storage = supabaseEdgeFunctionStorage({
+      signedUrlExpiresIn: 600,
+      supabaseServiceRoleKey: "service-role-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+    const paths = Array.from(
+      { length: 20 },
+      (_, index) => `assets/sha256/file-${index}.png`,
+    );
+
+    await expect(
+      Promise.all(
+        paths.map((path) =>
+          storage.profiles.runtime.getDownloadUrl(
+            `supabase-storage://updates/${path}`,
+          ),
+        ),
+      ),
+    ).resolves.toEqual(
+      paths.map((path) => ({
+        fileUrl: `https://example.supabase.co/600/${path}`,
+      })),
+    );
+
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(paths, 600);
+    expect(from).toHaveBeenCalledWith("updates");
+  });
+
+  it("keeps signed URL batches separated by bucket", async () => {
+    bucket.createSignedUrls.mockImplementation(async (paths: string[]) => ({
+      data: paths.map((path) => ({
+        error: null,
+        path,
+        signedUrl: `https://example.supabase.co/${path}`,
+      })),
+      error: null,
+    }));
+
+    const storage = supabaseEdgeFunctionStorage({
+      supabaseServiceRoleKey: "service-role-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+
+    await Promise.all([
+      storage.profiles.runtime.getDownloadUrl(
+        "supabase-storage://updates/assets/update.png",
+      ),
+      storage.profiles.runtime.getDownloadUrl(
+        "supabase-storage://previews/assets/preview.png",
+      ),
+    ]);
+
+    expect(from.mock.calls).toEqual([["updates"], ["previews"]]);
+    expect(bucket.createSignedUrls.mock.calls).toEqual([
+      [["assets/update.png"], 3600],
+      [["assets/preview.png"], 3600],
+    ]);
+  });
+
+  it("maps per-object batch errors to the matching request", async () => {
+    bucket.createSignedUrls.mockResolvedValueOnce({
+      data: [
+        {
+          error: null,
+          path: "assets/available.png",
+          signedUrl: "https://example.supabase.co/available.png",
+        },
+        {
+          error: "Object not found",
+          path: "assets/missing.png",
+          signedUrl: "",
+        },
+      ],
+      error: null,
+    });
+
+    const storage = supabaseEdgeFunctionStorage({
+      supabaseServiceRoleKey: "service-role-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+
+    const results = await Promise.allSettled([
+      storage.profiles.runtime.getDownloadUrl(
+        "supabase-storage://updates/assets/available.png",
+      ),
+      storage.profiles.runtime.getDownloadUrl(
+        "supabase-storage://updates/assets/missing.png",
+      ),
+    ]);
+
+    expect(results[0]).toEqual({
+      status: "fulfilled",
+      value: { fileUrl: "https://example.supabase.co/available.png" },
+    });
+    expect(results[1]).toEqual({
+      status: "rejected",
+      reason: new Error(
+        'Failed to generate download URL for "updates/assets/missing.png": Object not found',
+      ),
+    });
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/available.png", "assets/missing.png"],
+      3600,
+    );
   });
 
   it("surfaces signed URL generation errors", async () => {
-    bucket.createSignedUrl.mockResolvedValueOnce({
+    bucket.createSignedUrls.mockResolvedValueOnce({
       data: null,
       error: new Error("Object not found"),
     });
@@ -49,15 +171,15 @@ describe("supabaseEdgeFunctionStorage", () => {
       'Failed to generate download URL for "updates/assets/sha256/fi/file-hash.png": Object not found',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
-    expect(bucket.createSignedUrl).toHaveBeenCalledWith(
-      "assets/sha256/fi/file-hash.png",
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/sha256/fi/file-hash.png"],
       3600,
     );
   });
 
   it("surfaces thrown signed URL generation errors", async () => {
-    bucket.createSignedUrl.mockRejectedValueOnce(
+    bucket.createSignedUrls.mockRejectedValueOnce(
       new Error("Failed to generate download URL: Object not found"),
     );
 
@@ -75,11 +197,11 @@ describe("supabaseEdgeFunctionStorage", () => {
       'Failed to generate download URL for "updates/assets/sha256/fi/file-hash.png": Failed to generate download URL: Object not found',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces non-missing signed URL errors after one attempt", async () => {
-    bucket.createSignedUrl.mockResolvedValueOnce({
+    bucket.createSignedUrls.mockResolvedValueOnce({
       data: null,
       error: new Error("Storage API failed"),
     });
@@ -98,6 +220,6 @@ describe("supabaseEdgeFunctionStorage", () => {
       'Failed to generate download URL for "updates/assets/sha256/fi/file-hash.png": Storage API failed',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/supabase/src/supabaseEdgeFunctionStorage.ts
+++ b/plugins/supabase/src/supabaseEdgeFunctionStorage.ts
@@ -1,27 +1,13 @@
 import { createRuntimeStoragePlugin } from "@hot-updater/plugin-core";
 import { createClient } from "@supabase/supabase-js";
 
+import { createSupabaseSignedUrlBatcher } from "./supabaseSignedUrlBatcher";
 import type { Database } from "./types";
 
 export interface SupabaseEdgeFunctionStorageConfig {
   supabaseUrl: string;
   supabaseServiceRoleKey: string;
   signedUrlExpiresIn?: number;
-}
-
-function getErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (
-    error &&
-    typeof error === "object" &&
-    "message" in error &&
-    typeof error.message === "string"
-  ) {
-    return error.message;
-  }
-  return String(error);
 }
 
 const parseSupabaseStorageUri = (storageUri: string) => {
@@ -53,6 +39,12 @@ export const supabaseEdgeFunctionStorage =
         config.supabaseUrl,
         config.supabaseServiceRoleKey,
       );
+      const resolveSignedUrl = createSupabaseSignedUrlBatcher({
+        createSignedUrls: (bucketName, keys, expiresIn) =>
+          supabase.storage.from(bucketName).createSignedUrls(keys, expiresIn),
+        expiresIn: config.signedUrlExpiresIn ?? 3600,
+        formatObjectPath: (bucketName, key) => `${bucketName}/${key}`,
+      });
 
       return {
         async readText(storageUri) {
@@ -77,26 +69,8 @@ export const supabaseEdgeFunctionStorage =
         },
         async getDownloadUrl(storageUri) {
           const { bucketName, key } = parseSupabaseStorageUri(storageUri);
-          const bucket = supabase.storage.from(bucketName);
-          const expiresIn = config.signedUrlExpiresIn ?? 3600;
-
-          let data: { signedUrl?: string } | null = null;
-          let error: unknown = null;
-          try {
-            const response = await bucket.createSignedUrl(key, expiresIn);
-            data = response.data;
-            error = response.error;
-          } catch (thrownError) {
-            error = thrownError;
-          }
-
-          if (!error && data?.signedUrl) {
-            return { fileUrl: data.signedUrl };
-          }
-
-          throw new Error(
-            `Failed to generate download URL for "${bucketName}/${key}": ${getErrorMessage(error ?? new Error("missing signed URL"))}`,
-          );
+          const signedUrl = await resolveSignedUrl(bucketName, key);
+          return { fileUrl: signedUrl };
         },
       };
     },

--- a/plugins/supabase/src/supabaseSignedUrlBatcher.ts
+++ b/plugins/supabase/src/supabaseSignedUrlBatcher.ts
@@ -1,0 +1,119 @@
+type SignedUrlBatchResult = {
+  error?: string | null;
+  signedUrl?: string | null;
+};
+
+type PendingSignedUrl = {
+  key: string;
+  reject: (error: Error) => void;
+  resolve: (signedUrl: string) => void;
+};
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export const createSupabaseSignedUrlBatcher = ({
+  createSignedUrls,
+  expiresIn,
+  formatObjectPath,
+}: {
+  createSignedUrls: (
+    bucketName: string,
+    keys: string[],
+    expiresIn: number,
+  ) => Promise<{
+    data: SignedUrlBatchResult[] | null;
+    error?: unknown;
+  }>;
+  expiresIn: number;
+  formatObjectPath: (bucketName: string, key: string) => string;
+}) => {
+  let pendingByBucket = new Map<string, PendingSignedUrl[]>();
+  let flushScheduled = false;
+
+  const createSignedUrlError = (
+    bucketName: string,
+    key: string,
+    error: unknown,
+  ) =>
+    new Error(
+      `Failed to generate download URL for "${formatObjectPath(bucketName, key)}": ${getErrorMessage(error)}`,
+    );
+
+  const flush = async () => {
+    const batches = pendingByBucket;
+    pendingByBucket = new Map();
+    flushScheduled = false;
+
+    await Promise.all(
+      [...batches.entries()].map(async ([bucketName, pending]) => {
+        try {
+          const { data, error } = await createSignedUrls(
+            bucketName,
+            pending.map(({ key }) => key),
+            expiresIn,
+          );
+
+          if (error || !data) {
+            const batchError =
+              error ?? new Error("missing signed URL response");
+            for (const request of pending) {
+              request.reject(
+                createSignedUrlError(bucketName, request.key, batchError),
+              );
+            }
+            return;
+          }
+
+          pending.forEach((request, index) => {
+            const result = data[index];
+            if (!result?.error && result?.signedUrl) {
+              request.resolve(result.signedUrl);
+              return;
+            }
+
+            request.reject(
+              createSignedUrlError(
+                bucketName,
+                request.key,
+                result?.error ?? new Error("missing signed URL"),
+              ),
+            );
+          });
+        } catch (error) {
+          for (const request of pending) {
+            request.reject(
+              createSignedUrlError(bucketName, request.key, error),
+            );
+          }
+        }
+      }),
+    );
+  };
+
+  return (bucketName: string, key: string) =>
+    new Promise<string>((resolve, reject) => {
+      const pending = pendingByBucket.get(bucketName) ?? [];
+      pending.push({ key, reject, resolve });
+      pendingByBucket.set(bucketName, pending);
+
+      if (!flushScheduled) {
+        flushScheduled = true;
+        queueMicrotask(() => {
+          void flush();
+        });
+      }
+    });
+};

--- a/plugins/supabase/src/supabaseStorage.spec.ts
+++ b/plugins/supabase/src/supabaseStorage.spec.ts
@@ -9,6 +9,7 @@ import { supabaseStorage } from "./supabaseStorage";
 const { bucket, createClient } = vi.hoisted(() => {
   const bucket = {
     createSignedUrl: vi.fn(),
+    createSignedUrls: vi.fn(),
     exists: vi.fn(),
     upload: vi.fn(),
   };
@@ -30,6 +31,7 @@ vi.mock("@supabase/supabase-js", () => ({
 describe("supabaseStorage", () => {
   beforeEach(() => {
     bucket.createSignedUrl.mockReset();
+    bucket.createSignedUrls.mockReset();
     bucket.exists.mockReset();
     bucket.upload.mockReset();
     createClient.mockClear();
@@ -142,7 +144,7 @@ describe("supabaseStorage", () => {
   });
 
   it("surfaces signed URL generation errors", async () => {
-    bucket.createSignedUrl.mockResolvedValueOnce({
+    bucket.createSignedUrls.mockResolvedValueOnce({
       data: null,
       error: new Error("Object not found"),
     });
@@ -162,11 +164,52 @@ describe("supabaseStorage", () => {
       'Failed to generate download URL for "assets/sha256/fi/file-hash.png": Object not found',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
-    expect(bucket.createSignedUrl).toHaveBeenCalledWith(
-      "assets/sha256/fi/file-hash.png",
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/sha256/fi/file-hash.png"],
       3600,
     );
+  });
+
+  it("batches concurrent runtime signed URL requests", async () => {
+    bucket.createSignedUrls.mockImplementation(
+      async (paths: string[], expiresIn: number) => ({
+        data: paths.map((path) => ({
+          error: null,
+          path,
+          signedUrl: `https://example.supabase.co/${expiresIn}/${path}`,
+        })),
+        error: null,
+      }),
+    );
+
+    const storage = supabaseStorage({
+      bucketName: "updates",
+      supabaseAnonKey: "anon-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+    const paths = Array.from(
+      { length: 20 },
+      (_, index) => `assets/sha256/file-${index}.png`,
+    );
+
+    await expect(
+      Promise.all(
+        paths.map((path) =>
+          storage.profiles.runtime.getDownloadUrl(
+            `supabase-storage://updates/${path}`,
+          ),
+        ),
+      ),
+    ).resolves.toEqual(
+      paths.map((path) => ({
+        fileUrl: `https://example.supabase.co/3600/${path}`,
+      })),
+    );
+
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(paths, 3600);
+    expect(bucket.createSignedUrl).not.toHaveBeenCalled();
   });
 
   it("verifies uploaded objects are signable before returning", async () => {
@@ -212,7 +255,7 @@ describe("supabaseStorage", () => {
   });
 
   it("surfaces thrown signed URL generation errors", async () => {
-    bucket.createSignedUrl.mockRejectedValueOnce(
+    bucket.createSignedUrls.mockRejectedValueOnce(
       new Error("Failed to generate download URL: Object not found"),
     );
 
@@ -231,11 +274,11 @@ describe("supabaseStorage", () => {
       'Failed to generate download URL for "assets/sha256/fi/file-hash.png": Failed to generate download URL: Object not found',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces non-missing signed URL errors after one attempt", async () => {
-    bucket.createSignedUrl.mockResolvedValueOnce({
+    bucket.createSignedUrls.mockResolvedValueOnce({
       data: null,
       error: new Error("Storage API failed"),
     });
@@ -255,6 +298,6 @@ describe("supabaseStorage", () => {
       'Failed to generate download URL for "assets/sha256/fi/file-hash.png": Storage API failed',
     );
 
-    expect(bucket.createSignedUrl).toHaveBeenCalledTimes(1);
+    expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/supabase/src/supabaseStorage.ts
+++ b/plugins/supabase/src/supabaseStorage.ts
@@ -13,6 +13,7 @@ import {
   resolveSupabaseServiceRoleKey,
   type SupabaseServiceRoleConfig,
 } from "./supabaseConfig";
+import { createSupabaseSignedUrlBatcher } from "./supabaseSignedUrlBatcher";
 import type { Database } from "./types";
 
 type SupabaseStorageBucket = {
@@ -102,6 +103,12 @@ export const supabaseStorage =
 
       const bucket = supabase.storage.from(config.bucketName);
       const getStorageKey = createStorageKeyBuilder(config.basePath);
+      const resolveSignedUrl = createSupabaseSignedUrlBatcher({
+        createSignedUrls: (_bucketName, keys, expiresIn) =>
+          bucket.createSignedUrls(keys, expiresIn),
+        expiresIn: 3600,
+        formatObjectPath: (_bucketName, key) => key,
+      });
 
       return {
         node: {
@@ -247,11 +254,7 @@ export const supabaseStorage =
               key = key.substring(`${config.bucketName}/`.length);
             }
 
-            const signedUrl = await createSignedUrlOrThrow({
-              bucket,
-              key,
-              expiresIn: 3600,
-            });
+            const signedUrl = await resolveSignedUrl(config.bucketName, key);
 
             return { fileUrl: signedUrl };
           },


### PR DESCRIPTION
## Summary

- coalesce concurrent Supabase signed URL requests within the same event-loop turn
- issue one `createSignedUrls()` call per bucket instead of one `createSignedUrl()` call per changed asset
- preserve the existing runtime storage interface and map per-object failures back to the matching request
- apply the behavior to both generated Edge Function storage and universal Supabase storage

This keeps buckets private while removing the per-asset Storage API and Postgres lookup fan-out during update checks.

 #1145

## Verification

- `pnpm -w build`
- `pnpm -w lint`
- `pnpm -w test` (159 files, 2,098 tests)
- `pnpm --filter @hot-updater/supabase test:type`