### PR TITLE
fix(supabase): decode percent-encoded storage object keys

### DIFF
--- a/.changeset/decode-supabase-storage-keys.md
+++ b/.changeset/decode-supabase-storage-keys.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/supabase": patch
+---
+
+Decode percent-encoded object keys when parsing `supabase-storage://` URIs. Supabase upload responses echo a percent-encoded key, so an asset such as `logo-ios@2x.png` is stored as `logo-ios%402x.png`. Storage API calls that carry the key in the request path decode it server side, but `createSignedUrls` and `remove` send keys in the JSON body and looked up an object that does not exist, which failed update checks with "Either the object does not exist or you do not have access to it".

--- a/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
+++ b/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
@@ -222,4 +222,59 @@ describe("supabaseEdgeFunctionStorage", () => {
 
     expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
   });
+  it("decodes percent-encoded object keys before signing", async () => {
+    bucket.createSignedUrls.mockImplementation(async (paths: string[]) => ({
+      data: paths.map((path) => ({
+        error: null,
+        path,
+        signedUrl: `https://example.supabase.co/${path}`,
+      })),
+      error: null,
+    }));
+
+    const storage = supabaseEdgeFunctionStorage({
+      supabaseServiceRoleKey: "service-role-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+
+    await expect(
+      storage.profiles.runtime.getDownloadUrl(
+        "supabase-storage://updates/assets/bootsplash/logo-ios%402x.png",
+        {},
+      ),
+    ).resolves.toEqual({
+      fileUrl: "https://example.supabase.co/assets/bootsplash/logo-ios@2x.png",
+    });
+
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/bootsplash/logo-ios@2x.png"],
+      3600,
+    );
+  });
+
+  it("leaves keys with invalid percent sequences untouched", async () => {
+    bucket.createSignedUrls.mockImplementation(async (paths: string[]) => ({
+      data: paths.map((path) => ({
+        error: null,
+        path,
+        signedUrl: `https://example.supabase.co/${path}`,
+      })),
+      error: null,
+    }));
+
+    const storage = supabaseEdgeFunctionStorage({
+      supabaseServiceRoleKey: "service-role-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+
+    await storage.profiles.runtime.getDownloadUrl(
+      "supabase-storage://updates/assets/100%-off.png",
+      {},
+    );
+
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/100%-off.png"],
+      3600,
+    );
+  });
 });

--- a/plugins/supabase/src/supabaseEdgeFunctionStorage.ts
+++ b/plugins/supabase/src/supabaseEdgeFunctionStorage.ts
@@ -2,6 +2,7 @@ import { createRuntimeStoragePlugin } from "@hot-updater/plugin-core";
 import { createClient } from "@supabase/supabase-js";
 
 import { createSupabaseSignedUrlBatcher } from "./supabaseSignedUrlBatcher";
+import { decodeStorageObjectKey } from "./supabaseStorageKey";
 import type { Database } from "./types";
 
 export interface SupabaseEdgeFunctionStorageConfig {
@@ -18,7 +19,7 @@ const parseSupabaseStorageUri = (storageUri: string) => {
   }
 
   const bucketName = storageUrl.host;
-  const key = storageUrl.pathname.replace(/^\/+/, "");
+  const key = decodeStorageObjectKey(storageUrl.pathname.replace(/^\/+/, ""));
 
   if (!bucketName || !key) {
     throw new Error("Invalid Supabase storage URI");

--- a/plugins/supabase/src/supabaseStorage.spec.ts
+++ b/plugins/supabase/src/supabaseStorage.spec.ts
@@ -11,6 +11,7 @@ const { bucket, createClient } = vi.hoisted(() => {
     createSignedUrl: vi.fn(),
     createSignedUrls: vi.fn(),
     exists: vi.fn(),
+    remove: vi.fn(),
     upload: vi.fn(),
   };
 
@@ -33,6 +34,7 @@ describe("supabaseStorage", () => {
     bucket.createSignedUrl.mockReset();
     bucket.createSignedUrls.mockReset();
     bucket.exists.mockReset();
+    bucket.remove.mockReset();
     bucket.upload.mockReset();
     createClient.mockClear();
   });
@@ -299,5 +301,40 @@ describe("supabaseStorage", () => {
     );
 
     expect(bucket.createSignedUrls).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes percent-encoded object keys before signing and removing", async () => {
+    bucket.createSignedUrls.mockImplementation(async (paths: string[]) => ({
+      data: paths.map((path) => ({
+        error: null,
+        path,
+        signedUrl: `https://example.supabase.co/${path}`,
+      })),
+      error: null,
+    }));
+    bucket.remove.mockResolvedValueOnce({ data: [], error: null });
+
+    const storage = supabaseStorage({
+      bucketName: "updates",
+      supabaseAnonKey: "anon-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+    const storageUri =
+      "supabase-storage://updates/assets/bootsplash/logo-ios%402x.png";
+
+    await expect(
+      storage.profiles.runtime.getDownloadUrl(storageUri),
+    ).resolves.toEqual({
+      fileUrl: "https://example.supabase.co/assets/bootsplash/logo-ios@2x.png",
+    });
+    expect(bucket.createSignedUrls).toHaveBeenCalledWith(
+      ["assets/bootsplash/logo-ios@2x.png"],
+      3600,
+    );
+
+    await storage.profiles.node.delete(storageUri);
+    expect(bucket.remove).toHaveBeenCalledWith([
+      "assets/bootsplash/logo-ios@2x.png",
+    ]);
   });
 });

--- a/plugins/supabase/src/supabaseStorage.ts
+++ b/plugins/supabase/src/supabaseStorage.ts
@@ -14,6 +14,7 @@ import {
   type SupabaseServiceRoleConfig,
 } from "./supabaseConfig";
 import { createSupabaseSignedUrlBatcher } from "./supabaseSignedUrlBatcher";
+import { decodeStorageObjectKey } from "./supabaseStorageKey";
 import type { Database } from "./types";
 
 type SupabaseStorageBucket = {
@@ -83,6 +84,12 @@ async function verifyObjectCanBeSignedForRuntime({
   });
 }
 
+const parseSupabaseStorageUri = (storageUri: string) => {
+  const { bucket, key } = parseStorageUri(storageUri, "supabase-storage");
+
+  return { bucket, key: decodeStorageObjectKey(key) };
+};
+
 export type SupabaseStorageConfig = SupabaseServiceRoleConfig & {
   bucketName: string;
   /**
@@ -113,10 +120,8 @@ export const supabaseStorage =
       return {
         node: {
           async delete(storageUri) {
-            const { key, bucket: bucketName } = parseStorageUri(
-              storageUri,
-              "supabase-storage",
-            );
+            const { key, bucket: bucketName } =
+              parseSupabaseStorageUri(storageUri);
             if (bucketName !== config.bucketName) {
               throw new Error(
                 `Bucket name mismatch: expected "${config.bucketName}", but found "${bucketName}".`,
@@ -162,10 +167,8 @@ export const supabaseStorage =
             };
           },
           async exists(storageUri: string) {
-            const { key, bucket: bucketName } = parseStorageUri(
-              storageUri,
-              "supabase-storage",
-            );
+            const { key, bucket: bucketName } =
+              parseSupabaseStorageUri(storageUri);
             if (bucketName !== config.bucketName) {
               throw new Error(
                 `Bucket name mismatch: expected "${config.bucketName}", but found "${bucketName}".`,
@@ -188,10 +191,8 @@ export const supabaseStorage =
             return data;
           },
           async downloadFile(storageUri: string, filePath: string) {
-            const { key, bucket: bucketName } = parseStorageUri(
-              storageUri,
-              "supabase-storage",
-            );
+            const { key, bucket: bucketName } =
+              parseSupabaseStorageUri(storageUri);
             if (bucketName !== config.bucketName) {
               throw new Error(
                 `Bucket name mismatch: expected "${config.bucketName}", but found "${bucketName}".`,
@@ -215,10 +216,8 @@ export const supabaseStorage =
         },
         runtime: {
           async readText(storageUri: string) {
-            const { key, bucket: bucketName } = parseStorageUri(
-              storageUri,
-              "supabase-storage",
-            );
+            const { key, bucket: bucketName } =
+              parseSupabaseStorageUri(storageUri);
             if (bucketName !== config.bucketName) {
               throw new Error(
                 `Bucket name mismatch: expected "${config.bucketName}", but found "${bucketName}".`,
@@ -246,7 +245,9 @@ export const supabaseStorage =
               throw new Error("Invalid Supabase storage URI protocol");
             }
             // Extract key without bucket prefix if present
-            let key = `${u.host}${u.pathname}`.replace(/^\//, "");
+            let key = decodeStorageObjectKey(
+              `${u.host}${u.pathname}`.replace(/^\//, ""),
+            );
             if (!key) {
               throw new Error("Invalid Supabase storage URI: missing key");
             }

--- a/plugins/supabase/src/supabaseStorageKey.ts
+++ b/plugins/supabase/src/supabaseStorageKey.ts
@@ -1,0 +1,20 @@
+/**
+ * Supabase upload responses echo a percent-encoded object key (`data.Key`),
+ * so the `supabase-storage://` URIs built from them keep that encoding.
+ *
+ * Storage API endpoints that carry the key in the request path
+ * (`createSignedUrl`, `download`, `exists`) decode it server side, but the
+ * ones that carry keys in the JSON body (`createSignedUrls`, `remove`) do
+ * not, and look up an object whose name literally contains `%40`.
+ *
+ * Decoding when the URI is parsed keeps both request shapes pointing at the
+ * same object. Keys that are not valid percent-encoded sequences are left
+ * untouched.
+ */
+export const decodeStorageObjectKey = (key: string): string => {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+};


### PR DESCRIPTION
# fix(supabase): decode percent-encoded storage object keys

## Summary

Update checks on a Supabase-backed setup fail for any bundle whose manifest contains an asset with a URL-escaped character in its name — most commonly React Native's `@2x` / `@3x` images:

```
Hot Updater handler error: Error: Failed to generate download URL for
"my-bucket/01a01279-459e-7e0a-aa9c-b3fa9e6a1876/files/assets/Assets/bootsplash/logo-ios%402x.png":
Either the object does not exist or you do not have access to it
    at createSignedUrlError (.../hot-updater-supabase/dist/supabaseEdgeFunctionStorage-*.mjs:275:75)
    at async flush (.../supabaseEdgeFunctionStorage-*.mjs:280:3)
```

The object exists. Its real name is `logo-ios@2x.png`; the lookup asks for `logo-ios%402x.png`.

This is a regression from #1147 (the batching fix for #1145), released in `0.36.0`. On `0.31.4` the same bundle resolves fine.

## Root cause

`upload()` stores the storage URI built from the upload response:

```ts
// plugins/supabase/src/supabaseStorage.ts
const fullPath = upload.data.fullPath;
return { storageUri: `supabase-storage://${fullPath}` };
```

`fullPath` is `data.Key` echoed by the Storage API, and it is **percent-encoded**. So the URI persisted in `bundles` already contains `logo-ios%402x.png`, and every reader that parses it keeps that encoding:

```ts
const key = storageUrl.pathname.replace(/^\/+/, "");   // logo-ios%402x.png
```

Whether that breaks depends on how the Storage API endpoint receives the key:

| API | key travels in | server-side decoding | result |
| --- | --- | --- | --- |
| `createSignedUrl` | request path — `POST /object/sign/{bucket}/{key}` | yes | works |
| `download`, `exists` | request path | yes | works |
| `createSignedUrls` | JSON body — `{ paths }` | **no** | **404** |
| `remove` | JSON body — `{ prefixes }` | **no** | **silently deletes nothing** |

Signing used the path-based endpoint until #1147 switched it to the batch endpoint, which is where the pre-existing encoding mismatch started to surface. `remove()` has always been affected, so `bundle delete` and `storage prune` have been unable to delete these objects.

The deploy-time guard added in `0.36.0` cannot catch it either — `verifyObjectCanBeSignedForRuntime` runs against the pre-encoding key and through the single-URL API, so it always passes:

```ts
const Key = getStorageKey(key, filename);          // logo-ios@2x.png
await bucket.upload(Key, Body, { ... });
await verifyObjectCanBeSignedForRuntime({ bucket, key: Key });   // passes
const fullPath = upload.data.fullPath;             // logo-ios%402x.png
```

## Fix

Decode the object key when a `supabase-storage://` URI is parsed, so both request shapes address the same object. This also repairs bundles already deployed with an encoded URI, which a write-side-only fix would not.

Keys that are not valid percent-encoded sequences (`100%-off.png` would make `decodeURIComponent` throw) are left untouched.

## Test plan

- `decodes percent-encoded object keys before signing` — `createSignedUrls` is called with `assets/bootsplash/logo-ios@2x.png`
- `leaves keys with invalid percent sequences untouched` — `100%-off.png` is passed through unchanged
- `decodes percent-encoded object keys before signing and removing` — covers `remove()` on the node plugin

Both decode tests fail on `main` and pass with this change. `pnpm -w lint` and `pnpm -w test` pass.

Verified against a live project: the failing update check returns `HTTP 500` before the change and a signed URL after redeploying the edge function.

---

## 한국어 설명

### 요약

Supabase를 쓰는 환경에서, 매니페스트에 **파일명에 URL 이스케이프 대상 문자가 들어간 에셋**이 있으면 업데이트 체크가 실패합니다. React Native의 `@2x` / `@3x` 이미지가 대표적입니다.

```
Hot Updater handler error: Error: Failed to generate download URL for
"my-bucket/01a01279-459e-7e0a-aa9c-b3fa9e6a1876/files/assets/Assets/bootsplash/logo-ios%402x.png":
Either the object does not exist or you do not have access to it
```

객체는 존재합니다. 실제 이름은 `logo-ios@2x.png`인데, 조회는 `logo-ios%402x.png`로 들어갑니다.

`0.36.0`에 포함된 #1147(#1145에 대한 배치 처리 수정)의 회귀입니다. `0.31.4`에서는 같은 번들이 정상적으로 처리됩니다.

### 원인

`upload()`이 업로드 응답으로 받은 경로를 그대로 storage URI로 저장합니다.

```ts
const fullPath = upload.data.fullPath;
return { storageUri: `supabase-storage://${fullPath}` };
```

`fullPath`는 Storage API가 돌려주는 `data.Key`이고 **퍼센트 인코딩된 값**입니다. 그래서 `bundles`에 저장되는 URI에 이미 `logo-ios%402x.png`가 들어가고, 이 URI를 파싱하는 쪽은 인코딩된 키를 그대로 사용합니다.

```ts
const key = storageUrl.pathname.replace(/^\/+/, "");   // logo-ios%402x.png
```

문제가 드러나는지 여부는 **키가 어떤 통로로 Storage API에 전달되는지**에 달려 있습니다.

| API | 키 전달 위치 | 서버 측 디코딩 | 결과 |
| --- | --- | --- | --- |
| `createSignedUrl` | 요청 경로 — `POST /object/sign/{bucket}/{key}` | 함 | 정상 |
| `download`, `exists` | 요청 경로 | 함 | 정상 |
| `createSignedUrls` | JSON 본문 — `{ paths }` | **안 함** | **404** |
| `remove` | JSON 본문 — `{ prefixes }` | **안 함** | **아무것도 삭제되지 않음** |

서명은 #1147 전까지 경로 기반 엔드포인트를 썼고, 배치 엔드포인트로 바뀌면서 원래 있던 인코딩 불일치가 표면화됐습니다. `remove()`는 처음부터 영향을 받고 있었기 때문에, `bundle delete`와 `storage prune`이 해당 객체들을 삭제하지 못한 채 성공한 것처럼 동작했습니다.

`0.36.0`에 추가된 배포 시점 검사도 이 문제를 잡지 못합니다. `verifyObjectCanBeSignedForRuntime`는 **인코딩되기 전 키**를, 그것도 **단건 API**로 검사하므로 항상 통과합니다.

```ts
const Key = getStorageKey(key, filename);          // logo-ios@2x.png
await bucket.upload(Key, Body, { ... });
await verifyObjectCanBeSignedForRuntime({ bucket, key: Key });   // 통과
const fullPath = upload.data.fullPath;             // logo-ios%402x.png
```

### 수정

`supabase-storage://` URI를 파싱하는 시점에 객체 키를 디코딩해서, 두 방식의 요청이 같은 객체를 가리키도록 했습니다. 이렇게 하면 **이미 인코딩된 URI로 배포된 기존 번들까지 함께 복구**됩니다. 업로드 쪽만 고치면 기존 번들은 계속 깨진 상태로 남습니다.

`100%-off.png`처럼 유효한 퍼센트 인코딩 시퀀스가 아닌 키는 `decodeURIComponent`가 예외를 던지므로, 원본을 그대로 유지합니다.

### 테스트

- `decodes percent-encoded object keys before signing` — `createSignedUrls`가 `assets/bootsplash/logo-ios@2x.png`로 호출되는지 확인
- `leaves keys with invalid percent sequences untouched` — `100%-off.png`가 변형 없이 전달되는지 확인
- `decodes percent-encoded object keys before signing and removing` — node 플러그인의 `remove()`까지 확인

디코딩 테스트 2건은 `main`에서 실패하고 이 변경으로 통과합니다. `pnpm -w lint`, `pnpm -w test` 모두 통과했습니다.

실제 운영 프로젝트에서도 확인했습니다. 수정 전에는 업데이트 체크가 `HTTP 500`을 반환했고, 엣지 함수를 재배포한 뒤에는 정상적으로 signed URL을 반환합니다.
