### PR TITLE
fix(react-native): warn on mixed initialization

### DIFF
--- a/.changeset/warn-mixed-initialization.md
+++ b/.changeset/warn-mixed-initialization.md
@@ -1,0 +1,7 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Log a single error when `HotUpdater.init()` and `HotUpdater.wrap()` are used
+together, with guidance to use `init()` for manual update flows or `wrap()` for
+the automatic HOC flow.

--- a/packages/react-native/src/index.spec.ts
+++ b/packages/react-native/src/index.spec.ts
@@ -252,6 +252,46 @@ describe("HotUpdater client initialization", () => {
     });
   });
 
+  it.each([
+    ["init", "wrap"],
+    ["wrap", "init"],
+  ] as const)(
+    "reports %s and %s mixed usage exactly once",
+    async (first, second) => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const HotUpdater = await importHotUpdater();
+      const configure = (api: "init" | "wrap") => {
+        if (api === "init") {
+          HotUpdater.init({ baseURL: "https://updates.example.com" });
+          return;
+        }
+        HotUpdater.wrap({
+          baseURL: "https://updates.example.com",
+          updateStrategy: "appVersion",
+        });
+      };
+
+      configure(first);
+      configure(second);
+      configure(second);
+
+      expect(consoleError).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "HotUpdater.init() and HotUpdater.wrap() must not be used together",
+        ),
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "use HotUpdater.init() with HotUpdater.checkForUpdate()",
+        ),
+      );
+      consoleError.mockRestore();
+    },
+  );
+
   it("keeps deprecated manual wrap calls working", async () => {
     const resolver = {
       checkUpdate: vi.fn(),

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -118,6 +118,9 @@ const isManualWrapOptions = (
  * This function is called once on module initialization to create a singleton instance.
  */
 function createHotUpdaterClient() {
+  let configurationAPI: "init" | "wrap" | null = null;
+  let mixedConfigurationReported = false;
+
   // Global configuration stored from wrap
   const globalConfig: {
     resolver: HotUpdaterResolver | null;
@@ -230,6 +233,23 @@ function createHotUpdaterClient() {
     globalConfig.onError = options.onError;
   };
 
+  const reportMixedConfiguration = (nextAPI: "init" | "wrap") => {
+    if (
+      configurationAPI !== null &&
+      configurationAPI !== nextAPI &&
+      !mixedConfigurationReported
+    ) {
+      mixedConfigurationReported = true;
+      console.error(
+        "[HotUpdater] HotUpdater.init() and HotUpdater.wrap() must not be used together. " +
+          "For custom or manual update flows, use HotUpdater.init() with " +
+          "HotUpdater.checkForUpdate(). For the automatic HOC flow, use " +
+          "HotUpdater.wrap().",
+      );
+    }
+    configurationAPI ??= nextAPI;
+  };
+
   const ensureGlobalResolver = (methodName: string) => {
     if (!globalConfig.resolver) {
       throw new Error(
@@ -276,6 +296,7 @@ function createHotUpdaterClient() {
      */
     wrap: (options: HotUpdaterOptions) => {
       const normalizedOptions = normalizeOptions(options);
+      reportMixedConfiguration("wrap");
       configureGlobal(normalizedOptions, options);
 
       return wrap(normalizedOptions);
@@ -300,6 +321,7 @@ function createHotUpdaterClient() {
     init: (options: HotUpdaterInitOptions): void => {
       const normalizedOptions = normalizeInitOptions(options);
 
+      reportMixedConfiguration("init");
       configureGlobal(normalizedOptions, options);
 
       init(normalizedOptions);


### PR DESCRIPTION
## Summary
- log one console error when HotUpdater.init() and HotUpdater.wrap() are used together
- guide manual/custom flows to init() with checkForUpdate(), and automatic HOC flows to wrap()
- preserve existing runtime behavior and report the guidance only once

## Verification
- pnpm -w build
- pnpm -w test:type
- pnpm -w lint
- pnpm -w test
- pnpm -w test:integration