### PR TITLE
fix(android): backport Metro debug bundle handling to next

### DIFF
--- a/.changeset/metal-debug-bundle-next.md
+++ b/.changeset/metal-debug-bundle-next.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/expo": patch
+---
+
+Preserve Metro as the JavaScript bundle source for Android debug builds, migrate previously generated config-plugin output, and continue using Hot Updater bundles for release builds.

--- a/docs/content/docs/(latest)/get-started/basic-usage.mdx
+++ b/docs/content/docs/(latest)/get-started/basic-usage.mdx
@@ -275,7 +275,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+      jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+        null // [!code ++]
+      } else { // [!code ++]
+        HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+      }, // [!code ++]
     )
   }
 
@@ -325,7 +329,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -386,7 +394,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/(latest)/managed/aws.mdx
+++ b/docs/content/docs/(latest)/managed/aws.mdx
@@ -400,7 +400,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -448,7 +452,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -507,7 +515,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/(latest)/managed/cloudflare.mdx
+++ b/docs/content/docs/(latest)/managed/cloudflare.mdx
@@ -270,7 +270,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -318,7 +322,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -377,7 +385,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/(latest)/managed/firebase.mdx
+++ b/docs/content/docs/(latest)/managed/firebase.mdx
@@ -276,7 +276,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -324,7 +328,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -383,7 +391,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/(latest)/managed/supabase.mdx
+++ b/docs/content/docs/(latest)/managed/supabase.mdx
@@ -271,7 +271,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -319,7 +323,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -378,7 +386,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/v0/get-started/basic-usage.mdx
+++ b/docs/content/docs/v0/get-started/basic-usage.mdx
@@ -262,7 +262,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+      jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+        null // [!code ++]
+      } else { // [!code ++]
+        HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+      }, // [!code ++]
     )
   }
 
@@ -312,7 +316,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -373,7 +381,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/v0/managed/aws.mdx
+++ b/docs/content/docs/v0/managed/aws.mdx
@@ -308,7 +308,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -356,7 +360,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -415,7 +423,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/v0/managed/cloudflare.mdx
+++ b/docs/content/docs/v0/managed/cloudflare.mdx
@@ -237,7 +237,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -285,7 +289,11 @@ PackageList(this).packages.apply {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -344,7 +352,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/v0/managed/firebase.mdx
+++ b/docs/content/docs/v0/managed/firebase.mdx
@@ -236,7 +236,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -284,7 +288,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -342,7 +350,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/docs/content/docs/v0/managed/supabase.mdx
+++ b/docs/content/docs/v0/managed/supabase.mdx
@@ -233,7 +233,11 @@ To complete the integration of `hot-updater`, you'll need to add native code mod
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext), // [!code ++]
+        jsBundleFilePath = if (BuildConfig.DEBUG) { // [!code ++]
+          null // [!code ++]
+        } else { // [!code ++]
+          HotUpdater.getJSBundleFile(applicationContext) // [!code ++]
+        }, // [!code ++]
       )
 
     }
@@ -281,7 +285,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {  // [!code ++]
-          return HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          return if (BuildConfig.DEBUG) {  // [!code ++]
+            null  // [!code ++]
+          } else {  // [!code ++]
+            HotUpdater.getJSBundleFile(applicationContext)  // [!code ++]
+          }  // [!code ++]
         }  // [!code ++]
       }
 
@@ -339,7 +347,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override // [!code ++]
         protected String getJSBundleFile() {  // [!code ++]
-            return HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
+            return BuildConfig.DEBUG  // [!code ++]
+                ? null  // [!code ++]
+                : HotUpdater.Companion.getJSBundleFile(this.getApplication().getApplicationContext());  // [!code ++]
         }  // [!code ++]
 
         @Override

--- a/plugins/expo/plugin/src/transformers.ts
+++ b/plugins/expo/plugin/src/transformers.ts
@@ -84,6 +84,26 @@ function transformAndroidReactHost(contents: string): string {
   }
 
   const callContents = result.slice(callStartIndex, closeParenIndex + 1);
+  const kotlinLegacyBundlePathRegex =
+    /^([ \t]*)jsBundleFilePath = HotUpdater\.getJSBundleFile\(applicationContext\),[ \t]*\r?$/m;
+  const legacyBundlePathMatch = callContents.match(kotlinLegacyBundlePathRegex);
+
+  if (legacyBundlePathMatch) {
+    const paramIndent = legacyBundlePathMatch[1];
+    const jsBundleLines = [
+      `${paramIndent}jsBundleFilePath = if (BuildConfig.DEBUG) {`,
+      `${paramIndent}  null`,
+      `${paramIndent}} else {`,
+      `${paramIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+      `${paramIndent}},`,
+    ];
+    const migratedCallContents = callContents.replace(
+      kotlinLegacyBundlePathRegex,
+      jsBundleLines.join("\n"),
+    );
+    return `${result.slice(0, callStartIndex)}${migratedCallContents}${result.slice(closeParenIndex + 1)}`;
+  }
+
   if (callContents.includes("jsBundleFilePath")) {
     return result;
   }
@@ -136,8 +156,14 @@ function transformAndroidReactHost(contents: string): string {
     )}`;
   }
 
-  const jsBundleLine = `${paramIndent}jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),`;
-  return `${prefix}${jsBundleLine}\n${suffix}`;
+  const jsBundleLines = [
+    `${paramIndent}jsBundleFilePath = if (BuildConfig.DEBUG) {`,
+    `${paramIndent}  null`,
+    `${paramIndent}} else {`,
+    `${paramIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+    `${paramIndent}},`,
+  ];
+  return `${prefix}${jsBundleLines.join("\n")}\n${suffix}`;
 }
 
 /**
@@ -149,6 +175,8 @@ function transformAndroidDefaultHost(contents: string): string {
   const kotlinImportAnchor = "import com.facebook.react.ReactApplication";
   const kotlinReactNativeHostAnchor = "object : DefaultReactNativeHost(this) {";
   const kotlinMethodCheck = "HotUpdater.getJSBundleFile(applicationContext)";
+  const kotlinLegacyMethodRegex =
+    /^([ \t]*)override fun getJSBundleFile\(\): String\? \{[ \t]*\r?\n([ \t]*)return HotUpdater\.getJSBundleFile\(applicationContext\)[ \t]*\r?\n\1\}[ \t]*$/m;
   const kotlinExistingMethodRegex =
     /^\s*override fun getJSBundleFile\(\): String\?\s*\{[\s\S]*?^\s*\}/gm;
   const kotlinHermesAnchor =
@@ -163,6 +191,22 @@ function transformAndroidDefaultHost(contents: string): string {
 
   // 1. Add import if missing
   let result = addLinesOnce(contents, kotlinImportAnchor, [kotlinImport]);
+
+  const legacyMethodMatch = result.match(kotlinLegacyMethodRegex);
+  if (legacyMethodMatch) {
+    const methodIndent = legacyMethodMatch[1];
+    const bodyIndent = legacyMethodMatch[2];
+    const methodLines = [
+      `${methodIndent}override fun getJSBundleFile(): String? {`,
+      `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+      `${bodyIndent}  null`,
+      `${bodyIndent}} else {`,
+      `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+      `${bodyIndent}}`,
+      `${methodIndent}}`,
+    ];
+    result = result.replace(kotlinLegacyMethodRegex, methodLines.join("\n"));
+  }
 
   // 2. Add/Replace getJSBundleFile method if needed
   if (!result.includes(kotlinMethodCheck)) {
@@ -208,7 +252,11 @@ function transformAndroidDefaultHost(contents: string): string {
       const methodLines = [
         "", // blank line
         `${indent}override fun getJSBundleFile(): String? {`,
-        `${bodyIndent}return HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+        `${bodyIndent}  null`,
+        `${bodyIndent}} else {`,
+        `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}}`,
         `${indent}}`,
       ];
 
@@ -247,7 +295,11 @@ function transformAndroidDefaultHost(contents: string): string {
 
       const methodLines = [
         `${indent}override fun getJSBundleFile(): String? {`,
-        `${bodyIndent}return HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}return if (BuildConfig.DEBUG) {`,
+        `${bodyIndent}  null`,
+        `${bodyIndent}} else {`,
+        `${bodyIndent}  HotUpdater.getJSBundleFile(applicationContext)`,
+        `${bodyIndent}}`,
         `${indent}}`,
       ];
 

--- a/plugins/expo/plugin/src/withHotUpdater.spec.ts
+++ b/plugins/expo/plugin/src/withHotUpdater.spec.ts
@@ -144,7 +144,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
     )
   }
 
@@ -156,6 +160,65 @@ class MainApplication : Application(), ReactApplication {
 
       const result = transformAndroid(_input);
       expect(result).toBe(_expected);
+    });
+
+    it("RN 0.82+ Kotlin: migrates the previous HotUpdater bundle path", () => {
+      const input = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+    )
+  }
+}`;
+
+      const expected = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
+    )
+  }
+}`;
+
+      const result = transformAndroid(input);
+      expect(result).toBe(expected);
+      expect(transformAndroid(result)).toBe(result);
+    });
+
+    it("RN 0.82+ Kotlin: keeps a custom bundle path", () => {
+      const input = `package com.rndiffapp
+
+import com.facebook.react.ReactApplication
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList = emptyList(),
+      jsBundleFilePath = customBundlePath,
+    )
+  }
+}`;
+
+      expect(transformAndroid(input)).toBe(input);
     });
 
     it("RN 0.81 Kotlin: input -> output", () => {
@@ -232,7 +295,11 @@ class MainApplication : Application(), ReactApplication {
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
         override fun getJSBundleFile(): String? {
-          return HotUpdater.getJSBundleFile(applicationContext)
+          return if (BuildConfig.DEBUG) {
+            null
+          } else {
+            HotUpdater.getJSBundleFile(applicationContext)
+          }
         }
       }
 
@@ -247,6 +314,50 @@ class MainApplication : Application(), ReactApplication {
 
       const result = transformAndroid(_input);
       expect(result).toBe(_expected);
+    });
+
+    it("RN 0.81 Kotlin: migrates the previous HotUpdater bundle path", () => {
+      const input = `package com.hotupdaterexample
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactNativeHost: ReactNativeHost =
+    object : DefaultReactNativeHost(this) {
+      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+      override fun getJSBundleFile(): String? {
+        return HotUpdater.getJSBundleFile(applicationContext)
+      }
+    }
+}`;
+
+      const expected = `package com.hotupdaterexample
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.hotupdater.HotUpdater
+
+class MainApplication : Application(), ReactApplication {
+  override val reactNativeHost: ReactNativeHost =
+    object : DefaultReactNativeHost(this) {
+      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+      override fun getJSBundleFile(): String? {
+        return if (BuildConfig.DEBUG) {
+          null
+        } else {
+          HotUpdater.getJSBundleFile(applicationContext)
+        }
+      }
+    }
+}`;
+
+      const result = transformAndroid(input);
+      expect(result).toBe(expected);
+      expect(transformAndroid(result)).toBe(result);
     });
 
     it("Expo 54 Kotlin: input -> output", () => {
@@ -346,7 +457,11 @@ class MainApplication : Application(), ReactApplication {
           override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
 
           override fun getJSBundleFile(): String? {
-              return HotUpdater.getJSBundleFile(applicationContext)
+              return if (BuildConfig.DEBUG) {
+                null
+              } else {
+                HotUpdater.getJSBundleFile(applicationContext)
+              }
           }
       }
   )
@@ -417,7 +532,11 @@ class MainApplication : Application(), ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         },
-      jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+      jsBundleFilePath = if (BuildConfig.DEBUG) {
+        null
+      } else {
+        HotUpdater.getJSBundleFile(applicationContext)
+      },
     )
   }
 }`;
@@ -473,7 +592,11 @@ class MainApplication : Application(), ReactApplication {
           PackageList(this).packages.apply {
             // add(MyReactNativePackage())
           },
-        jsBundleFilePath = HotUpdater.getJSBundleFile(applicationContext),
+        jsBundleFilePath = if (BuildConfig.DEBUG) {
+          null
+        } else {
+          HotUpdater.getJSBundleFile(applicationContext)
+        },
       ),
     )
   }


### PR DESCRIPTION
## Summary

- Backport #1170 to the relocated `@hot-updater/expo` config plugin on `next`.
- Include the legacy-output migration from #1176 for both Android host patterns.
- Preserve custom bundle paths and repeated-transform idempotence.
- Update both `(latest)` and `v0` manual Android setup docs.
- Add a patch changeset for `@hot-updater/expo`.

## Context

Backport of #1170 together with the follow-up migration in #1176.

## Validation

- `pnpm -w build`
- Focused Android transformer suite: 14 tests passed
- `pnpm -w lint`
- `pnpm -w test`: 255 files / 2,350 tests passed
- `pnpm test:type`: 34 projects passed
- `git diff --check`