### PR TITLE
fix(react-native): support POSIX PAX paths on Android

### DIFF
--- a/.changeset/wise-tars-smile.md
+++ b/.changeset/wise-tars-smile.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Fix Android TAR extraction for long paths stored in POSIX PAX headers.

--- a/packages/react-native/android/src/main/java/com/hotupdater/TarArchiveInputStream.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/TarArchiveInputStream.kt
@@ -13,7 +13,7 @@ class TarArchiveInputStream(
 ) : InputStream() {
     private var currentEntry: TarArchiveEntry? = null
     private var currentEntryBytesRead: Long = 0
-    private var longName: String? = null
+    private var pendingName: String? = null
 
     companion object {
         private const val TAG = "TarInputStream"
@@ -73,14 +73,20 @@ class TarArchiveInputStream(
 
             // Handle GNU long filename extension
             if (entry.typeFlag == 'L') {
-                longName = readLongName(entry.size)
+                pendingName = readLongName(entry.size)
                 continue
             }
 
-            // Apply long name if present
-            if (longName != null) {
-                entry.name = longName!!
-                longName = null
+            // Handle POSIX PAX extended header
+            if (entry.typeFlag == 'x') {
+                readPaxPath(entry.size)?.let { pendingName = it }
+                continue
+            }
+
+            // Apply extended name if present
+            if (pendingName != null) {
+                entry.name = pendingName!!
+                pendingName = null
             }
 
             // Validate entry
@@ -304,6 +310,95 @@ class TarArchiveInputStream(
                 .takeIf { it >= 0 } ?: nameBytes.size
 
         return String(nameBytes, 0, nameLength, Charsets.UTF_8)
+    }
+
+    /**
+     * Read the path attribute from a POSIX PAX extended header.
+     * Record lengths are measured in bytes and include the length itself.
+     */
+    private fun readPaxPath(size: Long): String? {
+        if (size < 0 || size > MAX_FILE_SIZE) {
+            throw SecurityException("Invalid PAX header size: $size")
+        }
+
+        val data = ByteArray(size.toInt())
+        var bytesRead = 0
+        while (bytesRead < data.size) {
+            val count = input.read(data, bytesRead, data.size - bytesRead)
+            if (count < 0) throw EOFException("Unexpected end reading PAX header")
+            bytesRead += count
+        }
+        skipPadding(size)
+
+        var offset = 0
+        var path: String? = null
+        while (offset < data.size) {
+            val space = findByte(data, ' '.code.toByte(), offset, data.size)
+            if (space <= offset) throw IOException("Invalid PAX record length")
+
+            val recordLength = parsePaxRecordLength(data, offset, space)
+            if (recordLength <= 0 || recordLength > data.size - offset) {
+                throw IOException("Invalid PAX record length: $recordLength")
+            }
+
+            val recordEnd = offset + recordLength
+            if (recordEnd <= space + 2 || data[recordEnd - 1] != '\n'.code.toByte()) {
+                throw IOException("Invalid PAX record")
+            }
+
+            val valueEnd = recordEnd - 1
+            val equals = findByte(data, '='.code.toByte(), space + 1, valueEnd)
+            if (equals <= space + 1) throw IOException("Invalid PAX record")
+
+            val key =
+                String(
+                    data,
+                    space + 1,
+                    equals - space - 1,
+                    Charsets.UTF_8,
+                )
+            if (key == "path") {
+                path =
+                    String(
+                        data,
+                        equals + 1,
+                        valueEnd - equals - 1,
+                        Charsets.UTF_8,
+                    )
+            }
+
+            offset = recordEnd
+        }
+
+        return path
+    }
+
+    private fun parsePaxRecordLength(
+        bytes: ByteArray,
+        start: Int,
+        end: Int,
+    ): Int {
+        var result = 0
+        for (index in start until end) {
+            val digit = bytes[index].toInt() - '0'.code
+            if (digit !in 0..9 || result > (Int.MAX_VALUE - digit) / 10) {
+                throw IOException("Invalid PAX record length")
+            }
+            result = result * 10 + digit
+        }
+        return result
+    }
+
+    private fun findByte(
+        bytes: ByteArray,
+        value: Byte,
+        start: Int,
+        end: Int,
+    ): Int {
+        for (index in start until end) {
+            if (bytes[index] == value) return index
+        }
+        return -1
     }
 
     /**

--- a/packages/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt
@@ -1,0 +1,68 @@
+package com.hotupdater
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry as CommonsTarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class TarArchiveInputStreamTest {
+    @Test
+    fun `reads a long basename from a POSIX PAX header`() {
+        val path = "raw/${"long-name-".repeat(14)}asset.bmp"
+        val contents = "pax asset".toByteArray()
+        val archive = createPaxArchive(path, contents)
+
+        TarArchiveInputStream(ByteArrayInputStream(archive)).use { tar ->
+            val entry = tar.getNextEntry()
+
+            assertEquals(path, entry?.name)
+            assertArrayEquals(contents, tar.readBytes())
+            assertNull(tar.getNextEntry())
+        }
+    }
+
+    @Test
+    fun `rejects path traversal from a POSIX PAX header`() {
+        val path = "../${"long-name-".repeat(14)}asset.bmp"
+        val archive =
+            createPaxArchive(
+                path = path,
+                contents = "malicious".toByteArray(),
+                headerPath = "safe.bmp",
+            )
+
+        val error =
+            assertThrows(SecurityException::class.java) {
+                TarArchiveInputStream(ByteArrayInputStream(archive)).use { tar ->
+                    tar.getNextEntry()
+                }
+            }
+
+        assertEquals("Path traversal detected: $path", error.message)
+    }
+
+    private fun createPaxArchive(
+        path: String,
+        contents: ByteArray,
+        headerPath: String = path,
+    ): ByteArray {
+        val output = ByteArrayOutputStream()
+        TarArchiveOutputStream(output).use { tar ->
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
+            val entry =
+                CommonsTarArchiveEntry(headerPath).apply {
+                    size = contents.size.toLong()
+                    if (path != headerPath) addPaxHeader("path", path)
+                }
+            tar.putArchiveEntry(entry)
+            tar.write(contents)
+            tar.closeArchiveEntry()
+        }
+        return output.toByteArray()
+    }
+}

--- a/packages/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt
@@ -1,6 +1,5 @@
 package com.hotupdater
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry as CommonsTarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -9,6 +8,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry as CommonsTarArchiveEntry
 
 class TarArchiveInputStreamTest {
     @Test


### PR DESCRIPTION
## Summary

- consume POSIX PAX extended headers in the Android TAR reader and apply their `path` value to the following entry
- parse PAX record lengths as bytes so UTF-8 paths remain correct
- validate the resolved PAX path with the existing traversal protections
- add Android unit coverage using real POSIX PAX archives, including traversal rejection

## Root cause

The custom Android `TarArchiveInputStream` handled GNU long-name (`L`) records but returned POSIX PAX extended (`x`) records as normal files. Archives produced by npm `tar` use PAX for long paths, so Android extracted `PaxHeader/...` files and then used the truncated physical ustar name. The first OTA therefore looked installed but its asset paths were corrupted; the next manifest-driven OTA could not reuse those assets and fell back to the full archive.

Fixes #1184.

## Verification

- `./gradlew :hot-updater_react-native:testReleaseUnitTest`
- `.agents/skills/fix-ci/scripts/run_fixci.sh all`
  - build: pass
  - typecheck: pass
  - lint: pass
  - unit: 164 files / 2,152 tests pass
  - integration: 15 files / 1,455 tests pass

### Android Release / agent-device

Used `examples-server/hono-s3` with the example's `standaloneRepository` and a Release APK on `emulator-5554`.

1. Deployed a TAR.BR containing a basename longer than 100 bytes (`01a03227-bdf5-7c6b-ad7f-842f493cab86`). The stored archive was confirmed to contain a POSIX PAX `x` header followed by a truncated ustar physical name.
2. Installed it on device. The full PAX path existed in `bundle-store`; no `PaxHeader` or truncated artifact existed. Runtime bundle ID matched the deployment.
3. Deployed the next OTA (`01a03229-e5c4-76b1-a2a0-bf651931cec5`) with the first bundle as its patch base.
4. The client downloaded the 18,169-byte manifest and 115,301-byte bundle patch instead of the 708,670-byte full archive. Long shared assets were reused, with no `Reusable asset missing`, manifest install failure, or TAR fallback. Runtime bundle ID matched the second deployment.
