### PR TITLE
feat(console): support deployable console hosts

### DIFF
--- a/.changeset/calm-consoles-deploy.md
+++ b/.changeset/calm-consoles-deploy.md
@@ -1,0 +1,9 @@
+---
+"@hot-updater/console": minor
+"hot-updater": patch
+---
+
+Package the full Console application behind root and `/vite` exports so a thin
+Vite and Nitro host can deploy it with injected runtime configuration and
+authentication. Keep the CLI console unauthenticated but force it to bind to
+the loopback interface.

--- a/packages/console/.gitignore
+++ b/packages/console/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+/lib
 *.local
 count.txt
 .env

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -4,14 +4,27 @@
   "version": "0.36.0",
   "files": [
     ".output",
+    "lib",
+    "public",
+    "src",
+    "!src/**/*.spec.ts",
+    "!src/**/*.spec.tsx",
     "package.json"
   ],
   "exports": {
+    ".": {
+      "types": "./lib/index.d.mts",
+      "import": "./lib/index.mjs"
+    },
+    "./vite": {
+      "types": "./lib/vite.d.mts",
+      "import": "./lib/vite.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "vite dev --port 3000",
-    "build": "vite build && node copy-assets.mjs",
+    "build": "NODE_ENV=production vite build && tsdown",
     "check": "oxfmt --write \"**/*.{ts,tsx}\" && oxlint --fix --fix-suggestions --fix-dangerously .",
     "format": "oxfmt --write \"**/*.{ts,tsx}\"",
     "preview": "vite preview",
@@ -19,29 +32,51 @@
     "test:type": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@hot-updater/cli-tools": "*"
+    "@hot-updater/cli-tools": "*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vite": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@hot-updater/cli-tools": {
+      "optional": true
+    }
   },
   "dependencies": {
-    "@hot-updater/bsdiff": "workspace:*",
-    "@hot-updater/server": "workspace:*",
-    "recharts": "3.8.0"
-  },
-  "devDependencies": {
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/inter": "^5.2.8",
-    "@hot-updater/cli-tools": "workspace:*",
+    "@hot-updater/bsdiff": "workspace:*",
     "@hot-updater/core": "workspace:*",
-    "@hot-updater/mock": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
+    "@hot-updater/server": "workspace:*",
     "@tailwindcss/vite": "^4.2.1",
-    "@tanstack/devtools-vite": "^0.6.0",
     "@tanstack/react-devtools": "^0.10.0",
-    "@tanstack/react-form": "^1.28.5",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.167.0",
     "@tanstack/react-router-devtools": "^1.166.7",
     "@tanstack/react-router-ssr-query": "^1.166.7",
     "@tanstack/react-start": "^1.166.11",
+    "@vitejs/plugin-react": "^6.0.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "dayjs": "^1.11.20",
+    "lucide-react": "^0.577.0",
+    "next-themes": "^0.4.6",
+    "nitro": "3.0.260610-beta",
+    "react-grab": "^0.1.28",
+    "recharts": "3.8.0",
+    "shadcn": "^4.0.8",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.1",
+    "tw-animate-css": "^1.4.0",
+    "verkit": "0.3.2"
+  },
+  "devDependencies": {
+    "@hot-updater/cli-tools": "workspace:*",
+    "@hot-updater/mock": "workspace:*",
+    "@tanstack/devtools-vite": "^0.6.0",
+    "@tanstack/react-form": "^1.28.5",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/router-plugin": "^1.166.9",
     "@testing-library/dom": "^10.4.0",
@@ -50,27 +85,14 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.0",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "@vitejs/plugin-react": "^6.0.1",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "dayjs": "^1.11.20",
     "jsdom": "^29.0.0",
     "jszip": "^3.10.1",
-    "lucide-react": "^0.577.0",
-    "next-themes": "^0.4.6",
-    "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-grab": "^0.1.28",
-    "shadcn": "^4.0.8",
-    "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.1",
     "tar": "^7.5.16",
+    "tsdown": "catalog:tools",
     "tslib": "^2.8.1",
-    "tw-animate-css": "^1.4.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "verkit": "0.3.2",
     "vite": "8.0.8",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "catalog:",

--- a/packages/console/src/components/ConsoleAccessPage.spec.tsx
+++ b/packages/console/src/components/ConsoleAccessPage.spec.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props} />
+  ),
+}));
+
+import { ConsoleAccessPage } from "./ConsoleAccessPage";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ConsoleAccessPage", () => {
+  it("explains why an authenticated email was rejected", () => {
+    render(
+      <ConsoleAccessPage
+        access={{
+          status: "forbidden",
+          principal: { email: "viewer@example.com" },
+        }}
+        providers={["github"]}
+      />,
+    );
+
+    expect(screen.getByText("Access denied")).toBeTruthy();
+    expect(
+      screen.getByText("viewer@example.com is not in the console allowlist."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Continue with GitHub" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeTruthy();
+  });
+
+  it("starts the selected social sign-in and reports invalid responses", async () => {
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({}), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <ConsoleAccessPage
+        access={{ status: "unauthenticated" }}
+        providers={["google", "github"]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    );
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "The identity provider did not return a sign-in URL.",
+    );
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/sign-in/social", {
+      body: JSON.stringify({ callbackURL: "/", provider: "github" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+  });
+});

--- a/packages/console/src/components/ConsoleAccessPage.tsx
+++ b/packages/console/src/components/ConsoleAccessPage.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+
+import { HotUpdaterLogo } from "@/components/HotUpdaterLogo";
+import { Button } from "@/components/ui/button";
+
+import type { ConsoleAccess, ConsoleAuthProvider } from "../index";
+
+type ConsoleAccessPageProps = {
+  readonly access: Exclude<ConsoleAccess, { status: "authorized" }>;
+  readonly providers: readonly ConsoleAuthProvider[];
+};
+
+const providerLabel: Record<ConsoleAuthProvider, string> = {
+  github: "GitHub",
+  google: "Google",
+};
+
+export function ConsoleAccessPage({
+  access,
+  providers,
+}: ConsoleAccessPageProps) {
+  const [pendingProvider, setPendingProvider] =
+    useState<ConsoleAuthProvider | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signIn = async (provider: ConsoleAuthProvider) => {
+    setPendingProvider(provider);
+    setError(null);
+    try {
+      const response = await fetch("/api/auth/sign-in/social", {
+        body: JSON.stringify({ callbackURL: "/", provider }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const result = (await response.json()) as { readonly url?: unknown };
+      if (!response.ok || typeof result.url !== "string") {
+        throw new Error("The identity provider did not return a sign-in URL.");
+      }
+      window.location.assign(result.url);
+    } catch (cause) {
+      setPendingProvider(null);
+      setError(cause instanceof Error ? cause.message : "Sign-in failed.");
+    }
+  };
+
+  const signOut = async () => {
+    setSigningOut(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/auth/sign-out", { method: "POST" });
+      if (!response.ok) {
+        throw new Error("Sign-out failed.");
+      }
+      window.location.reload();
+    } catch (cause) {
+      setSigningOut(false);
+      setError(cause instanceof Error ? cause.message : "Sign-out failed.");
+    }
+  };
+
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center justify-center p-6">
+      <section className="border-border bg-card w-full max-w-sm rounded-xl border p-6 shadow-sm">
+        <div className="mb-6 flex items-center gap-3">
+          <HotUpdaterLogo className="h-10 w-7" />
+          <div>
+            <h1 className="text-lg font-semibold">Hot Updater Console</h1>
+            <p className="text-muted-foreground text-sm">
+              Sign in to manage OTA releases.
+            </p>
+          </div>
+        </div>
+
+        {access.status === "forbidden" ? (
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Access denied</p>
+            <p className="text-muted-foreground text-sm">
+              {access.principal.email} is not in the console allowlist.
+            </p>
+            <Button
+              className="w-full"
+              disabled={signingOut}
+              onClick={() => void signOut()}
+              size="lg"
+              variant="outline"
+            >
+              {signingOut ? "Signing out…" : "Sign out"}
+            </Button>
+          </div>
+        ) : providers.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No OAuth provider is configured for this console.
+          </p>
+        ) : (
+          <div className="grid gap-2">
+            {providers.map((provider) => (
+              <Button
+                className="w-full"
+                disabled={pendingProvider !== null}
+                key={provider}
+                onClick={() => void signIn(provider)}
+                size="lg"
+                variant="outline"
+              >
+                {pendingProvider === provider
+                  ? "Redirecting…"
+                  : `Continue with ${providerLabel[provider]}`}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {error ? (
+          <p className="text-destructive mt-3 text-sm" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -1,0 +1,36 @@
+import type { ConfigInput } from "@hot-updater/plugin-core";
+
+export type ConsoleAuthProvider = "google" | "github";
+
+export type ConsolePrincipal = Readonly<{
+  email: string;
+  name?: string | null;
+  image?: string | null;
+}>;
+
+export type ConsoleAccess =
+  | { status: "unauthenticated" }
+  | { status: "forbidden"; principal: ConsolePrincipal }
+  | { status: "authorized"; principal: ConsolePrincipal };
+
+export type ConsoleAuthAdapter = Readonly<{
+  handle(request: Request): Promise<Response>;
+  getAccess(request: Request): Promise<ConsoleAccess>;
+  getProviders(request: Request): Promise<readonly ConsoleAuthProvider[]>;
+}>;
+
+export type HotUpdaterConsoleConfig = Readonly<
+  Pick<ConfigInput, "authorityId" | "console" | "database" | "storage">
+>;
+
+export type HotUpdaterConsoleConfigSource =
+  | HotUpdaterConsoleConfig
+  | ((
+      request: Request,
+    ) => HotUpdaterConsoleConfig | Promise<HotUpdaterConsoleConfig>);
+
+export const defineConsoleConfig = <
+  const TConfig extends HotUpdaterConsoleConfigSource,
+>(
+  config: TConfig,
+): TConfig => config;

--- a/packages/console/src/lib/api-rpc.ts
+++ b/packages/console/src/lib/api-rpc.ts
@@ -226,6 +226,11 @@ export const deleteChannel = createServerFn({ method: "POST" })
 // GET /api/config-loaded
 export const getConfigLoaded = createServerFn().handler(async () => {
   try {
+    const [{ getRequest }, { requireConsoleAccess }] = await Promise.all([
+      import("@tanstack/react-start/server"),
+      import("./server/auth.server"),
+    ]);
+    await requireConsoleAccess(getRequest());
     const { isConfigLoaded } = await import("./server/config.server");
     const configLoaded = isConfigLoaded();
     return { configLoaded };

--- a/packages/console/src/lib/auth-rpc.ts
+++ b/packages/console/src/lib/auth-rpc.ts
@@ -1,0 +1,16 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+
+export const getConsoleAccessRpc = createServerFn({ method: "GET" }).handler(
+  async () => {
+    const { getConsoleAccess } = await import("./server/auth.server");
+    return getConsoleAccess(getRequest());
+  },
+);
+
+export const getConsoleAuthProvidersRpc = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { getConsoleAuthProviders } = await import("./server/auth.server");
+  return getConsoleAuthProviders(getRequest());
+});

--- a/packages/console/src/lib/server/auth.server.spec.ts
+++ b/packages/console/src/lib/server/auth.server.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ConsoleAuthAdapter } from "../../index";
+
+const { getConsoleAuthAdapterMock } = vi.hoisted(() => ({
+  getConsoleAuthAdapterMock: vi.fn(),
+}));
+
+vi.mock("./console-runtime.server", () => ({
+  getConsoleAuthAdapter: getConsoleAuthAdapterMock,
+}));
+
+import {
+  getConsoleAuthProviders,
+  handleConsoleAuth,
+  requireConsoleAccess,
+} from "./auth.server";
+
+const request = new Request("https://console.example.com/");
+
+const createAdapter = (
+  getAccess: ConsoleAuthAdapter["getAccess"],
+): ConsoleAuthAdapter => ({
+  getAccess,
+  getProviders: vi.fn(async () => ["google", "github"] as const),
+  handle: vi.fn(async () => new Response("auth-handler")),
+});
+
+beforeEach(() => {
+  getConsoleAuthAdapterMock.mockReset();
+});
+
+describe("console auth boundary", () => {
+  it("returns the authorized principal", async () => {
+    const principal = { email: "admin@example.com", name: "Admin" };
+    const adapter = createAdapter(
+      vi.fn(async () => ({ status: "authorized" as const, principal })),
+    );
+    getConsoleAuthAdapterMock.mockResolvedValue(adapter);
+
+    await expect(requireConsoleAccess(request)).resolves.toEqual(principal);
+    expect(adapter.getAccess).toHaveBeenCalledWith(request);
+  });
+
+  it.each([
+    {
+      access: { status: "unauthenticated" } as const,
+      expectedStatus: 401,
+    },
+    {
+      access: {
+        status: "forbidden",
+        principal: { email: "viewer@example.com" },
+      } as const,
+      expectedStatus: 403,
+    },
+  ])("rejects $access.status access", async ({ access, expectedStatus }) => {
+    getConsoleAuthAdapterMock.mockResolvedValue(
+      createAdapter(vi.fn(async () => access)),
+    );
+
+    await expect(requireConsoleAccess(request)).rejects.toMatchObject({
+      status: expectedStatus,
+    });
+  });
+
+  it("delegates provider discovery and auth protocol requests", async () => {
+    const adapter = createAdapter(
+      vi.fn(async () => ({ status: "unauthenticated" as const })),
+    );
+    getConsoleAuthAdapterMock.mockResolvedValue(adapter);
+
+    await expect(getConsoleAuthProviders(request)).resolves.toEqual([
+      "google",
+      "github",
+    ]);
+    const response = await handleConsoleAuth(request);
+
+    await expect(response.text()).resolves.toBe("auth-handler");
+    expect(adapter.getProviders).toHaveBeenCalledWith(request);
+    expect(adapter.handle).toHaveBeenCalledWith(request);
+  });
+});

--- a/packages/console/src/lib/server/auth.server.ts
+++ b/packages/console/src/lib/server/auth.server.ts
@@ -1,0 +1,43 @@
+import type {
+  ConsoleAccess,
+  ConsoleAuthProvider,
+  ConsolePrincipal,
+} from "../../index";
+import { getConsoleAuthAdapter } from "./console-runtime.server";
+
+const accessError = (
+  access: Exclude<ConsoleAccess, { status: "authorized" }>,
+) =>
+  new Response(
+    access.status === "unauthenticated" ? "Unauthorized" : "Forbidden",
+    { status: access.status === "unauthenticated" ? 401 : 403 },
+  );
+
+export const getConsoleAccess = async (
+  request: Request,
+): Promise<ConsoleAccess> => {
+  const adapter = await getConsoleAuthAdapter();
+  return adapter.getAccess(request);
+};
+
+export const getConsoleAuthProviders = async (
+  request: Request,
+): Promise<readonly ConsoleAuthProvider[]> => {
+  const adapter = await getConsoleAuthAdapter();
+  return adapter.getProviders(request);
+};
+
+export const handleConsoleAuth = async (request: Request) => {
+  const adapter = await getConsoleAuthAdapter();
+  return adapter.handle(request);
+};
+
+export const requireConsoleAccess = async (
+  request: Request,
+): Promise<ConsolePrincipal> => {
+  const access = await getConsoleAccess(request);
+  if (access.status !== "authorized") {
+    throw accessError(access);
+  }
+  return access.principal;
+};

--- a/packages/console/src/lib/server/config.server.spec.ts
+++ b/packages/console/src/lib/server/config.server.spec.ts
@@ -4,13 +4,24 @@ import {
   createDatabasePlugin,
   createStoragePlugin,
 } from "@hot-updater/plugin-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+const { requireConsoleAccessMock, resolveConsoleConfigMock } = vi.hoisted(
+  () => ({
+    requireConsoleAccessMock: vi.fn(),
+    resolveConsoleConfigMock: vi.fn(),
+  }),
+);
 
-vi.mock("@hot-updater/cli-tools", () => ({
-  loadConfig: loadConfigMock,
+vi.mock("./auth.server", () => ({
+  requireConsoleAccess: requireConsoleAccessMock,
 }));
+
+vi.mock("./console-runtime.server", () => ({
+  resolveConsoleConfig: resolveConsoleConfigMock,
+}));
+
+const request = new Request("https://console.example.com/");
 
 const createTestDatabasePlugin = (name: string) =>
   createDatabasePlugin({
@@ -66,7 +77,14 @@ function createTestStoragePlugin() {
 afterEach(() => {
   vi.resetModules();
   vi.restoreAllMocks();
-  loadConfigMock.mockReset();
+  requireConsoleAccessMock.mockReset();
+  resolveConsoleConfigMock.mockReset();
+});
+
+beforeEach(() => {
+  requireConsoleAccessMock.mockResolvedValue({
+    email: "admin@example.com",
+  });
 });
 
 describe("config.server", () => {
@@ -74,7 +92,7 @@ describe("config.server", () => {
     const database = createTestDatabasePlugin("db");
     const storagePlugin = createTestStoragePlugin();
 
-    loadConfigMock.mockResolvedValue({
+    resolveConsoleConfigMock.mockResolvedValue({
       console: { port: 1422 },
       database,
       storage: storagePlugin,
@@ -84,10 +102,11 @@ describe("config.server", () => {
 
     expect(isConfigLoaded()).toBe(false);
 
-    const first = await prepareConfig();
-    const second = await prepareConfig();
+    const first = await prepareConfig(request);
+    const second = await prepareConfig(request);
 
-    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(requireConsoleAccessMock).toHaveBeenCalledTimes(2);
+    expect(resolveConsoleConfigMock).toHaveBeenCalledTimes(1);
     expect(first.databaseClient).toBe(second.databaseClient);
     expect(first.config.database).toBe(database);
     expect(first.clientAccessKeyStore).toBe(database.models.clientAccessKeys);
@@ -104,7 +123,7 @@ describe("config.server", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    loadConfigMock
+    resolveConsoleConfigMock
       .mockRejectedValueOnce(new Error("load failed"))
       .mockResolvedValueOnce({
         console: { port: 1422 },
@@ -114,11 +133,11 @@ describe("config.server", () => {
 
     const { prepareConfig } = await import("./config.server");
 
-    await expect(prepareConfig()).rejects.toThrow("load failed");
+    await expect(prepareConfig(request)).rejects.toThrow("load failed");
 
-    const recovered = await prepareConfig();
+    const recovered = await prepareConfig(request);
 
-    expect(loadConfigMock).toHaveBeenCalledTimes(2);
+    expect(resolveConsoleConfigMock).toHaveBeenCalledTimes(2);
     expect(recovered.config.database).toBe(database);
     expect(recovered.storagePlugin).toBe(storagePlugin);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
@@ -135,7 +154,7 @@ describe("config.server", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    loadConfigMock.mockResolvedValue({
+    resolveConsoleConfigMock.mockResolvedValue({
       console: { port: 1422 },
       database,
       storage,
@@ -143,9 +162,24 @@ describe("config.server", () => {
 
     const { prepareConfig } = await import("./config.server");
 
-    await expect(prepareConfig()).rejects.toThrow(
+    await expect(prepareConfig(request)).rejects.toThrow(
       'Storage plugin "runtimeOnlyStorage" does not implement put.',
     );
     expect(consoleErrorSpy).toHaveBeenCalledOnce();
+  });
+
+  it("rejects unauthorized requests before resolving runtime config", async () => {
+    requireConsoleAccessMock.mockRejectedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { prepareConfig } = await import("./config.server");
+
+    await expect(prepareConfig(request)).rejects.toMatchObject({ status: 401 });
+
+    expect(resolveConsoleConfigMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/console/src/lib/server/config.server.ts
+++ b/packages/console/src/lib/server/config.server.ts
@@ -1,12 +1,21 @@
-import { type ConfigResponse, loadConfig } from "@hot-updater/cli-tools";
 import {
   assertStorageOperations,
   createDatabaseClient,
   type DatabaseClient,
   type StoragePluginWith,
 } from "@hot-updater/plugin-core";
+import { getRequest } from "@tanstack/react-start/server";
 
-let configPromise: Promise<ConfigResponse> | null = null;
+import type { HotUpdaterConsoleConfig } from "../../index";
+import { requireConsoleAccess } from "./auth.server";
+import { resolveConsoleConfig } from "./console-runtime.server";
+
+type ResolvedConsoleConfig = HotUpdaterConsoleConfig & {
+  readonly authorityId: string;
+  readonly console: NonNullable<HotUpdaterConsoleConfig["console"]>;
+};
+
+let configPromise: Promise<ResolvedConsoleConfig> | null = null;
 let databaseClient: DatabaseClient | null = null;
 let hotUpdater: ReturnType<
   typeof import("./runtime.server").createRuntimeHotUpdater
@@ -19,18 +28,24 @@ let storagePluginPromise: Promise<
   StoragePluginWith<"get" | "put" | "exists" | "delete">
 > | null = null;
 
-const loadCachedConfig = async () => {
+const loadCachedConfig = async (request: Request) => {
   if (!configPromise) {
-    configPromise = loadConfig(null).catch((error) => {
-      configPromise = null;
-      throw error;
-    });
+    configPromise = resolveConsoleConfig(request)
+      .then((config) => ({
+        ...config,
+        authorityId: config.authorityId ?? "default",
+        console: config.console ?? {},
+      }))
+      .catch((error) => {
+        configPromise = null;
+        throw error;
+      });
   }
 
   return configPromise;
 };
 
-const loadCachedStoragePlugin = async (config: ConfigResponse) => {
+const loadCachedStoragePlugin = async (config: ResolvedConsoleConfig) => {
   if (!storagePluginPromise) {
     storagePluginPromise = Promise.resolve(config.storage)
       .then((storagePlugin) => {
@@ -51,9 +66,10 @@ const loadCachedStoragePlugin = async (config: ConfigResponse) => {
   return storagePluginPromise;
 };
 
-export const prepareConfig = async () => {
+export const prepareConfig = async (request: Request = getRequest()) => {
   try {
-    const config = await loadCachedConfig();
+    await requireConsoleAccess(request);
+    const config = await loadCachedConfig(request);
 
     if (!databaseClient) {
       databaseClient = createDatabaseClient(config.database);
@@ -80,7 +96,14 @@ export const prepareConfig = async () => {
       storagePlugin,
     };
   } catch (error) {
-    console.error("Error during configuration initialization:", error);
+    if (
+      !(
+        error instanceof Response &&
+        (error.status === 401 || error.status === 403)
+      )
+    ) {
+      console.error("Error during configuration initialization:", error);
+    }
     throw error;
   }
 };

--- a/packages/console/src/lib/server/console-runtime.server.ts
+++ b/packages/console/src/lib/server/console-runtime.server.ts
@@ -1,0 +1,21 @@
+import type {
+  ConsoleAuthAdapter,
+  HotUpdaterConsoleConfig,
+  HotUpdaterConsoleConfigSource,
+} from "../../index";
+
+export const getConsoleAuthAdapter = async (): Promise<ConsoleAuthAdapter> => {
+  const module = await import("virtual:hot-updater-console/auth");
+  return module.default;
+};
+
+export const resolveConsoleConfig = async (
+  request: Request,
+): Promise<HotUpdaterConsoleConfig> => {
+  const { default: source } =
+    (await import("virtual:hot-updater-console/config")) as {
+      readonly default: HotUpdaterConsoleConfigSource;
+    };
+
+  return typeof source === "function" ? source(request) : source;
+};

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as InstallationsRouteImport } from './routes/installations'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as AccessKeysRouteImport } from './routes/access-keys'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ApiBundlesBundleIdDownloadRouteImport } from './routes/api/bundles/$bundleId/download'
 
 const InstallationsRoute = InstallationsRouteImport.update({
@@ -35,6 +36,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
+  id: '/api/auth/$',
+  path: '/api/auth/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiBundlesBundleIdDownloadRoute =
   ApiBundlesBundleIdDownloadRouteImport.update({
     id: '/api/bundles/$bundleId/download',
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/access-keys': typeof AccessKeysRoute
   '/analytics': typeof AnalyticsRoute
   '/installations': typeof InstallationsRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/bundles/$bundleId/download': typeof ApiBundlesBundleIdDownloadRoute
 }
 export interface FileRoutesByTo {
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/access-keys': typeof AccessKeysRoute
   '/analytics': typeof AnalyticsRoute
   '/installations': typeof InstallationsRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/bundles/$bundleId/download': typeof ApiBundlesBundleIdDownloadRoute
 }
 export interface FileRoutesById {
@@ -62,6 +70,7 @@ export interface FileRoutesById {
   '/access-keys': typeof AccessKeysRoute
   '/analytics': typeof AnalyticsRoute
   '/installations': typeof InstallationsRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/bundles/$bundleId/download': typeof ApiBundlesBundleIdDownloadRoute
 }
 export interface FileRouteTypes {
@@ -71,6 +80,7 @@ export interface FileRouteTypes {
     | '/access-keys'
     | '/analytics'
     | '/installations'
+    | '/api/auth/$'
     | '/api/bundles/$bundleId/download'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -78,6 +88,7 @@ export interface FileRouteTypes {
     | '/access-keys'
     | '/analytics'
     | '/installations'
+    | '/api/auth/$'
     | '/api/bundles/$bundleId/download'
   id:
     | '__root__'
@@ -85,6 +96,7 @@ export interface FileRouteTypes {
     | '/access-keys'
     | '/analytics'
     | '/installations'
+    | '/api/auth/$'
     | '/api/bundles/$bundleId/download'
   fileRoutesById: FileRoutesById
 }
@@ -93,6 +105,7 @@ export interface RootRouteChildren {
   AccessKeysRoute: typeof AccessKeysRoute
   AnalyticsRoute: typeof AnalyticsRoute
   InstallationsRoute: typeof InstallationsRoute
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiBundlesBundleIdDownloadRoute: typeof ApiBundlesBundleIdDownloadRoute
 }
 
@@ -126,6 +139,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/bundles/$bundleId/download': {
       id: '/api/bundles/$bundleId/download'
       path: '/api/bundles/$bundleId/download'
@@ -141,6 +161,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccessKeysRoute: AccessKeysRoute,
   AnalyticsRoute: AnalyticsRoute,
   InstallationsRoute: InstallationsRoute,
+  ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiBundlesBundleIdDownloadRoute: ApiBundlesBundleIdDownloadRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/console/src/router.tsx
+++ b/packages/console/src/router.tsx
@@ -1,9 +1,8 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
-
-// Import the generated route tree
-import { routeTree } from "./routeTree.gen";
+// Import the route tree selected by the local or hosted Vite integration.
+import { routeTree } from "virtual:hot-updater-console/route-tree";
 
 // Create a new router instance
 export const getRouter = () => {

--- a/packages/console/src/routes/-root-layout.spec.tsx
+++ b/packages/console/src/routes/-root-layout.spec.tsx
@@ -4,7 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("react-grab", () => ({}));
 
 vi.mock("@tanstack/react-router", () => ({
-  createRootRouteWithContext: () => (options: unknown) => ({ options }),
+  createRootRouteWithContext: () => (options: unknown) => ({
+    options,
+    useLoaderData: () => ({
+      access: {
+        status: "authorized",
+        principal: { email: "local@hot-updater.dev" },
+      },
+      providers: [],
+    }),
+  }),
   HeadContent: () => null,
   Outlet: () => <div>Current route</div>,
   Scripts: () => null,
@@ -34,6 +43,10 @@ vi.mock("@/components/ui/sidebar", () => ({
 vi.mock("@/lib/analytics-api", () => ({
   getAnalyticsCapabilityState: () => ({ status: "unsupported" }),
   useAnalyticsCapabilitiesQuery: () => ({ status: "success" }),
+}));
+vi.mock("@/lib/auth-rpc", () => ({
+  getConsoleAccessRpc: vi.fn(),
+  getConsoleAuthProvidersRpc: vi.fn(),
 }));
 
 import { Route } from "./__root";

--- a/packages/console/src/routes/__root.tsx
+++ b/packages/console/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import { useEffect, useState } from "react";
 
 import { AppSidebar } from "@/components/AppSidebar";
+import { ConsoleAccessPage } from "@/components/ConsoleAccessPage";
 import { AnalyticsCapabilityProvider } from "@/components/features/analytics/AnalyticsCapabilityContext";
 import { NotFoundPage } from "@/components/NotFoundPage";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -18,6 +19,10 @@ import {
   getAnalyticsCapabilityState,
   useAnalyticsCapabilitiesQuery,
 } from "@/lib/analytics-api";
+import {
+  getConsoleAccessRpc,
+  getConsoleAuthProvidersRpc,
+} from "@/lib/auth-rpc";
 
 import appCss from "../styles.css?url";
 
@@ -59,6 +64,14 @@ export const Route = createRootRouteWithContext<{
       },
     ],
   }),
+
+  loader: async () => {
+    const [access, providers] = await Promise.all([
+      getConsoleAccessRpc(),
+      getConsoleAuthProvidersRpc(),
+    ]);
+    return { access, providers };
+  },
 
   component: RootLayout,
   notFoundComponent: NotFoundPage,
@@ -126,6 +139,16 @@ export function RootDocument({ children }: { children: React.ReactNode }) {
 }
 
 function RootLayout() {
+  const { access, providers } = Route.useLoaderData();
+
+  if (access.status !== "authorized") {
+    return <ConsoleAccessPage access={access} providers={providers} />;
+  }
+
+  return <AuthorizedConsole />;
+}
+
+function AuthorizedConsole() {
   const capabilityQuery = useAnalyticsCapabilitiesQuery();
   const capability = getAnalyticsCapabilityState(capabilityQuery);
 

--- a/packages/console/src/routes/api/auth/$.ts
+++ b/packages/console/src/routes/api/auth/$.ts
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const handleAuthRequest = async ({
+  request,
+}: {
+  readonly request: Request;
+}) => {
+  const { handleConsoleAuth } = await import("@/lib/server/auth.server");
+  return handleConsoleAuth(request);
+};
+
+export const Route = createFileRoute("/api/auth/$")({
+  server: {
+    handlers: {
+      GET: handleAuthRequest,
+      POST: handleAuthRequest,
+    },
+  },
+});

--- a/packages/console/src/routes/api/bundles/$bundleId/download.ts
+++ b/packages/console/src/routes/api/bundles/$bundleId/download.ts
@@ -3,10 +3,10 @@ import { createFileRoute } from "@tanstack/react-router";
 export const Route = createFileRoute("/api/bundles/$bundleId/download")({
   server: {
     handlers: {
-      GET: async ({ params }) => {
+      GET: async ({ params, request }) => {
         const { prepareConfig } = await import("@/lib/server/config.server");
         const { downloadBundle } = await import("@/lib/server/downloadBundle");
-        const { databaseClient, storagePlugin } = await prepareConfig();
+        const { databaseClient, storagePlugin } = await prepareConfig(request);
         return downloadBundle(params.bundleId, {
           databaseClient,
           storagePlugin,

--- a/packages/console/src/routes/api/bundles/-download-route.spec.ts
+++ b/packages/console/src/routes/api/bundles/-download-route.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+
+const { downloadBundleMock, prepareConfigMock } = vi.hoisted(() => ({
+  downloadBundleMock: vi.fn(),
+  prepareConfigMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: unknown) => ({ options }),
+}));
+vi.mock("@/lib/server/config.server", () => ({
+  prepareConfig: prepareConfigMock,
+}));
+vi.mock("@/lib/server/downloadBundle", () => ({
+  downloadBundle: downloadBundleMock,
+}));
+
+import { Route } from "./$bundleId/download";
+
+type DownloadHandler = (input: {
+  readonly params: { readonly bundleId: string };
+  readonly request: Request;
+}) => Promise<Response>;
+
+const handler = (
+  Route as unknown as {
+    readonly options: {
+      readonly server: { readonly handlers: { readonly GET: DownloadHandler } };
+    };
+  }
+).options.server.handlers.GET;
+
+describe("bundle download route authorization", () => {
+  it("does not touch bundle storage when console access is denied", async () => {
+    const request = new Request(
+      "https://console.example.com/api/bundles/bundle-1/download",
+    );
+    prepareConfigMock.mockRejectedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    await expect(
+      handler({ params: { bundleId: "bundle-1" }, request }),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(prepareConfigMock).toHaveBeenCalledWith(request);
+    expect(downloadBundleMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/console/src/styles.css
+++ b/packages/console/src/styles.css
@@ -3,6 +3,8 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
 
+@source "./";
+
 @custom-variant dark (&:is(.dark *));
 
 body {

--- a/packages/console/src/virtual-modules.d.ts
+++ b/packages/console/src/virtual-modules.d.ts
@@ -1,0 +1,21 @@
+declare module "virtual:hot-updater-console/auth" {
+  import type { ConsoleAuthAdapter } from "./index";
+
+  const auth: ConsoleAuthAdapter;
+  export default auth;
+}
+
+declare module "virtual:hot-updater-console/config" {
+  import type { HotUpdaterConsoleConfigSource } from "./index";
+
+  const config: HotUpdaterConsoleConfigSource;
+  export default config;
+}
+
+declare module "virtual:hot-updater-console/package-router" {
+  export { getRouter } from "./router";
+}
+
+declare module "virtual:hot-updater-console/route-tree" {
+  export { routeTree } from "./routeTree.gen";
+}

--- a/packages/console/src/vite-internal.spec.ts
+++ b/packages/console/src/vite-internal.spec.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { ConfigEnv, Plugin, UserConfig } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createHostedConsolePlugins } from "./vite-internal";
+
+const temporaryDirectories: string[] = [];
+
+const createTemporaryDirectory = () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "hot-updater-console-"));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("hosted console Vite modules", () => {
+  it("generates the router shim and route tree in the host cache", () => {
+    const root = createTemporaryDirectory();
+    const plugin = createHostedConsolePlugins({})[0] as Plugin;
+    const config = plugin.config as (
+      config: UserConfig,
+      environment: ConfigEnv,
+    ) => UserConfig | undefined;
+
+    const resolvedConfig = config(
+      { root },
+      { command: "build", mode: "production" },
+    );
+
+    const oxc = resolvedConfig?.oxc as
+      | { jsx?: { development?: boolean } }
+      | undefined;
+    expect(oxc?.jsx?.development).toBe(false);
+
+    const shimFile = path.join(root, ".hot-updater/console/router.ts");
+    expect(readFileSync(shimFile, "utf8")).toContain(
+      '"virtual:hot-updater-console/package-router"',
+    );
+
+    const resolveId = plugin.resolveId as (id: string) => string | undefined;
+    expect(resolveId("virtual:hot-updater-console/route-tree")).toBe(
+      path.join(root, ".hot-updater/console/routeTree.gen.ts"),
+    );
+  });
+
+  it("statically imports host config and auth modules", () => {
+    const root = createTemporaryDirectory();
+    const plugin = createHostedConsolePlugins({
+      auth: "src/auth.ts",
+      config: "src/config.ts",
+    })[0] as Plugin;
+    const config = plugin.config as (
+      config: UserConfig,
+      environment: ConfigEnv,
+    ) => UserConfig | undefined;
+    config({ root }, { command: "build", mode: "production" });
+
+    const resolveId = plugin.resolveId as (id: string) => string | undefined;
+    const load = plugin.load as (id: string) => string | undefined;
+    const configId = resolveId("virtual:hot-updater-console/config");
+    const authId = resolveId("virtual:hot-updater-console/auth");
+
+    expect(configId).toBe("\0virtual:hot-updater-console/config");
+    expect(authId).toBe("\0virtual:hot-updater-console/auth");
+
+    const context = { addWatchFile() {} };
+    expect(load.call(context, configId as string)).toContain(
+      JSON.stringify(path.join(root, "src/config.ts")),
+    );
+    expect(load.call(context, authId as string)).toContain(
+      JSON.stringify(path.join(root, "src/auth.ts")),
+    );
+  });
+});

--- a/packages/console/src/vite-internal.ts
+++ b/packages/console/src/vite-internal.ts
@@ -1,0 +1,195 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import tailwindcss from "@tailwindcss/vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
+import { nitro } from "nitro/vite";
+import type { Plugin, PluginOption, UserConfig } from "vite";
+
+import type { HotUpdaterConsolePluginOptions } from "./vite";
+
+const virtualAuthModuleId = "virtual:hot-updater-console/auth";
+const virtualConfigModuleId = "virtual:hot-updater-console/config";
+const virtualPackageRouterModuleId =
+  "virtual:hot-updater-console/package-router";
+const virtualRouteTreeModuleId = "virtual:hot-updater-console/route-tree";
+
+const resolvedVirtualAuthModuleId = `\0${virtualAuthModuleId}`;
+const resolvedVirtualConfigModuleId = `\0${virtualConfigModuleId}`;
+const resolvedVirtualPackageRouterModuleId = `\0${virtualPackageRouterModuleId}`;
+
+const packageRoot = path.resolve(import.meta.dirname, "..");
+const packagePublicDirectory = path.join(packageRoot, "public");
+const packageRouterFile = path.join(packageRoot, "src/router.tsx");
+const packageRoutesDirectory = path.join(packageRoot, "src/routes");
+const packageSourceDirectory = path.join(packageRoot, "src");
+const localRouteTreeFile = path.join(
+  packageSourceDirectory,
+  "routeTree.gen.ts",
+);
+
+type ConsoleModuleMode =
+  | {
+      readonly type: "hosted";
+      readonly options: HotUpdaterConsolePluginOptions;
+    }
+  | { readonly type: "local" };
+
+const resolveFromRoot = (root: string, file: string) =>
+  path.isAbsolute(file) ? file : path.resolve(root, file);
+
+const toImportPath = (file: string) => file.split(path.sep).join("/");
+
+const writeFileIfChanged = (file: string, contents: string) => {
+  if (existsSync(file) && readFileSync(file, "utf8") === contents) {
+    return;
+  }
+
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, contents);
+};
+
+const createConsoleModulesPlugin = (mode: ConsoleModuleMode): Plugin => {
+  let authFile = "";
+  let configFile = "";
+  let generatedRouteTreeFile = localRouteTreeFile;
+
+  return {
+    name: `hot-updater-console:${mode.type}-modules`,
+    enforce: "pre",
+    config(userConfig, configEnvironment) {
+      const root = path.resolve(process.cwd(), userConfig.root ?? ".");
+
+      if (mode.type === "hosted") {
+        const cacheDirectory = path.join(root, ".hot-updater/console");
+        generatedRouteTreeFile = path.join(cacheDirectory, "routeTree.gen.ts");
+        authFile = resolveFromRoot(
+          root,
+          mode.options.auth ?? "console.auth.ts",
+        );
+        configFile = resolveFromRoot(
+          root,
+          mode.options.config ?? "hot-updater.config.ts",
+        );
+
+        writeFileIfChanged(
+          path.join(cacheDirectory, "router.ts"),
+          [
+            `export { getRouter } from ${JSON.stringify(virtualPackageRouterModuleId)};`,
+            "",
+          ].join("\n"),
+        );
+      }
+
+      return {
+        assetsInclude: ["**/*.node"],
+        oxc: {
+          jsx: {
+            development: configEnvironment.command === "serve",
+          },
+        },
+        resolve: {
+          alias: [
+            {
+              find: /^@\//,
+              replacement: `${toImportPath(packageSourceDirectory)}/`,
+            },
+          ],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "@tanstack/react-router",
+            "@tanstack/react-start",
+          ],
+        },
+      } satisfies UserConfig;
+    },
+    resolveId(id) {
+      if (id === virtualAuthModuleId) {
+        return resolvedVirtualAuthModuleId;
+      }
+      if (id === virtualConfigModuleId) {
+        return resolvedVirtualConfigModuleId;
+      }
+      if (id === virtualPackageRouterModuleId) {
+        return resolvedVirtualPackageRouterModuleId;
+      }
+      if (id === virtualRouteTreeModuleId) {
+        return generatedRouteTreeFile;
+      }
+      return undefined;
+    },
+    load(id) {
+      if (id === resolvedVirtualPackageRouterModuleId) {
+        return `export { getRouter } from ${JSON.stringify(toImportPath(packageRouterFile))};`;
+      }
+
+      if (id === resolvedVirtualConfigModuleId) {
+        if (mode.type === "local") {
+          return [
+            'import { loadConfig } from "@hot-updater/cli-tools";',
+            "export default async () => {",
+            "  const config = await loadConfig(null);",
+            "  return {",
+            "    authorityId: config.authorityId,",
+            "    console: { gitUrl: config.console.gitUrl },",
+            "    database: config.database,",
+            "    storage: config.storage,",
+            "  };",
+            "};",
+          ].join("\n");
+        }
+
+        this.addWatchFile(configFile);
+        return `export { default } from ${JSON.stringify(toImportPath(configFile))};`;
+      }
+
+      if (id === resolvedVirtualAuthModuleId) {
+        if (mode.type === "local") {
+          return [
+            'const principal = { email: "local@hot-updater.dev", name: "Local Console" };',
+            "export default {",
+            "  async handle() {",
+            '    return new Response("Not Found", { status: 404 });',
+            "  },",
+            "  async getAccess() {",
+            '    return { status: "authorized", principal };',
+            "  },",
+            "  async getProviders() {",
+            "    return [];",
+            "  },",
+            "};",
+          ].join("\n");
+        }
+
+        this.addWatchFile(authFile);
+        return `export { default } from ${JSON.stringify(toImportPath(authFile))};`;
+      }
+
+      return undefined;
+    },
+  };
+};
+
+export const createHostedConsolePlugins = (
+  options: HotUpdaterConsolePluginOptions,
+): PluginOption[] => [
+  createConsoleModulesPlugin({ type: "hosted", options }),
+  nitro({
+    publicAssets: [{ dir: packagePublicDirectory, maxAge: 60 * 60 * 24 }],
+  }),
+  tailwindcss(),
+  tanstackStart({
+    srcDirectory: ".hot-updater/console",
+    router: {
+      generatedRouteTree: "routeTree.gen.ts",
+      routesDirectory: packageRoutesDirectory,
+    },
+  }),
+  viteReact(),
+];
+
+export const createLocalConsoleModulesPlugin = (): Plugin =>
+  createConsoleModulesPlugin({ type: "local" });

--- a/packages/console/src/vite.ts
+++ b/packages/console/src/vite.ts
@@ -1,0 +1,12 @@
+import type { PluginOption } from "vite";
+
+import { createHostedConsolePlugins } from "./vite-internal";
+
+export interface HotUpdaterConsolePluginOptions {
+  readonly auth?: string;
+  readonly config?: string;
+}
+
+export const hotUpdaterConsole = (
+  options: HotUpdaterConsolePluginOptions = {},
+): PluginOption[] => createHostedConsolePlugins(options);

--- a/packages/console/tsdown.config.ts
+++ b/packages/console/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["./src/index.ts", "./src/vite.ts"],
+  format: ["esm"],
+  outDir: "lib",
+  dts: true,
+  clean: true,
+  unbundle: true,
+  exports: false,
+  failOnWarn: true,
+});

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -6,8 +6,11 @@ import { nitro } from "nitro/vite";
 import { defineConfig } from "vite";
 import viteTsConfigPaths from "vite-tsconfig-paths";
 
+import { createLocalConsoleModulesPlugin } from "./src/vite-internal";
+
 const config = defineConfig({
   plugins: [
+    createLocalConsoleModulesPlugin(),
     devtools(),
     nitro(),
     // this is the plugin that enables path aliases

--- a/packages/hot-updater/src/commands/console.spec.ts
+++ b/packages/hot-updater/src/commands/console.spec.ts
@@ -19,9 +19,9 @@ describe("getConsoleServerEnv", () => {
       expectedHost: "127.0.0.1",
     },
     {
-      name: "preserves an explicit host",
+      name: "overrides an explicit public host",
       processEnv: { NITRO_HOST: "0.0.0.0" },
-      expectedHost: "0.0.0.0",
+      expectedHost: "127.0.0.1",
     },
   ])("$name", ({ processEnv, expectedHost }) => {
     const env = getConsoleServerEnv(4_321, processEnv);

--- a/packages/hot-updater/src/commands/console.ts
+++ b/packages/hot-updater/src/commands/console.ts
@@ -32,9 +32,7 @@ export const getConsoleServerEnv = (
   ...processEnv,
   PORT: port.toString(),
   NITRO_PORT: port.toString(),
-  NITRO_HOST: processEnv["NITRO_HOST"]?.trim()
-    ? processEnv["NITRO_HOST"]
-    : "127.0.0.1",
+  NITRO_HOST: "127.0.0.1",
 });
 
 export const isConsoleServerReady = async (port: number) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1455,46 +1455,30 @@ importers:
 
   packages/console:
     dependencies:
-      '@hot-updater/bsdiff':
-        specifier: workspace:*
-        version: link:../bsdiff
-      '@hot-updater/server':
-        specifier: workspace:*
-        version: link:../server
-      recharts:
-        specifier: 3.8.0
-        version: 3.8.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(redux@5.0.1)
-    devDependencies:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.5.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
-      '@hot-updater/cli-tools':
+      '@hot-updater/bsdiff':
         specifier: workspace:*
-        version: link:../cli-tools
+        version: link:../bsdiff
       '@hot-updater/core':
         specifier: workspace:*
         version: link:../core
-      '@hot-updater/mock':
-        specifier: workspace:*
-        version: link:../../plugins/mock
       '@hot-updater/plugin-core':
         specifier: workspace:*
         version: link:../../plugins/plugin-core
+      '@hot-updater/server':
+        specifier: workspace:*
+        version: link:../server
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.3.0(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@tanstack/devtools-vite':
-        specifier: ^0.6.0
-        version: 0.6.1(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: ^0.10.0
         version: 0.10.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)
-      '@tanstack/react-form':
-        specifier: ^1.28.5
-        version: 1.33.0(@tanstack/react-start@1.168.25(@vitejs/plugin-rsc@0.5.27(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.101.0(react@19.2.6)
@@ -1510,6 +1494,64 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.166.11
         version: 1.168.25(@vitejs/plugin-rsc@0.5.27(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.2(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      dayjs:
+        specifier: ^1.11.20
+        version: 1.11.21
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.6)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      nitro:
+        specifier: 3.0.260610-beta
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.1)(@libsql/client@0.15.15)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@electric-sql/pglite@0.4.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@prisma/client@6.19.3(@typescript/typescript6@6.0.2)(prisma@6.19.3(@typescript/typescript6@6.0.2)))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.19.1(@types/node@25.9.3))(pg@8.21.0)(prisma@6.19.3(@typescript/typescript6@6.0.2)))(giget@2.0.0)(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260609.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1066.0)(socks@2.8.9))(mysql2@3.19.1(@types/node@25.9.3))(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.99.0(@cloudflare/workers-types@4.20260611.1))(xml2js@0.6.2)
+      react-grab:
+        specifier: ^0.1.28
+        version: 0.1.44(react@19.2.6)
+      recharts:
+        specifier: 3.8.0
+        version: 3.8.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(redux@5.0.1)
+      shadcn:
+        specifier: ^4.0.8
+        version: 4.11.0(@typescript/typescript6@6.0.2)(babel-plugin-macros@3.1.0)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.6.0
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.3.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      verkit:
+        specifier: 0.3.2
+        version: 0.3.2
+    devDependencies:
+      '@hot-updater/cli-tools':
+        specifier: workspace:*
+        version: link:../cli-tools
+      '@hot-updater/mock':
+        specifier: workspace:*
+        version: link:../../plugins/mock
+      '@tanstack/devtools-vite':
+        specifier: ^0.6.0
+        version: 0.6.1(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-form':
+        specifier: ^1.28.5
+        version: 1.33.0(@tanstack/react-start@1.168.25(@vitejs/plugin-rsc@0.5.27(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1534,69 +1576,30 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      class-variance-authority:
-        specifier: ^0.7.1
-        version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      dayjs:
-        specifier: ^1.11.20
-        version: 1.11.21
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1(@noble/hashes@2.2.0)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.6)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nitro:
-        specifier: latest
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.1)(@libsql/client@0.15.15)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@electric-sql/pglite@0.4.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@prisma/client@6.19.3(@typescript/typescript6@6.0.2)(prisma@6.19.3(@typescript/typescript6@6.0.2)))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.19.1(@types/node@25.9.3))(pg@8.21.0)(prisma@6.19.3(@typescript/typescript6@6.0.2)))(giget@2.0.0)(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260609.0)(mongodb@6.20.0(@aws-sdk/credential-providers@3.1066.0)(socks@2.8.9))(mysql2@3.19.1(@types/node@25.9.3))(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.99.0(@cloudflare/workers-types@4.20260611.1))(xml2js@0.6.2)
       react:
         specifier: ^19.2.4
         version: 19.2.6
       react-dom:
         specifier: ^19.2.4
         version: 19.2.6(react@19.2.6)
-      react-grab:
-        specifier: ^0.1.28
-        version: 0.1.44(react@19.2.6)
-      shadcn:
-        specifier: ^4.0.8
-        version: 4.11.0(@typescript/typescript6@6.0.2)(babel-plugin-macros@3.1.0)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.6.0
-      tailwindcss:
-        specifier: ^4.2.1
-        version: 4.3.0
       tar:
         specifier: ^7.5.16
         version: 7.5.16
+      tsdown:
+        specifier: catalog:tools
+        version: 0.21.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@typescript/typescript6@6.0.2)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
-      verkit:
-        specifier: 0.3.2
-        version: 0.3.2
       vite:
         specifier: 8.0.8
         version: 8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)


### PR DESCRIPTION
## Summary
- package the full Console application behind the root and /vite exports
- inject runtime Hot Updater config and hosted auth through the Vite plugin
- preserve the unauthenticated local CLI while forcing loopback binding
- add authorization boundary, regression tests, and a release changeset

## Verification
- pnpm --filter @hot-updater/console test:type
- pnpm --filter @hot-updater/console test
- pnpm --filter hot-updater test:type
- pnpm vitest run packages/hot-updater/src/commands/console.spec.ts
- pnpm --filter @hot-updater/console build
- pnpm lint
- Node runtime smoke test