### PR TITLE
feat(console): show unreachable releases

### DIFF
--- a/.changeset/calm-bundles-reach.md
+++ b/.changeset/calm-bundles-reach.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Show when a Release cannot currently be selected first by any catalog segment or cohort.

--- a/.changeset/calm-bundles-reach.md
+++ b/.changeset/calm-bundles-reach.md
@@ -1,5 +1,7 @@
 ---
 "@hot-updater/console": patch
+"@hot-updater/server": minor
 ---
 
-Show when a Release cannot currently be selected first by any catalog segment or cohort.
+Show when a Release cannot currently be selected first by any catalog segment
+or cohort, and surface batched 30-day Bundle movement in the Release list.

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
@@ -2,7 +2,13 @@ import {
   getNumericCohortRolloutPosition,
   NUMERIC_COHORT_SIZE,
 } from "@hot-updater/core";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RolloutCohortsDialog } from "./RolloutCohortsDialog";
@@ -40,18 +46,29 @@ describe("RolloutCohortsDialog", () => {
     ).toBeDefined();
     expect(screen.getByText(String(rolloutCohorts[0]))).toBeDefined();
     expect(screen.getByText("qa-group")).toBeDefined();
+    expect(
+      screen
+        .getByText("Additional cohorts")
+        .compareDocumentPosition(screen.getByText("Numeric cohorts")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
-  it("summarizes a full rollout without rendering every cohort", () => {
+  it("renders every numeric cohort for a full rollout", () => {
     render(
       <RolloutCohortsDialog releaseId="release-1" rolloutCohortCount={1_000} />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Preview cohorts" }));
 
+    const included = screen.getByRole("list", {
+      name: "Included numeric cohorts",
+    });
+    expect(within(included).getAllByRole("listitem")).toHaveLength(1_000);
+    expect(within(included).getByText("1")).toBeDefined();
+    expect(within(included).getByText("1000")).toBeDefined();
     expect(
-      screen.getByText("All 1000 numeric cohorts are included."),
-    ).toBeDefined();
-    expect(screen.queryAllByText(/^\d+$/)).toHaveLength(2);
+      screen.queryByText("All 1000 numeric cohorts are included."),
+    ).toBeNull();
   });
 });

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
@@ -31,6 +31,11 @@ interface RolloutCohortsDialogProps {
   readonly targetCohorts?: readonly string[] | null | undefined;
 }
 
+const ALL_NUMERIC_COHORTS = Array.from(
+  { length: NUMERIC_COHORT_SIZE },
+  (_, index) => index + 1,
+);
+
 export function RolloutCohortsDialog({
   releaseId,
   rolloutCohortCount,
@@ -45,16 +50,15 @@ export function RolloutCohortsDialog({
   const isFullRollout = normalizedRolloutCount === NUMERIC_COHORT_SIZE;
   const isMobile = useIsMobile();
 
-  const rolloutCohorts = isPartialRollout
-    ? Array.from(
-        { length: NUMERIC_COHORT_SIZE },
-        (_, index) => index + 1,
-      ).filter(
-        (cohortValue) =>
-          getNumericCohortRolloutPosition(releaseId, cohortValue) <
-          normalizedRolloutCount,
-      )
-    : [];
+  const rolloutCohorts = isFullRollout
+    ? ALL_NUMERIC_COHORTS
+    : isPartialRollout
+      ? ALL_NUMERIC_COHORTS.filter(
+          (cohortValue) =>
+            getNumericCohortRolloutPosition(releaseId, cohortValue) <
+            normalizedRolloutCount,
+        )
+      : [];
   const rolloutPercentage = (normalizedRolloutCount / 10).toFixed(1);
   const selectedCount = isFullRollout
     ? NUMERIC_COHORT_SIZE
@@ -82,35 +86,6 @@ export function RolloutCohortsDialog({
         </Card>
       </div>
 
-      <Card>
-        <CardHeader className="p-4 pb-3">
-          <CardTitle className="text-sm">Numeric cohorts</CardTitle>
-        </CardHeader>
-        <CardContent className="p-4 pt-0">
-          <div className="max-h-[50vh] overflow-y-auto overscroll-contain rounded-lg border bg-muted/20 p-3 sm:max-h-[45vh]">
-            {isPartialRollout ? (
-              <div className="grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-8">
-                {rolloutCohorts.map((cohortValue) => (
-                  <Badge
-                    className="justify-center font-mono tabular-nums"
-                    key={cohortValue}
-                    variant="outline"
-                  >
-                    {cohortValue}
-                  </Badge>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                {isFullRollout
-                  ? `All ${NUMERIC_COHORT_SIZE} numeric cohorts are included.`
-                  : "No numeric cohorts are included."}
-              </p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
       {hasTargetCohorts ? (
         <Card>
           <CardHeader className="p-4 pb-3">
@@ -134,6 +109,38 @@ export function RolloutCohortsDialog({
           </CardContent>
         </Card>
       ) : null}
+
+      <Card>
+        <CardHeader className="p-4 pb-3">
+          <CardTitle className="text-sm">Numeric cohorts</CardTitle>
+        </CardHeader>
+        <CardContent className="p-4 pt-0">
+          <div className="max-h-[50vh] overflow-y-auto overscroll-contain rounded-lg border bg-muted/20 p-3 sm:max-h-[45vh]">
+            {rolloutCohorts.length > 0 ? (
+              <div
+                aria-label="Included numeric cohorts"
+                className="grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-8"
+                role="list"
+              >
+                {rolloutCohorts.map((cohortValue) => (
+                  <Badge
+                    className="justify-center font-mono tabular-nums"
+                    key={cohortValue}
+                    role="listitem"
+                    variant="outline"
+                  >
+                    {cohortValue}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No numeric cohorts are included.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -241,7 +241,7 @@ describe("ReleaseEditorSheet", () => {
     fireEvent.click(previewButton);
 
     expect(
-      screen.getByText("All 1000 numeric cohorts are included."),
+      screen.getByRole("list", { name: "Included numeric cohorts" }),
     ).toBeDefined();
   });
 

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -156,6 +156,9 @@ describe("ReleaseEditorSheet", () => {
     ).toBeDefined();
     expect(screen.getByText("Activity · 30 days")).toBeDefined();
     expect(screen.getByText("Metadata")).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: "Delivery settings" }),
+    ).toBeDefined();
     expect(screen.getAllByText("Target app version").length).toBeGreaterThan(0);
     expect(screen.getByText("Bundle hash")).toBeDefined();
     expect(
@@ -169,14 +172,17 @@ describe("ReleaseEditorSheet", () => {
     expect(
       screen.queryByText("Manage delivery settings and actions"),
     ).toBeNull();
+    expect(container.textContent!.indexOf("Activity · 30 days")).toBeLessThan(
+      container.textContent!.indexOf("Delivery settings"),
+    );
+    expect(container.textContent!.indexOf("Delivery settings")).toBeLessThan(
+      container.textContent!.indexOf("Message"),
+    );
     expect(container.textContent!.indexOf("Message")).toBeLessThan(
       container.textContent!.indexOf("Actions"),
     );
     expect(container.textContent!.indexOf("Actions")).toBeLessThan(
       container.textContent!.indexOf("Metadata"),
-    );
-    expect(container.textContent!.indexOf("Metadata")).toBeLessThan(
-      container.textContent!.indexOf("Activity · 30 days"),
     );
     expect(screen.queryByRole("heading", { name: "Delivery" })).toBeNull();
 

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -248,7 +248,7 @@ describe("ReleaseEditorSheet", () => {
     ).toBeDefined();
   });
 
-  it("keeps the v0 move model and accepts a brand-new target channel", async () => {
+  it("keeps the v0 move model and selects the target from a listbox", async () => {
     render(
       <ReleaseEditorSheet
         channels={[
@@ -276,9 +276,17 @@ describe("ReleaseEditorSheet", () => {
       ),
     ).toBeDefined();
 
-    fireEvent.change(within(dialog).getByLabelText("Target Channel"), {
-      target: { value: "nightly" },
-    });
+    fireEvent.click(
+      within(dialog).getByRole("combobox", { name: "Target Channel" }),
+    );
+    const betaOption = screen.getByRole("option", { name: "beta" });
+    fireEvent.pointerDown(betaOption);
+    fireEvent.click(betaOption);
+    expect(
+      within(dialog).queryByRole("button", {
+        name: "Use beta as target channel",
+      }),
+    ).toBeNull();
     fireEvent.click(within(dialog).getByRole("button", { name: "Move" }));
 
     await waitFor(() => {
@@ -286,7 +294,7 @@ describe("ReleaseEditorSheet", () => {
         action: "move",
         expectedRevision: 2,
         releaseId: "release-1",
-        targetChannel: "nightly",
+        targetChannel: "beta",
       });
     });
   });
@@ -321,10 +329,11 @@ describe("ReleaseEditorSheet", () => {
       ),
     ).toBeDefined();
     fireEvent.click(
-      within(dialog).getByRole("button", {
-        name: "Use beta as target channel",
-      }),
+      within(dialog).getByRole("combobox", { name: "Target Channel" }),
     );
+    const betaOption = screen.getByRole("option", { name: "beta" });
+    fireEvent.pointerDown(betaOption);
+    fireEvent.click(betaOption);
     fireEvent.click(within(dialog).getByRole("button", { name: "Copy" }));
 
     await waitFor(() => {

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ReleaseEditorSheet } from "./ReleaseEditorSheet";
 
 const preflight = vi.fn();
+const promote = vi.fn();
 const update = vi.fn();
 
 const release = {
@@ -90,7 +91,7 @@ vi.mock("@/lib/api", () => ({
   }),
   usePromoteReleaseMutation: () => ({
     isPending: false,
-    mutateAsync: vi.fn(),
+    mutateAsync: promote,
   }),
   useReleaseCatalogDiagnosticsQuery: () => ({ data: null }),
   useReleaseQuery: () => ({ data: releaseValue, isError: false }),
@@ -104,6 +105,8 @@ describe("ReleaseEditorSheet", () => {
     releaseValue = release;
     preflight.mockReset();
     preflight.mockResolvedValue({});
+    promote.mockReset();
+    promote.mockResolvedValue({});
     update.mockReset();
     update.mockResolvedValue({});
   });
@@ -243,6 +246,95 @@ describe("ReleaseEditorSheet", () => {
     expect(
       screen.getByRole("list", { name: "Included numeric cohorts" }),
     ).toBeDefined();
+  });
+
+  it("keeps the v0 move model and accepts a brand-new target channel", async () => {
+    render(
+      <ReleaseEditorSheet
+        channels={[
+          { id: "channel-1", name: "production" },
+          { id: "channel-2", name: "beta" },
+        ]}
+        onOpenChange={vi.fn()}
+        open
+        releaseId={release.id}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote to channel" }));
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Promote to Channel",
+    });
+    expect(
+      within(dialog).getByRole("combobox", { name: "Action" }).textContent,
+    ).toContain("Move bundle");
+    expect(within(dialog).queryByText("Current channel")).toBeNull();
+    expect(
+      within(dialog).getByText(
+        "Move this Bundle to the target channel. Devices in the current channel may fall back to an earlier Bundle.",
+      ),
+    ).toBeDefined();
+
+    fireEvent.change(within(dialog).getByLabelText("Target Channel"), {
+      target: { value: "nightly" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Move" }));
+
+    await waitFor(() => {
+      expect(promote).toHaveBeenCalledWith({
+        action: "move",
+        expectedRevision: 2,
+        releaseId: "release-1",
+        targetChannel: "nightly",
+      });
+    });
+  });
+
+  it("maps the v0 copy action to keeping the source Release enabled", async () => {
+    render(
+      <ReleaseEditorSheet
+        channels={[
+          { id: "channel-1", name: "production" },
+          { id: "channel-2", name: "beta" },
+        ]}
+        onOpenChange={vi.fn()}
+        open
+        releaseId={release.id}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote to channel" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Action" }));
+    const copyOption = await screen.findByRole("option", {
+      name: "Copy bundle",
+    });
+    fireEvent.pointerDown(copyOption);
+    fireEvent.click(copyOption);
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Promote to Channel",
+    });
+    expect(
+      within(dialog).getByText(
+        "Make this Bundle available in the target channel and keep it in the current channel.",
+      ),
+    ).toBeDefined();
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "Use beta as target channel",
+      }),
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(promote).toHaveBeenCalledWith({
+        action: "copy",
+        expectedRevision: 2,
+        releaseId: "release-1",
+        targetChannel: "beta",
+      });
+    });
   });
 
   it("uses disabling as the only rollback action", async () => {

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -53,6 +53,7 @@ import {
   InputGroupInput,
   InputGroupText,
 } from "@/components/ui/input-group";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -93,8 +94,8 @@ interface Draft {
 }
 
 const promoteActionItems = [
-  { label: "Keep source enabled", value: "copy" },
-  { label: "Disable source after promoting", value: "move" },
+  { label: "Move bundle", value: "move" },
+  { label: "Copy bundle", value: "copy" },
 ];
 
 const draftFromRelease = (release: ReleaseRow): Draft => ({
@@ -228,7 +229,7 @@ export function ReleaseEditorSheet({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showPromote, setShowPromote] = useState(false);
   const [targetChannel, setTargetChannel] = useState("");
-  const [promoteAction, setPromoteAction] = useState<"copy" | "move">("copy");
+  const [promoteAction, setPromoteAction] = useState<"copy" | "move">("move");
 
   useEffect(() => {
     setDraft(release ? draftFromRelease(release) : null);
@@ -309,16 +310,23 @@ export function ReleaseEditorSheet({
   const availableChannels = channels.filter(
     (channel) => channel.id !== release?.channel_id,
   );
-  const availableChannelItems = [
-    { label: "Select a channel", value: null },
-    ...availableChannels.map((channel) => ({
-      label: channel.name,
-      value: channel.name,
-    })),
-  ];
+  const normalizedTargetChannel = targetChannel.trim();
+  const isSameTargetChannel = normalizedTargetChannel === channelName;
+  const isCopyPromotion = promoteAction === "copy";
   const normalizedTargetAppVersion = draft
     ? normalizeRange(draft.targetAppVersion.trim())
     : null;
+
+  const resetPromoteDialog = () => {
+    setTargetChannel("");
+    setPromoteAction("move");
+  };
+
+  const handlePromoteOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && promote.isPending) return;
+    setShowPromote(nextOpen);
+    if (!nextOpen) resetPromoteDialog();
+  };
 
   return (
     <>
@@ -754,65 +762,101 @@ export function ReleaseEditorSheet({
         </AlertDialogContent>
       </AlertDialog>
 
-      <Dialog onOpenChange={setShowPromote} open={showPromote}>
-        <DialogContent>
+      <Dialog onOpenChange={handlePromoteOpenChange} open={showPromote}>
+        <DialogContent showCloseButton={!promote.isPending}>
           <DialogHeader>
-            <DialogTitle>Promote to channel</DialogTitle>
+            <DialogTitle>Promote to Channel</DialogTitle>
             <DialogDescription>
-              Reuse this Bundle in another channel without copying its file.
+              Choose how to promote this Bundle, then select the target channel.
             </DialogDescription>
           </DialogHeader>
-          <FieldGroup>
-            <Field>
-              <FieldLabel>Target channel</FieldLabel>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="promote-action">Action</Label>
               <Select
-                items={availableChannelItems}
-                onValueChange={(value) => setTargetChannel(value ?? "")}
-                value={targetChannel || null}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {availableChannels.map((channel) => (
-                      <SelectItem key={channel.id} value={channel.name}>
-                        {channel.name}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field>
-              <FieldLabel>Current channel</FieldLabel>
-              <Select
+                disabled={promote.isPending}
                 items={promoteActionItems}
                 onValueChange={(value) =>
                   setPromoteAction(value as "copy" | "move")
                 }
                 value={promoteAction}
               >
-                <SelectTrigger>
-                  <SelectValue />
+                <SelectTrigger className="w-full" id="promote-action">
+                  <SelectValue placeholder="Select an action" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    <SelectItem value="copy">Keep source enabled</SelectItem>
-                    <SelectItem value="move">
-                      Disable source after promoting
-                    </SelectItem>
+                    <SelectItem value="move">Move bundle</SelectItem>
+                    <SelectItem value="copy">Copy bundle</SelectItem>
                   </SelectGroup>
                 </SelectContent>
               </Select>
-            </Field>
-          </FieldGroup>
+              <p className="text-xs text-muted-foreground">
+                {isCopyPromotion
+                  ? "Make this Bundle available in the target channel and keep it in the current channel."
+                  : "Move this Bundle to the target channel. Devices in the current channel may fall back to an earlier Bundle."}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="target-channel">Target Channel</Label>
+              <Input
+                aria-invalid={isSameTargetChannel}
+                disabled={promote.isPending}
+                id="target-channel"
+                list="available-channels"
+                onChange={(event) => setTargetChannel(event.target.value)}
+                placeholder="Enter a channel name"
+                value={targetChannel}
+              />
+              <datalist id="available-channels">
+                {availableChannels.map((channel) => (
+                  <option key={channel.id} value={channel.name} />
+                ))}
+              </datalist>
+              {availableChannels.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {availableChannels.map((channel) => (
+                    <Button
+                      aria-label={`Use ${channel.name} as target channel`}
+                      disabled={promote.isPending}
+                      key={channel.id}
+                      onClick={() => setTargetChannel(channel.name)}
+                      size="xs"
+                      type="button"
+                      variant="outline"
+                    >
+                      {channel.name}
+                    </Button>
+                  ))}
+                </div>
+              ) : null}
+              <p className="text-xs text-muted-foreground">
+                Choose an existing channel or enter a new one.
+              </p>
+              {isSameTargetChannel ? (
+                <p className="text-xs text-destructive" role="alert">
+                  Target channel must be different from the current channel.
+                </p>
+              ) : null}
+            </div>
+          </div>
+
           <DialogFooter>
-            <Button onClick={() => setShowPromote(false)} variant="outline">
+            <Button
+              disabled={promote.isPending}
+              onClick={() => handlePromoteOpenChange(false)}
+              variant="outline"
+            >
               Cancel
             </Button>
             <Button
-              disabled={!targetChannel || promote.isPending}
+              disabled={
+                !normalizedTargetChannel ||
+                isSameTargetChannel ||
+                promote.isPending
+              }
               onClick={async () => {
                 if (!release) return;
                 try {
@@ -820,21 +864,33 @@ export function ReleaseEditorSheet({
                     action: promoteAction,
                     expectedRevision: release.revision,
                     releaseId: release.id,
-                    targetChannel,
+                    targetChannel: normalizedTargetChannel,
                   });
-                  setShowPromote(false);
-                  toast.success(`Bundle promoted to ${targetChannel}`);
+                  handlePromoteOpenChange(false);
+                  toast.success(
+                    isCopyPromotion
+                      ? `Bundle copied to ${normalizedTargetChannel}`
+                      : `Bundle moved to ${normalizedTargetChannel}`,
+                    release.bundle_id
+                      ? { description: `bundleId: ${release.bundle_id}` }
+                      : undefined,
+                  );
                 } catch (caught) {
-                  setError(
+                  toast.error(
                     caught instanceof Error
                       ? caught.message
                       : "Bundle could not be promoted.",
                   );
-                  setShowPromote(false);
                 }
               }}
             >
-              {promote.isPending ? "Promoting…" : "Promote"}
+              {promote.isPending
+                ? isCopyPromotion
+                  ? "Copying…"
+                  : "Moving…"
+                : isCopyPromotion
+                  ? "Copy"
+                  : "Move"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -310,8 +310,11 @@ export function ReleaseEditorSheet({
   const availableChannels = channels.filter(
     (channel) => channel.id !== release?.channel_id,
   );
+  const availableChannelItems = availableChannels.map((channel) => ({
+    label: channel.name,
+    value: channel.name,
+  }));
   const normalizedTargetChannel = targetChannel.trim();
-  const isSameTargetChannel = normalizedTargetChannel === channelName;
   const isCopyPromotion = promoteAction === "copy";
   const normalizedTargetAppVersion = draft
     ? normalizeRange(draft.targetAppVersion.trim())
@@ -801,45 +804,25 @@ export function ReleaseEditorSheet({
 
             <div className="space-y-2">
               <Label htmlFor="target-channel">Target Channel</Label>
-              <Input
-                aria-invalid={isSameTargetChannel}
+              <Select
                 disabled={promote.isPending}
-                id="target-channel"
-                list="available-channels"
-                onChange={(event) => setTargetChannel(event.target.value)}
-                placeholder="Enter a channel name"
-                value={targetChannel}
-              />
-              <datalist id="available-channels">
-                {availableChannels.map((channel) => (
-                  <option key={channel.id} value={channel.name} />
-                ))}
-              </datalist>
-              {availableChannels.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {availableChannels.map((channel) => (
-                    <Button
-                      aria-label={`Use ${channel.name} as target channel`}
-                      disabled={promote.isPending}
-                      key={channel.id}
-                      onClick={() => setTargetChannel(channel.name)}
-                      size="xs"
-                      type="button"
-                      variant="outline"
-                    >
-                      {channel.name}
-                    </Button>
-                  ))}
-                </div>
-              ) : null}
-              <p className="text-xs text-muted-foreground">
-                Choose an existing channel or enter a new one.
-              </p>
-              {isSameTargetChannel ? (
-                <p className="text-xs text-destructive" role="alert">
-                  Target channel must be different from the current channel.
-                </p>
-              ) : null}
+                items={availableChannelItems}
+                onValueChange={(value) => setTargetChannel(value ?? "")}
+                value={targetChannel || null}
+              >
+                <SelectTrigger className="w-full" id="target-channel">
+                  <SelectValue placeholder="Select a channel" />
+                </SelectTrigger>
+                <SelectContent className="max-h-64">
+                  <SelectGroup>
+                    {availableChannels.map((channel) => (
+                      <SelectItem key={channel.id} value={channel.name}>
+                        {channel.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
             </div>
           </div>
 
@@ -852,11 +835,7 @@ export function ReleaseEditorSheet({
               Cancel
             </Button>
             <Button
-              disabled={
-                !normalizedTargetChannel ||
-                isSameTargetChannel ||
-                promote.isPending
-              }
+              disabled={!normalizedTargetChannel || promote.isPending}
               onClick={async () => {
                 if (!release) return;
                 try {

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -398,7 +398,20 @@ export function ReleaseEditorSheet({
 
             {release && draft ? (
               <div className="flex flex-col gap-6 px-4 pb-4 sm:px-6 sm:pb-6">
-                <section className="flex flex-col gap-6">
+                {release.bundle_id ? (
+                  <BundleAnalyticsSummary bundleId={release.bundle_id} />
+                ) : null}
+
+                <section
+                  aria-labelledby="delivery-settings-heading"
+                  className="flex flex-col gap-4"
+                >
+                  <h3
+                    className="text-sm font-medium"
+                    id="delivery-settings-heading"
+                  >
+                    Delivery settings
+                  </h3>
                   <FieldGroup className="gap-6">
                     <Field>
                       <FieldLabel htmlFor="release-message">Message</FieldLabel>
@@ -623,10 +636,6 @@ export function ReleaseEditorSheet({
                 ) : null}
                 {!release.bundle_id || !bundleQuery.isPending ? (
                   <BundleMetadata bundle={bundle} release={release} />
-                ) : null}
-
-                {release.bundle_id ? (
-                  <BundleAnalyticsSummary bundleId={release.bundle_id} />
                 ) : null}
 
                 <details className="rounded-lg border bg-muted/10 p-4 text-xs">

--- a/packages/console/src/lib/analytics-rpc.spec.ts
+++ b/packages/console/src/lib/analytics-rpc.spec.ts
@@ -71,6 +71,7 @@ const createRuntime = () => ({
   appendBundleEvent: vi.fn(),
   getActiveInstallationOverview: vi.fn(),
   getBundleEventSummary: vi.fn(),
+  getBundleEventSummaries: vi.fn(),
   getBundleEventAnalytics: vi.fn(),
   getBundleEventOverview: vi.fn(),
   searchInstallations: vi.fn(),

--- a/packages/console/src/lib/api-rpc.ts
+++ b/packages/console/src/lib/api-rpc.ts
@@ -20,6 +20,7 @@ import {
 } from "./analytics-input";
 import { DEFAULT_PAGE_LIMIT } from "./constants";
 import { listReleases } from "./server/listReleases";
+import { getReleaseActivity30d } from "./server/releaseActivity";
 import { addReleaseReachability } from "./server/releaseReachability";
 
 type GetBundlesInput = {
@@ -77,7 +78,7 @@ export const getReleases = createServerFn({ method: "GET" })
   .inputValidator((input: GetReleasesInput | undefined) => input)
   .handler(async ({ data }) => {
     const { prepareConfig } = await import("./server/config.server");
-    const { config } = await prepareConfig();
+    const { config, hotUpdater } = await prepareConfig();
     const result = await listReleases(config.database.models.releases, {
       ...(data?.afterReleaseId === undefined
         ? {}
@@ -95,12 +96,22 @@ export const getReleases = createServerFn({ method: "GET" })
         : { targetAppVersion: data.targetAppVersion }),
       limit: data?.limit ?? DEFAULT_PAGE_LIMIT,
     });
-    return {
-      ...result,
-      data: await addReleaseReachability(
+    const [releases, activityByBundleId] = await Promise.all([
+      addReleaseReachability(
         config.database.models.releaseCatalogs,
         result.data,
       ),
+      getReleaseActivity30d(hotUpdater, result.data),
+    ]);
+    return {
+      ...result,
+      data: releases.map((release) => ({
+        ...release,
+        activity30d:
+          release.bundle_id === null
+            ? null
+            : (activityByBundleId.get(release.bundle_id) ?? null),
+      })),
     };
   });
 

--- a/packages/console/src/lib/api-rpc.ts
+++ b/packages/console/src/lib/api-rpc.ts
@@ -20,6 +20,7 @@ import {
 } from "./analytics-input";
 import { DEFAULT_PAGE_LIMIT } from "./constants";
 import { listReleases } from "./server/listReleases";
+import { addReleaseReachability } from "./server/releaseReachability";
 
 type GetBundlesInput = {
   platform?: "ios" | "android";
@@ -77,7 +78,7 @@ export const getReleases = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     const { prepareConfig } = await import("./server/config.server");
     const { config } = await prepareConfig();
-    return listReleases(config.database.models.releases, {
+    const result = await listReleases(config.database.models.releases, {
       ...(data?.afterReleaseId === undefined
         ? {}
         : { afterReleaseId: data.afterReleaseId }),
@@ -94,6 +95,13 @@ export const getReleases = createServerFn({ method: "GET" })
         : { targetAppVersion: data.targetAppVersion }),
       limit: data?.limit ?? DEFAULT_PAGE_LIMIT,
     });
+    return {
+      ...result,
+      data: await addReleaseReachability(
+        config.database.models.releaseCatalogs,
+        result.data,
+      ),
+    };
   });
 
 export const getRelease = createServerFn({ method: "GET" })

--- a/packages/console/src/lib/server/releaseActivity.spec.ts
+++ b/packages/console/src/lib/server/releaseActivity.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import type { ReleaseRow } from "@hot-updater/plugin-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getReleaseActivity30d } from "./releaseActivity";
+
+const createRelease = (id: string, bundleId: string | null): ReleaseRow =>
+  ({ id, bundle_id: bundleId }) as ReleaseRow;
+
+describe("getReleaseActivity30d", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("requests one 30-day summary for the distinct Bundles on the page", async () => {
+    const getBundleEventSummaries = vi.fn().mockResolvedValue([
+      { bundleId: "bundle-a", installed: 2, recovered: 1 },
+      { bundleId: "bundle-b", installed: 3, recovered: 0 },
+    ]);
+
+    const result = await getReleaseActivity30d({ getBundleEventSummaries }, [
+      createRelease("release-a", "bundle-a"),
+      createRelease("release-a-promoted", "bundle-a"),
+      createRelease("release-b", "bundle-b"),
+      createRelease("release-built-in", null),
+    ]);
+
+    expect(getBundleEventSummaries).toHaveBeenCalledOnce();
+    expect(getBundleEventSummaries).toHaveBeenCalledWith(
+      ["bundle-a", "bundle-b"],
+      "30d",
+    );
+    expect(result.get("bundle-a")).toEqual({
+      bundleId: "bundle-a",
+      installed: 2,
+      recovered: 1,
+    });
+  });
+
+  it("keeps the Release list available when Analytics cannot be read", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const getBundleEventSummaries = vi
+      .fn()
+      .mockRejectedValue(new Error("scan limit exceeded"));
+
+    const result = await getReleaseActivity30d({ getBundleEventSummaries }, [
+      createRelease("release-a", "bundle-a"),
+    ]);
+
+    expect(result.size).toBe(0);
+  });
+});

--- a/packages/console/src/lib/server/releaseActivity.ts
+++ b/packages/console/src/lib/server/releaseActivity.ts
@@ -1,0 +1,27 @@
+import type { ReleaseRow } from "@hot-updater/plugin-core";
+import type {
+  AnalyticsProvider,
+  BundleEventSummaryByBundle,
+} from "@hot-updater/server";
+
+export async function getReleaseActivity30d(
+  analytics: Pick<AnalyticsProvider, "getBundleEventSummaries"> | null,
+  releases: readonly ReleaseRow[],
+): Promise<ReadonlyMap<string, BundleEventSummaryByBundle>> {
+  const bundleIds = [
+    ...new Set(
+      releases.flatMap(({ bundle_id }) =>
+        bundle_id === null ? [] : [bundle_id],
+      ),
+    ),
+  ];
+  if (analytics === null || bundleIds.length === 0) return new Map();
+
+  try {
+    const summaries = await analytics.getBundleEventSummaries(bundleIds, "30d");
+    return new Map(summaries.map((summary) => [summary.bundleId, summary]));
+  } catch (error) {
+    console.error("Error during Release list activity retrieval:", error);
+    return new Map();
+  }
+}

--- a/packages/console/src/lib/server/releaseReachability.spec.ts
+++ b/packages/console/src/lib/server/releaseReachability.spec.ts
@@ -1,0 +1,150 @@
+import type { Release } from "@hot-updater/core";
+import type { ReleaseCatalogRow, ReleaseRow } from "@hot-updater/plugin-core";
+import { compileReleaseCatalog } from "@hot-updater/plugin-core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  addReleaseReachability,
+  collectCurrentlyReachableReleaseIds,
+} from "./releaseReachability";
+
+const releaseId = (sequence: number): string =>
+  `00000000-0000-7000-8000-${String(sequence).padStart(12, "0")}`;
+
+const bundleId = (sequence: number): string =>
+  `00000000-0000-7001-8000-${String(sequence).padStart(12, "0")}`;
+
+const release = (
+  sequence: number,
+  overrides: Partial<Release> = {},
+): Release => ({
+  bundleId: bundleId(sequence),
+  channelId: "production",
+  createdAtMs: sequence,
+  enabled: true,
+  fingerprintHash: null,
+  id: releaseId(sequence),
+  kind: "BUNDLE",
+  message: null,
+  operation: "DEPLOY",
+  platform: "ios",
+  revision: 1,
+  rolloutCohortCount: 1_000,
+  shouldForceUpdate: false,
+  sourceReleaseId: null,
+  strategy: "APP_VERSION",
+  targetAppVersion: "1.x",
+  targetCohorts: [],
+  updatedAtMs: sequence,
+  ...overrides,
+});
+
+const releaseRow = (
+  value: Release,
+  scopeKey = "scope-production",
+): ReleaseRow => ({
+  bundle_id: value.bundleId,
+  channel_id: value.channelId,
+  created_at_ms: value.createdAtMs,
+  enabled: value.enabled,
+  fingerprint_hash: value.fingerprintHash,
+  id: value.id,
+  kind: value.kind,
+  message: value.message,
+  operation: value.operation,
+  platform: value.platform,
+  revision: value.revision,
+  rollout_cohort_count: value.rolloutCohortCount,
+  scope_key: scopeKey,
+  should_force_update: value.shouldForceUpdate,
+  source_release_id: value.sourceReleaseId,
+  strategy: value.strategy,
+  target_app_version: value.targetAppVersion,
+  target_cohorts: value.targetCohorts,
+  updated_at_ms: value.updatedAtMs,
+});
+
+const catalogRow = (
+  payload: string,
+  scopeKey = "scope-production",
+): ReleaseCatalogRow => ({
+  authority_id: "authority",
+  byte_size: payload.length,
+  catalog_hash: "sha256:test",
+  channel_id: "production",
+  channel_key: "production",
+  fingerprint_hash: null,
+  generation: 1,
+  is_tombstone: false,
+  payload,
+  platform: "ios",
+  scope_key: scopeKey,
+  strategy: "APP_VERSION",
+  updated_at_ms: 1,
+});
+
+describe("Release reachability", () => {
+  it("makes the previous Release reachable after the latest one is disabled", async () => {
+    const latest = release(2);
+    const previous = release(1);
+    const before = await compileReleaseCatalog({
+      releases: [latest, previous],
+      strategy: "APP_VERSION",
+    });
+    const after = await compileReleaseCatalog({
+      releases: [{ ...latest, enabled: false }, previous],
+      strategy: "APP_VERSION",
+    });
+
+    expect([...collectCurrentlyReachableReleaseIds(before.payload)]).toEqual([
+      latest.id,
+    ]);
+    expect([...collectCurrentlyReachableReleaseIds(after.payload)]).toEqual([
+      previous.id,
+    ]);
+  });
+
+  it("keeps Releases reachable when different cohorts can select them first", async () => {
+    const qaOnly = release(2, {
+      rolloutCohortCount: 0,
+      targetCohorts: ["qa"],
+    });
+    const general = release(1);
+    const compilation = await compileReleaseCatalog({
+      releases: [qaOnly, general],
+      strategy: "APP_VERSION",
+    });
+
+    expect(collectCurrentlyReachableReleaseIds(compilation.payload)).toEqual(
+      new Set([qaOnly.id, general.id]),
+    );
+  });
+
+  it("adds a derived flag while loading each page scope only once", async () => {
+    const latest = release(2);
+    const previous = release(1);
+    const compilation = await compileReleaseCatalog({
+      releases: [latest, previous],
+      strategy: "APP_VERSION",
+    });
+    const row = catalogRow(compilation.canonicalPayload);
+    const findByScopeKey = vi.fn(async () => row);
+
+    const result = await addReleaseReachability({ findByScopeKey }, [
+      releaseRow(latest),
+      releaseRow(previous),
+    ]);
+
+    expect(
+      result.map(({ id, currentlyUnreachable }) => ({
+        currentlyUnreachable,
+        id,
+      })),
+    ).toEqual([
+      { currentlyUnreachable: false, id: latest.id },
+      { currentlyUnreachable: true, id: previous.id },
+    ]);
+    expect(findByScopeKey).toHaveBeenCalledTimes(1);
+    expect(findByScopeKey).toHaveBeenCalledWith("scope-production");
+  });
+});

--- a/packages/console/src/lib/server/releaseReachability.ts
+++ b/packages/console/src/lib/server/releaseReachability.ts
@@ -1,0 +1,90 @@
+import {
+  isReleaseEligibleForCohort,
+  NUMERIC_COHORT_SIZE,
+} from "@hot-updater/core";
+import type {
+  CompiledReleaseCatalog,
+  ReleaseCatalogModel,
+  ReleaseRow,
+} from "@hot-updater/plugin-core";
+
+export type ReleaseListRow = ReleaseRow & {
+  readonly currentlyUnreachable: boolean;
+};
+
+const NON_TARGETED_COHORT = "release-catalog-non-targeted-cohort";
+
+function collectReachableFromIndexes(
+  catalog: CompiledReleaseCatalog,
+  indexes: readonly number[],
+  reachableReleaseIds: Set<string>,
+) {
+  const descriptors = indexes.flatMap((index) => {
+    const descriptor = catalog.releaseDescriptors[index];
+    return descriptor === undefined ? [] : [descriptor];
+  });
+  const cohorts = new Set<string | undefined>([
+    undefined,
+    ...Array.from({ length: NUMERIC_COHORT_SIZE }, (_, index) =>
+      String(index + 1),
+    ),
+    ...descriptors.flatMap(({ targetCohorts }) => targetCohorts),
+    NON_TARGETED_COHORT,
+  ]);
+
+  for (const cohort of cohorts) {
+    const selected = descriptors.find(
+      (descriptor) =>
+        descriptor.kind === "BUNDLE" &&
+        descriptor.bundleId !== null &&
+        isReleaseEligibleForCohort(descriptor, cohort),
+    );
+    if (selected !== undefined) {
+      reachableReleaseIds.add(selected.releaseId);
+    }
+  }
+}
+
+export function collectCurrentlyReachableReleaseIds(
+  catalog: CompiledReleaseCatalog,
+): ReadonlySet<string> {
+  const reachableReleaseIds = new Set<string>();
+  const indexGroups =
+    catalog.strategy === "APP_VERSION"
+      ? catalog.segments.map(({ releaseIndexes }) => releaseIndexes)
+      : [catalog.releaseIndexes];
+
+  for (const indexes of indexGroups) {
+    collectReachableFromIndexes(catalog, indexes, reachableReleaseIds);
+  }
+
+  return reachableReleaseIds;
+}
+
+export async function addReleaseReachability(
+  releaseCatalogs: Pick<ReleaseCatalogModel, "findByScopeKey">,
+  releases: readonly ReleaseRow[],
+): Promise<readonly ReleaseListRow[]> {
+  const scopeKeys = [...new Set(releases.map(({ scope_key }) => scope_key))];
+  const reachableByScope = new Map(
+    await Promise.all(
+      scopeKeys.map(async (scopeKey) => {
+        const row = await releaseCatalogs.findByScopeKey(scopeKey);
+        const reachableReleaseIds =
+          row === null
+            ? new Set<string>()
+            : collectCurrentlyReachableReleaseIds(
+                JSON.parse(row.payload) as CompiledReleaseCatalog,
+              );
+        return [scopeKey, reachableReleaseIds] as const;
+      }),
+    ),
+  );
+
+  return releases.map((release) => ({
+    ...release,
+    currentlyUnreachable: !reachableByScope
+      .get(release.scope_key)
+      ?.has(release.id),
+  }));
+}

--- a/packages/console/src/lib/server/releaseReachability.ts
+++ b/packages/console/src/lib/server/releaseReachability.ts
@@ -7,9 +7,14 @@ import type {
   ReleaseCatalogModel,
   ReleaseRow,
 } from "@hot-updater/plugin-core";
+import type { BundleEventSummary } from "@hot-updater/server";
 
-export type ReleaseListRow = ReleaseRow & {
+export type ReleaseReachabilityRow = ReleaseRow & {
   readonly currentlyUnreachable: boolean;
+};
+
+export type ReleaseListRow = ReleaseReachabilityRow & {
+  readonly activity30d: BundleEventSummary | null;
 };
 
 const NON_TARGETED_COHORT = "release-catalog-non-targeted-cohort";
@@ -64,7 +69,7 @@ export function collectCurrentlyReachableReleaseIds(
 export async function addReleaseReachability(
   releaseCatalogs: Pick<ReleaseCatalogModel, "findByScopeKey">,
   releases: readonly ReleaseRow[],
-): Promise<readonly ReleaseListRow[]> {
+): Promise<readonly ReleaseReachabilityRow[]> {
   const scopeKeys = [...new Set(releases.map(({ scope_key }) => scope_key))];
   const reachableByScope = new Map(
     await Promise.all(

--- a/packages/console/src/lib/server/runtime.server.spec.ts
+++ b/packages/console/src/lib/server/runtime.server.spec.ts
@@ -53,6 +53,7 @@ const createRuntime = () => ({
   appendBundleEvent: vi.fn(),
   getActiveInstallationOverview: vi.fn(),
   getBundleEventSummary: vi.fn(),
+  getBundleEventSummaries: vi.fn(),
   getBundleEventAnalytics: vi.fn(),
   getBundleEventOverview: vi.fn(),
   searchInstallations: vi.fn(),

--- a/packages/console/src/lib/server/runtime.server.ts
+++ b/packages/console/src/lib/server/runtime.server.ts
@@ -68,6 +68,7 @@ export function createClientAccessKeyStore(config: {
 const providerMethods = [
   "appendBundleEvent",
   "getBundleEventSummary",
+  "getBundleEventSummaries",
   "getBundleEventAnalytics",
   "getBundleEventOverview",
   "getActiveInstallationOverview",

--- a/packages/console/src/routes/-bundles.spec.tsx
+++ b/packages/console/src/routes/-bundles.spec.tsx
@@ -71,6 +71,7 @@ const release = vi.hoisted(
       target_cohorts: [],
       updated_at_ms: Date.UTC(2026, 6, 18),
       currentlyUnreachable: false,
+      activity30d: { installed: 1, recovered: 0 },
     }) as ReleaseRow & { currentlyUnreachable: boolean },
 );
 const baseBundle = {
@@ -178,6 +179,13 @@ describe("BundlesPage", () => {
     expect(within(row).getByText("Enabled")).toBeDefined();
     expect(within(row).getByText("Optional")).toBeDefined();
     expect(within(row).getByText("100.0%").className).toContain("bg-primary");
+    const movement = within(row).getByRole("group", {
+      name: "Bundle movement over 30 days, distinct installations",
+    });
+    expect(within(movement).getByText("Applied")).toBeDefined();
+    expect(within(movement).getByText("1")).toBeDefined();
+    expect(within(movement).getByText("Recovered")).toBeDefined();
+    expect(within(movement).getByText("0")).toBeDefined();
     expect(within(row).queryByText("DEPLOY")).toBeNull();
     expect(within(row).queryByText("rev 1")).toBeNull();
   });
@@ -192,8 +200,9 @@ describe("BundlesPage", () => {
     const state = within(row).getByText("Unreachable");
 
     expect(row.className).toContain("bg-muted/35");
-    expect(row.className).toContain("opacity-70");
-    expect(row.className).toContain("hover:opacity-90");
+    expect(row.className).toContain("saturate-50");
+    expect(row.className).toContain("hover:saturate-100");
+    expect(row.className).toContain("motion-reduce:transition-none");
     expect(state.getAttribute("title")).toBe(
       "No catalog segment or cohort selects this release first with the current delivery settings.",
     );

--- a/packages/console/src/routes/-bundles.spec.tsx
+++ b/packages/console/src/routes/-bundles.spec.tsx
@@ -70,7 +70,8 @@ const release = vi.hoisted(
       target_app_version: "1.2.x",
       target_cohorts: [],
       updated_at_ms: Date.UTC(2026, 6, 18),
-    }) as ReleaseRow,
+      currentlyUnreachable: false,
+    }) as ReleaseRow & { currentlyUnreachable: boolean },
 );
 
 vi.mock("@/lib/api", () => ({
@@ -108,6 +109,7 @@ const BundlesPage = (Route as unknown as { readonly component: ComponentType })
 describe("BundlesPage", () => {
   beforeEach(() => {
     mocks.search.mockReturnValue({});
+    release.currentlyUnreachable = false;
   });
 
   afterEach(() => {
@@ -160,5 +162,20 @@ describe("BundlesPage", () => {
     expect(within(row).getByText("100.0%")).toBeDefined();
     expect(within(row).queryByText("DEPLOY")).toBeNull();
     expect(within(row).queryByText("rev 1")).toBeNull();
+  });
+
+  it("subdues a Release that no catalog path currently selects first", () => {
+    release.currentlyUnreachable = true;
+
+    render(<BundlesPage />);
+    const row = screen.getByRole("row", {
+      name: "Open bundle 019ff641-01eb-72ea-8a03-a28aef188d32",
+    });
+    const state = within(row).getByText("Unreachable");
+
+    expect(row.className).toContain("bg-muted/35");
+    expect(state.getAttribute("title")).toBe(
+      "No catalog segment or cohort selects this release first with the current delivery settings.",
+    );
   });
 });

--- a/packages/console/src/routes/-bundles.spec.tsx
+++ b/packages/console/src/routes/-bundles.spec.tsx
@@ -192,6 +192,8 @@ describe("BundlesPage", () => {
     const state = within(row).getByText("Unreachable");
 
     expect(row.className).toContain("bg-muted/35");
+    expect(row.className).toContain("opacity-70");
+    expect(row.className).toContain("hover:opacity-90");
     expect(state.getAttribute("title")).toBe(
       "No catalog segment or cohort selects this release first with the current delivery settings.",
     );

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -1,9 +1,10 @@
-import type { ChannelRow, ReleaseRow } from "@hot-updater/plugin-core";
+import type { ChannelRow } from "@hot-updater/plugin-core";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   AlertTriangle,
   ChevronLeft,
   ChevronRight,
+  CircleOff,
   Fingerprint,
   Filter,
   Package,
@@ -48,6 +49,8 @@ import {
   useChannelsQuery,
   useReleasesQuery,
 } from "@/lib/api";
+import type { ReleaseListRow } from "@/lib/server/releaseReachability";
+import { cn } from "@/lib/utils";
 
 import {
   type ReleaseSearch,
@@ -205,7 +208,7 @@ function BundleEntry({
   release,
 }: {
   onOpen: () => void;
-  release: ReleaseRow;
+  release: ReleaseListRow;
 }) {
   const bundleLabel = release.bundle_id
     ? `bundle ${release.bundle_id}`
@@ -238,6 +241,16 @@ function BundleEntry({
         <Badge className="shrink-0 font-normal" variant="secondary">
           {operationLabel}
         </Badge>
+      ) : null}
+      {release.currentlyUnreachable ? (
+        <span
+          aria-label="Currently unreachable. No catalog segment or cohort selects this release first."
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+          title="No catalog segment or cohort selects this release first with the current delivery settings."
+        >
+          <CircleOff className="size-3.5" />
+          Unreachable
+        </span>
       ) : null}
     </div>
   );
@@ -343,7 +356,10 @@ function BundlesPage() {
 
                     return (
                       <article
-                        className="flex flex-col gap-4 border-b p-4 last:border-b-0"
+                        className={cn(
+                          "flex flex-col gap-4 border-b p-4 last:border-b-0",
+                          release.currentlyUnreachable && "bg-muted/35",
+                        )}
                         key={release.id}
                       >
                         <div className="flex items-start justify-between gap-3">
@@ -461,7 +477,11 @@ function BundlesPage() {
                     : releases.map((release) => (
                         <TableRow
                           aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
-                          className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&>td]:py-3"
+                          className={cn(
+                            "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&>td]:py-3",
+                            release.currentlyUnreachable &&
+                              "bg-muted/35 hover:bg-muted/50",
+                          )}
                           data-state={
                             search.releaseId === release.id
                               ? "selected"

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -496,7 +496,8 @@ function BundlesPage() {
                         <article
                           className={cn(
                             "flex flex-col gap-4 border-b p-4 last:border-b-0",
-                            release.currentlyUnreachable && "bg-muted/35",
+                            release.currentlyUnreachable &&
+                              "bg-muted/35 opacity-70 transition-opacity focus-within:opacity-100",
                             isExpanded && "border-b-0 bg-primary/5",
                           )}
                         >
@@ -641,9 +642,9 @@ function BundlesPage() {
                             <TableRow
                               aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
                               className={cn(
-                                "cursor-pointer transition-colors hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3",
+                                "cursor-pointer transition-[background-color,opacity] hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3",
                                 release.currentlyUnreachable &&
-                                  "bg-muted/35 hover:bg-muted/50",
+                                  "bg-muted/35 opacity-70 hover:bg-muted/50 hover:opacity-90 focus-within:opacity-100",
                                 isExpanded && "bg-primary/5",
                               )}
                               data-state={

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -86,6 +86,46 @@ export const Route = createFileRoute("/")({
 const shortId = (id: string) =>
   id.length > 18 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
 
+function BundleMovementSummary({
+  summary,
+}: {
+  readonly summary: ReleaseListRow["activity30d"];
+}) {
+  if (summary === null) {
+    return (
+      <span
+        aria-label="30-day Bundle activity unavailable"
+        className="text-sm text-muted-foreground"
+        title="Analytics are unavailable for this Bundle."
+      >
+        —
+      </span>
+    );
+  }
+
+  return (
+    <div
+      aria-label="Bundle movement over 30 days, distinct installations"
+      className="flex min-w-[140px] items-baseline gap-3 whitespace-nowrap"
+      role="group"
+      title="Distinct installations over the last 30 days."
+    >
+      <span className="flex items-baseline gap-1.5">
+        <span className="text-xs text-muted-foreground">Applied</span>
+        <span className="text-sm font-medium tabular-nums">
+          {summary.installed}
+        </span>
+      </span>
+      <span className="flex items-baseline gap-1.5">
+        <span className="text-xs text-muted-foreground">Recovered</span>
+        <span className="text-sm font-medium tabular-nums">
+          {summary.recovered}
+        </span>
+      </span>
+    </div>
+  );
+}
+
 function BundleFilterToolbar({
   channels,
   onChange,
@@ -497,7 +537,7 @@ function BundlesPage() {
                           className={cn(
                             "flex flex-col gap-4 border-b p-4 last:border-b-0",
                             release.currentlyUnreachable &&
-                              "bg-muted/35 opacity-70 transition-opacity focus-within:opacity-100",
+                              "bg-muted/35 saturate-50 transition-[background-color,filter] focus-within:saturate-100 motion-reduce:transition-none",
                             isExpanded && "border-b-0 bg-primary/5",
                           )}
                         >
@@ -556,6 +596,16 @@ function BundlesPage() {
                                         patchCount === 1 ? "patch" : "patches"
                                       }`
                                     : "—"}
+                              </dd>
+                            </div>
+                            <div className="col-span-2 rounded-md bg-muted/40 p-3">
+                              <dt className="text-muted-foreground">
+                                Activity · 30d
+                              </dt>
+                              <dd className="mt-1">
+                                <BundleMovementSummary
+                                  summary={release.activity30d}
+                                />
                               </dd>
                             </div>
                             <div className="col-span-2 flex flex-wrap items-center gap-2 rounded-md bg-muted/40 p-3">
@@ -620,6 +670,9 @@ function BundlesPage() {
                     <TableHead>Enabled</TableHead>
                     <TableHead>Force update</TableHead>
                     <TableHead>Rollout</TableHead>
+                    <TableHead title="Distinct installations over the last 30 days.">
+                      Activity · 30d
+                    </TableHead>
                     <TableHead>Message</TableHead>
                     <TableHead>Created</TableHead>
                   </TableRow>
@@ -628,7 +681,7 @@ function BundlesPage() {
                   {releasesQuery.isPending
                     ? Array.from({ length: 7 }, (_, index) => (
                         <TableRow key={index}>
-                          <TableCell colSpan={10}>
+                          <TableCell colSpan={11}>
                             <Skeleton className="h-8 w-full" />
                           </TableCell>
                         </TableRow>
@@ -642,9 +695,9 @@ function BundlesPage() {
                             <TableRow
                               aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
                               className={cn(
-                                "cursor-pointer transition-[background-color,opacity] hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3",
+                                "cursor-pointer transition-[background-color,filter] hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:transition-none data-[state=selected]:bg-muted/15 [&>td]:py-3",
                                 release.currentlyUnreachable &&
-                                  "bg-muted/35 opacity-70 hover:bg-muted/50 hover:opacity-90 focus-within:opacity-100",
+                                  "bg-muted/35 saturate-50 hover:bg-muted/50 hover:saturate-100 focus-within:saturate-100",
                                 isExpanded && "bg-primary/5",
                               )}
                               data-state={
@@ -785,6 +838,11 @@ function BundlesPage() {
                                   percentage={release.rollout_cohort_count / 10}
                                 />
                               </TableCell>
+                              <TableCell>
+                                <BundleMovementSummary
+                                  summary={release.activity30d}
+                                />
+                              </TableCell>
                               <TableCell
                                 className="text-sm text-muted-foreground"
                                 title={release.message ?? undefined}
@@ -806,7 +864,7 @@ function BundlesPage() {
                               <TableRow className="hover:bg-transparent">
                                 <TableCell
                                   className="border-t-0 p-0"
-                                  colSpan={10}
+                                  colSpan={11}
                                 >
                                   <ReleaseBundleChildrenPanel
                                     onDetailClick={openChildBundle}

--- a/packages/server/src/analytics/bounded/provider.spec.ts
+++ b/packages/server/src/analytics/bounded/provider.spec.ts
@@ -111,6 +111,52 @@ describe("createAnalyticsProvider", () => {
     });
   });
 
+  it("collects distinct 30-day movement for multiple Bundles in one scan", async () => {
+    const now = Date.UTC(2026, 7, 18, 12);
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const applied = eventRow("applied", now - 1_000, "install-applied");
+    const duplicateApplied = eventRow(
+      "applied-again",
+      now - 900,
+      "install-applied",
+    );
+    const recovered = {
+      ...eventRow("recovered", now - 800, "install-recovered"),
+      type: "RECOVERED" as const,
+      from_bundle_id: "new",
+      to_bundle_id: "fallback",
+      update_strategy: "fingerprint" as const,
+    } satisfies BundleEventPersistenceRow;
+    const other = {
+      ...eventRow("other", now - 700, "install-other"),
+      to_bundle_id: "other",
+    };
+    const outsideWindow = eventRow(
+      "outside-window",
+      now - 31 * 24 * 60 * 60 * 1_000,
+      "install-old",
+    );
+    const persistence = inMemoryPersistence([
+      outsideWindow,
+      applied,
+      duplicateApplied,
+      recovered,
+      other,
+    ]);
+    const scan = vi.spyOn(persistence, "scan");
+    const provider = createAnalyticsProvider(persistence);
+
+    await expect(
+      provider.getBundleEventSummaries(["new", "other", "missing"], "30d"),
+    ).resolves.toEqual([
+      { bundleId: "new", installed: 1, recovered: 1 },
+      { bundleId: "other", installed: 1, recovered: 0 },
+      { bundleId: "missing", installed: 0, recovered: 0 },
+    ]);
+    expect(scan).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
+  });
+
   it("counts an installation whose current bundle is reported by UNCHANGED", async () => {
     const unchanged: BundleEventPersistenceRow = {
       ...eventRow("unchanged", 1, "install-unchanged"),

--- a/packages/server/src/analytics/bounded/provider.ts
+++ b/packages/server/src/analytics/bounded/provider.ts
@@ -98,6 +98,43 @@ const getAnalyticsResult = async (
   };
 };
 
+const getAnalyticsSummaries = async (
+  persistence: AnalyticsPersistence,
+  bundleIds: readonly string[],
+  window: BundleEventAnalyticsWindow,
+) => {
+  const normalizedBundleIds = [...new Set(bundleIds)];
+  if (normalizedBundleIds.length === 0) return [];
+
+  const requestedBundleIds = new Set(normalizedBundleIds);
+  const installedByBundleId = new Map<string, Set<string>>();
+  const recoveredByBundleId = new Map<string, Set<string>>();
+  const rows = (
+    await materializeRowsForWindow(
+      { persistence, cutoffMs: Date.now() },
+      window,
+    )
+  ).filter(isTransitionEventRow);
+
+  for (const row of rows) {
+    const bundleId =
+      row.type === "UPDATE_APPLIED" ? row.to_bundle_id : row.from_bundle_id;
+    if (bundleId === null || !requestedBundleIds.has(bundleId)) continue;
+
+    const counts =
+      row.type === "UPDATE_APPLIED" ? installedByBundleId : recoveredByBundleId;
+    const installIds = counts.get(bundleId) ?? new Set<string>();
+    installIds.add(row.install_id);
+    counts.set(bundleId, installIds);
+  }
+
+  return normalizedBundleIds.map((bundleId) => ({
+    bundleId,
+    installed: installedByBundleId.get(bundleId)?.size ?? 0,
+    recovered: recoveredByBundleId.get(bundleId)?.size ?? 0,
+  }));
+};
+
 export const createAnalyticsProvider = (
   persistence: AnalyticsPersistence,
 ): AnalyticsProvider =>
@@ -119,6 +156,9 @@ export const createAnalyticsProvider = (
           rows.filter((row) => isRecoveredFromBundle(row, bundleId)),
         ),
       };
+    },
+    getBundleEventSummaries(bundleIds, window) {
+      return getAnalyticsSummaries(persistence, bundleIds, window);
     },
     getBundleEventAnalytics(bundleId, window, limit, offset) {
       return getAnalyticsResult(persistence, bundleId, window, limit, offset);

--- a/packages/server/src/analytics/domain.ts
+++ b/packages/server/src/analytics/domain.ts
@@ -40,6 +40,10 @@ export type BundleEventSummary = {
   readonly recovered: number;
 };
 
+export type BundleEventSummaryByBundle = BundleEventSummary & {
+  readonly bundleId: string;
+};
+
 export type BundleEventAnalyticsWindow = "24h" | "7d" | "30d" | "all";
 export type ActiveInstallationWindow = "24h" | "7d" | "30d";
 

--- a/packages/server/src/analytics/types.ts
+++ b/packages/server/src/analytics/types.ts
@@ -5,6 +5,7 @@ import type {
   BundleEventAnalyticsWindow,
   BundleEventOverview,
   BundleEventSummary,
+  BundleEventSummaryByBundle,
   CreateBundleEventRequest,
   InstallationHistoryRow,
   InstallationSearchRow,
@@ -16,6 +17,10 @@ export type AnalyticsProvider = {
   readonly maxMatchingRows: number;
   appendBundleEvent(input: CreateBundleEventRequest): Promise<void>;
   getBundleEventSummary(bundleId: string): Promise<BundleEventSummary>;
+  getBundleEventSummaries(
+    bundleIds: readonly string[],
+    window: BundleEventAnalyticsWindow,
+  ): Promise<readonly BundleEventSummaryByBundle[]>;
   getBundleEventAnalytics(
     bundleId: string,
     window: BundleEventAnalyticsWindow,


### PR DESCRIPTION
## Summary

- derive a currentlyUnreachable Console read-model field from the canonical Release Catalog
- evaluate the first normal selection across app-version segments and numeric/custom cohorts
- subdue unreachable Release rows and show one concise Unreachable state on desktop and mobile
- keep the database schema and createDatabasePlugin contract unchanged by reusing deduplicated scope-key reads

## Semantics

Unreachable means no current catalog segment or cohort selects the Release first. It is intentionally a policy-level signal, not an inventory of observed devices or shipped binary floors.

## Verification

- pnpm --filter @hot-updater/console... build
- pnpm --filter @hot-updater/console test:type
- pnpm --filter @hot-updater/console test (43 files, 184 tests)
- targeted oxfmt and oxlint checks
- git diff --check