### PR TITLE
fix(docs): repair Shiki transformer annotations

### DIFF
--- a/docs/content/docs/guides/channel-management.mdx
+++ b/docs/content/docs/guides/channel-management.mdx
@@ -47,7 +47,7 @@ The default channel is the release channel embedded in your native app at build 
       <application ...>
         <meta-data
           android:name="com.hotupdater.CHANNEL"
-          android:value="your_set_channel" /> // [!code ++]
+          android:value="your_set_channel" /> <!-- [!code ++] -->
       </application>
       ```
       </Tab>

--- a/docs/content/docs/policy/app-review.mdx
+++ b/docs/content/docs/policy/app-review.mdx
@@ -32,8 +32,8 @@ Updates that only modify JS code can be handled by HotUpdater without review.
    export default function App() {
        return (
            <View>
-             <Text>Hello</Text> // [!code --]
-             <Text>Update Hello</Text> // [!code ++]
+             <Text>Hello</Text> {/* [!code --] */}
+             <Text>Update Hello</Text> {/* [!code ++] */}
            </View>
        );
    }

--- a/docs/content/docs/policy/app-review.mdx
+++ b/docs/content/docs/policy/app-review.mdx
@@ -32,8 +32,10 @@ Updates that only modify JS code can be handled by HotUpdater without review.
    export default function App() {
        return (
            <View>
-             <Text>Hello</Text> {/* [!code --] */}
-             <Text>Update Hello</Text> {/* [!code ++] */}
+             {/* [!code --] */}
+             <Text>Hello</Text>
+             {/* [!code ++] */}
+             <Text>Update Hello</Text>
            </View>
        );
    }

--- a/docs/content/docs/react-native-api/wrap.mdx
+++ b/docs/content/docs/react-native-api/wrap.mdx
@@ -163,7 +163,7 @@ function App() {
   );
 }
 
-export default HotUpdater.wrap({ // [!code hl:25]
+export default HotUpdater.wrap({ // [!code hl:32]
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion", // or "fingerprint"
   fallbackComponent: ({ progress, status, message }) => (
@@ -322,7 +322,7 @@ import { Alert } from "react-native";
 export default HotUpdater.wrap({
   baseURL: "<your-update-server-url>",
   updateStrategy: "appVersion",
-  onError: (error) => { // [!code hl:18]
+  onError: (error) => { // [!code hl:5]
     // Handle other errors
     console.error("Update error:", error);
   },
@@ -384,7 +384,6 @@ export default HotUpdater.wrap({
         }), // [!code ++]
         headers: params.requestHeaders, // [!code ++]
       }); // [!code ++]
-// [!code ++]
       if (!response.ok) return null; // [!code ++]
       return response.json(); // [!code ++]
     }, // [!code ++]


### PR DESCRIPTION
## Summary

- use language-appropriate XML and directive-only JSX comments for Shiki diff annotations
- correct stale highlight ranges in the `wrap` examples
- remove a standalone diff annotation that retargeted the following line

## Root cause

Shiki could not recognize JavaScript-style comments inside XML and nested JSX, leaving annotations visible without diff classes. Inline JSX block directives applied classes but retained visible `{}` tokens, so the directives must precede their target nodes. A pair of range counts and a marker-only diff line also selected the wrong lines.

## Verification

- `pnpm --dir docs build`
- `pnpm --dir docs test:type`
- Fumadocs compiler audit: 67 code blocks / 279 directives, 0 leaked markers, 0 class/range mismatches, 0 inline JSX directives, 0 errors
- app-review render audit: 1 added line, 1 removed line, 0 leaked markers, 0 visible empty braces