### PR TITLE
docs: clarify update activation timing

### DIFF
--- a/docs/content/docs/(latest)/react-native-api/updateBundle.mdx
+++ b/docs/content/docs/(latest)/react-native-api/updateBundle.mdx
@@ -1,13 +1,15 @@
 ---
 title: "updateBundle"
-description: "The `updateBundle` function applies a bundle transition selected by `checkForUpdate` to your React Native application."
+description: "Stage a selected transition without reloading the current React Native runtime."
 icon: Download
 ---
 
 ## Usage
 
-Use `updateBundle` to apply an available update. Normally, call the pre-filled
-helper returned by `checkForUpdate()`.
+Use `updateBundle` to stage the selected transition, downloading and verifying
+a bundle when needed. Normally, call the pre-filled helper returned by
+`checkForUpdate()`. The function does not reload the React Native runtime
+currently in use.
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
@@ -16,7 +18,7 @@ HotUpdater.init({
   baseURL: "<your-update-server-url>",
 });
 
-async function applyAppUpdate() {
+async function stageAppUpdate() {
   try {
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion", // or "fingerprint"
@@ -34,13 +36,18 @@ async function applyAppUpdate() {
     // Recommended: use the helper with all update arguments pre-filled.
     const didUpdate = await updateInfo.updateBundle();
 
-    if (didUpdate && updateInfo.shouldForceUpdate) {
-      await HotUpdater.reload();
+    if (!didUpdate) {
+      console.warn("Update transition was not staged");
+      return;
     }
 
-    console.log("Update applied successfully");
+    console.log("Bundle transition staged successfully");
+
+    if (updateInfo.shouldForceUpdate) {
+      await HotUpdater.reload();
+    }
   } catch (error) {
-    console.error("Failed to apply update:", error);
+    console.error("Failed to stage update:", error);
   }
 }
 ```
@@ -76,8 +83,13 @@ await HotUpdater.updateBundle({
   public key. A failed verification aborts the update and deletes the download.
 - A `null` URL or hash represents a transition that does not use that archive
   value; the properties must still be present in the object.
-- Applies the selected bundle transition for the application.
-- Requires an explicit call to `HotUpdater.reload()` if you want to immediately reload the application after updating, particularly when `shouldForceUpdate` is true.
+- Stages the selected bundle transition for the next React Native runtime start
+  without replacing the code already running.
+- Never reloads the app by itself. Call `HotUpdater.reload()` explicitly to
+  start the staged transition immediately; the automatic `HotUpdater.wrap` flow
+  handles force updates separately.
+- An in-progress download is not guaranteed to finish after the app is
+  force-quit.
 
 ### Security Recommendation
 

--- a/docs/content/docs/(latest)/react-native-api/wrap.mdx
+++ b/docs/content/docs/(latest)/react-native-api/wrap.mdx
@@ -1,6 +1,6 @@
 ---
 title: "wrap"
-description: "`HotUpdater.wrap` checks for updates at the entry point, and if there is a bundle to update, it downloads the bundle and applies the update strategy."
+description: "`HotUpdater.wrap` stages standard updates for the next app start and reloads force updates by default."
 icon: Package
 ---
 
@@ -14,6 +14,14 @@ icon: Package
 `HotUpdater.wrap` always runs the automatic update flow. `updateMode` is not
 accepted. For a manual flow, use
 [`HotUpdater.init`](/docs/react-native-api/init).
+
+A standard update is prepared and staged without reloading the React Native
+runtime currently in use. Once staging finishes successfully, it becomes active
+the next time that runtime starts, normally on the next cold app launch. In the
+automatic `HotUpdater.wrap` flow, responses with `shouldForceUpdate: true`,
+including bundle-changing server-directed rollbacks, prepare the selected
+transition and then reload by default. Set `reloadOnForceUpdate: false` when the
+current session must remain uninterrupted.
 
 ### Automatic Updates
 
@@ -198,7 +206,15 @@ export default HotUpdater.wrap({ // [!code hl:25]
 
 #### `reloadOnForceUpdate`
 
-When a force update bundle is downloaded, the app will automatically reload. If `false`, `shouldForceUpdate` will be returned as `true` in `onUpdateProcessCompleted` but the app won't reload. Default is `true`.
+When the automatic `HotUpdater.wrap` flow receives an update with
+`shouldForceUpdate: true`, it prepares the selected transition and reloads the
+app by default. Bundle-changing server-directed rollbacks also use this path.
+If set to `false`, the current React Native runtime keeps running and the staged
+update becomes active on the next runtime start or after a later explicit
+`HotUpdater.reload()` call.
+
+This option only controls the automatic `HotUpdater.wrap` flow.
+`updateBundle()` never reloads the app by itself.
 
 The actual reload behavior follows [`HotUpdater.setReloadBehavior()`](/docs/react-native-api/setReloadBehavior).
 
@@ -248,19 +264,18 @@ export default HotUpdater.wrap({
   requestHeaders: {
     "Authorization": "Bearer <your-access-token>",
   },
-  reloadOnForceUpdate: false, // The app won't reload on force updates // [!code hl:7]
-  onUpdateProcessCompleted: async ({ status, shouldForceUpdate, id, message }) => {
-    console.log("Bundle updated:", status, shouldForceUpdate, id, message);
-    if (shouldForceUpdate) {
-      await HotUpdater.reload();
-    }
-  },
+  reloadOnForceUpdate: false, // Keep the current session running // [!code hl]
 })(App);
 ```
 
 #### `onUpdateProcessCompleted`
 
-Allows you to perform additional actions after the update process is completed.
+Reports when automatic update handling has finished from the wrapper's
+perspective.
+
+For a non-force update, the automatic flow invokes this callback after starting
+the non-blocking download, not after the download finishes. Do not use it as a
+download-readiness signal.
 
 **Callback Arguments:**
 
@@ -394,7 +409,7 @@ export default HotUpdater.wrap({
 
 ## Flag Behavior
 
-| Update Type   | When Applied                                              | How to Enable                              |
-|---------------|----------------------------------------------------------|-------------------------------------------|
-| Default       | Downloads the update bundle in the background and applies it when the user restarts the app. | Default setting                           |
-| Force Update  | Downloads the update bundle and applies it immediately.   | Use the `--force-update` flag or console. |
+| Update Response                  | Runtime Behavior                                                                                                            | How to Enable                                                     |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `shouldForceUpdate: false`       | Stages the selected bundle without reloading the current runtime; it becomes active on the next runtime start.              | Default setting                                                   |
+| `shouldForceUpdate: true`        | `HotUpdater.wrap` reloads after preparing the selected transition; `reloadOnForceUpdate: false` defers it to a later start. | Use `--force-update` or the console; bundle-changing rollbacks also return it. |

--- a/docs/content/docs/v0/react-native-api/updateBundle.mdx
+++ b/docs/content/docs/v0/react-native-api/updateBundle.mdx
@@ -1,13 +1,15 @@
 ---
 title: "updateBundle"
-description: "The `updateBundle` function applies a bundle transition selected by `checkForUpdate` to your React Native application."
+description: "Stage a selected transition without reloading the current React Native runtime."
 icon: Download
 ---
 
 ## Usage
 
-Use `updateBundle` to apply an available update. Normally, call the pre-filled
-helper returned by `checkForUpdate()`.
+Use `updateBundle` to stage the selected transition, downloading and verifying
+a bundle when needed. Normally, call the pre-filled helper returned by
+`checkForUpdate()`. The function does not reload the React Native runtime
+currently in use.
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
@@ -16,7 +18,7 @@ HotUpdater.init({
   baseURL: "<your-update-server-url>",
 });
 
-async function applyAppUpdate() {
+async function stageAppUpdate() {
   try {
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion", // or "fingerprint"
@@ -34,13 +36,18 @@ async function applyAppUpdate() {
     // Recommended: use the helper with all update arguments pre-filled.
     const didUpdate = await updateInfo.updateBundle();
 
-    if (didUpdate && updateInfo.shouldForceUpdate) {
-      await HotUpdater.reload();
+    if (!didUpdate) {
+      console.warn("Update transition was not staged");
+      return;
     }
 
-    console.log("Update applied successfully");
+    console.log("Bundle transition staged successfully");
+
+    if (updateInfo.shouldForceUpdate) {
+      await HotUpdater.reload();
+    }
   } catch (error) {
-    console.error("Failed to apply update:", error);
+    console.error("Failed to stage update:", error);
   }
 }
 ```
@@ -76,8 +83,13 @@ await HotUpdater.updateBundle({
   public key. A failed verification aborts the update and deletes the download.
 - A `null` URL or hash represents a transition that does not use that archive
   value; the properties must still be present in the object.
-- Applies the selected bundle transition for the application.
-- Requires an explicit call to `HotUpdater.reload()` if you want to immediately reload the application after updating, particularly when `shouldForceUpdate` is true.
+- Stages the selected bundle transition for the next React Native runtime start
+  without replacing the code already running.
+- Never reloads the app by itself. Call `HotUpdater.reload()` explicitly to
+  start the staged transition immediately; the automatic `HotUpdater.wrap` flow
+  handles force updates separately.
+- An in-progress download is not guaranteed to finish after the app is
+  force-quit.
 
 ### Security Recommendation
 

--- a/docs/content/docs/v0/react-native-api/wrap.mdx
+++ b/docs/content/docs/v0/react-native-api/wrap.mdx
@@ -1,6 +1,6 @@
 ---
 title: "wrap"
-description: "`HotUpdater.wrap` checks for updates at the entry point, and if there is a bundle to update, it downloads the bundle and applies the update strategy."
+description: "`HotUpdater.wrap` stages standard updates for the next app start and reloads force updates by default."
 icon: Package
 ---
 
@@ -13,6 +13,14 @@ icon: Package
 
 `HotUpdater.wrap` configures automatic updates. The automatic mode is the
 default, so `updateMode` is no longer needed.
+
+A standard update is prepared and staged without reloading the React Native
+runtime currently in use. Once staging finishes successfully, it becomes active
+the next time that runtime starts, normally on the next cold app launch. In the
+automatic `HotUpdater.wrap` flow, responses with `shouldForceUpdate: true`,
+including bundle-changing server-directed rollbacks, prepare the selected
+transition and then reload by default. Set `reloadOnForceUpdate: false` when the
+current session must remain uninterrupted.
 
 ### Automatic Updates
 
@@ -191,7 +199,15 @@ export default HotUpdater.wrap({ // [!code hl:25]
 
 #### `reloadOnForceUpdate`
 
-When a force update bundle is downloaded, the app will automatically reload. If `false`, `shouldForceUpdate` will be returned as `true` in `onUpdateProcessCompleted` but the app won't reload. Default is `true`.
+When the automatic `HotUpdater.wrap` flow receives an update with
+`shouldForceUpdate: true`, it prepares the selected transition and reloads the
+app by default. Bundle-changing server-directed rollbacks also use this path.
+If set to `false`, the current React Native runtime keeps running and the staged
+update becomes active on the next runtime start or after a later explicit
+`HotUpdater.reload()` call.
+
+This option only controls the automatic `HotUpdater.wrap` flow.
+`updateBundle()` never reloads the app by itself.
 
 The actual reload behavior follows [`HotUpdater.setReloadBehavior()`](/docs/v0/react-native-api/setReloadBehavior).
 
@@ -241,19 +257,18 @@ export default HotUpdater.wrap({
   requestHeaders: {
     "Authorization": "Bearer <your-access-token>",
   },
-  reloadOnForceUpdate: false, // The app won't reload on force updates // [!code hl:7]
-  onUpdateProcessCompleted: async ({ status, shouldForceUpdate, id, message }) => {
-    console.log("Bundle updated:", status, shouldForceUpdate, id, message);
-    if (shouldForceUpdate) {
-      await HotUpdater.reload();
-    }
-  },
+  reloadOnForceUpdate: false, // Keep the current session running // [!code hl]
 })(App);
 ```
 
 #### `onUpdateProcessCompleted`
 
-Allows you to perform additional actions after the update process is completed.
+Reports when automatic update handling has finished from the wrapper's
+perspective.
+
+For a non-force update, the automatic flow invokes this callback after starting
+the non-blocking download, not after the download finishes. Do not use it as a
+download-readiness signal.
 
 **Callback Arguments:**
 
@@ -381,7 +396,7 @@ export default HotUpdater.wrap({
 
 ## Flag Behavior
 
-| Update Type   | When Applied                                              | How to Enable                              |
-|---------------|----------------------------------------------------------|-------------------------------------------|
-| Default       | Downloads the update bundle in the background and applies it when the user restarts the app. | Default setting                           |
-| Force Update  | Downloads the update bundle and applies it immediately.   | Use the `--force-update` flag or console. |
+| Update Response                  | Runtime Behavior                                                                                                            | How to Enable                                                     |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `shouldForceUpdate: false`       | Stages the selected bundle without reloading the current runtime; it becomes active on the next runtime start.              | Default setting                                                   |
+| `shouldForceUpdate: true`        | `HotUpdater.wrap` reloads after preparing the selected transition; `reloadOnForceUpdate: false` defers it to a later start. | Use `--force-update` or the console; bundle-changing rollbacks also return it. |


### PR DESCRIPTION
## Summary\n\n- clarify update activation timing in both the latest and v0 React Native API docs\n- distinguish automatic wrap reloads for force-update responses from manual updateBundle behavior\n- remove the no-auto-reload example's explicit reload and document force-quit download limits\n\n## Validation\n\n- pnpm --dir docs build\n- pnpm --dir docs test:type\n- git diff --check\n\n## Scope\n\nDocumentation only; no runtime behavior changes.