### PR TITLE
fix(docs): correct JSX diff markers

### DIFF
--- a/docs/content/docs/(latest)/custom/frameworks/elysia.mdx
+++ b/docs/content/docs/(latest)/custom/frameworks/elysia.mdx
@@ -46,7 +46,6 @@ if (!authToken) {
 new Elysia()
   .use(bearer()) // [!code ++]
   .onBeforeHandle(({ bearer, request }) => {
-    // [!code ++]
     const pathname = new URL(request.url).pathname; // [!code ++]
     if (
       pathname === "/hot-updater/api" ||
@@ -54,7 +53,6 @@ new Elysia()
     ) {
       // [!code ++]
       if (bearer !== authToken) {
-        // [!code ++]
         return new Response("Unauthorized", { status: 401 }); // [!code ++]
       } // [!code ++]
     } // [!code ++]

--- a/docs/content/docs/(latest)/custom/frameworks/hono.mdx
+++ b/docs/content/docs/(latest)/custom/frameworks/hono.mdx
@@ -46,7 +46,6 @@ if (!authToken) {
 }
 
 app.use(
-  // [!code ++]
   "/hot-updater/api/*", // [!code ++]
   bearerAuth({ token: authToken }), // [!code ++]
 ); // [!code ++]

--- a/docs/content/docs/(latest)/custom/quick-start.mdx
+++ b/docs/content/docs/(latest)/custom/quick-start.mdx
@@ -94,12 +94,10 @@ const app = new Hono();
 
 const authToken = process.env.HOT_UPDATER_AUTH_TOKEN; // [!code ++]
 if (!authToken) {
-  // [!code ++]
   throw new Error("HOT_UPDATER_AUTH_TOKEN is required"); // [!code ++]
 } // [!code ++]
 
 app.use(
-  // [!code ++]
   "/hot-updater/api/*", // [!code ++]
   bearerAuth({ token: authToken }), // [!code ++]
 ); // [!code ++]

--- a/docs/content/docs/(latest)/policy/app-review.mdx
+++ b/docs/content/docs/(latest)/policy/app-review.mdx
@@ -32,8 +32,10 @@ Updates that only modify JS code can be handled by HotUpdater without review.
    export default function App() {
        return (
            <View>
-             <Text>Hello</Text> // [!code --]
-             <Text>Update Hello</Text> // [!code ++]
+             {/* [!code --] */}
+             <Text>Hello</Text>
+             {/* [!code ++] */}
+             <Text>Update Hello</Text>
            </View>
        );
    }

--- a/docs/content/docs/(latest)/react-native-api/wrap.mdx
+++ b/docs/content/docs/(latest)/react-native-api/wrap.mdx
@@ -170,7 +170,7 @@ function App() {
   );
 }
 
-export default HotUpdater.wrap({ // [!code hl:25]
+export default HotUpdater.wrap({ // [!code hl:32]
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion", // or "fingerprint"
   fallbackComponent: ({ progress, status, message }) => (
@@ -329,7 +329,7 @@ import { Alert } from "react-native";
 export default HotUpdater.wrap({
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion",
-  onError: (error) => { // [!code hl:18]
+  onError: (error) => { // [!code hl:5]
     // Handle other errors
     console.error("Update error:", error);
   },
@@ -396,7 +396,6 @@ export default HotUpdater.wrap({
         }), // [!code ++]
         headers: params.requestHeaders, // [!code ++]
       }); // [!code ++]
-// [!code ++]
       if (!response.ok) return null; // [!code ++]
       return response.json(); // [!code ++]
     }, // [!code ++]

--- a/docs/content/docs/v0/policy/app-review.mdx
+++ b/docs/content/docs/v0/policy/app-review.mdx
@@ -32,8 +32,10 @@ Updates that only modify JS code can be handled by HotUpdater without review.
    export default function App() {
        return (
            <View>
-             <Text>Hello</Text> // [!code --]
-             <Text>Update Hello</Text> // [!code ++]
+             {/* [!code --] */}
+             <Text>Hello</Text>
+             {/* [!code ++] */}
+             <Text>Update Hello</Text>
            </View>
        );
    }

--- a/docs/content/docs/v0/react-native-api/wrap.mdx
+++ b/docs/content/docs/v0/react-native-api/wrap.mdx
@@ -163,7 +163,7 @@ function App() {
   );
 }
 
-export default HotUpdater.wrap({ // [!code hl:25]
+export default HotUpdater.wrap({ // [!code hl:32]
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion", // or "fingerprint"
   fallbackComponent: ({ progress, status, message }) => (
@@ -322,7 +322,7 @@ import { Alert } from "react-native";
 export default HotUpdater.wrap({
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion",
-  onError: (error) => { // [!code hl:18]
+  onError: (error) => { // [!code hl:5]
     // Handle other errors
     console.error("Update error:", error);
   },
@@ -383,7 +383,6 @@ export default HotUpdater.wrap({
         }), // [!code ++]
         headers: params.requestHeaders, // [!code ++]
       }); // [!code ++]
-// [!code ++]
       if (!response.ok) return null; // [!code ++]
       return response.json(); // [!code ++]
     }, // [!code ++]


### PR DESCRIPTION
## Summary

- use directive-only JSX comments so Shiki diff markers style the intended lines without leaking syntax
- correct stale highlight ranges in both the latest and v0 `wrap` examples
- remove redundant marker-only diff directives from resolver and latest server setup examples

## Root cause

Inline `//` comments after JSX child elements are not tokenized as comments by Shiki, leaving markers visible without diff classes. The fallback and error ranges no longer matched their snippets, while standalone diff markers retargeted following lines that already had their own annotations.

## Tests

- `pnpm --dir docs test:type`
- `pnpm --dir docs build`
- semantic Fumadocs `rehypeCode` audit: 132 code blocks / 525 directives / 609 target-class checks
- audit result: 0 leaked markers, 0 class or range mismatches, 0 redundant marker-only directives, 0 render errors