### PR TITLE
fix(storage): harden prune compatibility and guidance

### DIFF
--- a/.changeset/bright-dodos-clean.md
+++ b/.changeset/bright-dodos-clean.md
@@ -1,0 +1,8 @@
+---
+"@hot-updater/aws": patch
+"hot-updater": patch
+---
+
+Preserve UUIDv7 S3 channels while avoiding per-prefix legacy traversal, respect
+standalone server pagination limits during storage pruning and batch deletion,
+and document the safe storage cleanup workflow.

--- a/.changeset/fix-s3-management-listing.md
+++ b/.changeset/fix-s3-management-listing.md
@@ -7,4 +7,4 @@
 "hot-updater": minor
 ---
 
-Reduce S3 management query work by skipping legacy UUIDv7 artifact traversal, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>` while preserving legacy reads, and add exact target app version filters to the CLI and Console. Add an exclusive-maintenance `hot-updater storage prune` command for orphaned bundle objects and unreferenced shared assets, with explicit `--dry-run`, minimum-age, and fail-closed reference validation safeguards.
+Reduce S3 management query work by skipping legacy UUIDv7 artifact traversal, deriving channels from canonical manifest keys, and batching multi-bundle deletion scans and commits. Store new bundle artifacts below `bundles/<bundle-id>` while preserving legacy reads, and add exact target app version filters to the CLI and Console. Add an exclusive-maintenance `hot-updater storage prune` command for orphaned bundle objects and unreferenced shared assets, with an explicit `--dry-run` candidate table, a recent-object protection window, and fail-closed reference validation safeguards.

--- a/docs/content/docs/guides/console.mdx
+++ b/docs/content/docs/guides/console.mdx
@@ -62,6 +62,10 @@ npx hot-updater bundle update <bundle-id> --target-cohorts qa,dogfood -y
 Add `--json` to `bundle list`, `bundle show`, or `bundle update` when another
 tool needs to read the raw bundle data.
 
+After deleting bundle records, use the [Storage Cleanup](/docs/guides/storage-cleanup)
+workflow to preview and reclaim bundle objects and shared assets that are no
+longer referenced.
+
 ## Rollback
 
 When you set a bundle's `enabled` status to `false` in the console, users who have that bundle will immediately force update to the **previous bundle**.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -8,6 +8,7 @@
     "bundle-diffing",
     "rollout-cohorts",
     "console",
+    "storage-cleanup",
     "ai-agents",
     "simulator-test",
     "channel-management",

--- a/docs/content/docs/guides/storage-cleanup.mdx
+++ b/docs/content/docs/guides/storage-cleanup.mdx
@@ -1,0 +1,88 @@
+---
+title: "Storage Cleanup"
+description: "Safely reclaim unreferenced bundle artifacts and shared assets with the storage prune command."
+icon: Trash2
+---
+
+## How pruning works
+
+`hot-updater storage prune` is reference-aware garbage collection. It reads all
+bundle records and their manifests, lists the configured storage prefix, and
+selects only objects that are no longer referenced.
+
+It can remove:
+
+- Orphaned bundle objects in both the legacy `<bundle-id>/...` layout and the
+  current `bundles/<bundle-id>/...` layout.
+- Unreferenced content-addressed assets under `assets/sha256/...`.
+
+Live bundle objects, referenced assets, recently modified objects, objects
+without a modification timestamp, and unknown files are protected.
+
+<Callout type="info">
+  Pruning is not a retention policy. Upgrading Hot Updater fixes new S3
+  management scans without deleting live bundle records. Delete records you no
+  longer need before pruning their objects.
+</Callout>
+
+## Select old bundle records
+
+List the records you intend to remove. Narrow the result by channel, platform,
+or exact target app version as needed:
+
+```package-install
+npx hot-updater bundle list --channel production --platform ios --target-app-version 1.0.0 --limit 100 --json
+```
+
+Delete one or more selected records:
+
+```package-install
+npx hot-updater bundle delete <bundle-id> <another-bundle-id> --yes
+```
+
+`bundle delete` removes database records. Shared assets and bundle files remain
+until a reference-aware prune confirms that no remaining record uses them.
+
+## Preview eligible objects
+
+Run an explicit dry run first:
+
+```package-install
+npx hot-updater storage prune --dry-run
+```
+
+The preview shows each eligible object, its modification time, size, type, and
+the total reclaimable size. The command fails closed if it cannot load all
+bundle references or required manifests.
+
+The default `--protect-newer-than 24h` window compares the current time with
+each object's storage `lastModified` timestamp. It does **not** measure time
+since the bundle record was deleted. Increase the window when deployments may
+remain in flight for longer:
+
+```package-install
+npx hot-updater storage prune --dry-run --protect-newer-than 7d
+```
+
+Durations accept `m`, `h`, `d`, or `w`, such as `30m`, `24h`, `7d`, or `2w`.
+
+## Delete eligible objects
+
+Pause every deploy and promote process that writes to the same storage prefix,
+then run:
+
+```package-install
+npx hot-updater storage prune --protect-newer-than 24h --yes
+```
+
+Before deletion, Hot Updater reloads bundle and manifest references and removes
+objects from the candidate set if they became live.
+
+<Callout type="warn">
+  The configured database must own every object under the configured storage
+  prefix. If databases or environments share a bucket, assign each one a
+  separate storage `basePath` before pruning.
+</Callout>
+
+Storage pruning currently requires the management capabilities provided by
+`s3Storage`, including AWS S3 and S3-compatible services such as Cloudflare R2.

--- a/docs/content/docs/storage-plugins/aws.mdx
+++ b/docs/content/docs/storage-plugins/aws.mdx
@@ -96,6 +96,16 @@ This prefix is stored in the `storageUri` field in the database.
 This means the same `s3Storage` configuration can be used in both
 `hot-updater.config.ts` and `createHotUpdater`.
 
+## Maintenance
+
+`s3Storage` provides the object listing and exact deletion capabilities used by
+`hot-updater storage prune`. Follow the [Storage Cleanup](/docs/guides/storage-cleanup)
+guide to remove unreferenced bundle objects and shared assets safely.
+
+Use a separate `basePath` for every database or environment that shares a
+bucket. Pruning assumes that the configured database owns every object below
+its storage prefix.
+
 ## Custom Server Usage
 
 Use `s3Storage` with `createHotUpdater` for self-hosted servers:

--- a/packages/hot-updater/src/commands/bundle.spec.ts
+++ b/packages/hot-updater/src/commands/bundle.spec.ts
@@ -398,6 +398,7 @@ describe("handleBundleUpdate", () => {
 describe("handleBundleDelete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDatabasePlugin.name = "mock-database";
     stubLoadedConfig();
   });
   afterEach(() => {
@@ -501,6 +502,39 @@ describe("handleBundleDelete", () => {
     expect(mockCli.p.log.info).toHaveBeenCalledWith(
       "No bundle with id missing. Skipping.",
     );
+  });
+
+  it("chunks standalone lookups at the server limit and commits once", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mockDatabasePlugin.name = "standalone-repository";
+    const ids = Array.from({ length: 101 }, (_, index) => `B${index + 1}`);
+    mockDatabasePlugin.getBundles.mockImplementation(
+      async (options: { limit: number; where: { id: { in: string[] } } }) => {
+        if (options.limit > 100) {
+          throw new Error("limit must be less than or equal to 100");
+        }
+        return {
+          data: options.where.id.in.map((id) => buildBundle({ id })),
+          pagination: { total: options.where.id.in.length },
+        };
+      },
+    );
+    mockDatabasePlugin.getBundleById.mockResolvedValue(null);
+
+    const { handleBundleDelete } = await import("./bundle");
+    await handleBundleDelete(ids, { yes: true });
+
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledTimes(2);
+    expect(mockDatabasePlugin.getBundles).toHaveBeenNthCalledWith(1, {
+      where: { id: { in: ids.slice(0, 100) } },
+      limit: 100,
+    });
+    expect(mockDatabasePlugin.getBundles).toHaveBeenNthCalledWith(2, {
+      where: { id: { in: ids.slice(100) } },
+      limit: 1,
+    });
+    expect(mockDatabasePlugin.deleteBundle).toHaveBeenCalledTimes(101);
+    expect(mockDatabasePlugin.commitBundle).toHaveBeenCalledOnce();
   });
 
   it("exits 1 when no ids are provided", async () => {

--- a/packages/hot-updater/src/commands/bundle.ts
+++ b/packages/hot-updater/src/commands/bundle.ts
@@ -74,6 +74,8 @@ export type BundleDeleteOptions = BundleMutationOptions;
 const DEFAULT_LIMIT = 20;
 const DELETE_VERIFY_ATTEMPTS = 12;
 const DELETE_VERIFY_DELAY_MS = 1000;
+const STANDALONE_DATABASE_NAME = "standalone-repository";
+const STANDALONE_DELETE_LOOKUP_LIMIT = 100;
 
 const formatRow = (bundle: Bundle): Record<ListField, string> => {
   const out = {} as Record<ListField, string>;
@@ -357,12 +359,30 @@ export const handleBundleDelete = async (
   const config = await loadConfig(null);
   const databasePlugin: DatabasePlugin = await config.database();
   try {
-    // Resolve the complete target set from one management snapshot. Blob-backed
-    // databases otherwise rescan storage once for every missing ID.
-    const { data: matchedBundles } = await databasePlugin.getBundles({
-      where: { id: { in: ids } },
-      limit: ids.length,
-    });
+    // Resolve local/blob targets from one management snapshot. The standard
+    // standalone API caps list requests at 100 IDs, so only that remote plugin
+    // uses bounded lookups.
+    const lookupBatches =
+      databasePlugin.name === STANDALONE_DATABASE_NAME
+        ? Array.from(
+            {
+              length: Math.ceil(ids.length / STANDALONE_DELETE_LOOKUP_LIMIT),
+            },
+            (_, index) =>
+              ids.slice(
+                index * STANDALONE_DELETE_LOOKUP_LIMIT,
+                (index + 1) * STANDALONE_DELETE_LOOKUP_LIMIT,
+              ),
+          )
+        : [ids];
+    const matchedBundles: Bundle[] = [];
+    for (const batch of lookupBatches) {
+      const { data } = await databasePlugin.getBundles({
+        where: { id: { in: batch } },
+        limit: batch.length,
+      });
+      matchedBundles.push(...data);
+    }
     const matchedById = new Map(
       matchedBundles.map((bundle) => [bundle.id, bundle]),
     );

--- a/packages/hot-updater/src/commands/storage.spec.ts
+++ b/packages/hot-updater/src/commands/storage.spec.ts
@@ -106,15 +106,15 @@ const object = (
   storageUri: `s3://bucket/${key}`,
 });
 
-describe("parseStoragePruneMinAge", () => {
+describe("parseStoragePruneProtection", () => {
   it("parses minute, hour, day, and week durations", async () => {
-    const { parseStoragePruneMinAge } = await import("./storage");
+    const { parseStoragePruneProtection } = await import("./storage");
 
-    expect(parseStoragePruneMinAge("30m")).toBe(30 * 60 * 1000);
-    expect(parseStoragePruneMinAge("24h")).toBe(24 * 60 * 60 * 1000);
-    expect(parseStoragePruneMinAge("7d")).toBe(7 * 24 * 60 * 60 * 1000);
-    expect(parseStoragePruneMinAge("2w")).toBe(14 * 24 * 60 * 60 * 1000);
-    expect(() => parseStoragePruneMinAge("tomorrow")).toThrow(
+    expect(parseStoragePruneProtection("30m")).toBe(30 * 60 * 1000);
+    expect(parseStoragePruneProtection("24h")).toBe(24 * 60 * 60 * 1000);
+    expect(parseStoragePruneProtection("7d")).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(parseStoragePruneProtection("2w")).toBe(14 * 24 * 60 * 60 * 1000);
+    expect(() => parseStoragePruneProtection("tomorrow")).toThrow(
       "must use a duration",
     );
   });
@@ -217,9 +217,53 @@ describe("handleStoragePrune", () => {
 
     await handleStoragePrune(options);
 
+    const output = mockCli.p.log.message.mock.calls
+      .map(([message]) => String(message))
+      .join("\n");
     expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+    expect(output).toContain(
+      `assets/sha256/${ORPHAN_HASH.slice(0, 2)}/${ORPHAN_HASH}.png`,
+    );
+    expect(output).toContain(`${DEAD_BUNDLE_ID}/bundle.zip`);
+    expect(output).toContain(`${DEAD_BUNDLE_ID}/files/logo.png`);
+    expect(output).toContain(`bundles/${DEAD_BUNDLE_ID}/manifest.json`);
+    expect(output).toContain("shared asset");
+    expect(output).toContain("bundle data");
+    expect(output).toContain("30 B");
+    expect(output).toContain(old.toISOString());
+    expect(output).not.toContain(YOUNG_ORPHAN_HASH);
+    expect(output).not.toContain(`${LIVE_BUNDLE_ID}/bundle.zip`);
     expect(mockCli.p.log.info).toHaveBeenCalledWith(
       expect.stringContaining("Dry run only"),
+    );
+  });
+
+  it("protects unreferenced objects modified within the configured window", async () => {
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({
+      protectNewerThan: 3 * 24 * 60 * 60 * 1000,
+      yes: true,
+    });
+
+    expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+    expect(mockCli.p.log.success).toHaveBeenCalledWith(
+      "No objects are eligible for pruning.",
+    );
+  });
+
+  it("preserves the protection window in the suggested delete command", async () => {
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({
+      dryRun: true,
+      protectNewerThan: 24 * 60 * 60 * 1000,
+    });
+
+    expect(mockCli.p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "hot-updater storage prune --protect-newer-than 1d --yes",
+      ),
     );
   });
 

--- a/packages/hot-updater/src/commands/storage.spec.ts
+++ b/packages/hot-updater/src/commands/storage.spec.ts
@@ -129,6 +129,7 @@ describe("handleStoragePrune", () => {
     vi.clearAllMocks();
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(now);
+    mockDatabasePlugin.name = "mock-database";
 
     mockCli.loadConfig.mockResolvedValue({
       database: vi.fn().mockResolvedValue(mockDatabasePlugin),
@@ -483,6 +484,46 @@ describe("handleStoragePrune", () => {
     expect(mockStorageNode.downloadFile).not.toHaveBeenCalled();
     expect(mockStorageNode.listObjects).not.toHaveBeenCalled();
     expect(mockStorageNode.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it("loads standalone references in pages within the server limit", async () => {
+    mockDatabasePlugin.name = "standalone-repository";
+    mockDatabasePlugin.getBundles.mockImplementation(
+      async (options: { cursor?: { after: string }; limit: number }) => {
+        if (options.limit > 100) {
+          throw new Error("limit must be less than or equal to 100");
+        }
+        if (!options.cursor) {
+          return {
+            data: [liveBundle],
+            pagination: {
+              hasNextPage: true,
+              nextCursor: "page-2",
+            },
+          };
+        }
+        return {
+          data: [],
+          pagination: { hasNextPage: false, nextCursor: null },
+        };
+      },
+    );
+    const { handleStoragePrune } = await import("./storage");
+
+    await handleStoragePrune({ dryRun: true });
+
+    expect(mockDatabasePlugin.getBundles).toHaveBeenCalledTimes(2);
+    expect(mockDatabasePlugin.getBundles).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cursor: undefined, limit: 100 }),
+    );
+    expect(mockDatabasePlugin.getBundles).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cursor: { after: "page-2" },
+        limit: 100,
+      }),
+    );
   });
 
   it("protects exact and legacy-prefix URIs referenced by live bundles", async () => {

--- a/packages/hot-updater/src/commands/storage.ts
+++ b/packages/hot-updater/src/commands/storage.ts
@@ -34,11 +34,11 @@ const UUID_V7_RE =
 const CONTENT_ADDRESSED_ASSET_KEY_RE =
   /^assets\/sha256\/[0-9a-f]{2}\/[0-9a-f]{64}(?:\.[^/]+)?$/i;
 
-export const DEFAULT_STORAGE_PRUNE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_STORAGE_PRUNE_PROTECTION_MS = 24 * 60 * 60 * 1000;
 
 export interface StoragePruneOptions {
   dryRun?: boolean;
-  minAge?: number;
+  protectNewerThan?: number;
   yes?: boolean;
 }
 
@@ -56,7 +56,7 @@ interface PruneCandidate extends StorageObject {
   reason: "asset" | "bundle";
 }
 
-export function parseStoragePruneMinAge(value: string): number {
+export function parseStoragePruneProtection(value: string): number {
   const match = value.trim().match(/^(\d+)(m|h|d|w)$/i);
   if (!match) {
     throw new Error("must use a duration such as 30m, 24h, or 7d");
@@ -102,6 +102,32 @@ function formatDuration(value: number): string {
     return `${value / hour}h`;
   }
   return `${value / (60 * 1000)}m`;
+}
+
+type PruneCandidateColumn = "key" | "modified" | "size" | "type";
+
+const PRUNE_CANDIDATE_COLUMNS = [
+  { key: "type", label: "Type" },
+  { key: "size", label: "Size" },
+  { key: "modified", label: "Modified", format: ui.muted },
+  { key: "key", label: "Key", format: ui.path },
+] as const satisfies readonly {
+  key: PruneCandidateColumn;
+  label: string;
+  format?: (value: string) => string;
+}[];
+
+function formatPruneCandidateTable(candidates: readonly PruneCandidate[]) {
+  const rows: Record<PruneCandidateColumn, string>[] = candidates.map(
+    (candidate) => ({
+      key: candidate.key,
+      modified: candidate.lastModifiedAt?.toISOString() ?? "-",
+      size: formatBytes(candidate.size),
+      type: candidate.reason === "asset" ? "shared asset" : "bundle data",
+    }),
+  );
+
+  return ui.table(PRUNE_CANDIDATE_COLUMNS, rows);
 }
 
 function normalizeStorageUri(storageUri: string): string {
@@ -445,9 +471,12 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
     throw new Error("Storage prune --dry-run cannot be used with --yes.");
   }
 
-  const minAge = options.minAge ?? DEFAULT_STORAGE_PRUNE_MIN_AGE_MS;
-  if (!Number.isFinite(minAge) || minAge < 0) {
-    throw new Error("Storage prune min age must be a non-negative duration.");
+  const protectNewerThan =
+    options.protectNewerThan ?? DEFAULT_STORAGE_PRUNE_PROTECTION_MS;
+  if (!Number.isFinite(protectNewerThan) || protectNewerThan < 0) {
+    throw new Error(
+      "Storage prune protection must be a non-negative duration.",
+    );
   }
 
   const config = await loadConfig(null);
@@ -497,7 +526,7 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
       referencedAssetUris: referencedUris,
     });
 
-    const cutoff = Date.now() - minAge;
+    const cutoff = Date.now() - protectNewerThan;
     let candidates = unreferenced.filter((object) => {
       const modifiedAt = object.lastModifiedAt?.getTime();
       return modifiedAt !== undefined && modifiedAt <= cutoff;
@@ -538,7 +567,7 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
           ui.kv("Bundles", bundles.length),
           ui.kv("Manifests", manifestCount),
           ui.kv("Objects", objects.length),
-          ui.kv("Min age", formatDuration(minAge)),
+          ui.kv("Protect newer", formatDuration(protectNewerThan)),
           ui.kv("Bundle data", bundleObjects.length),
           ui.kv("Shared assets", assetObjects.length),
           ui.kv("Reclaimable", formatBytes(candidateBytes)),
@@ -555,8 +584,13 @@ export async function handleStoragePrune(options: StoragePruneOptions = {}) {
     }
 
     if (!options.yes) {
+      p.log.message(
+        ui.block("Eligible objects", [formatPruneCandidateTable(candidates)]),
+      );
       p.log.info(
-        `Dry run only. Delete with ${ui.command("hot-updater storage prune --yes")}.`,
+        `Dry run only. Delete with ${ui.command(
+          `hot-updater storage prune --protect-newer-than ${formatDuration(protectNewerThan)} --yes`,
+        )}.`,
       );
       return;
     }

--- a/packages/hot-updater/src/commands/storage.ts
+++ b/packages/hot-updater/src/commands/storage.ts
@@ -28,6 +28,8 @@ import { printBanner } from "@/utils/printBanner";
 import { ui } from "../utils/cli-ui";
 
 const BUNDLE_PAGE_SIZE = 10_000;
+const STANDALONE_BUNDLE_PAGE_SIZE = 100;
+const STANDALONE_DATABASE_NAME = "standalone-repository";
 const MANIFEST_READ_CONCURRENCY = 4;
 const UUID_V7_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -223,12 +225,16 @@ async function forEachWithConcurrency<T>(
 async function loadAllBundles(databasePlugin: DatabasePlugin) {
   const bundles: Bundle[] = [];
   const seenCursors = new Set<string>();
+  const pageSize =
+    databasePlugin.name === STANDALONE_DATABASE_NAME
+      ? STANDALONE_BUNDLE_PAGE_SIZE
+      : BUNDLE_PAGE_SIZE;
   let after: string | undefined;
 
   while (true) {
     const { data, pagination } = await databasePlugin.getBundles({
       cursor: after ? { after } : undefined,
-      limit: BUNDLE_PAGE_SIZE,
+      limit: pageSize,
       orderBy: { direction: "desc", field: "id" },
     });
     bundles.push(...data);

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -254,9 +254,7 @@ const storageCommand = program
 
 storageCommand
   .command("prune")
-  .description(
-    "Find and delete unreferenced objects (requires exclusive storage access)",
-  )
+  .description("Find or delete unreferenced bundle objects and shared assets")
   .addOption(
     new Option(
       "--protect-newer-than <duration>",
@@ -284,6 +282,18 @@ storageCommand
       "-y, --yes",
       "delete eligible objects after reference validation",
     ).conflicts("dryRun"),
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ hot-updater storage prune --dry-run
+  $ hot-updater storage prune --protect-newer-than 24h --yes
+
+Only unreferenced bundle objects and shared assets are eligible.
+Protection uses object modification time, not time since bundle deletion.
+Deletion requires exclusive storage access; stop deploy and promote first.
+`,
   )
   .action(
     (options: { dryRun?: boolean; protectNewerThan: number; yes?: boolean }) =>

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -55,9 +55,9 @@ import { migrate } from "./commands/migrate";
 import { handlePromote } from "./commands/promote";
 import { handleRollback } from "./commands/rollback";
 import {
-  DEFAULT_STORAGE_PRUNE_MIN_AGE_MS,
+  DEFAULT_STORAGE_PRUNE_PROTECTION_MS,
   handleStoragePrune,
-  parseStoragePruneMinAge,
+  parseStoragePruneProtection,
 } from "./commands/storage";
 
 const DEFAULT_CHANNEL = "production";
@@ -259,19 +259,19 @@ storageCommand
   )
   .addOption(
     new Option(
-      "--min-age <duration>",
-      "only prune objects older than this duration (for example 24h or 7d)",
+      "--protect-newer-than <duration>",
+      "protect unreferenced objects modified within this duration",
     )
       .argParser((value) => {
         try {
-          return parseStoragePruneMinAge(value);
+          return parseStoragePruneProtection(value);
         } catch (error) {
           throw new InvalidArgumentError(
             error instanceof Error ? error.message : String(error),
           );
         }
       })
-      .default(DEFAULT_STORAGE_PRUNE_MIN_AGE_MS, "24h"),
+      .default(DEFAULT_STORAGE_PRUNE_PROTECTION_MS, "24h"),
   )
   .addOption(
     new Option(
@@ -285,8 +285,9 @@ storageCommand
       "delete eligible objects after reference validation",
     ).conflicts("dryRun"),
   )
-  .action((options: { dryRun?: boolean; minAge: number; yes?: boolean }) =>
-    handleStoragePrune(options),
+  .action(
+    (options: { dryRun?: boolean; protectNewerThan: number; yes?: boolean }) =>
+      handleStoragePrune(options),
   );
 
 const keysCommand = program

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -583,6 +583,7 @@ describe("s3Database plugin", () => {
     );
 
     seedUpdateManifests([bundle]);
+    fakeStore["assets/sha256/aa/shared-asset.png"] = "asset";
     for (let index = 0; index < 100; index += 1) {
       const bundleId = `0198a408-8f13-7d9b-8df4-${String(index).padStart(12, "0")}`;
       fakeStore[`${bundleId}/bundle.zip`] = "zip";
@@ -598,12 +599,17 @@ describe("s3Database plugin", () => {
       data: [bundle],
     });
 
-    expect(listedObjectPrefixes).toEqual([
-      "",
-      "bundles/",
-      "production/",
-      "production/ios/",
-    ]);
+    expect(listedObjectRequests).toContainEqual({ delimiter: "/", prefix: "" });
+    expect(listedObjectRequests).toContainEqual({ prefix: "0" });
+    expect(listedObjectRequests).not.toContainEqual({ prefix: "" });
+    expect(listedObjectPrefixes).toContain("bundles/");
+    expect(listedObjectPrefixes).toContain("production/");
+    expect(listedObjectPrefixes).toContain("production/ios/");
+    expect(
+      listedObjectPrefixes.some((prefix) =>
+        prefix.startsWith("0198a408-8f13-7d9b-8df4-"),
+      ),
+    ).toBe(false);
   });
 
   it("preserves assets and bundles as channel names", async () => {
@@ -674,20 +680,37 @@ describe("s3Database plugin", () => {
     expect(loadedObjectKeys).toEqual(["production/ios/1.0.0/update.json"]);
   });
 
-  it("rejects new UUIDv7 channel names that collide with legacy bundle storage", async () => {
+  it("reads and writes UUIDv7 channels without traversing each UUID prefix", async () => {
+    const basePath = "environments/production";
+    const channel = "0198a408-8f13-7d9b-8df4-123456789abc";
     const bundle = createBundleJson(
-      "0198a408-8f13-7d9b-8df4-123456789abc",
+      channel,
       "ios",
       "1.0.0",
       "uuid-channel-bundle",
     );
 
+    plugin = createPlugin({ basePath });
     await plugin.appendBundle(bundle);
+    await expect(plugin.commitBundle()).resolves.toBeUndefined();
+    fakeStore[`${basePath}/${channel}/bundle.zip`] = "legacy artifact";
 
-    await expect(plugin.commitBundle()).rejects.toThrow(
-      "S3 database channel cannot use a UUIDv7 name",
+    plugin = createPlugin({ basePath });
+    listedObjectRequests = [];
+    loadedObjectKeys = [];
+
+    await expect(plugin.getChannels()).resolves.toEqual([channel]);
+    await expect(plugin.getBundles({ limit: 20 })).resolves.toMatchObject({
+      data: [bundle],
+    });
+    expect(listedObjectRequests).toContainEqual({ prefix: `${basePath}/0` });
+    expect(listedObjectRequests).not.toContainEqual({
+      delimiter: "/",
+      prefix: `${basePath}/${channel}/`,
+    });
+    expect(loadedObjectKeys).toContain(
+      `${basePath}/${channel}/ios/1.0.0/update.json`,
     );
-    expect(putObjectKeys).toEqual([]);
   });
 
   it("paginates more than 1000 legacy root prefixes without traversing them", async () => {
@@ -709,9 +732,16 @@ describe("s3Database plugin", () => {
     await expect(plugin.getBundles({ limit: 20 })).resolves.toMatchObject({
       data: [bundle],
     });
-    expect(listedObjectPrefixes.filter((prefix) => prefix === "")).toHaveLength(
-      2,
-    );
+    expect(
+      listedObjectRequests.filter(
+        (request) => request.prefix === "" && request.delimiter === "/",
+      ),
+    ).toHaveLength(2);
+    expect(
+      listedObjectRequests.filter(
+        (request) => request.prefix === "0" && request.delimiter === undefined,
+      ),
+    ).toHaveLength(2);
     expect(
       listedObjectPrefixes.some((prefix) =>
         prefix.startsWith("0198a408-8f13-7d9b-8df4-"),

--- a/plugins/aws/src/s3Database.ts
+++ b/plugins/aws/src/s3Database.ts
@@ -153,14 +153,27 @@ function isLegacyBundleStorageDirectoryPrefix(prefix: string) {
   );
 }
 
-function validateS3Channel(channel: string) {
-  if (isLegacyBundleStorageDirectoryPrefix(channel)) {
-    throw new Error(`S3 database channel cannot use a UUIDv7 name: ${channel}`);
-  }
-}
-
 function isUpdateJsonKey(key: string) {
   return key.endsWith(`${S3_DIRECTORY_DELIMITER}update.json`);
+}
+
+function isUuidChannelUpdateJsonKey(
+  key: string,
+  rootPrefix: string,
+  uuidChannels: ReadonlySet<string>,
+) {
+  const [channel, platform, target, fileName, ...rest] =
+    getRelativeDirectoryPrefix(key, rootPrefix).split(S3_DIRECTORY_DELIMITER);
+
+  return (
+    channel !== undefined &&
+    uuidChannels.has(channel) &&
+    (platform === "ios" || platform === "android") &&
+    target !== undefined &&
+    target.length > 0 &&
+    fileName === "update.json" &&
+    rest.length === 0
+  );
 }
 
 async function mapWithConcurrency<T, TResult>(
@@ -246,7 +259,10 @@ async function listObjectsInS3(
 ) {
   const normalizedRootPrefix = normalizeDirectoryPrefix(rootPrefix);
 
-  const listPrefix = async (currentPrefix: string) => {
+  const listPrefix = async (
+    currentPrefix: string,
+    delimiter: string | null = S3_DIRECTORY_DELIMITER,
+  ) => {
     let continuationToken: string | undefined;
     const keys: string[] = [];
     const commonPrefixes = new Set<string>();
@@ -256,7 +272,7 @@ async function listObjectsInS3(
         new ListObjectsV2Command({
           Bucket: bucketName,
           Prefix: currentPrefix,
-          Delimiter: S3_DIRECTORY_DELIMITER,
+          Delimiter: delimiter ?? undefined,
           ContinuationToken: continuationToken,
         }),
       );
@@ -293,11 +309,15 @@ async function listObjectsInS3(
       ];
     }
 
+    const uuidPrefixes =
+      depth === 0
+        ? commonPrefixes.filter(isLegacyBundleStorageDirectoryPrefix)
+        : [];
+    const uuidPrefixSet = new Set(uuidPrefixes);
     const nextPrefixes =
       depth === 0
         ? commonPrefixes.filter(
-            (commonPrefix) =>
-              !isLegacyBundleStorageDirectoryPrefix(commonPrefix),
+            (commonPrefix) => !uuidPrefixSet.has(commonPrefix),
           )
         : depth === 1
           ? commonPrefixes.filter(isPlatformDirectoryPrefix)
@@ -307,7 +327,34 @@ async function listObjectsInS3(
       S3_LIST_OBJECTS_CONCURRENCY,
       (nextPrefix) => collectUpdateJsonKeys(nextPrefix),
     );
-    return nestedKeys.flat();
+    const uuidChannels = new Set(
+      uuidPrefixes
+        .map(getLastDirectorySegment)
+        .filter((segment): segment is string => !!segment),
+    );
+    // UUIDv7 channels collide with legacy bundle directory names. Scan only
+    // their leading key ranges so assets and the new bundles prefix stay out
+    // of the compatibility fallback, without traversing every UUID directory.
+    const uuidScanPrefixes = Array.from(
+      new Set(
+        Array.from(
+          uuidChannels,
+          (channel) => `${normalizedRootPrefix}${channel[0]}`,
+        ),
+      ),
+    );
+    const uuidChannelKeys = (
+      await mapWithConcurrency(
+        uuidScanPrefixes,
+        S3_LIST_OBJECTS_CONCURRENCY,
+        async (scanPrefix) => (await listPrefix(scanPrefix, null)).keys,
+      )
+    )
+      .flat()
+      .filter((key) =>
+        isUuidChannelUpdateJsonKey(key, normalizedRootPrefix, uuidChannels),
+      );
+    return [...nestedKeys.flat(), ...uuidChannelKeys];
   };
 
   const normalizedPrefix = normalizeDirectoryPrefix(prefix);
@@ -450,7 +497,6 @@ export const s3Database = createBlobDatabasePlugin<S3DatabaseConfig>({
         deleteObjectInS3(client, bucketName, toStorageKey(key)),
       shouldSkipLoadObjectError: (error) =>
         error instanceof Error && error.name === "S3ArchivedObjectError",
-      validateChannel: validateS3Channel,
       invalidatePaths: (pathsToInvalidate: string[]) => {
         if (
           cloudfrontClient &&


### PR DESCRIPTION
## Summary

- clarify `storage prune` as reference-aware garbage collection with explicit dry-run output and a `--protect-newer-than` safety barrier
- page standalone prune reads within the server limit and chunk multi-ID standalone deletion lookups at 100 records
- preserve existing UUIDv7-named S3 channels without restoring per-UUID recursive LIST requests
- add actionable CLI help, a Storage Cleanup guide, AWS maintenance guidance, and a release changeset

## Issue #1131 outcome

The management slowdown came from unfiltered S3 discovery traversing every legacy root-level UUID bundle directory and repeatedly loading metadata during deletion. The scan fix from #1146 avoids that traversal and stores new bundle artifacts below `bundles/<bundle-id>`, so upgrading improves management scans without requiring storage deletion.

Existing UUIDv7 channel names remain compatible. When legacy UUID roots exist, the compatibility path performs a bounded, paginated scan only over the matching leading key range, excludes `assets/` and `bundles/`, and accepts only exact `<uuid-channel>/<platform>/<target>/update.json` keys. It never issues one recursive LIST per UUID directory.

Pruning is optional physical cleanup. The operator workflow is:

1. Select obsolete records with `hot-updater bundle list`, including `--target-app-version` when useful.
2. Delete the exact records with one multi-ID `hot-updater bundle delete <bundle-ids...> --yes` command.
3. Review physical cleanup with `hot-updater storage prune --dry-run`.
4. Stop deploy/promote writers and run `hot-updater storage prune --protect-newer-than 24h --yes`.

The protection duration uses storage object modification time, not time since record deletion. Separate databases or environments sharing a bucket must use separate storage `basePath` values before pruning.

## Follow-up to #1146 review

- standalone prune pagination stays at the server maximum of 100
- standalone multi-ID deletion chunks lookups at 100 and still commits once
- UUIDv7 S3 channels remain readable and writable while legacy artifact roots avoid per-prefix traversal

## Verification

- targeted regressions: 3 files, 114 tests
- built CLI `storage prune --help` verified with dry-run and deletion examples
- docs production build and dead-link checks passed
- full local FixCI sequence passed:
  - build: 26 projects
  - type-check: 34 projects
  - lint: 0 warnings, 0 errors
  - unit: 162 files, 2,129 tests
  - integration: 15 files, 1,454 tests

Follow-up to #1146 and #1131.