### PR TITLE
fix(console): restore additional cohort preview

### DIFF
--- a/.changeset/restore-console-cohort-preview.md
+++ b/.changeset/restore-console-cohort-preview.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/console": patch
+---
+
+Restore the cohort preview action in the Additional Cohorts editor, including
+full rollouts with explicitly targeted cohorts.

--- a/packages/console/src/components/features/bundles/BundleEditorForm.spec.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorForm.spec.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -275,6 +276,47 @@ describe("BundleEditorForm", () => {
         }),
       });
     });
+  });
+
+  it("previews additional cohorts from the full-rollout edit form", () => {
+    render(
+      <BundleEditorForm
+        bundle={{
+          ...bundle,
+          targetCohorts: ["qa-group"],
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    const additionalCohortsLabel = screen.getByText(
+      "Additional Cohorts (optional)",
+    );
+    const previewButton = within(
+      additionalCohortsLabel.parentElement!,
+    ).getByRole("button", { name: "Preview Cohorts" });
+
+    fireEvent.click(previewButton);
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Additional Cohorts")).toBeTruthy();
+    expect(screen.getAllByText("qa-group").length).toBeGreaterThan(1);
+  });
+
+  it("offers the preview from Additional Cohorts after lowering rollout", () => {
+    render(<BundleEditorForm bundle={bundle} onClose={() => {}} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Preview Cohorts" }),
+    ).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Rollout Percentage"), {
+      target: { value: "10" },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Preview Cohorts" }),
+    ).toBeTruthy();
   });
 
   it("submits null when the last target cohort is removed", async () => {

--- a/packages/console/src/components/features/bundles/BundleEditorForm.tsx
+++ b/packages/console/src/components/features/bundles/BundleEditorForm.tsx
@@ -448,19 +448,7 @@ export function BundleEditorForm({
         <form.Field name="rolloutCohortCount">
           {(field) => (
             <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="rolloutPercentage">Rollout Percentage</Label>
-                <div className="flex items-center gap-2">
-                  <RolloutCohortsDialog
-                    bundleId={bundle.id}
-                    rolloutCohortCount={field.state.value}
-                    targetCohorts={targetCohorts}
-                    triggerLabel="Preview Cohorts"
-                    triggerVariant="outline"
-                    triggerSize="sm"
-                  />
-                </div>
-              </div>
+              <Label htmlFor="rolloutPercentage">Rollout Percentage</Label>
               <RolloutPercentageInput
                 value={field.state.value}
                 onChange={field.handleChange}
@@ -472,9 +460,22 @@ export function BundleEditorForm({
         <form.Field name="targetCohorts">
           {(field) => (
             <div className="space-y-2">
-              <Label>Target Cohorts (optional)</Label>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <Label htmlFor="targetCohort">
+                  Additional Cohorts (optional)
+                </Label>
+                <RolloutCohortsDialog
+                  bundleId={bundle.id}
+                  rolloutCohortCount={form.getFieldValue("rolloutCohortCount")}
+                  targetCohorts={targetCohorts}
+                  triggerLabel="Preview Cohorts"
+                  triggerVariant="outline"
+                  triggerSize="sm"
+                />
+              </div>
               <div className="flex gap-2">
                 <Input
+                  id="targetCohort"
                   value={newCohort}
                   onChange={(e) => setNewCohort(e.target.value)}
                   onKeyDown={handleKeyDown}

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
@@ -2,12 +2,14 @@ import {
   getNumericCohortRolloutPosition,
   NUMERIC_COHORT_SIZE,
 } from "@hot-updater/core";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { RolloutCohortsDialog } from "./RolloutCohortsDialog";
 
 describe("RolloutCohortsDialog", () => {
+  afterEach(cleanup);
+
   it("renders a trigger and shows the rolled out cohorts for partial rollout", () => {
     const bundleId = "0195a408-8f13-7d9b-8df4-123456789abc";
     const rolloutCohorts = Array.from(
@@ -54,11 +56,11 @@ describe("RolloutCohortsDialog", () => {
     expect(screen.queryByRole("button", { name: "View Cohorts" })).toBeNull();
   });
 
-  it("keeps the trigger when target cohorts supplement gradual rollout", () => {
+  it("keeps the trigger when target cohorts supplement full rollout", () => {
     render(
       <RolloutCohortsDialog
         bundleId="0195a408-8f13-7d9b-8df4-123456789abc"
-        rolloutCohortCount={100}
+        rolloutCohortCount={1000}
         targetCohorts={["qa-group"]}
       />,
     );
@@ -67,10 +69,10 @@ describe("RolloutCohortsDialog", () => {
 
     expect(
       screen.getByText(
-        /Target Cohorts are added on top of this numeric rollout\./,
+        /Additional Cohorts are added on top of this numeric rollout\./,
       ),
     ).toBeTruthy();
-    expect(screen.getByText("Target Cohorts")).toBeTruthy();
+    expect(screen.getByText("Additional Cohorts")).toBeTruthy();
     expect(screen.getByText("qa-group")).toBeTruthy();
   });
 });

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
@@ -52,7 +52,7 @@ export function RolloutCohortsDialog({
   const isPartialRollout =
     normalizedRolloutCount > 0 && normalizedRolloutCount < NUMERIC_COHORT_SIZE;
 
-  if (!isPartialRollout) {
+  if (!isPartialRollout && !hasTargetCohorts) {
     return null;
   }
 
@@ -122,7 +122,7 @@ export function RolloutCohortsDialog({
       {hasTargetCohorts ? (
         <Card>
           <CardHeader className="p-4 pb-3">
-            <CardTitle className="text-sm">Target Cohorts</CardTitle>
+            <CardTitle className="text-sm">Additional Cohorts</CardTitle>
             <CardDescription>
               These cohorts are also included, even if they are outside the
               numeric rollout.
@@ -177,7 +177,7 @@ export function RolloutCohortsDialog({
                 cohorts. The selected set stays stable for this bundle as you
                 expand or shrink rollout.
                 {hasTargetCohorts
-                  ? " Target Cohorts are added on top of this numeric rollout."
+                  ? " Additional Cohorts are added on top of this numeric rollout."
                   : ""}
               </DialogDescription>
             </DialogHeader>
@@ -199,7 +199,7 @@ export function RolloutCohortsDialog({
                 cohorts. The selected set stays stable for this bundle as you
                 expand or shrink rollout.
                 {hasTargetCohorts
-                  ? " Target Cohorts are added on top of this numeric rollout."
+                  ? " Additional Cohorts are added on top of this numeric rollout."
                   : ""}
               </DialogDescription>
             </DialogHeader>


### PR DESCRIPTION
## Summary

- place Preview Cohorts alongside Additional Cohorts in the bundle edit form
- keep the preview available for full rollouts when explicit additional cohorts exist
- align the editor and dialog on Additional Cohorts terminology
- add regression coverage and a console patch changeset

## Design review

StyleSeed: 96/100 (A), up from 89/100 (B). The preview now uses the existing outline button and Lucide icon language, sits with the field it explains, and covers both partial and full-rollout states.

## Test plan

- pnpm -w build
- pnpm -w lint
- pnpm -w test
- pnpm --dir packages/console test:type
- pnpm --dir packages/console test