### PR TITLE
fix(console): restore bundle lineage and cohort preview

### DIFF
--- a/.changeset/tidy-bundles-return.md
+++ b/.changeset/tidy-bundles-return.md
@@ -2,5 +2,6 @@
 "@hot-updater/console": patch
 ---
 
-Restore the compact main Console layout for the Bundles table and Bundle detail
-form while preserving Release analytics and cohort preview behavior.
+Restore the compact main Console layout and patch-lineage expansion for the
+Bundles table. Keep the Bundle detail form familiar while preserving Release
+analytics and an always-available cohort preview.

--- a/packages/console/src/components/features/bundles/BundleChildrenPanel.tsx
+++ b/packages/console/src/components/features/bundles/BundleChildrenPanel.tsx
@@ -1,0 +1,201 @@
+import type { Bundle } from "@hot-updater/plugin-core";
+import { ArrowRight } from "lucide-react";
+
+import { BundleIdDisplay } from "@/components/BundleIdDisplay";
+import { TimestampDisplay } from "@/components/TimestampDisplay";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+interface BundleChildrenPanelProps {
+  panelId: string;
+  bundle: Bundle;
+  bundles: Bundle[];
+  loading: boolean;
+  onDetailClick: (bundle: Bundle) => void;
+}
+
+export function BundleChildrenPanel({
+  panelId,
+  bundle,
+  bundles,
+  loading,
+  onDetailClick,
+}: BundleChildrenPanelProps) {
+  const isMobile = useIsMobile();
+
+  return (
+    <div
+      aria-live="polite"
+      className="border-t bg-muted/10 p-3 sm:p-4"
+      id={panelId}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-2 text-sm sm:items-center">
+            <span className="text-muted-foreground">Base bundle</span>
+            <BundleIdDisplay bundleId={bundle.id} fullOnMobile maxLength={18} />
+          </div>
+          <Badge variant="outline">
+            {bundles.length} {bundles.length === 1 ? "patch" : "patches"}
+          </Badge>
+        </div>
+
+        {loading ? (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : bundles.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            <div className="text-xs font-semibold uppercase text-muted-foreground/70">
+              Patch bundles from this base
+            </div>
+            {isMobile ? (
+              <div className="flex flex-col gap-2">
+                {bundles.map((childBundle) => (
+                  <div
+                    className="rounded-md border bg-background p-3"
+                    key={childBundle.id}
+                  >
+                    <div className="flex flex-col gap-3">
+                      <div className="space-y-1">
+                        <div className="text-[11px] font-medium uppercase text-muted-foreground/70">
+                          Patch Bundle
+                        </div>
+                        <BundleIdDisplay
+                          bundleId={childBundle.id}
+                          fullOnMobile
+                          maxLength={18}
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <div className="text-[11px] font-medium uppercase text-muted-foreground/70">
+                          Relation
+                        </div>
+                        <div className="flex flex-col items-start gap-1 text-sm">
+                          <BundleIdDisplay
+                            bundleId={bundle.id}
+                            fullOnMobile
+                            maxLength={12}
+                          />
+                          <ArrowRight className="size-4 rotate-90 text-muted-foreground" />
+                          <BundleIdDisplay
+                            bundleId={childBundle.id}
+                            fullOnMobile
+                            maxLength={12}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="space-y-1">
+                          <div className="text-[11px] font-medium uppercase text-muted-foreground/70">
+                            Artifact
+                          </div>
+                          <Badge variant="secondary">bsdiff</Badge>
+                        </div>
+                        <div className="space-y-1 text-right">
+                          <div className="text-[11px] font-medium uppercase text-muted-foreground/70">
+                            Created
+                          </div>
+                          <div className="text-xs tabular-nums text-foreground">
+                            <TimestampDisplay uuid={childBundle.id} />
+                          </div>
+                        </div>
+                      </div>
+                      <Button
+                        className="w-full"
+                        onClick={() => onDetailClick(childBundle)}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        Detail
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="overflow-x-auto rounded-md border bg-background">
+                <Table className="min-w-max">
+                  <TableHeader>
+                    <TableRow className="hover:bg-transparent">
+                      <TableHead>Patch Bundle</TableHead>
+                      <TableHead>Relation</TableHead>
+                      <TableHead>Artifact</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="w-24 text-right">Detail</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {bundles.map((childBundle) => (
+                      <TableRow key={childBundle.id}>
+                        <TableCell>
+                          <BundleIdDisplay
+                            bundleId={childBundle.id}
+                            fullOnMobile
+                            maxLength={18}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex min-w-[280px] flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2">
+                            <BundleIdDisplay
+                              bundleId={bundle.id}
+                              fullOnMobile
+                              maxLength={12}
+                            />
+                            <ArrowRight className="size-4 shrink-0 rotate-90 text-muted-foreground sm:rotate-0" />
+                            <BundleIdDisplay
+                              bundleId={childBundle.id}
+                              fullOnMobile
+                              maxLength={12}
+                            />
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">bsdiff</Badge>
+                        </TableCell>
+                        <TableCell className="tabular-nums">
+                          <TimestampDisplay uuid={childBundle.id} />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            onClick={() => onDetailClick(childBundle)}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            Detail
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="text-xs font-semibold uppercase text-muted-foreground/70">
+              Patch bundles from this base
+            </div>
+            <div className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+              No direct patch bundles.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.spec.tsx
@@ -42,21 +42,16 @@ describe("RolloutCohortsDialog", () => {
     expect(screen.getByText("qa-group")).toBeDefined();
   });
 
-  it("matches main by hiding the preview outside gradual rollout", () => {
-    const { rerender } = render(
+  it("summarizes a full rollout without rendering every cohort", () => {
+    render(
       <RolloutCohortsDialog releaseId="release-1" rolloutCohortCount={1_000} />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Preview cohorts" }),
-    ).toBeNull();
-
-    rerender(
-      <RolloutCohortsDialog releaseId="release-1" rolloutCohortCount={0} />,
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Preview cohorts" }));
 
     expect(
-      screen.queryByRole("button", { name: "Preview cohorts" }),
-    ).toBeNull();
+      screen.getByText("All 1000 numeric cohorts are included."),
+    ).toBeDefined();
+    expect(screen.queryAllByText(/^\d+$/)).toHaveLength(2);
   });
 });

--- a/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
+++ b/packages/console/src/components/features/bundles/RolloutCohortsDialog.tsx
@@ -42,22 +42,24 @@ export function RolloutCohortsDialog({
   const hasTargetCohorts = normalizedTargetCohorts.length > 0;
   const isPartialRollout =
     normalizedRolloutCount > 0 && normalizedRolloutCount < NUMERIC_COHORT_SIZE;
+  const isFullRollout = normalizedRolloutCount === NUMERIC_COHORT_SIZE;
   const isMobile = useIsMobile();
 
-  if (!isPartialRollout) {
-    return null;
-  }
-
-  const rolloutCohorts = Array.from(
-    { length: NUMERIC_COHORT_SIZE },
-    (_, index) => index + 1,
-  ).filter(
-    (cohortValue) =>
-      getNumericCohortRolloutPosition(releaseId, cohortValue) <
-      normalizedRolloutCount,
-  );
+  const rolloutCohorts = isPartialRollout
+    ? Array.from(
+        { length: NUMERIC_COHORT_SIZE },
+        (_, index) => index + 1,
+      ).filter(
+        (cohortValue) =>
+          getNumericCohortRolloutPosition(releaseId, cohortValue) <
+          normalizedRolloutCount,
+      )
+    : [];
   const rolloutPercentage = (normalizedRolloutCount / 10).toFixed(1);
-  const excludedCount = NUMERIC_COHORT_SIZE - rolloutCohorts.length;
+  const selectedCount = isFullRollout
+    ? NUMERIC_COHORT_SIZE
+    : rolloutCohorts.length;
+  const excludedCount = NUMERIC_COHORT_SIZE - selectedCount;
 
   const dialogBody = (
     <div className="flex flex-col gap-4">
@@ -66,7 +68,7 @@ export function RolloutCohortsDialog({
           <CardHeader className="p-4">
             <CardDescription>Selected cohorts</CardDescription>
             <CardTitle className="font-mono text-2xl tabular-nums">
-              {rolloutCohorts.length}
+              {selectedCount}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -86,17 +88,25 @@ export function RolloutCohortsDialog({
         </CardHeader>
         <CardContent className="p-4 pt-0">
           <div className="max-h-[50vh] overflow-y-auto overscroll-contain rounded-lg border bg-muted/20 p-3 sm:max-h-[45vh]">
-            <div className="grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-8">
-              {rolloutCohorts.map((cohortValue) => (
-                <Badge
-                  className="justify-center font-mono tabular-nums"
-                  key={cohortValue}
-                  variant="outline"
-                >
-                  {cohortValue}
-                </Badge>
-              ))}
-            </div>
+            {isPartialRollout ? (
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-8">
+                {rolloutCohorts.map((cohortValue) => (
+                  <Badge
+                    className="justify-center font-mono tabular-nums"
+                    key={cohortValue}
+                    variant="outline"
+                  >
+                    {cohortValue}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {isFullRollout
+                  ? `All ${NUMERIC_COHORT_SIZE} numeric cohorts are included.`
+                  : "No numeric cohorts are included."}
+              </p>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -147,7 +157,7 @@ export function RolloutCohortsDialog({
             <DialogHeader className="shrink-0 border-b border-border/70 px-4 py-4">
               <DialogTitle>Rolled out cohorts</DialogTitle>
               <DialogDescription>
-                {rolloutPercentage}% includes {rolloutCohorts.length} of{" "}
+                {rolloutPercentage}% includes {selectedCount} of{" "}
                 {NUMERIC_COHORT_SIZE} numeric cohorts.
                 {hasTargetCohorts
                   ? " Additional cohorts are always included."
@@ -167,7 +177,7 @@ export function RolloutCohortsDialog({
             <DialogHeader>
               <DialogTitle>Rolled out cohorts</DialogTitle>
               <DialogDescription>
-                {rolloutPercentage}% includes {rolloutCohorts.length} of{" "}
+                {rolloutPercentage}% includes {selectedCount} of{" "}
                 {NUMERIC_COHORT_SIZE} numeric cohorts.
                 {hasTargetCohorts
                   ? " Additional cohorts are always included."

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -202,16 +202,41 @@ describe("ReleaseEditorSheet", () => {
       />,
     );
 
-    const rolloutLabel = screen.getByText("Rollout percentage");
-    const previewButton = within(rolloutLabel.parentElement!).getByRole(
-      "button",
-      { name: "Preview cohorts" },
+    const additionalCohortsLabel = screen.getByText(
+      "Additional cohorts (optional)",
     );
+    const previewButton = within(
+      additionalCohortsLabel.parentElement!,
+    ).getByRole("button", { name: "Preview cohorts" });
 
     fireEvent.click(previewButton);
 
     expect(screen.getByRole("dialog")).toBeDefined();
     expect(screen.getByText("Selected cohorts")).toBeDefined();
+  });
+
+  it("keeps Preview cohorts available at full rollout", () => {
+    render(
+      <ReleaseEditorSheet
+        channels={[{ id: "channel-1", name: "production" }]}
+        onOpenChange={vi.fn()}
+        open
+        releaseId={release.id}
+      />,
+    );
+
+    const additionalCohortsLabel = screen.getByText(
+      "Additional cohorts (optional)",
+    );
+    const previewButton = within(
+      additionalCohortsLabel.parentElement!,
+    ).getByRole("button", { name: "Preview cohorts" });
+
+    fireEvent.click(previewButton);
+
+    expect(
+      screen.getByText("All 1000 numeric cohorts are included."),
+    ).toBeDefined();
   });
 
   it("uses disabling as the only rollback action", async () => {

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -473,16 +473,9 @@ export function ReleaseEditorSheet({
                       />
                     </Field>
                     <Field>
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <FieldLabel htmlFor="release-rollout-percentage">
-                          Rollout percentage
-                        </FieldLabel>
-                        <RolloutCohortsDialog
-                          releaseId={release.id}
-                          rolloutCohortCount={draft.rolloutCohortCount}
-                          targetCohorts={draft.targetCohorts}
-                        />
-                      </div>
+                      <FieldLabel htmlFor="release-rollout-percentage">
+                        Rollout percentage
+                      </FieldLabel>
                       <RolloutPercentageInput
                         onChange={(rolloutCohortCount) =>
                           setDraft({ ...draft, rolloutCohortCount })
@@ -491,9 +484,16 @@ export function ReleaseEditorSheet({
                       />
                     </Field>
                     <Field>
-                      <FieldLabel htmlFor="release-cohort">
-                        Additional cohorts (optional)
-                      </FieldLabel>
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <FieldLabel htmlFor="release-cohort">
+                          Additional cohorts (optional)
+                        </FieldLabel>
+                        <RolloutCohortsDialog
+                          releaseId={release.id}
+                          rolloutCohortCount={draft.rolloutCohortCount}
+                          targetCohorts={draft.targetCohorts}
+                        />
+                      </div>
                       <div className="flex gap-2">
                         <Input
                           autoComplete="off"

--- a/packages/console/src/routes/-bundles.spec.tsx
+++ b/packages/console/src/routes/-bundles.spec.tsx
@@ -1,4 +1,4 @@
-import type { ReleaseRow } from "@hot-updater/plugin-core";
+import type { Bundle, ReleaseRow } from "@hot-updater/plugin-core";
 import {
   cleanup,
   fireEvent,
@@ -72,10 +72,28 @@ const release = vi.hoisted(
       updated_at_ms: Date.UTC(2026, 6, 18),
     }) as ReleaseRow,
 );
+const baseBundle = {
+  id: "019ff641-01eb-72ea-8a03-a28aef188d32",
+  platform: "ios",
+} as Bundle;
+const childBundle = {
+  id: "019ff642-01eb-72ea-8a03-a28aef188d33",
+  platform: "ios",
+} as Bundle;
 
 vi.mock("@/lib/api", () => ({
   useBundleChildCountsQuery: () => ({
-    data: { "019ff641-01eb-72ea-8a03-a28aef188d32": 0 },
+    data: { "019ff641-01eb-72ea-8a03-a28aef188d32": 1 },
+  }),
+  useBundleChildrenQuery: () => ({
+    data: [childBundle],
+    isError: false,
+    isPending: false,
+  }),
+  useBundleQuery: () => ({
+    data: baseBundle,
+    isError: false,
+    isPending: false,
   }),
   useChannelsQuery: () => ({
     data: [
@@ -160,6 +178,23 @@ describe("BundlesPage", () => {
     expect(within(row).getByText("100.0%").className).toContain("bg-primary");
     expect(within(row).queryByText("DEPLOY")).toBeNull();
     expect(within(row).queryByText("rev 1")).toBeNull();
+  });
+
+  it("expands the base-to-patch relationship from the Bundle row", () => {
+    render(<BundlesPage />);
+    const row = screen.getByRole("row", {
+      name: "Open bundle 019ff641-01eb-72ea-8a03-a28aef188d32",
+    });
+
+    fireEvent.click(within(row).getByRole("button", { name: "Show Lineage" }));
+
+    expect(screen.getByText("Base bundle")).toBeDefined();
+    expect(screen.getByText("Patch bundles from this base")).toBeDefined();
+    expect(screen.getAllByText(childBundle.id).length).toBeGreaterThan(0);
+    expect(screen.getByText("bsdiff")).toBeDefined();
+    expect(
+      within(row).getByRole("button", { name: "Hide Lineage" }),
+    ).toBeDefined();
   });
 
   it("keeps the main Console filters and pagination summary", () => {

--- a/packages/console/src/routes/index.tsx
+++ b/packages/console/src/routes/index.tsx
@@ -1,7 +1,8 @@
-import type { ChannelRow, ReleaseRow } from "@hot-updater/plugin-core";
+import type { Bundle, ChannelRow, ReleaseRow } from "@hot-updater/plugin-core";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   AlertTriangle,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Fingerprint,
@@ -11,11 +12,12 @@ import {
   Tags,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import { BundleIdDisplay } from "@/components/BundleIdDisplay";
 import { ChannelBadge } from "@/components/ChannelBadge";
 import { EnabledStatusIcon } from "@/components/EnabledStatusIcon";
+import { BundleChildrenPanel } from "@/components/features/bundles/BundleChildrenPanel";
 import { ChannelManagementDialog } from "@/components/features/channels/ChannelManagementDialog";
 import { ReleaseEditorSheet } from "@/components/features/releases/ReleaseEditorSheet";
 import { ReleaseStateBadge } from "@/components/features/releases/ReleaseStateBadge";
@@ -47,9 +49,12 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   useBundleChildCountsQuery,
+  useBundleChildrenQuery,
+  useBundleQuery,
   useChannelsQuery,
   useReleasesQuery,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 import {
   type ReleaseSearch,
@@ -227,10 +232,14 @@ function BundleFilterToolbar({
 }
 
 function BundleEntry({
+  expanded,
   onOpen,
+  onToggleExpand,
   release,
 }: {
+  expanded: boolean;
   onOpen: () => void;
+  onToggleExpand: () => void;
   release: ReleaseRow;
 }) {
   const bundleLabel = release.bundle_id
@@ -244,7 +253,23 @@ function BundleEntry({
         : null;
 
   return (
-    <div className="flex min-w-[240px] items-center gap-2">
+    <div className="flex min-w-[240px] items-center gap-3">
+      {release.bundle_id ? (
+        <Button
+          aria-controls={`bundle-lineage-panel-${release.id}`}
+          aria-expanded={expanded}
+          aria-label={expanded ? "Hide Lineage" : "Show Lineage"}
+          className="size-8 shrink-0 touch-manipulation"
+          onClick={onToggleExpand}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          {expanded ? <ChevronDown /> : <ChevronRight />}
+        </Button>
+      ) : (
+        <span aria-hidden="true" className="size-8 shrink-0" />
+      )}
       <button
         aria-label={`Open details for ${bundleLabel}`}
         className="min-w-0 rounded-sm text-left text-foreground transition-colors underline-offset-4 hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -269,11 +294,73 @@ function BundleEntry({
   );
 }
 
+function ReleaseBundleChildrenPanel({
+  onDetailClick,
+  panelId,
+  release,
+}: {
+  onDetailClick: (bundle: Bundle) => void;
+  panelId: string;
+  release: ReleaseRow;
+}) {
+  const bundleId = release.bundle_id ?? "";
+  const bundleQuery = useBundleQuery(bundleId);
+  const childrenQuery = useBundleChildrenQuery(bundleId);
+
+  if (bundleQuery.isError || childrenQuery.isError) {
+    return (
+      <div
+        aria-live="polite"
+        className="border-t bg-muted/10 p-4 text-sm text-muted-foreground"
+        id={panelId}
+      >
+        Patch lineage could not be loaded.
+      </div>
+    );
+  }
+
+  if (bundleQuery.isPending) {
+    return (
+      <div
+        aria-live="polite"
+        className="flex flex-col gap-2 border-t bg-muted/10 p-4"
+        id={panelId}
+      >
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  if (!bundleQuery.data) {
+    return (
+      <div
+        aria-live="polite"
+        className="border-t bg-muted/10 p-4 text-sm text-muted-foreground"
+        id={panelId}
+      >
+        Bundle details are unavailable.
+      </div>
+    );
+  }
+
+  return (
+    <BundleChildrenPanel
+      bundle={bundleQuery.data}
+      bundles={childrenQuery.data ?? []}
+      loading={childrenQuery.isPending}
+      onDetailClick={onDetailClick}
+      panelId={panelId}
+    />
+  );
+}
+
 function BundlesPage() {
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
   const isMobile = useIsMobile();
   const [channelsOpen, setChannelsOpen] = useState(false);
+  const [expandedReleaseId, setExpandedReleaseId] = useState<string>();
   const releasesQuery = useReleasesQuery({
     afterReleaseId: search.afterReleaseId,
     beforeReleaseId: search.beforeReleaseId,
@@ -302,10 +389,30 @@ function BundlesPage() {
     channels.map((channel) => [channel.id, channel.name]),
   );
 
+  useEffect(() => {
+    if (
+      expandedReleaseId &&
+      !releases.some((release) => release.id === expandedReleaseId)
+    ) {
+      setExpandedReleaseId(undefined);
+    }
+  }, [expandedReleaseId, releases]);
+
   const go = (nextSearch: ReleaseSearch, resetScroll = true) =>
     void navigate({ resetScroll, search: nextSearch, to: "/" });
   const changeFilters = (filters: Partial<ReleaseSearch>) =>
     go(updateReleaseFilters(search, filters));
+  const openChildBundle = (bundle: Bundle) => {
+    const childRelease = releases.find(
+      (release) => release.bundle_id === bundle.id,
+    );
+    setExpandedReleaseId(undefined);
+    if (childRelease) {
+      go({ ...search, releaseId: childRelease.id }, false);
+      return;
+    }
+    changeFilters({ bundleId: bundle.id });
+  };
   const currentPage = pagination?.currentPage ?? 1;
   const startEntry =
     releases.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1;
@@ -369,85 +476,110 @@ function BundlesPage() {
                     const patchCount = release.bundle_id
                       ? patchCountsByBundleId[release.bundle_id]
                       : 0;
+                    const isExpanded = expandedReleaseId === release.id;
+                    const panelId = `bundle-lineage-panel-${release.id}`;
 
                     return (
-                      <article
-                        className="flex flex-col gap-4 border-b p-4 last:border-b-0"
-                        key={release.id}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <BundleEntry
-                            onOpen={() =>
-                              go({ ...search, releaseId: release.id }, false)
-                            }
+                      <Fragment key={release.id}>
+                        <article
+                          className={cn(
+                            "flex flex-col gap-4 border-b p-4 last:border-b-0",
+                            isExpanded && "border-b-0 bg-primary/5",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <BundleEntry
+                              expanded={isExpanded}
+                              onOpen={() =>
+                                go({ ...search, releaseId: release.id }, false)
+                              }
+                              onToggleExpand={() =>
+                                setExpandedReleaseId(
+                                  isExpanded ? undefined : release.id,
+                                )
+                              }
+                              release={release}
+                            />
+                            <ChannelBadge
+                              channel={channelName}
+                              className="shrink-0"
+                            />
+                          </div>
+                          <dl className="grid grid-cols-2 gap-3 text-xs">
+                            <div className="rounded-md bg-muted/40 p-3">
+                              <dt className="text-muted-foreground">
+                                Platform
+                              </dt>
+                              <dd className="mt-1 flex items-center gap-2 font-medium">
+                                <PlatformIcon
+                                  className="size-4"
+                                  platform={release.platform}
+                                />
+                                {release.platform === "ios" ? "iOS" : "Android"}
+                              </dd>
+                            </div>
+                            <div className="rounded-md bg-muted/40 p-3">
+                              <dt className="text-muted-foreground">Created</dt>
+                              <dd className="mt-1 tabular-nums">
+                                {dateFormatter.format(release.created_at_ms)}
+                              </dd>
+                            </div>
+                            <div className="rounded-md bg-muted/40 p-3">
+                              <dt className="text-muted-foreground">Rollout</dt>
+                              <dd className="mt-1">
+                                <RolloutPercentageBadge
+                                  percentage={release.rollout_cohort_count / 10}
+                                />
+                              </dd>
+                            </div>
+                            <div className="rounded-md bg-muted/40 p-3">
+                              <dt className="text-muted-foreground">Patches</dt>
+                              <dd className="mt-1">
+                                {patchCount === undefined
+                                  ? "Checking"
+                                  : patchCount > 0
+                                    ? `${patchCount} ${
+                                        patchCount === 1 ? "patch" : "patches"
+                                      }`
+                                    : "—"}
+                              </dd>
+                            </div>
+                            <div className="col-span-2 flex flex-wrap items-center gap-2 rounded-md bg-muted/40 p-3">
+                              <ReleaseStateBadge release={release} />
+                              {release.should_force_update ? (
+                                <Badge variant="secondary">Force update</Badge>
+                              ) : null}
+                            </div>
+                            <div className="col-span-2 grid gap-2 rounded-md border bg-background/80 p-3">
+                              <div className="flex items-start justify-between gap-3">
+                                <dt className="text-muted-foreground">
+                                  Target
+                                </dt>
+                                <dd className="min-w-0 truncate text-right font-mono">
+                                  {release.target_app_version ??
+                                    release.fingerprint_hash ??
+                                    "—"}
+                                </dd>
+                              </div>
+                              <div className="flex items-start justify-between gap-3">
+                                <dt className="text-muted-foreground">
+                                  Message
+                                </dt>
+                                <dd className="min-w-0 text-right text-foreground">
+                                  {release.message || "—"}
+                                </dd>
+                              </div>
+                            </div>
+                          </dl>
+                        </article>
+                        {isExpanded && release.bundle_id ? (
+                          <ReleaseBundleChildrenPanel
+                            onDetailClick={openChildBundle}
+                            panelId={panelId}
                             release={release}
                           />
-                          <ChannelBadge
-                            channel={channelName}
-                            className="shrink-0"
-                          />
-                        </div>
-                        <dl className="grid grid-cols-2 gap-3 text-xs">
-                          <div className="rounded-md bg-muted/40 p-3">
-                            <dt className="text-muted-foreground">Platform</dt>
-                            <dd className="mt-1 flex items-center gap-2 font-medium">
-                              <PlatformIcon
-                                className="size-4"
-                                platform={release.platform}
-                              />
-                              {release.platform === "ios" ? "iOS" : "Android"}
-                            </dd>
-                          </div>
-                          <div className="rounded-md bg-muted/40 p-3">
-                            <dt className="text-muted-foreground">Created</dt>
-                            <dd className="mt-1 tabular-nums">
-                              {dateFormatter.format(release.created_at_ms)}
-                            </dd>
-                          </div>
-                          <div className="rounded-md bg-muted/40 p-3">
-                            <dt className="text-muted-foreground">Rollout</dt>
-                            <dd className="mt-1">
-                              <RolloutPercentageBadge
-                                percentage={release.rollout_cohort_count / 10}
-                              />
-                            </dd>
-                          </div>
-                          <div className="rounded-md bg-muted/40 p-3">
-                            <dt className="text-muted-foreground">Patches</dt>
-                            <dd className="mt-1">
-                              {patchCount === undefined
-                                ? "Checking"
-                                : patchCount > 0
-                                  ? `${patchCount} ${
-                                      patchCount === 1 ? "patch" : "patches"
-                                    }`
-                                  : "—"}
-                            </dd>
-                          </div>
-                          <div className="col-span-2 flex flex-wrap items-center gap-2 rounded-md bg-muted/40 p-3">
-                            <ReleaseStateBadge release={release} />
-                            {release.should_force_update ? (
-                              <Badge variant="secondary">Force update</Badge>
-                            ) : null}
-                          </div>
-                          <div className="col-span-2 grid gap-2 rounded-md border bg-background/80 p-3">
-                            <div className="flex items-start justify-between gap-3">
-                              <dt className="text-muted-foreground">Target</dt>
-                              <dd className="min-w-0 truncate text-right font-mono">
-                                {release.target_app_version ??
-                                  release.fingerprint_hash ??
-                                  "—"}
-                              </dd>
-                            </div>
-                            <div className="flex items-start justify-between gap-3">
-                              <dt className="text-muted-foreground">Message</dt>
-                              <dd className="min-w-0 text-right text-foreground">
-                                {release.message || "—"}
-                              </dd>
-                            </div>
-                          </div>
-                        </dl>
-                      </article>
+                        ) : null}
+                      </Fragment>
                     );
                   })
                 ) : (
@@ -463,7 +595,7 @@ function BundlesPage() {
                 )}
               </div>
             ) : (
-              <Table>
+              <Table className="min-w-max">
                 <TableHeader className="bg-muted/40">
                   <TableRow className="border-b border-border/60 hover:bg-transparent [&>th]:h-10 [&>th]:text-xs [&>th]:font-semibold [&>th]:uppercase [&>th]:text-muted-foreground/70">
                     <TableHead>Bundle ID</TableHead>
@@ -487,143 +619,190 @@ function BundlesPage() {
                           </TableCell>
                         </TableRow>
                       ))
-                    : releases.map((release) => (
-                        <TableRow
-                          aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
-                          className="cursor-pointer transition-colors hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3"
-                          data-state={
-                            search.releaseId === release.id
-                              ? "selected"
-                              : undefined
-                          }
-                          key={release.id}
-                          onClick={(event) => {
-                            if (
-                              event.target instanceof Element &&
-                              event.target.closest(
-                                "button, a, input, select, textarea",
-                              )
-                            ) {
-                              return;
-                            }
-                            go({ ...search, releaseId: release.id }, false);
-                          }}
-                          onKeyDown={(event) => {
-                            if (
-                              event.target !== event.currentTarget ||
-                              (event.key !== "Enter" && event.key !== " ")
-                            ) {
-                              return;
-                            }
-                            event.preventDefault();
-                            go({ ...search, releaseId: release.id }, false);
-                          }}
-                          tabIndex={0}
-                        >
-                          <TableCell>
-                            <BundleEntry
-                              onOpen={() =>
-                                go({ ...search, releaseId: release.id }, false)
+                    : releases.map((release) => {
+                        const isExpanded = expandedReleaseId === release.id;
+                        const panelId = `bundle-lineage-panel-${release.id}`;
+
+                        return (
+                          <Fragment key={release.id}>
+                            <TableRow
+                              aria-label={`Open bundle ${release.bundle_id ?? release.id}`}
+                              className={cn(
+                                "cursor-pointer transition-colors hover:bg-muted/10 focus-within:bg-muted/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring data-[state=selected]:bg-muted/15 [&>td]:py-3",
+                                isExpanded && "bg-primary/5",
+                              )}
+                              data-state={
+                                search.releaseId === release.id
+                                  ? "selected"
+                                  : undefined
                               }
-                              release={release}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <ChannelBadge
-                              channel={
-                                channelNames.get(release.channel_id) ??
-                                release.channel_id
-                              }
-                            />
-                          </TableCell>
-                          <TableCell className="whitespace-nowrap">
-                            <span className="flex items-center gap-2">
-                              <PlatformIcon
-                                className="size-4"
-                                platform={release.platform}
-                              />
-                              {release.platform === "ios" ? "iOS" : "Android"}
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            {release.bundle_id &&
-                            patchCountsByBundleId[release.bundle_id] ===
-                              undefined ? (
-                              <span className="text-sm text-muted-foreground">
-                                Checking
-                              </span>
-                            ) : release.bundle_id &&
-                              patchCountsByBundleId[release.bundle_id]! > 0 ? (
-                              <Badge variant="secondary">
-                                {patchCountsByBundleId[release.bundle_id]}{" "}
-                                {patchCountsByBundleId[release.bundle_id] === 1
-                                  ? "patch"
-                                  : "patches"}
-                              </Badge>
-                            ) : (
-                              <span className="text-muted-foreground">-</span>
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            {release.target_app_version ? (
-                              <span className="flex items-center gap-2">
-                                <Package className="size-4 shrink-0 text-muted-foreground" />
-                                <span className="font-medium">
-                                  {release.target_app_version}
-                                </span>
-                              </span>
-                            ) : release.fingerprint_hash ? (
-                              <span className="flex min-w-[160px] items-center gap-2">
-                                <Fingerprint className="size-4 shrink-0 text-muted-foreground" />
-                                <HashValueDisplay
-                                  maxLength={12}
-                                  value={release.fingerprint_hash}
+                              onClick={(event) => {
+                                if (
+                                  event.target instanceof Element &&
+                                  event.target.closest(
+                                    "button, a, input, select, textarea",
+                                  )
+                                ) {
+                                  return;
+                                }
+                                go({ ...search, releaseId: release.id }, false);
+                              }}
+                              onKeyDown={(event) => {
+                                if (
+                                  event.target !== event.currentTarget ||
+                                  (event.key !== "Enter" && event.key !== " ")
+                                ) {
+                                  return;
+                                }
+                                event.preventDefault();
+                                go({ ...search, releaseId: release.id }, false);
+                              }}
+                              tabIndex={0}
+                            >
+                              <TableCell>
+                                <BundleEntry
+                                  expanded={isExpanded}
+                                  onOpen={() =>
+                                    go(
+                                      { ...search, releaseId: release.id },
+                                      false,
+                                    )
+                                  }
+                                  onToggleExpand={() =>
+                                    setExpandedReleaseId(
+                                      isExpanded ? undefined : release.id,
+                                    )
+                                  }
+                                  release={release}
                                 />
-                              </span>
-                            ) : (
-                              <span className="text-muted-foreground">-</span>
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            <span className="flex items-center">
-                              <EnabledStatusIcon enabled={release.enabled} />
-                              <span className="sr-only">
-                                {release.enabled ? "Enabled" : "Disabled"}
-                              </span>
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            <span className="flex items-center">
-                              <EnabledStatusIcon
-                                enabled={release.should_force_update}
-                                falseIcon="minus"
-                              />
-                              <span className="sr-only">
-                                {release.should_force_update
-                                  ? "Required"
-                                  : "Optional"}
-                              </span>
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            <RolloutPercentageBadge
-                              percentage={release.rollout_cohort_count / 10}
-                            />
-                          </TableCell>
-                          <TableCell
-                            className="max-w-44 truncate text-xs text-muted-foreground"
-                            title={release.message ?? undefined}
-                          >
-                            {release.message || "-"}
-                          </TableCell>
-                          <TableCell
-                            className="whitespace-nowrap text-xs text-muted-foreground"
-                            title={dateFormatter.format(release.created_at_ms)}
-                          >
-                            {tableDateFormatter.format(release.created_at_ms)}
-                          </TableCell>
-                        </TableRow>
-                      ))}
+                              </TableCell>
+                              <TableCell>
+                                <ChannelBadge
+                                  channel={
+                                    channelNames.get(release.channel_id) ??
+                                    release.channel_id
+                                  }
+                                />
+                              </TableCell>
+                              <TableCell className="whitespace-nowrap">
+                                <span className="flex items-center gap-2">
+                                  <PlatformIcon
+                                    className="size-4"
+                                    platform={release.platform}
+                                  />
+                                  {release.platform === "ios"
+                                    ? "iOS"
+                                    : "Android"}
+                                </span>
+                              </TableCell>
+                              <TableCell>
+                                {release.bundle_id &&
+                                patchCountsByBundleId[release.bundle_id] ===
+                                  undefined ? (
+                                  <span className="text-sm text-muted-foreground">
+                                    Checking
+                                  </span>
+                                ) : release.bundle_id &&
+                                  patchCountsByBundleId[release.bundle_id]! >
+                                    0 ? (
+                                  <Badge variant="secondary">
+                                    {patchCountsByBundleId[release.bundle_id]}{" "}
+                                    {patchCountsByBundleId[
+                                      release.bundle_id
+                                    ] === 1
+                                      ? "patch"
+                                      : "patches"}
+                                  </Badge>
+                                ) : (
+                                  <span className="text-muted-foreground">
+                                    -
+                                  </span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                {release.target_app_version ? (
+                                  <span className="flex items-center gap-2">
+                                    <Package className="size-4 shrink-0 text-muted-foreground" />
+                                    <span className="font-medium">
+                                      {release.target_app_version}
+                                    </span>
+                                  </span>
+                                ) : release.fingerprint_hash ? (
+                                  <span className="flex min-w-[160px] items-center gap-2">
+                                    <Fingerprint className="size-4 shrink-0 text-muted-foreground" />
+                                    <HashValueDisplay
+                                      maxLength={12}
+                                      value={release.fingerprint_hash}
+                                    />
+                                  </span>
+                                ) : (
+                                  <span className="text-muted-foreground">
+                                    -
+                                  </span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <span className="flex items-center">
+                                  <EnabledStatusIcon
+                                    enabled={release.enabled}
+                                  />
+                                  <span className="sr-only">
+                                    {release.enabled ? "Enabled" : "Disabled"}
+                                  </span>
+                                </span>
+                              </TableCell>
+                              <TableCell>
+                                <span className="flex items-center">
+                                  <EnabledStatusIcon
+                                    enabled={release.should_force_update}
+                                    falseIcon="minus"
+                                  />
+                                  <span className="sr-only">
+                                    {release.should_force_update
+                                      ? "Required"
+                                      : "Optional"}
+                                  </span>
+                                </span>
+                              </TableCell>
+                              <TableCell>
+                                <RolloutPercentageBadge
+                                  percentage={release.rollout_cohort_count / 10}
+                                />
+                              </TableCell>
+                              <TableCell
+                                className="text-sm text-muted-foreground"
+                                title={release.message ?? undefined}
+                              >
+                                {release.message || "-"}
+                              </TableCell>
+                              <TableCell
+                                className="whitespace-nowrap text-xs text-muted-foreground"
+                                title={dateFormatter.format(
+                                  release.created_at_ms,
+                                )}
+                              >
+                                {tableDateFormatter.format(
+                                  release.created_at_ms,
+                                )}
+                              </TableCell>
+                            </TableRow>
+                            {isExpanded && release.bundle_id ? (
+                              <TableRow className="hover:bg-transparent">
+                                <TableCell
+                                  className="border-t-0 p-0"
+                                  colSpan={10}
+                                >
+                                  <ReleaseBundleChildrenPanel
+                                    onDetailClick={openChildBundle}
+                                    panelId={panelId}
+                                    release={release}
+                                  />
+                                </TableCell>
+                              </TableRow>
+                            ) : null}
+                          </Fragment>
+                        );
+                      })}
                   {!releasesQuery.isPending && releases.length === 0 ? (
                     <TableRow>
                       <TableCell


### PR DESCRIPTION
## Summary

- restore the main-style Bundle row chevron and expandable base → patch relationship table, including artifact, creation time, and child detail navigation
- preserve full-width table content with horizontal scrolling and show bundle messages without clipping
- keep Preview cohorts beside Additional cohorts for every rollout value, with compact full/empty rollout summaries

## StyleSeed design review

- Bundles table + lineage: **96/100 (A)** — coherent semantic components and spacing (`routes/index.tsx:462`, `routes/index.tsx:598-610`), full content overflow handling (`routes/index.tsx:768-776`), and explicit loading/error/empty lineage states (`routes/index.tsx:310-345`, `BundleChildrenPanel.tsx:53-59`, `BundleChildrenPanel.tsx:188-195`). The existing highlighted rollout badge on most rows is the only rubric deduction.
- Bundle SheetForm + cohort preview: **100/100 (A)** — Preview cohorts is grouped with Additional cohorts (`ReleaseEditorSheet.tsx:486-496`), the dialog uses consistent cards/tokens and responsive full-screen mobile treatment (`RolloutCohortsDialog.tsx:64-137`, `RolloutCohortsDialog.tsx:140-190`), and 0%/100% states remain readable without rendering 1,000 badges.

## Verification

- `pnpm -w build`
- `pnpm --dir packages/console test:type`
- `pnpm -w lint`
- `pnpm -w test` — 257 files, 2,512 tests passed
