### PR TITLE
test(storage): cover percent-encoded object keys on next

### DIFF
--- a/plugins/aws/src/s3Storage.spec.ts
+++ b/plugins/aws/src/s3Storage.spec.ts
@@ -71,7 +71,7 @@ describe("s3Storage", () => {
     vi.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
       expect(command).toBeInstanceOf(GetObjectCommand);
       expect(command).toMatchObject({
-        input: { Bucket: "updates", Key: "bundles/한글 #%.zip" },
+        input: { Bucket: "updates", Key: "bundles/한글@2x #%.zip" },
       });
       return {
         Body: {
@@ -84,7 +84,7 @@ describe("s3Storage", () => {
     const storage = s3Storage({ bucketName: "updates", region: "us-east-1" });
 
     const { response } = await storage.get({
-      storageUri: "s3://updates/bundles/%ED%95%9C%EA%B8%80%20%23%25.zip",
+      storageUri: "s3://updates/bundles/%ED%95%9C%EA%B8%80%402x%20%23%25.zip",
     });
 
     expect(response?.headers.get("content-type")).toBe("application/zip");

--- a/plugins/cloudflare/src/r2Storage.spec.ts
+++ b/plugins/cloudflare/src/r2Storage.spec.ts
@@ -160,7 +160,7 @@ describe("r2Storage", () => {
         secretAccessKey: "secret-access-key",
       },
     });
-    const key = "릴리스 folder/#100%/bundle.zip";
+    const key = "릴리스 folder/logo@2x #100%/bundle.zip";
 
     const uploaded = await storage.put?.({
       key,
@@ -168,6 +168,7 @@ describe("r2Storage", () => {
       contentLength: 6,
       contentType: "application/zip",
     });
+    expect(uploaded?.storageUri).toContain("logo%402x");
     expect(uploaded?.storageUri).not.toContain("#100%");
     await expect(
       storage.get?.({ storageUri: uploaded!.storageUri }),

--- a/plugins/cloudflare/src/r2WorkerStorage.spec.ts
+++ b/plugins/cloudflare/src/r2WorkerStorage.spec.ts
@@ -106,13 +106,14 @@ describe("r2WorkerStorage", () => {
       bucketName: "bundles",
       downloadUrlSigningKey: "test-signing-key",
     });
-    const key = "릴리스 folder/#100%/bundle.zip";
+    const key = "릴리스 folder/logo@2x #100%/bundle.zip";
 
     const uploaded = await storage.put({
       key,
       body: new Response("bundle").body!,
       contentType: "application/zip",
     });
+    expect(uploaded.storageUri).toContain("logo%402x");
     await storage.delete({ storageUri: uploaded.storageUri });
     await storage.delete({ storageUri: uploaded.storageUri });
 

--- a/plugins/firebase/src/firebaseStorage.spec.ts
+++ b/plugins/firebase/src/firebaseStorage.spec.ts
@@ -57,15 +57,15 @@ describe("firebaseStorage", () => {
 
     await expect(
       createStorage().put({
-        key: "releases/한글 #%.zip",
+        key: "releases/한글@2x #%.zip",
         body: stream("bundle"),
         contentLength: 6,
         contentType: "application/zip",
       }),
     ).resolves.toEqual({
-      storageUri: "gs://updates/releases/%ED%95%9C%EA%B8%80%20%23%25.zip",
+      storageUri: "gs://updates/releases/%ED%95%9C%EA%B8%80%402x%20%23%25.zip",
     });
-    expect(bucket.file).toHaveBeenCalledWith("releases/한글 #%.zip");
+    expect(bucket.file).toHaveBeenCalledWith("releases/한글@2x #%.zip");
     expect(file.save).toHaveBeenCalledWith(new TextEncoder().encode("bundle"), {
       metadata: {
         cacheControl: "public, max-age=31536000, immutable",
@@ -126,10 +126,10 @@ describe("firebaseStorage", () => {
 
     await expect(
       storage.getDownloadUrl({
-        storageUri: "gs://updates/releases/%ED%95%9C%EA%B8%80%20%23%25.zip",
+        storageUri: "gs://updates/releases/logo%402x.png",
       }),
     ).resolves.toEqual({
-      url: "https://cdn.example.com/downloads/releases/%ED%95%9C%EA%B8%80%20%23%25.zip",
+      url: "https://cdn.example.com/downloads/releases/logo%402x.png",
     });
     expect(file.getSignedUrl).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-core/src/parseStorageUri.spec.ts
+++ b/plugins/plugin-core/src/parseStorageUri.spec.ts
@@ -7,13 +7,13 @@ describe("storage URI", () => {
     const input = {
       protocol: "r2",
       bucket: "updates",
-      key: "releases/한글 bundle #100%/bundle.zip",
+      key: "releases/한글 logo@2x #100%/bundle.zip",
     } as const;
 
     const storageUri = createStorageUri(input);
 
     expect(storageUri).toBe(
-      "r2://updates/releases/%ED%95%9C%EA%B8%80%20bundle%20%23100%25/bundle.zip",
+      "r2://updates/releases/%ED%95%9C%EA%B8%80%20logo%402x%20%23100%25/bundle.zip",
     );
     expect(parseStorageUri(storageUri, "r2")).toEqual(input);
   });

--- a/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
+++ b/plugins/supabase/src/supabaseEdgeFunctionStorage.spec.ts
@@ -27,7 +27,7 @@ describe("supabaseEdgeFunctionStorage", () => {
     });
 
     const { response } = await storage.get({
-      storageUri: "supabase-storage://updates/manifest.json",
+      storageUri: "supabase-storage://updates/logo%402x.json",
     });
 
     await expect(response?.text()).resolves.toBe("manifest");
@@ -35,5 +35,6 @@ describe("supabaseEdgeFunctionStorage", () => {
       "https://example.supabase.co",
       "service-role-key",
     );
+    expect(bucket.download).toHaveBeenCalledWith("logo@2x.json");
   });
 });

--- a/plugins/supabase/src/supabaseStorage.spec.ts
+++ b/plugins/supabase/src/supabaseStorage.spec.ts
@@ -99,7 +99,7 @@ describe("supabaseStorage", () => {
   });
 
   it("round-trips reserved characters through exact Supabase object keys", async () => {
-    const key = "릴리스 folder/#100%/bundle.zip";
+    const key = "릴리스 folder/logo@2x #100%/bundle.zip";
     bucket.upload.mockResolvedValue({
       data: { fullPath: `updates/${key}` },
       error: null,
@@ -112,6 +112,7 @@ describe("supabaseStorage", () => {
       contentLength: 6,
       contentType: "application/zip",
     });
+    expect(uploaded.storageUri).toContain("logo%402x");
     expect(uploaded.storageUri).not.toContain("#100%");
     await createStorage().delete({ storageUri: uploaded.storageUri });
 
@@ -159,7 +160,7 @@ describe("supabaseStorage", () => {
       data: [
         {
           error: null,
-          path: "assets/file-hash.png",
+          path: "assets/logo@2x.png",
           signedUrl: "https://example.supabase.co/signed",
         },
       ],
@@ -168,11 +169,11 @@ describe("supabaseStorage", () => {
 
     await expect(
       createStorage().getDownloadUrl({
-        storageUri: "supabase-storage://updates/assets/file-hash.png",
+        storageUri: "supabase-storage://updates/assets/logo%402x.png",
       }),
     ).resolves.toEqual({ url: "https://example.supabase.co/signed" });
     expect(bucket.createSignedUrls).toHaveBeenCalledWith(
-      ["assets/file-hash.png"],
+      ["assets/logo@2x.png"],
       3600,
     );
   });


### PR DESCRIPTION
## Summary

- Verify the shared vNext storage URI codec encodes `@` as `%40` in storage URIs and decodes it before provider calls.
- Extend provider regression coverage for AWS S3, Cloudflare R2 S3/Worker, Firebase Storage, Supabase, and Supabase Edge.
- Confirm CDN HTTP URLs retain the encoded path.

The `next` branch already routes these providers through the shared `createStorageUri` and `parseStorageUri` implementation, so no production source change is required.

## Test plan

- Targeted provider suites — 66 tests passed
- `pnpm -w build`
- `pnpm -w test:type`
- `pnpm -w lint`
- `pnpm -w test` — 2,347 tests passed