### PR TITLE
fix(android): migrate legacy debug bundle overrides

### DIFF
--- a/.changeset/metal-debug-bundle.md
+++ b/.changeset/metal-debug-bundle.md
@@ -2,4 +2,4 @@
 "@hot-updater/react-native": patch
 ---
 
-Preserve Metro as the JavaScript bundle source for Android debug builds while continuing to use Hot Updater bundles for release builds.
+Preserve Metro as the JavaScript bundle source for Android debug builds, migrate previously generated config-plugin output, and continue using Hot Updater bundles for release builds.

--- a/docs/content/docs/get-started/basic-usage.mdx
+++ b/docs/content/docs/get-started/basic-usage.mdx
@@ -262,7 +262,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+      jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+        null // [!code ++]
+      } else { // [!code ++]
+        HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+      }, // [!code ++]
     )
   }
 
@@ -312,7 +316,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -373,7 +381,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/managed/aws.mdx
+++ b/docs/content/docs/managed/aws.mdx
@@ -302,7 +302,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -350,7 +354,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -409,7 +417,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/managed/cloudflare.mdx
+++ b/docs/content/docs/managed/cloudflare.mdx
@@ -229,7 +229,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -277,7 +281,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -336,7 +344,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/managed/firebase.mdx
+++ b/docs/content/docs/managed/firebase.mdx
@@ -233,7 +233,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -281,7 +285,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -339,7 +347,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/managed/supabase.mdx
+++ b/docs/content/docs/managed/supabase.mdx
@@ -220,7 +220,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -268,7 +272,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -326,7 +334,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/packages/react-native/plugin/src/transformers.ts
+++ b/packages/react-native/plugin/src/transformers.ts
@@ -84,6 +84,26 @@ function transformAndroidReactHost(contents: string): string {
   }
 
   const callContents = result.slice(callStartIndex, closeParenIndex + 1);
+  const kotlinLegacyBundlePathRegex =
+    /^([ \t]*)jsBundleFilePath = HotUpdater\.getJSBundleFile\(applicationContext\),[ \t]*\r?$/m;
+  const legacyBundlePathMatch = callContents.match(kotlinLegacyBundlePathRegex);
+
+  if (legacyBundlePathMatch) {
+    const paramIndent = legacyBundlePathMatch[1];
+    const jsBundleLines = [
+      `${paramIndent}jsBundleFilePath = if (BuildConfig.DEBUG) {`,
+      `${paramIndent}  null`,
+      `${paramIndent}} else {`,
+      `${paramIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+      `${paramIndent}},`,
+    ];
+    const migratedCallContents = callContents.replace(
+      kotlinLegacyBundlePathRegex,
+      jsBundleLines.join("\n"),
+    );
+    return `${result.slice(0, callStartIndex)}${migratedCallContents}${result.slice(closeParenIndex + 1)}`;
+  }
+
   if (callContents.includes("jsBundleFilePath")) {
     return result;
   }
@@ -155,6 +175,8 @@ function transformAndroidDefaultHost(contents: string): string {
   const kotlinImportAnchor = "import com.facebook.react.ReactApplication";
   const kotlinReactNativeHostAnchor = "object : DefaultReactNativeHost(this) {";
   const kotlinMethodCheck = "HotUpdater.getJSBundleFile(applicationContext)";
+  const kotlinLegacyMethodRegex =
+    /^([ \t]*)override fun getJSBundleFile\(\): String\? \{[ \t]*\r?\n([ \t]*)return HotUpdater\.getJSBundleFile\(applicationContext\)[ \t]*\r?\n\1\}[ \t]*$/m;
   const kotlinExistingMethodRegex =
     /^\s*override fun getJSBundleFile\(\): String\?\s*\{[\s\S]*?^\s*\}/gm;
   const kotlinHermesAnchor =
@@ -169,6 +191,22 @@ function transformAndroidDefaultHost(contents: string): string {
 
   // 1. Add import if missing
   let result = addLinesOnce(contents, kotlinImportAnchor, [kotlinImport]);
+
+  const legacyMethodMatch = result.match(kotlinLegacyMethodRegex);
+  if (legacyMethodMatch) {
+    const methodIndent = legacyMethodMatch[1];
+    const bodyIndent = legacyMethodMatch[2];
+    const methodLines = [
+      `${methodIndent}override fun getJSBundleFile(): String? {`,
+      `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+      `${bodyIndent}  null`,
+      `${bodyIndent}} else {`,
+      `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+      `${bodyIndent}}`,
+      `${methodIndent}}`,
+    ];
+    result = result.replace(kotlinLegacyMethodRegex, methodLines.join("\n"));
+  }
 
   // 2. Add/Replace getJSBundleFile method if needed
   if (!result.includes(kotlinMethodCheck)) {

--- a/packages/react-native/plugin/src/withHotUpdater.spec.ts
+++ b/packages/react-native/plugin/src/withHotUpdater.spec.ts
@@ -162,6 +162,65 @@ class MainApplication : Application(), ReactApplication {
       expect(result).toBe(_expected);
     });
 
+    it("RN 0.82+ Kotlin: migrates the previous HotUpdater bundle path", () => {
+      const input = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+    )
+  }
+}`;
+
+      const expected = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
+    )
+  }
+}`;
+
+      const result = transformAndroid(input);
+      expect(result).toBe(expected);
+      expect(transformAndroid(result)).toBe(result);
+    });
+
+    it("RN 0.82+ Kotlin: keeps a custom bundle path", () => {
+      const input = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = customBundlePath,
+    )
+  }
+}`;
+
+      expect(transformAndroid(input)).toBe(input);
+    });
+
     it("RN 0.81 Kotlin: input -> output", () => {
       // Input: RN 0.81 template with old pattern
       const _input = `package com.hotupdaterexample
@@ -255,6 +314,50 @@ class MainApplication : Application(), ReactApplication {
 
       const result = transformAndroid(_input);
       expect(result).toBe(_expected);
+    });
+
+    it("RN 0.81 Kotlin: migrates the previous HotUpdater bundle path", () => {
+      const input = `package com.hotupdaterexample
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactNativeHost: ReactNativeHost =
+    object : DefaultReactNativeHost(this) {
+      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+      override fun getJSBundleFile(): String? {
+        return HotUpdater.getJSBundleFile(applicationContext)
+      }
+    }
+}`;
+
+      const expected = `package com.hotupdaterexample
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactNativeHost: ReactNativeHost =
+    object : DefaultReactNativeHost(this) {
+      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+      override fun getJSBundleFile(): String? {
+        return if (BuildConfig.DEBUG) {
+          null
+        } else {
+          HotUpdater.getJSBundleFile(applicationContext)
+        }
+      }
+    }
+}`;
+
+      const result = transformAndroid(input);
+      expect(result).toBe(expected);
+      expect(transformAndroid(result)).toBe(result);
     });
 
     it("Expo 54 Kotlin: input -> output", () => {


### PR DESCRIPTION
## Summary

- Migrate the exact Android config-plugin output generated before #1170 for both RN 0.82+ `getDefaultReactHost` and older `DefaultReactNativeHost` projects.
- Keep custom `jsBundleFilePath` values untouched and keep repeated transforms idempotent.
- Update manual Android setup docs so debug builds use Metro while release builds use Hot Updater.
- Extend the existing `@hot-updater/react-native` changeset description.

## Context

Follow-up to #1170 and its [legacy-output migration review](https://github.com/gronxb/hot-updater/pull/1170#discussion_r3818481889).

## Validation

- `pnpm -w build`
- Focused Android transformer suite: 14 tests passed
- `pnpm -w lint`
- `pnpm -w test`: 162 files / 2,141 tests passed
- `pnpm test:type`: 34 projects passed
- `git diff --check`