### PR TITLE
fix(android): preserve Metro in debug builds

### DIFF
--- a/.changeset/metal-debug-bundle.md
+++ b/.changeset/metal-debug-bundle.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Preserve Metro as the JavaScript bundle source for Android debug builds while continuing to use Hot Updater bundles for release builds.

--- a/packages/react-native/plugin/src/transformers.ts
+++ b/packages/react-native/plugin/src/transformers.ts
@@ -136,8 +136,14 @@ function transformAndroidReactHost(contents: string): string {
     )}`;
   }
 
-  const jsBundleLine = `${paramIndent}jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),`;
-  return `${prefix}${jsBundleLine}\n${suffix}`;
+  const jsBundleLines = [
+    `${paramIndent}jsBundleFilePath = if (BuildConfig.DEBUG) {`,
+    `${paramIndent}  null`,
+    `${paramIndent}} else {`,
+    `${paramIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+    `${paramIndent}},`,
+  ];
+  return `${prefix}${jsBundleLines.join("\n")}\n${suffix}`;
 }
 
 /**
@@ -208,7 +214,11 @@ function transformAndroidDefaultHost(contents: string): string {
       const methodLines = [
         "", // blank line
         `${indent}override fun getJSBundleFile(): String? {`,
-        `${bodyIndent}return HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+        `${bodyIndent}  null`,
+        `${bodyIndent}} else {`,
+        `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}}`,
         `${indent}}`,
       ];
 
@@ -247,7 +257,11 @@ function transformAndroidDefaultHost(contents: string): string {
 
       const methodLines = [
         `${indent}override fun getJSBundleFile(): String? {`,
-        `${bodyIndent}return HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+        `${bodyIndent}  null`,
+        `${bodyIndent}} else {`,
+        `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}}`,
         `${indent}}`,
       ];
 

--- a/packages/react-native/plugin/src/withHotUpdater.spec.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.spec.ts
@@ -144,7 +144,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
     )
   }
 
@@ -232,7 +236,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {
-          return HotUpdater.getJSBundleFile(applicationContext)
+          return if (BuildConfig.DEBUG) {
+            null
+          } else {
+            HotUpdater.getJSBundleFile(applicationContext)
+          }
         }
       }
 
@@ -346,7 +354,11 @@ class MainApplication : Application(), ReactApplication {
           override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
 
           override fun getJSBundleFile(): String? {
-              return HotUpdater.getJSBundleFile(applicationContext)
+              return if (BuildConfig.DEBUG) {
+                null
+              } else {
+                HotUpdater.getJSBundleFile(applicationContext)
+              }
           }
       }
   )
@@ -417,7 +429,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
     )
   }
 }`;
@@ -473,7 +489,11 @@ class MainApplication : Application(), ReactApplication {
           PackageList(this).packages.apply {
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+        jsBundleFilePath = if (BuildConfig.DEBUG) {
+          null
+        } else {
+          HotUpdater.getJSBundleFile(applicationContext)
+        },
       ),
     )
   }


### PR DESCRIPTION
## Summary

- Keep Metro as the JavaScript bundle source for Android debug builds.
- Use `HotUpdater.getJSBundleFile(...)` only for Android release builds.
- Cover both the RN 0.82+ `getDefaultReactHost` and RN 0.81/Expo host transformation paths.
- Add a patch changeset for `@hot-updater/react-native`.

## Why

The Android config-plugin transform currently injects `HotUpdater.getJSBundleFile(applicationContext)` unconditionally. In a debug build launched with `npm run android` / Expo, that bypasses Metro and can leave the app stuck on the launch screen instead of loading the development bundle.

The iOS transform is intentionally unchanged: its generated `#if DEBUG` branch already continues to use Metro.

## Validation

- `git diff --check`
- `pnpm dlx oxfmt@0.43.0 --check packages/react-native/plugin/src/transformers.ts packages/react-native/plugin/src/withHotUpdater.spec.ts`
- Focused Node 24 transformer assertions for both Android host patterns, idempotence, and the unchanged iOS debug path

The full workspace test suite was not run in the lightweight upstream checkout; CI should run the repository test matrix.

## Attribution

Generated by 5.6 Luna Max at the request of the Queue App team.
