### PR TITLE
fix(console): restore main bundle management layout

### DIFF
--- a/.changeset/tidy-bundles-return.md
+++ b/.changeset/tidy-bundles-return.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/console": patch
+---
+
+Restore the compact main Console layout for the Bundles table and Bundle detail
+form while preserving Release analytics and cohort preview behavior.

--- a/packages/console/src/components/ChannelBadge.spec.tsx
+++ b/packages/console/src/components/ChannelBadge.spec.tsx
@@ -6,13 +6,13 @@ import { ChannelBadge } from "./ChannelBadge";
 describe("ChannelBadge", () => {
   afterEach(cleanup);
 
-  it("keeps the main channel color for a scoped production channel", () => {
+  it("keeps custom channel names neutral like the main Console", () => {
     render(
       <ChannelBadge channel="e2e-job-20260812132427-android-production" />,
     );
 
     const badge = screen.getByText("e2e-job-20260812132427-android-production");
-    expect(badge.className).toContain("bg-green-500/10");
-    expect(badge.className).toContain("text-green-700");
+    expect(badge.className).toContain("bg-gray-500/10");
+    expect(badge.className).toContain("text-gray-700");
   });
 });

--- a/packages/console/src/components/ChannelBadge.tsx
+++ b/packages/console/src/components/ChannelBadge.tsx
@@ -15,24 +15,15 @@ const channelColors: Record<string, string> = {
     "bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border-yellow-500/20",
 };
 
-function getChannelColor(channel: string) {
-  const normalizedChannel = channel.toLowerCase();
-  const semanticName = normalizedChannel
-    .split(/[-_.]/)
-    .find((part) => part in channelColors);
-
-  return (
-    channelColors[normalizedChannel] ??
-    (semanticName ? channelColors[semanticName] : undefined) ??
-    "bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20"
-  );
-}
-
 export function ChannelBadge({ channel, className }: ChannelBadgeProps) {
   return (
     <Badge
       variant="outline"
-      className={cn(getChannelColor(channel), className)}
+      className={cn(
+        channelColors[channel.toLowerCase()] ||
+          "bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20",
+        className,
+      )}
     >
       {channel}
     </Badge>

--- a/packages/console/src/components/RolloutPercentageBadge.tsx
+++ b/packages/console/src/components/RolloutPercentageBadge.tsx
@@ -16,19 +16,12 @@ export function RolloutPercentageBadge({
   const isPartialRollout = percentage < 100;
   const formattedPercentage = percentage.toFixed(1);
 
-  if (!isPartialRollout) {
-    return (
-      <span
-        className={cn("text-xs tabular-nums text-muted-foreground", className)}
-      >
-        {formattedPercentage}%
-      </span>
-    );
-  }
-
   return (
-    <Badge variant="secondary" className={cn("gap-1 font-normal", className)}>
-      <AlertTriangle className="h-3 w-3" />
+    <Badge
+      className={cn("gap-1", className)}
+      variant={isPartialRollout ? "secondary" : "default"}
+    >
+      {isPartialRollout ? <AlertTriangle className="h-3 w-3" /> : null}
       {formattedPercentage}%
     </Badge>
   );

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
@@ -2,12 +2,14 @@ import {
   getNumericCohortRolloutPosition,
   NUMERIC_COHORT_SIZE,
 } from "@hot-updater/core";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RolloutCohortsDialog } from "./RolloutCohortsDialog";
 
 vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+
+afterEach(cleanup);
 
 describe("RolloutCohortsDialog", () => {
   it("previews the cohorts selected by the Release identity", () => {

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -160,15 +161,34 @@ describe("ReleaseEditorSheet", () => {
     expect(
       screen.getByRole("button", { name: "Remove from channel" }),
     ).toBeDefined();
+    expect(screen.getByText("Channel")).toBeDefined();
+    expect(screen.getByText("Platform")).toBeDefined();
     expect(screen.queryByText(/deployment/i)).toBeNull();
     expect(screen.queryByText("s3://updates/bundle-1")).toBeNull();
     expect(screen.queryByText("DEPLOY")).toBeNull();
     expect(
       screen.queryByText("Manage delivery settings and actions"),
     ).toBeNull();
-    expect(container.textContent!.indexOf("Activity · 30 days")).toBeLessThan(
-      container.textContent!.indexOf("Delivery"),
+    expect(container.textContent!.indexOf("Message")).toBeLessThan(
+      container.textContent!.indexOf("Actions"),
     );
+    expect(container.textContent!.indexOf("Actions")).toBeLessThan(
+      container.textContent!.indexOf("Metadata"),
+    );
+    expect(container.textContent!.indexOf("Metadata")).toBeLessThan(
+      container.textContent!.indexOf("Activity · 30 days"),
+    );
+    expect(screen.queryByRole("heading", { name: "Delivery" })).toBeNull();
+
+    for (const actionName of [
+      "Promote to channel",
+      "Download bundle",
+      "Remove from channel",
+    ]) {
+      expect(
+        screen.getByRole("button", { name: actionName }).className,
+      ).toContain("w-full");
+    }
   });
 
   it("restores the main Console cohort preview for gradual rollout", () => {
@@ -182,7 +202,13 @@ describe("ReleaseEditorSheet", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Preview cohorts" }));
+    const rolloutLabel = screen.getByText("Rollout percentage");
+    const previewButton = within(rolloutLabel.parentElement!).getByRole(
+      "button",
+      { name: "Preview cohorts" },
+    );
+
+    fireEvent.click(previewButton);
 
     expect(screen.getByRole("dialog")).toBeDefined();
     expect(screen.getByText("Selected cohorts")).toBeDefined();

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -8,7 +8,7 @@ import type {
   ReleasePolicyPatch,
   ReleaseRow,
 } from "@hot-updater/plugin-core";
-import { AlertTriangle, Box, Download, Plus, Trash2, X } from "lucide-react";
+import { AlertTriangle, Download, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { normalizeRange } from "verkit";
@@ -17,6 +17,7 @@ import { BundleIdDisplay } from "@/components/BundleIdDisplay";
 import { BundleAnalyticsSummary } from "@/components/features/bundles/BundleAnalyticsSummary";
 import { BundleMetadata } from "@/components/features/bundles/BundleMetadata";
 import { RolloutCohortsDialog } from "@/components/features/bundles/RolloutCohortsDialog";
+import { PlatformIcon } from "@/components/PlatformIcon";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -60,6 +61,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -80,8 +82,6 @@ import {
   useReleaseQuery,
   useUpdateReleaseMutation,
 } from "@/lib/api";
-
-import { ReleaseStateBadge } from "./ReleaseStateBadge";
 
 interface Draft {
   enabled: boolean;
@@ -316,43 +316,68 @@ export function ReleaseEditorSheet({
       value: channel.name,
     })),
   ];
+  const normalizedTargetAppVersion = draft
+    ? normalizeRange(draft.targetAppVersion.trim())
+    : null;
+
   return (
     <>
       <Sheet
         onOpenChange={(nextOpen) => (nextOpen ? undefined : requestClose())}
         open={open}
       >
-        <SheetContent className="min-w-0 overflow-hidden data-[side=right]:w-full sm:max-w-[620px]">
-          <SheetHeader className="shrink-0 border-b p-4 pr-12 sm:p-6 sm:pr-12">
+        <SheetContent className="min-w-0 overflow-hidden data-[side=right]:w-full sm:max-w-[600px]">
+          <SheetHeader className="shrink-0 pr-12">
             <SheetTitle>Bundle Detail</SheetTitle>
             <SheetDescription className="sr-only">
               Edit bundle delivery settings.
             </SheetDescription>
             {release ? (
-              <div className="flex min-w-0 flex-col gap-2 pt-1 text-xs text-muted-foreground">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <ReleaseStateBadge release={release} />
-                  <Badge className="max-w-full" variant="outline">
-                    <span className="truncate">{channelName}</span>
-                  </Badge>
-                  <Badge variant="outline">
-                    {release.platform === "ios" ? "iOS" : "Android"}
-                  </Badge>
-                </div>
-                <div
-                  className="min-w-0 text-foreground"
-                  title={release.bundle_id ?? undefined}
-                >
-                  {release.bundle_id ? (
-                    <BundleIdDisplay
-                      bundleId={release.bundle_id}
-                      className="block truncate break-normal"
+              <div className="mt-1 flex min-w-0 flex-col gap-3 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex items-center gap-2">
+                    <PlatformIcon
+                      className="size-4"
+                      platform={release.platform}
                     />
-                  ) : (
-                    <span className="inline-flex items-center gap-2 font-medium">
-                      <Box className="size-4" /> Built-in app
+                    <span className="font-medium">
+                      {release.platform === "ios" ? "iOS" : "Android"}
                     </span>
-                  )}
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-start gap-2">
+                  <span className="font-medium text-muted-foreground">
+                    Bundle
+                  </span>
+                  <span className="min-w-0 basis-full sm:basis-auto">
+                    {release.bundle_id ? (
+                      <BundleIdDisplay
+                        bundleId={release.bundle_id}
+                        fullOnMobile
+                        maxLength={18}
+                      />
+                    ) : (
+                      <span className="text-xs text-foreground">
+                        Built-in app
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-muted-foreground">
+                    Channel
+                  </span>
+                  <span className="text-xs text-foreground" translate="no">
+                    {channelName}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-muted-foreground">
+                    Platform
+                  </span>
+                  <span className="text-xs text-foreground">
+                    {release.platform === "ios" ? "iOS" : "Android"}
+                  </span>
                 </div>
               </div>
             ) : (
@@ -372,14 +397,9 @@ export function ReleaseEditorSheet({
             ) : null}
 
             {release && draft ? (
-              <div className="flex flex-col gap-8 px-4 py-6 sm:px-6">
-                {release.bundle_id ? (
-                  <BundleAnalyticsSummary bundleId={release.bundle_id} />
-                ) : null}
-
-                <section className="flex flex-col gap-5">
-                  <h3 className="text-sm font-semibold">Delivery</h3>
-                  <FieldGroup className="gap-5">
+              <div className="flex flex-col gap-6 px-4 pb-4 sm:px-6 sm:pb-6">
+                <section className="flex flex-col gap-6">
+                  <FieldGroup className="gap-6">
                     <Field>
                       <FieldLabel htmlFor="release-message">Message</FieldLabel>
                       <Textarea
@@ -389,7 +409,7 @@ export function ReleaseEditorSheet({
                         onChange={(event) =>
                           setDraft({ ...draft, message: event.target.value })
                         }
-                        rows={2}
+                        rows={3}
                         value={draft.message}
                       />
                     </Field>
@@ -410,6 +430,11 @@ export function ReleaseEditorSheet({
                           }
                           value={draft.targetAppVersion}
                         />
+                        {normalizedTargetAppVersion ? (
+                          <FieldDescription>
+                            {normalizedTargetAppVersion}
+                          </FieldDescription>
+                        ) : null}
                       </Field>
                     ) : null}
                     <Field>
@@ -541,6 +566,49 @@ export function ReleaseEditorSheet({
                   </Button>
                 </section>
 
+                <Separator className="my-2" />
+
+                <section className="flex flex-col gap-4">
+                  <h3 className="text-sm font-medium">Actions</h3>
+                  <Button
+                    className="w-full"
+                    disabled={release.kind !== "BUNDLE" || busy}
+                    onClick={() => setShowPromote(true)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Promote to channel
+                  </Button>
+                  {release.bundle_id ? (
+                    <Button
+                      className="w-full"
+                      disabled={busy}
+                      onClick={() => {
+                        window.open(
+                          `/api/bundles/${encodeURIComponent(release.bundle_id!)}/download`,
+                          "_blank",
+                          "noopener,noreferrer",
+                        );
+                        toast.success("Bundle download started");
+                      }}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <Download data-icon="inline-start" />
+                      Download bundle
+                    </Button>
+                  ) : null}
+                  <Button
+                    className="w-full"
+                    disabled={release.enabled || busy}
+                    onClick={() => setConfirmDelete(true)}
+                    size="sm"
+                    variant="destructive"
+                  >
+                    Remove from channel
+                  </Button>
+                </section>
+
                 {release.bundle_id && bundleQuery.isPending ? (
                   <Skeleton className="h-40 w-full" />
                 ) : null}
@@ -557,35 +625,9 @@ export function ReleaseEditorSheet({
                   <BundleMetadata bundle={bundle} release={release} />
                 ) : null}
 
-                <section className="flex flex-col gap-4 border-t pt-8">
-                  <h3 className="text-sm font-semibold">Actions</h3>
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    <Button
-                      disabled={release.kind !== "BUNDLE" || busy}
-                      onClick={() => setShowPromote(true)}
-                      variant="outline"
-                    >
-                      Promote to channel
-                    </Button>
-                    {release.bundle_id ? (
-                      <Button
-                        disabled={busy}
-                        onClick={() => {
-                          window.open(
-                            `/api/bundles/${encodeURIComponent(release.bundle_id!)}/download`,
-                            "_blank",
-                            "noopener,noreferrer",
-                          );
-                          toast.success("Bundle download started");
-                        }}
-                        variant="outline"
-                      >
-                        <Download data-icon="inline-start" />
-                        Download bundle
-                      </Button>
-                    ) : null}
-                  </div>
-                </section>
+                {release.bundle_id ? (
+                  <BundleAnalyticsSummary bundleId={release.bundle_id} />
+                ) : null}
 
                 <details className="rounded-lg border bg-muted/10 p-4 text-xs">
                   <summary className="cursor-pointer font-medium">
@@ -632,25 +674,6 @@ export function ReleaseEditorSheet({
                     </p>
                   ) : null}
                 </details>
-
-                <section className="flex flex-col gap-4 border-t pt-8">
-                  <div>
-                    <h3 className="text-sm font-semibold text-destructive">
-                      Remove from channel
-                    </h3>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Disable before removing.
-                    </p>
-                  </div>
-                  <Button
-                    disabled={release.enabled || busy}
-                    onClick={() => setConfirmDelete(true)}
-                    variant="destructive"
-                  >
-                    <Trash2 data-icon="inline-start" />
-                    Remove from channel
-                  </Button>
-                </section>
               </div>
             ) : null}
           </div>

--- a/packages/console/src/routes/-bundles.spec.tsx
+++ b/packages/console/src/routes/-bundles.spec.tsx
@@ -157,8 +157,30 @@ describe("BundlesPage", () => {
     expect(within(row).getByText("1.2.x")).toBeDefined();
     expect(within(row).getByText("Enabled")).toBeDefined();
     expect(within(row).getByText("Optional")).toBeDefined();
-    expect(within(row).getByText("100.0%")).toBeDefined();
+    expect(within(row).getByText("100.0%").className).toContain("bg-primary");
     expect(within(row).queryByText("DEPLOY")).toBeNull();
     expect(within(row).queryByText("rev 1")).toBeNull();
+  });
+
+  it("keeps the main Console filters and pagination summary", () => {
+    render(<BundlesPage />);
+
+    const targetAppVersion = screen.getByLabelText("Target app version");
+    fireEvent.change(targetAppVersion, { target: { value: "1.2.x" } });
+    fireEvent.keyDown(targetAppVersion, { key: "Enter" });
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      resetScroll: true,
+      search: { targetAppVersion: "1.2.x" },
+      to: "/",
+    });
+    expect(
+      screen.getByText((_, node) =>
+        Boolean(node?.textContent === "Showing 1 to 1 entries"),
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText((_, node) => Boolean(node?.textContent === "Page 1")),
+    ).toBeDefined();
   });
 });

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -11,10 +11,11 @@ import {
   Tags,
   X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { BundleIdDisplay } from "@/components/BundleIdDisplay";
 import { ChannelBadge } from "@/components/ChannelBadge";
+import { EnabledStatusIcon } from "@/components/EnabledStatusIcon";
 import { ChannelManagementDialog } from "@/components/features/channels/ChannelManagementDialog";
 import { ReleaseEditorSheet } from "@/components/features/releases/ReleaseEditorSheet";
 import { ReleaseStateBadge } from "@/components/features/releases/ReleaseStateBadge";
@@ -24,6 +25,7 @@ import { RolloutPercentageBadge } from "@/components/RolloutPercentageBadge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -90,6 +92,9 @@ function BundleFilterToolbar({
   onManageChannels: () => void;
   search: ReleaseSearch;
 }) {
+  const [targetAppVersion, setTargetAppVersion] = useState(
+    search.targetAppVersion ?? "",
+  );
   const hasFilters = Boolean(
     search.bundleId ||
     search.channelId ||
@@ -104,9 +109,17 @@ function BundleFilterToolbar({
       value: channel.id,
     })),
   ];
+  const applyTargetAppVersion = () => {
+    const value = targetAppVersion.trim();
+    onChange({ targetAppVersion: value || undefined });
+  };
+
+  useEffect(() => {
+    setTargetAppVersion(search.targetAppVersion ?? "");
+  }, [search.targetAppVersion]);
 
   return (
-    <header className="sticky top-0 z-20 flex shrink-0 flex-wrap items-center gap-2 border-b bg-background px-3 py-3 sm:h-12 sm:flex-nowrap sm:bg-card/85 sm:px-4 sm:py-0 sm:backdrop-blur-sm">
+    <header className="sticky top-0 z-10 flex shrink-0 flex-wrap items-center gap-2 border-b bg-background px-3 py-3 sm:h-12 sm:flex-nowrap sm:bg-card/70 sm:px-4 sm:py-0 sm:backdrop-blur-sm">
       <SidebarTrigger className="-ml-1" />
       <h1 className="sr-only">Bundles</h1>
       <div className="ml-1 flex items-center gap-1.5 text-muted-foreground sm:ml-2">
@@ -137,6 +150,19 @@ function BundleFilterToolbar({
           </SelectGroup>
         </SelectContent>
       </Select>
+      <Input
+        aria-label="Target app version"
+        className="h-8 w-full min-w-[132px] text-xs sm:w-[160px]"
+        onBlur={applyTargetAppVersion}
+        onChange={(event) => setTargetAppVersion(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            applyTargetAppVersion();
+          }
+        }}
+        placeholder="Target version"
+        value={targetAppVersion}
+      />
       <Select
         items={channelFilterItems}
         onValueChange={(value) =>
@@ -281,6 +307,9 @@ function BundlesPage() {
   const changeFilters = (filters: Partial<ReleaseSearch>) =>
     go(updateReleaseFilters(search, filters));
   const currentPage = pagination?.currentPage ?? 1;
+  const startEntry =
+    releases.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1;
+  const endEntry = startEntry === 0 ? 0 : startEntry + releases.length - 1;
   const previousPage = currentPage - 1;
   const firstReleaseId = releases[0]?.id;
   const lastReleaseId = releases.at(-1)?.id;
@@ -306,7 +335,7 @@ function BundlesPage() {
       : null;
 
   return (
-    <div className="flex h-svh min-h-0 min-w-0 flex-col bg-muted/5">
+    <div className="flex h-svh min-h-0 min-w-0 flex-col">
       <BundleFilterToolbar
         channels={channels}
         onChange={changeFilters}
@@ -315,7 +344,7 @@ function BundlesPage() {
         search={search}
       />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4 p-3 sm:p-6">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-6 bg-muted/5 p-3 sm:p-6">
         {releasesQuery.isError ? (
           <Alert variant="destructive">
             <AlertTriangle />
@@ -323,7 +352,7 @@ function BundlesPage() {
             <AlertDescription>{releasesQuery.error.message}</AlertDescription>
           </Alert>
         ) : (
-          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border bg-card shadow-sm [&_[data-slot=table-container]]:h-full [&_[data-slot=table-container]]:overflow-auto">
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm [&_[data-slot=table-container]]:h-full [&_[data-slot=table-container]]:overflow-auto">
             {isMobile ? (
               <div className="h-full overflow-y-auto">
                 {releasesQuery.isPending ? (
@@ -435,8 +464,8 @@ function BundlesPage() {
               </div>
             ) : (
               <Table>
-                <TableHeader className="sticky top-0 z-10 bg-card/95 backdrop-blur">
-                  <TableRow>
+                <TableHeader className="bg-muted/40">
+                  <TableRow className="border-b border-border/60 hover:bg-transparent [&>th]:h-10 [&>th]:text-xs [&>th]:font-semibold [&>th]:uppercase [&>th]:text-muted-foreground/70">
                     <TableHead>Bundle ID</TableHead>
                     <TableHead>Channel</TableHead>
                     <TableHead>Platform</TableHead>
@@ -461,7 +490,7 @@ function BundlesPage() {
                     : releases.map((release) => (
                         <TableRow
                           aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
-                          className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&>td]:py-3"
+                          className="cursor-pointer transition-colors hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3"
                           data-state={
                             search.releaseId === release.id
                               ? "selected"
@@ -505,7 +534,6 @@ function BundlesPage() {
                                 channelNames.get(release.channel_id) ??
                                 release.channel_id
                               }
-                              className="min-w-64 max-w-72 whitespace-normal break-words py-1 font-normal leading-4"
                             />
                           </TableCell>
                           <TableCell className="whitespace-nowrap">
@@ -533,7 +561,7 @@ function BundlesPage() {
                                   : "patches"}
                               </Badge>
                             ) : (
-                              <span className="text-muted-foreground">—</span>
+                              <span className="text-muted-foreground">-</span>
                             )}
                           </TableCell>
                           <TableCell>
@@ -553,25 +581,29 @@ function BundlesPage() {
                                 />
                               </span>
                             ) : (
-                              <span className="text-muted-foreground">—</span>
+                              <span className="text-muted-foreground">-</span>
                             )}
                           </TableCell>
                           <TableCell>
-                            <ReleaseStateBadge release={release} />
-                          </TableCell>
-                          <TableCell>
-                            {release.should_force_update ? (
-                              <Badge
-                                className="font-normal"
-                                variant="secondary"
-                              >
-                                Required
-                              </Badge>
-                            ) : (
-                              <span className="text-muted-foreground">
-                                Optional
+                            <span className="flex items-center">
+                              <EnabledStatusIcon enabled={release.enabled} />
+                              <span className="sr-only">
+                                {release.enabled ? "Enabled" : "Disabled"}
                               </span>
-                            )}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="flex items-center">
+                              <EnabledStatusIcon
+                                enabled={release.should_force_update}
+                                falseIcon="minus"
+                              />
+                              <span className="sr-only">
+                                {release.should_force_update
+                                  ? "Required"
+                                  : "Optional"}
+                              </span>
+                            </span>
                           </TableCell>
                           <TableCell>
                             <RolloutPercentageBadge
@@ -582,7 +614,7 @@ function BundlesPage() {
                             className="max-w-44 truncate text-xs text-muted-foreground"
                             title={release.message ?? undefined}
                           >
-                            {release.message || "—"}
+                            {release.message || "-"}
                           </TableCell>
                           <TableCell
                             className="whitespace-nowrap text-xs text-muted-foreground"
@@ -617,15 +649,23 @@ function BundlesPage() {
         {!releasesQuery.isError && !releasesQuery.isPending ? (
           <nav
             aria-label="Bundle pagination"
-            className="flex items-center justify-between gap-3"
+            className="flex flex-col gap-3 px-2 sm:flex-row sm:items-center sm:justify-between"
           >
-            <p className="text-xs text-muted-foreground">
-              Page {pagination?.currentPage ?? 1}
+            <p className="text-xs font-medium text-muted-foreground">
+              Showing <span className="text-foreground">{startEntry}</span> to{" "}
+              <span className="text-foreground">{endEntry}</span> entries
             </p>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap items-center gap-3 sm:justify-end">
+              <p className="text-xs font-medium text-muted-foreground">
+                Page <span className="text-foreground">{currentPage}</span>
+              </p>
               {previousSearch ? (
                 <Link
-                  className={buttonVariants({ size: "sm", variant: "outline" })}
+                  className={buttonVariants({
+                    className: "h-8 flex-1 px-3 text-xs sm:flex-none",
+                    size: "sm",
+                    variant: "outline",
+                  })}
                   search={previousSearch}
                   to="/"
                 >
@@ -633,14 +673,23 @@ function BundlesPage() {
                   Previous
                 </Link>
               ) : (
-                <Button disabled size="sm" variant="outline">
+                <Button
+                  className="h-8 flex-1 px-3 text-xs sm:flex-none"
+                  disabled
+                  size="sm"
+                  variant="outline"
+                >
                   <ChevronLeft data-icon="inline-start" />
                   Previous
                 </Button>
               )}
               {nextSearch ? (
                 <Link
-                  className={buttonVariants({ size: "sm", variant: "outline" })}
+                  className={buttonVariants({
+                    className: "h-8 flex-1 px-3 text-xs sm:flex-none",
+                    size: "sm",
+                    variant: "outline",
+                  })}
                   search={nextSearch}
                   to="/"
                 >
@@ -648,7 +697,12 @@ function BundlesPage() {
                   <ChevronRight data-icon="inline-end" />
                 </Link>
               ) : (
-                <Button disabled size="sm" variant="outline">
+                <Button
+                  className="h-8 flex-1 px-3 text-xs sm:flex-none"
+                  disabled
+                  size="sm"
+                  variant="outline"
+                >
                   Next
                   <ChevronRight data-icon="inline-end" />
                 </Button>


### PR DESCRIPTION
## Summary

- restore the `origin/main` Bundles toolbar, table density, state icons, badges, and pagination spacing on the Release-backed `next` Console
- reshape Bundle Detail to the familiar main flow: bundle info, edit form, stacked actions, metadata, then the retained analytics card
- retain Release-specific behavior while covering the gradual-rollout **Preview cohorts** action with a regression test

## Design review

Reviewed after implementation with `styleseed-design-review`.

- Bundles table: **96/100 (A)** — the repeated primary rollout badge is the only deduction and intentionally matches the supplied `origin/main` reference
- Bundle Edit SheetForm: **100/100 (A)**

## Verification

- `pnpm -w build`
- `pnpm --dir packages/console test:type`
- `pnpm -w lint`
- `pnpm -w test` (257 files, 2,512 tests)
- targeted Console regression suite (11 tests)