### PR TITLE
fix(react-native): reject incomplete bundle manifests

### DIFF
--- a/.changeset/calm-bundles-check.md
+++ b/.changeset/calm-bundles-check.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Reject incomplete manifest-driven bundles before installing or launching them.

--- a/.github/workflows/integration-android.yml
+++ b/.github/workflows/integration-android.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Library Build
         run: pnpm build
 
+      - name: Android Unit Tests
+        run: cd examples/v0.85.0/android && ./gradlew :hot-updater_react-native:testDebugUnitTest --build-cache
+
       - name: Build Android
         run: cd examples/v0.76.1-new-arch/android && ./gradlew assembleDebug --build-cache && cd ../..
         env:

--- a/examples/v0.85.0/android/app/src/androidTest/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/androidTest/AndroidManifest.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <application>
-    <activity
-      android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
-      android:exported="true" />
-    <activity
-      android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
-      android:exported="true" />
-    <activity
-      android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
-      android:exported="true" />
-  </application>
+    <application>
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity" android:exported="true"/>
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity" android:exported="true"/>
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity" android:exported="true"/>
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="8993a59e7bed3c6788e1e612b272100625773d0d"/>
+    </application>
 </manifest>

--- a/examples/v0.85.0/android/app/src/debug/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="8993a59e7bed3c6788e1e612b272100625773d0d"/>
+    </application>
 </manifest>

--- a/examples/v0.85.0/android/app/src/main/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/main/AndroidManifest.xml
@@ -1,34 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-permission android:name="android.permission.INTERNET" />
-
-  <application
-    android:name=".MainApplication"
-    android:label="@string/app_name"
-    android:icon="@mipmap/ic_launcher"
-    android:roundIcon="@mipmap/ic_launcher_round"
-    android:allowBackup="false"
-    android:theme="@style/AppTheme"
-    android:supportsRtl="true"
-    android:networkSecurityConfig="@xml/network_security_config"
-    android:usesCleartextTraffic="true">
-    <activity
-      android:name=".MainActivity"
-      android:label="@string/app_name"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-      android:launchMode="singleTask"
-      android:windowSoftInputMode="adjustResize"
-      android:exported="true"
-      android:theme="@style/BootTheme">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="hotupdaterexample" />
-      </intent-filter>
-    </activity>
-  </application>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true" android:networkSecurityConfig="@xml/network_security_config" android:usesCleartextTraffic="true">
+        <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true" android:theme="@style/BootTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="hotupdaterexample"/>
+            </intent-filter>
+        </activity>
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="8993a59e7bed3c6788e1e612b272100625773d0d"/>
+    </application>
 </manifest>

--- a/examples/v0.85.0/android/app/src/main/res/values/strings.xml
+++ b/examples/v0.85.0/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">HotUpdaterExample</string>
-    <string name="hot_updater_fingerprint_hash" moduleConfig="true">64edb00dbbb1d97b7289937d39f5dd6d9ea5cacb</string>
     <string name="hot_updater_channel" moduleConfig="true">production</string>
     <string name="hot_updater_public_key" moduleConfig="true">-----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAm41X+uLNeey4oYa4IA91

--- a/examples/v0.85.0/fingerprint.json
+++ b/examples/v0.85.0/fingerprint.json
@@ -11,11 +11,247 @@
       },
       {
         "type": "dir",
+        "filePath": "node_modules/@callstack/repack",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "dc3acea09d7a8fcfc69288fdd7ca7f0770fcc2ab",
+        "debugInfo": {
+          "path": "node_modules/@callstack/repack",
+          "children": [
+            {
+              "path": "node_modules/@callstack/repack/android",
+              "children": [
+                {
+                  "path": "node_modules/@callstack/repack/android/build.gradle",
+                  "hash": "a89f20f0090f61f07b66615f4ad5c51857dade6f"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/android/CMakeLists.txt",
+                  "hash": "836a27e7d9fb769014724131f023869cd9c3a271"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/NativeScriptLoader.cpp",
+                              "hash": "ff41bccda571e81fbf98aa05a957d0d3a732a02c"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/NativeScriptLoader.h",
+                              "hash": "485a50f6b0d596e081c0280bb5b0945946497f69"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/OnLoad.cpp",
+                              "hash": "050534575fa518719ef4aceb2712f18d14fe9e18"
+                            }
+                          ],
+                          "hash": "eff7db109fc285484022d838000d76d466206516"
+                        },
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt",
+                                          "hash": "177d09d6cfd5965d740cd6efc53cc28a7f387e29"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt",
+                                          "hash": "3544923fdb98c4decff87c1e1b80dc8b704cf520"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt",
+                                          "hash": "c9ee5f4a659f6813b90f24ae58edd34c870ea125"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt",
+                                          "hash": "eb79f0fa044a0308e66508bbec2ea3c8943927e3"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptLoadingError.kt",
+                                          "hash": "9d9771e159b442e40a233403615be4177cd20e9a"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt",
+                                          "hash": "6348861f19208b5aaab8b340a73f39ea4b025970"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptManagerPackage.kt",
+                                          "hash": "196f5631ce0877a19c7d56b5f753a62c23b9c101"
+                                        }
+                                      ],
+                                      "hash": "70bbb6cd50be70a1b690e683f31b89896b3dc31b"
+                                    }
+                                  ],
+                                  "hash": "78f30092efd79effceb160212cf0837e937f2ae4"
+                                }
+                              ],
+                              "hash": "af58469aefb97e9d1a62bbb7d1a72cf7856ef13f"
+                            }
+                          ],
+                          "hash": "8aba5e06dcc1b6f9693d40c5c543fb95e27a520e"
+                        }
+                      ],
+                      "hash": "5d421d3eb70f8865c3d798aa253600161d8e5cc2"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/newarch",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/newarch/ScriptManagerSpec.kt",
+                          "hash": "676b44a5546b0ef72d105c54de5cf8582b3197c8"
+                        }
+                      ],
+                      "hash": "8b40f3dc9493ef2c209c947fe9e18d760d626bae"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/oldarch",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/oldarch/ScriptManagerSpec.kt",
+                          "hash": "73a6659b6ba2984173f2b6f38269712a57ae89bf"
+                        }
+                      ],
+                      "hash": "c619e02c412472284c904f6038fabebf9cf5e5ea"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/versioned",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack/repack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack/repack/NativeScriptLoader.kt",
+                                              "hash": "95894468ba5ffb8a0c64d0788b8d4606f4e216e2"
+                                            }
+                                          ],
+                                          "hash": "414da8506f8b3a90f022a445fe0372ac61c0b5d7"
+                                        }
+                                      ],
+                                      "hash": "18a0532df8ffa3d411bb9c6448fca5e28c6bad81"
+                                    }
+                                  ],
+                                  "hash": "5691b7581b286cc18ee97cfd63174c765ebd633f"
+                                }
+                              ],
+                              "hash": "c69dd92b641c2fb200d4e94806c0629caae3fe9f"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack/repack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack/repack/NativeScriptLoader.kt",
+                                              "hash": "b3107a1227fa43612a0040e40104cdae6516e5cb"
+                                            }
+                                          ],
+                                          "hash": "3b95b541d155e6f0a41b4f893ad5f8245e41e69d"
+                                        }
+                                      ],
+                                      "hash": "a2edbb85d6c9296eb3f0c1b445002a891bc9c85b"
+                                    }
+                                  ],
+                                  "hash": "8177159ae2c907b6db6d81a9ffbb7bc43206a136"
+                                }
+                              ],
+                              "hash": "196e17a89f158997ea40640c54422b2459fa460c"
+                            }
+                          ],
+                          "hash": "719d44357a148216a90e759e0b65808880e6b2f2"
+                        }
+                      ],
+                      "hash": "622e290a06eed467162ef146943fe6cabab42271"
+                    }
+                  ],
+                  "hash": "7b09a87d60ae5512e63ba04688f9c7347c0a5369"
+                }
+              ],
+              "hash": "12cdaff4ed7aa640dce14af86b342a43ce1da21e"
+            },
+            {
+              "path": "node_modules/@callstack/repack/callstack-repack.podspec",
+              "hash": "c61f4e2b2979d246e6dc94df9e74e2a879f720e8"
+            },
+            {
+              "path": "node_modules/@callstack/repack/ios",
+              "children": [
+                {
+                  "path": "node_modules/@callstack/repack/ios/CodeSigningErrors.swift",
+                  "hash": "c6db9f01818c88534166033c34fd5d4a443d2c5f"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/CodeSigningUtils.swift",
+                  "hash": "300dab18d58b0a5b0f7b9c28b64c117dfe11292e"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ErrorCodes.h",
+                  "hash": "6c272a5cce8e91ee7ac4b7d6feffdc80839a67e2"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptConfig.h",
+                  "hash": "0ac1df0b2a6089dfc296d58ef31ce37b92e82ff2"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptConfig.mm",
+                  "hash": "ffefd4264cd9cf85c91a017e99e2fe043d259c9b"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptManager.h",
+                  "hash": "96f5a4544fe03c183d49c50bd7bd6101c8dc3c11"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptManager.mm",
+                  "hash": "93b0633775d040f3b6b75750a4af395f622e4fb4"
+                }
+              ],
+              "hash": "8648e04123f14796515fa95a152edb54bb4900ee"
+            }
+          ],
+          "hash": "dc3acea09d7a8fcfc69288fdd7ca7f0770fcc2ab"
+        }
+      },
+      {
+        "type": "dir",
         "filePath": "node_modules/@hot-updater/react-native",
         "reasons": [
-          "rncoreAutolinkingIos"
+          "rncoreAutolinking"
         ],
-        "hash": "d91000a070c9f9ab83c0585714aca5356e6dd26d",
+        "hash": "a72cb93a3847dfaa05e17fe9044ea1c8f84f9283",
         "debugInfo": {
           "path": "node_modules/@hot-updater/react-native",
           "children": [
@@ -24,15 +260,15 @@
               "children": [
                 {
                   "path": "node_modules/@hot-updater/react-native/android/build.gradle",
-                  "hash": "78d6e231d72d4cff9def556dd871d4f2f77f131a"
+                  "hash": "82ce1dac836ccb3b26ed0c92b04dfa36854bab83"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/proguard-rules.pro",
-                  "hash": "62e423236bd393540d4876356b997ab01325fab6"
+                  "hash": "6e369fa0f1da0ba0d99fde4a00d8df8b55aa3b24"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/react-native-helpers.gradle",
-                  "hash": "fa2094af6b8dd1d41aec725e16baee598b5ccf48"
+                  "hash": "85cff141aab7c15aa5672c97fa17522c7d3d1080"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/src",
@@ -40,6 +276,20 @@
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/main",
                       "children": [
+                        {
+                          "path": "node_modules/@hot-updater/react-native/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/main/cpp/CMakeLists.txt",
+                              "hash": "d7c6e7d34d838fe9b3514b98dbf8ef59a0f536dc"
+                            },
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/main/cpp/HotUpdaterRecovery.cpp",
+                              "hash": "ec33ebcbac32bf9d49577f95fbb8f83854274a87"
+                            }
+                          ],
+                          "hash": "341f58e19183ec5ecd928c5cd8f3135050740971"
+                        },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/main/java",
                           "children": [
@@ -50,12 +300,20 @@
                                   "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater",
                                   "children": [
                                     {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BsdiffPatch.kt",
+                                      "hash": "0185ffbffba3862768ed0ef94588e09dfc5d60e2"
+                                    },
+                                    {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt",
-                                      "hash": "8641999f74a80c9e7c3645d81b35173a73fa7102"
+                                      "hash": "a4b06b73fe861fd221a6cbb8c94646f4f02fc543"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleMetadata.kt",
-                                      "hash": "73c398ec847910cb9323a9261457f45950d58f5d"
+                                      "hash": "e8d617586f0dec0bcb3446e4a987de692f276b3f"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/CohortService.kt",
+                                      "hash": "32d97f9971458ce85361e5be17ce7b073d1c7131"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/DecompressionStrategy.kt",
@@ -63,51 +321,79 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/DecompressService.kt",
-                                      "hash": "b960c59e3bfc5aa9beace8a960e9ded135b33a49"
+                                      "hash": "fac169137d4c633045d45493c167c88194b2d2bd"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/FileManagerService.kt",
-                                      "hash": "69860dcb3f4ce5e6dafb06f27dddffe1fa62a515"
+                                      "hash": "1bc609ce2261ca821cb1be21ed0ed27fa4d49797"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HashUtils.kt",
                                       "hash": "c441a04536a87f930dde20e6a18e2389dc1e3907"
                                     },
                                     {
-                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt",
-                                      "hash": "dbfc5f03e97e8f4291038e34a1690a44f25f3ad0"
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterConfig.kt",
+                                      "hash": "6e5b57306d58b449b8edd582f02b1b7dfe1d3e45"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterException.kt",
-                                      "hash": "abbc8b846c4332e2e07521fd33c9a763ebbd0d65"
+                                      "hash": "d92c2c55f0660fb13530dbfce9a42c45e5419914"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt",
-                                      "hash": "ed203df8caa43aac771cefb99ec3cb542d622b20"
+                                      "hash": "bb216b18cb6f324c3401249cba8537fb21c2c2b5"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRecoveryManager.kt",
+                                      "hash": "fa20ed9fa2da632a05d6b4f14b068cfddf14a358"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRecoveryReceiver.kt",
+                                      "hash": "06dc026004041af8cbd9cedaddd9f30d2ffc4de2"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRestartActivity.kt",
+                                      "hash": "0363d655ab9652261fe2d19bc05a305354640f7d"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt",
+                                      "hash": "99f79b46d10fb7820eb5b6d9b202d5f92f3ef7fd"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/OkHttpDownloadService.kt",
-                                      "hash": "c997a6aff6ab359992079977613930403b5674af"
+                                      "hash": "3dcd2f16868afe310986fb7b2f2a737cb2d9c4e5"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ReactIntegrationManagerBase.kt",
                                       "hash": "edc166023f86025e71584993c7f5b38654fbce41"
                                     },
                                     {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ReactNativeValueConverters.kt",
+                                      "hash": "e1d2aed44ba20d3b9c133dc9e22bdb6ba6dd61c0"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/RelativePathResolver.kt",
+                                      "hash": "609ac569ca61e5495e235cf12bd2c02477cbfec0"
+                                    },
+                                    {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/SignatureVerifier.kt",
-                                      "hash": "e31eed019170f898f4278f91edc9c9e60528df11"
+                                      "hash": "8440cc497dbaeaf6349491f8bef4c763cbf0768d"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/StringResourceUtils.kt",
+                                      "hash": "7b632931e5fea501a3dda45734fc9f30055c91b6"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarArchiveInputStream.kt",
-                                      "hash": "ba5f1a48bdf8cb2f1962ebe6c7ccb408b94f0ae7"
+                                      "hash": "9f509ee5633269151e157d287977c7e061489ed4"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarBrDecompressionStrategy.kt",
-                                      "hash": "9f571ddac577a596ee00668c96b96c686e5e1094"
+                                      "hash": "e0ce9f6b1195c1a66503c711763b15590f244eb5"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarGzDecompressionStrategy.kt",
-                                      "hash": "f5dfce60b18333b442049f5d357ad3832702644f"
+                                      "hash": "dfd05ced7bb9740a499fec2e039faecb5169bc79"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/VersionedPreferencesService.kt",
@@ -115,26 +401,30 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ZipDecompressionStrategy.kt",
-                                      "hash": "e30536e08dca22b95714a088f95c4605634a15ef"
+                                      "hash": "37887140bb6a2909fa0f8b214b33fb9299854361"
                                     }
                                   ],
-                                  "hash": "fda4026ada6dd17c45ab18502c92f7f797c25db1"
+                                  "hash": "09cb7a7225af03f95c4ad508c08c78e2a0af6af4"
                                 }
                               ],
-                              "hash": "cb228dab273ed1f22a1f3e29853ba0a27d6d9a1d"
+                              "hash": "676007ada277bd78b51a4a63bab0707d5e534615"
                             }
                           ],
-                          "hash": "7f064addf5c994ea06733bf0fe98f6a28b5a8d0d"
+                          "hash": "9c712ec8cad4c2bf8595bfd1455dbb891d0ebb3d"
                         }
                       ],
-                      "hash": "2d9c5e8976ae804c0a75c3f1665d5dbc82f725a5"
+                      "hash": "4e14c9cc93e6d73553370780c4ea5f8e28011cf6"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/newarch",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdater.kt",
+                          "hash": "09b480efc63a70bdc6c8b6a5463c4a4c97d4a45c"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdaterModule.kt",
-                          "hash": "64566e2c6c53cf59ba7e96e861c3bcab8cfe8bbd"
+                          "hash": "d1e0cf5d376970927ae9cdc9ab233cfb24c49300"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdaterPackage.kt",
@@ -145,18 +435,26 @@
                           "hash": "e7c1f793e0c67767bdac1bc8ef25e49525f31f70"
                         },
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/newarch/ReactHostHolder.kt",
+                          "hash": "9a3d61f4b340bf8d7304b6a008c37ed79658adaa"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/ReactIntegrationManager.kt",
-                          "hash": "396d0992b8bacee2d277a412ea62ced950ec78ee"
+                          "hash": "cbafabc415e79f898caa22478db8725729135068"
                         }
                       ],
-                      "hash": "4b4d5136d3c88643fb4500071ad831d4b7e2b4a0"
+                      "hash": "60a8af5ee52d2cb62875deda875aea0dc309d372"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/oldarch",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdater.kt",
+                          "hash": "a7f9b6d8813189d6eb2b57469998b79feaad08fc"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterModule.kt",
-                          "hash": "b5c14e6596d5cc5107956839682f3155c7f74793"
+                          "hash": "46bcf7f012412562d436934ee7ae3c9bef909ebc"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterPackage.kt",
@@ -164,24 +462,72 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterSpec.kt",
-                          "hash": "6ce0075cb888f878409ef077fd4f0f192d26a1fd"
+                          "hash": "98f0ffbcb03a8e5e5127a1a8b12dbb08c266cb5d"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/ReactIntegrationManager.kt",
-                          "hash": "f21e4efde4031d73b16381199e58a991243533c1"
+                          "hash": "3a43affdface6224cb16d675e3d9cf8437eb28a7"
                         }
                       ],
-                      "hash": "104671261be6d324eabd629caa643d096ae83558"
+                      "hash": "005e75c80b2fe53f0053e42ce4893125397a4010"
+                    },
+                    {
+                      "path": "node_modules/@hot-updater/react-native/android/src/test",
+                      "children": [
+                        {
+                          "path": "node_modules/@hot-updater/react-native/android/src/test/java",
+                          "children": [
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/test/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BsdiffPatchTest.kt",
+                                      "hash": "478e6fc46dca958db7ed7e812436b69786ec3091"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt",
+                                      "hash": "ad2de262a349c896374a4bfca70970fcebc1d334"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/HotUpdaterImplTest.kt",
+                                      "hash": "dd33ba327dff1595bf09dc353868e1c0450d1072"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/NativeConfigUtilsTest.kt",
+                                      "hash": "8ba3106d7c65fc60913d3eb8b1ec296c8428d3af"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/OkHttpDownloadServiceTest.kt",
+                                      "hash": "1562feb1879dd2321be46698102156f70d0573be"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt",
+                                      "hash": "ce7276d44a1978121e2128edcd9278ce7aa52bd4"
+                                    }
+                                  ],
+                                  "hash": "a855169ae5c29dae5204545bfc3a4b9bdb84cd5d"
+                                }
+                              ],
+                              "hash": "cdb25757dc119aef5e71e6f4d34569d8618d71ee"
+                            }
+                          ],
+                          "hash": "33d29c74e671e742ab50f2d013759e9cbeef46a5"
+                        }
+                      ],
+                      "hash": "b111dd09b5f860b00bf7c40d552420b3a051a599"
                     }
                   ],
-                  "hash": "a49851e35f663a4cd2140aefba0474bc2b606e0d"
+                  "hash": "e43a7ec58de195f4f8bb3b18556aab43f402deac"
                 }
               ],
-              "hash": "3f175c34f306556f52c32ca2c2e5a59aa3f7a263"
+              "hash": "f278621d2670d4448af70782726dca6d908df331"
             },
             {
               "path": "node_modules/@hot-updater/react-native/HotUpdater.podspec",
-              "hash": "ccd5e76d8a20d2f99e72abe2df81f71ee96246ad"
+              "hash": "f3d12124616dce2f101435a7b195b848f7a1266f"
             },
             {
               "path": "node_modules/@hot-updater/react-native/ios",
@@ -193,12 +539,28 @@
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ArchiveExtractionUtilities.swift",
+                          "hash": "28a89f474d87c258e6a8502c2e71265841f49993"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BsdiffPatchBridge.h",
+                          "hash": "345d32891e87b349ffc25df0d0e20a9a6746f293"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BsdiffPatchBridge.mm",
+                          "hash": "503b86b2df26eb512935fa7b48a679ae853de8d5"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift",
-                          "hash": "ac581014ce0aad7194e5f8a8eb6e040aafd38da2"
+                          "hash": "699394246a0d7cd68d3c65943697a0462953ac0f"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleMetadata.swift",
-                          "hash": "19e81827ae242920e21e5520780a66bf88169432"
+                          "hash": "ffdd34407e94619adae076acfaf02534323a736b"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/CohortService.swift",
+                          "hash": "d93d2e0183b97994d566a35a037e1b218e954cef"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/DecompressionStrategy.swift",
@@ -206,7 +568,7 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/DecompressService.swift",
-                          "hash": "367af8e4940336777ab843139ebacae7a928e04f"
+                          "hash": "59cd0e74865f55087f37c553a0128374534b71ba"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/FileManagerService.swift",
@@ -218,88 +580,354 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdater-Bridging-Header.h",
-                          "hash": "3250415134e6b9ef79bdf41a4ee947674c31e155"
+                          "hash": "53caff96ed2c510f2332636f368591bd3f203b15"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdater.mm",
-                          "hash": "053c4462b3e854274bae68e50b7efef5207eb3fa"
+                          "hash": "c9fa6eae1e7983c0dfdbeaa6bf56d5a22d843546"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterConfig.swift",
+                          "hash": "58de094fe85f0d0418b09dbdd650929792350b03"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterCrashHandler.h",
+                          "hash": "ef03e14974e02c2ea07c6c26baef3debe5711a70"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterCrashHandler.mm",
+                          "hash": "e9e1e5a4f578eaa97f72c58716769eef8c6d17d6"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterImpl.swift",
-                          "hash": "60f64166bc77017eb72fe6dcc51924aee13f1922"
+                          "hash": "ec00e2160062318a8cb96672ff5e2b86e0376d95"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/NotificationExtension.swift",
-                          "hash": "47d7a97efcbe1b0c1bfe0bcb25143516a6b54d6c"
+                          "hash": "df1fccf112d9d5283292d11617ce4a6194828ec1"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/SignatureVerifier.swift",
-                          "hash": "f4bc7d76c6b611c3d63ae10d8ba33db6c3b8fd7e"
+                          "hash": "371232a8c622b57948949246476bb7cc4091e18a"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/StreamingTarArchiveExtractor.swift",
+                          "hash": "bab395b8f7f1c7e3fdfb10bc0a89c3a981bd8c70"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarArchiveExtractor.swift",
+                          "hash": "d0e091858190bf71feb81aadeb86964d355c5e22"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarBrDecompressionStrategy.swift",
-                          "hash": "5c9b3087aeb00b9a4e2a7a0522035ed5a8fb5997"
+                          "hash": "c2170852ab98cca72e109b3a39a8b4a83f4f556d"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarGzDecompressionStrategy.swift",
-                          "hash": "c4185dcdbfeaacef413b388b27501283864bceb2"
+                          "hash": "57f070f40a3546d7d88b1399ca63f13f6b6f165b"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift",
-                          "hash": "e2f4ed722fc40837b681f3617d392cfc1f2d2e8a"
+                          "hash": "424bf417fe5ac0ee80d20c33d5cb2c9a89f4dbe8"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/VersionedPreferencesService.swift",
                           "hash": "11ede903c1b4e7d8caff8df2785e770c2d0451bb"
                         },
                         {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ZipArchiveExtractor.swift",
+                          "hash": "8584221bbd3be1aff935a6ac94e0fc65ec7f4b10"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ZipDecompressionStrategy.swift",
-                          "hash": "3ceb9e7ffe85a591f482a247ec96cb9bbb1a6bca"
+                          "hash": "1819cbfc897319e45aeac88691ea325ae7a99d58"
                         }
                       ],
-                      "hash": "25d2b7885ae2ebe691357c7caf8c687316065b0e"
+                      "hash": "7c49d7859faa18ad0c4240a03d2cb627a1bb3e91"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Package.swift",
-                      "hash": "73f973b0ff9ab004d7010414e0d22edc9b5624bd"
+                      "hash": "368b68a5a4ee5ed44ec139e5d324e51093fe2ee4"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Public",
                       "children": [
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Public/HotUpdater.h",
-                          "hash": "c836f779ed1b7a65a2f286539f6d7e1769d582d5"
+                          "hash": "d57e6a6f6aeb746d737954c3c40fa4074c1ae11e"
                         }
                       ],
-                      "hash": "a4593f7ab9ba903d02694cb8a31675ea385452c3"
+                      "hash": "7fe52522dca6e3f2488e4c6e224031879c05dc4b"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test",
                       "children": [
                         {
-                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/TempTest.swift",
-                          "hash": "adeb43fe8e8c510cc48a779ce0038d83b8969a7d"
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ArchiveExtractionTests.swift",
+                          "hash": "2827d86f6dc61b014c12ac2466df982386093822"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ArchiveExtractionXCTestFallback.swift",
+                          "hash": "0bb86b753281edf0d7a28a80dd481859142914b2"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift",
+                          "hash": "1b3f8aad854d493ea86d6d8c6909cf8b0172dca6"
                         }
                       ],
-                      "hash": "70e11214e1f054d0a80d669f5d6e1c34b22d8f05"
+                      "hash": "5dab09e737339fffba28642d58f240834b67229f"
                     }
                   ],
-                  "hash": "e6cf44e1ada2811ba4b5dac0d7d65db0f8651b73"
+                  "hash": "150d6d00df531ffa1eb1b1f5b2a73f207d385b9b"
                 }
               ],
-              "hash": "bb987ec257378184dea04da293eaae0b96c3e986"
+              "hash": "a8e70fee0b213511b704f13b0e1adb69da7e32df"
             }
           ],
-          "hash": "d91000a070c9f9ab83c0585714aca5356e6dd26d"
+          "hash": "a72cb93a3847dfaa05e17fe9044ea1c8f84f9283"
+        }
+      },
+      {
+        "type": "dir",
+        "filePath": "node_modules/react-native-bootsplash",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "35536164716c88f7c7be14e1ae5413022409240a",
+        "debugInfo": {
+          "path": "node_modules/react-native-bootsplash",
+          "children": [
+            {
+              "path": "node_modules/react-native-bootsplash/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-bootsplash/android/build.gradle",
+                  "hash": "a73762aecef135cf5b55524afd6b53f08a58f1f8"
+                },
+                {
+                  "path": "node_modules/react-native-bootsplash/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.kt",
+                                          "hash": "e1ce2e5a63b59628558a86da826c8e3431e7b14c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashDialog.kt",
+                                          "hash": "57993c1e2c06439d8020744786612ab4b8adfee4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.kt",
+                                          "hash": "45ba6379677abbffb677d133474ee909989dd19d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashPackage.kt",
+                                          "hash": "07194523fd2082468cb80687ba68fb794b9488fe"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashQueue.kt",
+                                          "hash": "51390acbc0c4fbcb54889d3507c66094184fceaa"
+                                        }
+                                      ],
+                                      "hash": "9265c2e46b97d36708e4c656d64800cb36ce30a1"
+                                    }
+                                  ],
+                                  "hash": "ab2ca2fb3e6b15a0cbeddb6615341592840fff96"
+                                }
+                              ],
+                              "hash": "f43c8cef1d2aff6da79062a33b6a2680907235ba"
+                            }
+                          ],
+                          "hash": "a31d69cded92a01e3907658e3d89275b8551bdb6"
+                        }
+                      ],
+                      "hash": "8bfe34e2db53aa46d719a90871726f0858acbe60"
+                    },
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/newarch",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/newarch/com",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek/rnbootsplash",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek/rnbootsplash/RNBootSplashModule.kt",
+                                      "hash": "7ab6c029c57e088d2b90a7240e877a575ac5ec67"
+                                    }
+                                  ],
+                                  "hash": "e671163e059c501691d7689bde184317a3c1f75b"
+                                }
+                              ],
+                              "hash": "f1783f798a984c0612f1ebf7a642e63e17b76c6f"
+                            }
+                          ],
+                          "hash": "e1491620fb6cdc3a69521834eaf02fb32bb0ec78"
+                        }
+                      ],
+                      "hash": "8a2a5fff7851f6e3ae1840298a197c354b39c4ec"
+                    },
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/oldarch",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/oldarch/com",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek/rnbootsplash",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek/rnbootsplash/RNBootSplashModule.kt",
+                                      "hash": "f07da75230af4592043eb505031364e1e6ec14b6"
+                                    }
+                                  ],
+                                  "hash": "545c4e0b7badd9dd327d598a2cd066cbf3b096cd"
+                                }
+                              ],
+                              "hash": "6707620fa7c9414448c64a3261979a2caadebc23"
+                            }
+                          ],
+                          "hash": "42cec3e9587ae5455a9e415e60fed33619236e97"
+                        }
+                      ],
+                      "hash": "fed1422876439df1c192e793576ab69cb6d1d601"
+                    }
+                  ],
+                  "hash": "db88382b2b2ddd3f2bb5e576d80e8b43e6e19777"
+                }
+              ],
+              "hash": "324c57c1d5135cd41c9a4bdc263447e1d9bf5439"
+            },
+            {
+              "path": "node_modules/react-native-bootsplash/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-bootsplash/ios/RNBootSplash.h",
+                  "hash": "70376f79433f8d78c7f4233ccc9a87d94c6b7b25"
+                },
+                {
+                  "path": "node_modules/react-native-bootsplash/ios/RNBootSplash.mm",
+                  "hash": "932e02b76b6298aff0182f474001a8bd95a8eb5e"
+                }
+              ],
+              "hash": "949456a0fc953f67129ec62f36ccbf865b45d2d4"
+            },
+            {
+              "path": "node_modules/react-native-bootsplash/RNBootSplash.podspec",
+              "hash": "01111b3d01e7158ece80f3be49ce105c03738c35"
+            }
+          ],
+          "hash": "35536164716c88f7c7be14e1ae5413022409240a"
+        }
+      },
+      {
+        "type": "dir",
+        "filePath": "node_modules/react-native-launch-arguments",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "84678b09037a1e7f35d78938f9afeff3f8a4279b",
+        "debugInfo": {
+          "path": "node_modules/react-native-launch-arguments",
+          "children": [
+            {
+              "path": "node_modules/react-native-launch-arguments/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-launch-arguments/android/build.gradle",
+                  "hash": "e6b4f83705581a7519a01dad3483063993a567a3"
+                },
+                {
+                  "path": "node_modules/react-native-launch-arguments/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-launch-arguments/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-launch-arguments/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-launch-arguments/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java",
+                                      "hash": "c6de38f2b17ca01cb1f8520d72248ad7b1b05ce8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsPackage.java",
+                                      "hash": "74a3e7f14f7303b6f1e1ca3779685f9873271df1"
+                                    }
+                                  ],
+                                  "hash": "31ad9696e8fb0845c8ab00559bba9466edf424b7"
+                                }
+                              ],
+                              "hash": "7cd1f96fec59c5a7241d13e4bd109a47aa8b5445"
+                            }
+                          ],
+                          "hash": "9caa598f548a15da1035d01582d468105508bb2f"
+                        }
+                      ],
+                      "hash": "1b1c98dce6a4ef8d097ee1fae2292f723050d531"
+                    }
+                  ],
+                  "hash": "768ebe72570e72badeca3c3e2b04fac68c952a96"
+                }
+              ],
+              "hash": "6f6f49f88e0b8dbdb478050e1766eb6a31265e32"
+            },
+            {
+              "path": "node_modules/react-native-launch-arguments/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-launch-arguments/ios/LaunchArguments.h",
+                  "hash": "90228301258b813b7c745f512760a2a874a8da28"
+                },
+                {
+                  "path": "node_modules/react-native-launch-arguments/ios/LaunchArguments.m",
+                  "hash": "5f5bc81165f42c59bad7b256598812688d5d2184"
+                }
+              ],
+              "hash": "f03d12f79d3dab304a987a5886c92082c0e4dcc6"
+            },
+            {
+              "path": "node_modules/react-native-launch-arguments/react-native-launch-arguments.podspec",
+              "hash": "84da4e71be0739299484accec986a3252101fc6f"
+            }
+          ],
+          "hash": "84678b09037a1e7f35d78938f9afeff3f8a4279b"
         }
       },
       {
         "type": "dir",
         "filePath": "node_modules/react-native-safe-area-context",
         "reasons": [
-          "rncoreAutolinkingIos"
+          "rncoreAutolinking"
         ],
-        "hash": "e031acae2aadfce18f9e0b4c5e91a8f6dfc75c09",
+        "hash": "872e7ecfe93e702cafb1e8cbe9e8524bd90ff25e",
         "debugInfo": {
           "path": "node_modules/react-native-safe-area-context",
           "children": [
@@ -400,7 +1028,7 @@
                                         },
                                         {
                                           "path": "node_modules/react-native-safe-area-context/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.kt",
-                                          "hash": "ff1054b7a5293e161b2740b958834034b1a65533"
+                                          "hash": "e5e6b3af1e5f14a0a143410edac629adb05dc77a"
                                         },
                                         {
                                           "path": "node_modules/react-native-safe-area-context/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewEdges.kt",
@@ -427,16 +1055,16 @@
                                           "hash": "073b88ec5f57125d9091abe303c455124777cee5"
                                         }
                                       ],
-                                      "hash": "97b0b14a89d38c1377406b3671d4ca8518558fcd"
+                                      "hash": "827382474eaf9fbca3c417a2985e84344aecc448"
                                     }
                                   ],
-                                  "hash": "7c0a97caa3653154872cc7ea08e30ba6e1408ff7"
+                                  "hash": "c22270e0acc856486d550dc65c19e4a4c1157567"
                                 }
                               ],
-                              "hash": "748d3a71b0626dfe87d9da353f36592627b6c7c1"
+                              "hash": "e28c9d6d2c1ae5c72c58a4c49820236a1b36cf8d"
                             }
                           ],
-                          "hash": "47928e93a85a9f434fe5ad61180d4c1b0a629bb3"
+                          "hash": "76f9a948d7816e2d7cf5829e29aea67d41f425a0"
                         },
                         {
                           "path": "node_modules/react-native-safe-area-context/android/src/main/jni",
@@ -453,7 +1081,7 @@
                           "hash": "75301d1c17281162eb24d71f21a16ca53bcba541"
                         }
                       ],
-                      "hash": "60580f1a5b43012c5620e5a571e303b050c97a9c"
+                      "hash": "50cd1e539b5301888eeee1d0bbf0ce6230400fde"
                     },
                     {
                       "path": "node_modules/react-native-safe-area-context/android/src/paper",
@@ -532,10 +1160,10 @@
                       "hash": "cc8e28811027625fce15e328444f68aeb317c7ce"
                     }
                   ],
-                  "hash": "6fc5333f4d8b70cfceb282b8eedc8255ab194089"
+                  "hash": "1b373c52d0d9bd87f4cee422f38ce5659bafafec"
                 }
               ],
-              "hash": "31c4c77b37508fa58d1d9ce6651b816e3bad4eb5"
+              "hash": "333f517550cb5fd08422966e5f39fe2b3ba23804"
             },
             {
               "path": "node_modules/react-native-safe-area-context/common",
@@ -640,7 +1268,7 @@
                 },
                 {
                   "path": "node_modules/react-native-safe-area-context/ios/RNCSafeAreaProvider.m",
-                  "hash": "f39079a1dee7f529db7f68fa7e2ecfcfbac982a4"
+                  "hash": "228bf9a5f44c7bec4c7b0a32c88d8c532c0aff32"
                 },
                 {
                   "path": "node_modules/react-native-safe-area-context/ios/RNCSafeAreaProviderManager.h",
@@ -715,54 +1343,2406 @@
                   "hash": "f0534b50c6299da7ee011d5b7369ab0720bb04e6"
                 }
               ],
-              "hash": "c044599e861f888edddd4b0c3254b14742aec27e"
+              "hash": "2cd1398ce0cd5065f9620e5e1f2826d7565e00bc"
             },
             {
               "path": "node_modules/react-native-safe-area-context/react-native-safe-area-context.podspec",
-              "hash": "fef1ca82be2c4f1107c5e284728b8c0327d6743e"
+              "hash": "2bfce6ed1a27a637a5ba554c0f986a4bfa9f91ad"
             }
           ],
-          "hash": "e031acae2aadfce18f9e0b4c5e91a8f6dfc75c09"
+          "hash": "872e7ecfe93e702cafb1e8cbe9e8524bd90ff25e"
         }
       },
       {
-        "type": "contents",
-        "id": "expoAutolinkingConfig:ios",
-        "contents": "{\"extraDependencies\":[],\"modules\":[]}",
+        "type": "dir",
+        "filePath": "node_modules/react-native-screens",
         "reasons": [
-          "expoAutolinkingIos"
+          "rncoreAutolinking"
         ],
-        "hash": "a11c4dfdbf37b1bdcc11fcac45a79dc9228dcb0f",
+        "hash": "cebea40d794bc3c3b5c1726186e27e18e6212b77",
         "debugInfo": {
-          "hash": "a11c4dfdbf37b1bdcc11fcac45a79dc9228dcb0f"
+          "path": "node_modules/react-native-screens",
+          "children": [
+            {
+              "path": "node_modules/react-native-screens/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/android/build.gradle",
+                  "hash": "97921c17ae33f0f49d8fd318b0a66b9afea1aa72"
+                },
+                {
+                  "path": "node_modules/react-native-screens/android/CMakeLists.txt",
+                  "hash": "d7b32d6d6b89187a31c14d8d815f5c1727dbd036"
+                },
+                {
+                  "path": "node_modules/react-native-screens/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/android/src/fabric",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/android/src/fabric/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/fabric/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt",
+                                          "hash": "287536a4c90f9dc6c706af25bcab02ee2731d025"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt",
+                                          "hash": "7df1f99a691d492c87b31ae6f7ce9febec87fb93"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt",
+                                          "hash": "79869775c4e6ad47026884f72baae8ae631773f5"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt",
+                                          "hash": "5b4e5598643790c36b0f21455525ecabe52bdb8b"
+                                        }
+                                      ],
+                                      "hash": "4767e305595ff21912478ef443d48565133f78be"
+                                    }
+                                  ],
+                                  "hash": "7de5d16dc2961073a61ede6a0bd4bc606918f09b"
+                                }
+                              ],
+                              "hash": "2651820bf02cdaf7bad3bed752ed37234fecdbef"
+                            }
+                          ],
+                          "hash": "6ed80249e1eab198e18a3299cf70d73896e9668c"
+                        }
+                      ],
+                      "hash": "f5540136b635d3922dd5fc1eb14a4be68ffeb74f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/jni-adapter.cpp",
+                              "hash": "7e15ab3a692933f36e0962b85f924596200d211b"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/NativeProxy.cpp",
+                              "hash": "8be561505be8c9bf5a0c19436232c0cf23511001"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/NativeProxy.h",
+                              "hash": "857256053c2823e87c78951852e310a8eded2b2f"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/OnLoad.cpp",
+                              "hash": "2de272c2e66e1c16aff335e9ca4121252104b999"
+                            }
+                          ],
+                          "hash": "3928c3d6e9a47c79ab470dda7f1a6d7544904240"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetBehaviorExt.kt",
+                                              "hash": "608568ef57b0a96e238e49e28d7fcd89fc57d982"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetDialogRootView.kt",
+                                              "hash": "036245a41814f7ed9366d305580948a4ff454a95"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetDialogScreen.kt",
+                                              "hash": "0e55d0c9fbde36d342e5443390a2e1da65899bcb"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt",
+                                              "hash": "06a396c5ffd52bf444e8c67247bb9ce1ac7969be"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetWindowInsetListenerChain.kt",
+                                              "hash": "a6b08b6110f4cac39ee9612274d37e99c2edeede"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt",
+                                              "hash": "05118a529e3e91df5a49b2b08632a85721ff6d42"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt",
+                                              "hash": "a0b5a14a28cc33a0f0b6422b84830d0a80aa2254"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewPointerEvents.kt",
+                                              "hash": "d71edd5ccc4c4ab8d19a02a060245fe558912297"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt",
+                                              "hash": "3f9c91bf3ebba8462fa68add19563b90221b01d4"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt",
+                                              "hash": "04c3fc910ace76a40773672d61572ae59bc06622"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDetents.kt",
+                                              "hash": "63ba4f687ff4a9758f3e5f7dace36160fa105872"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt",
+                                              "hash": "bce7f59d2a55ab9e6cc257af5519d5ecb321a1ac"
+                                            }
+                                          ],
+                                          "hash": "95cd0885e485a29e6866631febe08b251bdea10f"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/CustomSearchView.kt",
+                                          "hash": "6d5fd8d80810d896d99e1a8a97c3f2c1ed0ad2cc"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt",
+                                          "hash": "3284f1d8fa23ca900d33d0af2732b7f40d427289"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt",
+                                              "hash": "e4e6c670eea3ada1d6a1a55ca8e715d032c3b029"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt",
+                                              "hash": "501b8d9c72e7274c8c8498daf5a721cd6ff549bc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt",
+                                              "hash": "9c3304aae7d572282c8a5fc5a36ca7a0adfed5d6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt",
+                                              "hash": "1a3411f947d191145202338d86453fd80b110dcf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenAnimationDelegate.kt",
+                                              "hash": "22dc3f1cddfb4bf47732d9e41ad20ca7b04df981"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenAppearEvent.kt",
+                                              "hash": "5d9dd52444298e70d5732828c869935c2a8307ec"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt",
+                                              "hash": "ddb4a286fd5da6b7eb69ef906e129bf25297cacf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenDismissedEvent.kt",
+                                              "hash": "05c5af5d71567d293163840c41698c84a16ed752"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt",
+                                              "hash": "db838ed6e37bfe34acbdc0614c79678eecdb8490"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt",
+                                              "hash": "6a69fff09c65f835f982752ed0a6c89f3f29c738"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillAppearEvent.kt",
+                                              "hash": "0fff5cf9166c4b549e8ce16b689cade46833cb59"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillDisappearEvent.kt",
+                                              "hash": "84bc7a76588b03e7eca147662b3c4db1602e5441"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt",
+                                              "hash": "ac6e8e9023627c3b68c69a82e87eae689fa9f721"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt",
+                                              "hash": "7bab111a6587ba76c24a30e03477228e6dcd6a8d"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt",
+                                              "hash": "9b41faed4c175d52774ceccad1b6e1fe15edd257"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt",
+                                              "hash": "41a3561edea27e5b0c1588b819710ee2e8318c1f"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt",
+                                              "hash": "4e06b0c4117c151cf4ebf4a295086eb2c85c82e6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt",
+                                              "hash": "7476325ccc3173e4d96583290ec398f5532d9d34"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SheetDetentChangedEvent.kt",
+                                              "hash": "9ba9bb10095a53f8f213ab853c8e4a140d0c6d6c"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/StackFinishTransitioningEvent.kt",
+                                              "hash": "1961be8dfad2b31e7f17b16fae5c2a56809f2628"
+                                            }
+                                          ],
+                                          "hash": "eb4dabe35e402c3124d86c30e50df87749a35a6d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/FragmentExt.kt",
+                                              "hash": "ce319a9d0c5427733dcc3a298381384a58baed6b"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/NumericExt.kt",
+                                              "hash": "1a52014a4bdda3e7d9a80d0ab4d99fe23c948cfd"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt",
+                                              "hash": "6c0d3bd1a98dd71682b536e14bb83bfcfcc3df1b"
+                                            }
+                                          ],
+                                          "hash": "858c54f6ee62aab70145eca102a330de9d3ff8d7"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/AutoRemovingFragment.kt",
+                                                  "hash": "dd901bb482d3d6d02b2a3be96e02f50968617415"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt",
+                                                  "hash": "13ec8ad8b79230177a0773acb32a115bf460ec55"
+                                                }
+                                              ],
+                                              "hash": "8817e30678e78720c57d3286750f7f62472ff7a0"
+                                            }
+                                          ],
+                                          "hash": "aff3531e8370e8f4c6784634aaf28053072bd1e9"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/FragmentBackPressOverrider.kt",
+                                          "hash": "2517db4275d8cb377b7d42013ac8d2e1068a73d5"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/FragmentHolder.kt",
+                                          "hash": "9b0fb079c524c78e7207a12b456fece87e1c7528"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorScheme.kt",
+                                                      "hash": "065c39f5c1040bec00582e3059702a4840dd5eea"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeCoordinator.kt",
+                                                      "hash": "75ebc3de9cd60002e2036f9bb42cc0e1ef4d8cd4"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeListener.kt",
+                                                      "hash": "d8ded388da33cdf95d73425e2201a3054f423218"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeProviding.kt",
+                                                      "hash": "c394d1891eb2f631703fadee72c7808c35da75de"
+                                                    }
+                                                  ],
+                                                  "hash": "f04d58711363d587f8b7c7a0c06a2cd507931cbd"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/BaseEventEmitter.kt",
+                                                      "hash": "e324e6eeee280f1dbf0f9bb8a65c8b043c3ea789"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/NamingAwareEventType.kt",
+                                                      "hash": "07e11b698b55109c1427d864e44513e13819fe42"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/ViewAppearanceEventEmitter.kt",
+                                                      "hash": "740d6b0fead67e37f32358bcc3e8f295ddb81a0f"
+                                                    }
+                                                  ],
+                                                  "hash": "a7cbff3eb6927b1a995ac349f859c0b2ad41043f"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt",
+                                                  "hash": "9e92148c4dd3afab4c16426b2e3444896223bf51"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/ShadowStateProxy.kt",
+                                                  "hash": "aca7ab2ac38614a35e447bdab64b49379a99154a"
+                                                }
+                                              ],
+                                              "hash": "c579ed19603e49a45ec34e8f60aed3d89714b788"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/EventHelpers.kt",
+                                                  "hash": "b8debe37713994e9a95c601c34feeeec0dccbed0"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt",
+                                                  "hash": "c3dff7ed709c23ce68414fe697673410a0357ad7"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt",
+                                                  "hash": "12103a7b915f68c231a431b58c4919c0526d1b11"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/SystemDrawable.kt",
+                                                  "hash": "622846dc57bc714daa3adda63efa5bce6fff2f22"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/UIManagerHelperExt.kt",
+                                                  "hash": "ceac9e883f3609b4a09ee655f298333623dfae53"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewFinder.kt",
+                                                  "hash": "796beedb5db8e7e4f16adc9c83af7b50e3df7f0b"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt",
+                                                  "hash": "5580e1fb049e9f4014d2b473ca68e312b4bf6609"
+                                                }
+                                              ],
+                                              "hash": "08e94d2ae70bdaedde844e0abd1902e117929bbf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarker.kt",
+                                                  "hash": "49780ddbea103d429940428944c7d92ba7668db5"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt",
+                                                  "hash": "c25f2370550b2f275fcfd56280821a31537c12bb"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewSeeking.kt",
+                                                  "hash": "bd94a5fd7b48f0a419c27f2f9ce8287de68af3e0"
+                                                }
+                                              ],
+                                              "hash": "b6412e579a5d175223fa08682003a42fc54647fc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/OnHeaderConfigAttachListener.kt",
+                                                          "hash": "446364ae4cbcd19d963e4ffb7daeda97d76e1aee"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/OnHeaderConfigChangeListener.kt",
+                                                          "hash": "a008c90c488c9351d904708feae8b31a880d8cbb"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt",
+                                                          "hash": "8be6097398b0f2f2caf204a37ec51df1c3d761f2"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt",
+                                                          "hash": "3e2f91ee893f803c533eb90a0144912863369ea0"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt",
+                                                          "hash": "c9f1b7c40aae7de1914230ea4c401d5c8590c6ac"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderType.kt",
+                                                          "hash": "a6de4d8471c91bdf90fccddff1a87262e32720b8"
+                                                        }
+                                                      ],
+                                                      "hash": "3bcdc4f2d7cfe47333625301113c87af78a97d26"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt",
+                                                      "hash": "e5697959c519a41ba21d08182e5b4d04d590039e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt",
+                                                      "hash": "f0c31f8eff9cf775abaf3177373e3aa7f22fabea"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt",
+                                                      "hash": "802ab2ea84cab86ec23cf1683cc5ce1898bdbcd2"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt",
+                                                      "hash": "5d1d57a8107da29b84fd7870cd0f62e408cc0cbb"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderScrollingViewBehavior.kt",
+                                                      "hash": "3e9b81f31e32c21fd3774953e1d4d12063d376a3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/OnStackHeaderSubviewChangeListener.kt",
+                                                          "hash": "f01afb06becf237860359ad35973f7f3a69e026c"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt",
+                                                          "hash": "b2b60af38f15e9778a51938d0eb3624496806dac"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewCollapseMode.kt",
+                                                          "hash": "9838d3ea3e7a0d849720f8d70acd73e92a166a1f"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewProviding.kt",
+                                                          "hash": "886dfa45f765bb554c1d9e7313eeb14e5b48a343"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewType.kt",
+                                                          "hash": "322355d25c921be7055b4de7acc7685fb6aeebfa"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewViewManager.kt",
+                                                          "hash": "ebc6e5881a8478f508b5e0f813eff2f052c22a2d"
+                                                        }
+                                                      ],
+                                                      "hash": "a4d2bb8b0be4f9c918dcd33992556468d44931d2"
+                                                    }
+                                                  ],
+                                                  "hash": "cb3093ac1ecf55ea4a16f4c810f6ed2d3cb59f0b"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/FragmentOperation.kt",
+                                                      "hash": "a68d46443afe7719466a2ccc024b109a7f40312e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/FragmentOperationExecutor.kt",
+                                                      "hash": "757d7d086bbef69f850189893feda079e2b572d3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt",
+                                                      "hash": "1819e4948921a1b6a66451d1b348498eec6a7986"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerDelegate.kt",
+                                                      "hash": "7da1cac5b0926c1a7ba21427062d9fa264358043"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerParent.kt",
+                                                      "hash": "d0d87d312a970086a1f6ba9dc2c20eac45b8d5f0"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerUpdateCoordinator.kt",
+                                                      "hash": "6f3362c276bdf539105d8454b0ffd4cc2cf113d9"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHost.kt",
+                                                      "hash": "ed410178a797ae7b840fc21a5b6bcd0cd7a9a1e8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHostViewManager.kt",
+                                                      "hash": "d5356f106ac8735061cf3dddb91f4de53b57d62c"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackOperation.kt",
+                                                      "hash": "79f3fc609c71dec4c59d2ca3d0eeb021287e3241"
+                                                    }
+                                                  ],
+                                                  "hash": "472c6eae977a925f434a1da1e5acb2b2f1613ac9"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDidAppearEvent.kt",
+                                                          "hash": "dd4a3521c2fa33e73bbb6fdd656ad7b8a8f2ed0a"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDidDisappearEvent.kt",
+                                                          "hash": "990e6f915c609da4b5778ae824c8e20c7159eefe"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDismissEvent.kt",
+                                                          "hash": "48f66220d4be83452b813a4e518b123227030661"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenLifecycleEvent.kt",
+                                                          "hash": "525d22f69f4e129607febddda4eb1cb7ee26b667"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenNativeDismissPreventedEvent.kt",
+                                                          "hash": "654af77363f1b827a70e22cc5fb12d9c26506f3e"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenWillAppearEvent.kt",
+                                                          "hash": "b3a6cb8e791ae86a0615879107146170b7cca2ae"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenWillDisappearEvent.kt",
+                                                          "hash": "e05074ee898f69543247d11c36b077451a43bc2e"
+                                                        }
+                                                      ],
+                                                      "hash": "ba34d26c5443b2e14f15a58b67284ee62a1691eb"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/PreventNativeDismissCallback.kt",
+                                                      "hash": "b331720144c16cf4137dff2c658d5418b1610573"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/PreventNativeDismissChangeObserver.kt",
+                                                      "hash": "0a3464f23c64a3773c01cc9438d5fe927b570aa8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt",
+                                                      "hash": "11bf5fdff39f3f57579eeafdf68f9a25ebffc3e8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenAppearanceEventsEmitter.kt",
+                                                      "hash": "92f19255283601f84b6d085a8507761161e0f136"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenEventEmitter.kt",
+                                                      "hash": "d38d428a4dd095862ec555bd8262997687bdc482"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenFragment.kt",
+                                                      "hash": "22c06f876c264d4c7b104e8873123805ca276d31"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenViewManager.kt",
+                                                      "hash": "772d27c3915cd9877ac0148e0b0f194f4b38b6e3"
+                                                    }
+                                                  ],
+                                                  "hash": "e7dfcbef2d5667f3b37ea8ca7bd17dad948702b3"
+                                                }
+                                              ],
+                                              "hash": "24d43172bd85469c8b1cb81c66b4c4bdbe0bcd00"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceApplicator.kt",
+                                                      "hash": "0d98d3d89f476993933383002fe24d97b5155d80"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceCoordinator.kt",
+                                                      "hash": "d61eb52d547f20469e56fdc1e41946fbfd9a71e2"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceModel.kt",
+                                                      "hash": "2038ab2e61eced8988559fe74a86d6921bbe1165"
+                                                    }
+                                                  ],
+                                                  "hash": "f739b745561beacb1cd2a9559329911e75ab97d1"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/CustomBottomNavigationView.kt",
+                                                      "hash": "09670d02d6aa4e6f5d881e406f7f34ce3733b5d3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/MenuHelpers.kt",
+                                                      "hash": "cb6cf987d4f4933e9085849b453ece948889398e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsActionOrigin.kt",
+                                                      "hash": "6194f0570c687370968a4ae043ad6ba82bd42584"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt",
+                                                      "hash": "f5d516975c7ead6f360691d843f299a78137f499"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationState.kt",
+                                                      "hash": "38b24a4c393e1b1fe8880c9e4c04b50ab5ceec17"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserver.kt",
+                                                      "hash": "821b39bf9da7a04f2b4b3ba504610e0d56dca4f7"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt",
+                                                      "hash": "d0999378ca922236e5c035ea5415922dcc9e2e28"
+                                                    }
+                                                  ],
+                                                  "hash": "ba0bc67052b5d3f30efbe5e4376683ae30271a92"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectedEvent.kt",
+                                                          "hash": "48d8bac77729c6c65250adfc49cd7f58fe53272a"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt",
+                                                          "hash": "0e06036b3da0245baca8f6e36c485f5ef764a34e"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt",
+                                                          "hash": "bb62696153dab0c918a78ab1410bc3ce80f718da"
+                                                        }
+                                                      ],
+                                                      "hash": "73ece090b9011ad44f7bdfbfbd38dc4af3426007"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt",
+                                                      "hash": "f21ada8dbfa35833a13ac90f2adf12dd4b5825d1"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostA11yCoordinator.kt",
+                                                      "hash": "dff00edd01ff5ee77151b595764eaad5018de26f"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt",
+                                                      "hash": "09d36833a6f0cdc0fb0c26a7c4fa3d79b0b36b2f"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt",
+                                                      "hash": "838bc711cd927a0c5ff931f5d217d26da01bcf73"
+                                                    }
+                                                  ],
+                                                  "hash": "8541a662c2a0514c1d3c6cde26550883253dc939"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenDidAppearEvent.kt",
+                                                          "hash": "337a1356c467bbef84ebf4033e72009803f75d9d"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenDidDisappearEvent.kt",
+                                                          "hash": "351e51f03f65acf0d5b0423b2bc42aa2be5d2073"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenWillAppearEvent.kt",
+                                                          "hash": "efa74526aa8c046b76079fef3b09bf3ccc4fefd1"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenWillDisappearEvent.kt",
+                                                          "hash": "aaf896f80806309525753ef8a6703f274eafb9c0"
+                                                        }
+                                                      ],
+                                                      "hash": "388fcd45f12c56d4f6d24cfe6e872c37c78a7f7b"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt",
+                                                      "hash": "4132946e699fa678cbd23228bb289cc4d89c612b"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenDelegate.kt",
+                                                      "hash": "2718ae4b5f93c78ac224a69dc4d704751f2ce573"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenEventEmitter.kt",
+                                                      "hash": "30010d8b3f7ba8966f031f4d3889912fc9133368"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt",
+                                                      "hash": "3aa990519d5265e47a415f82c665445b3e54617e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt",
+                                                      "hash": "2006d7a624a01d07feead3dc936f0f2cd4a7a3c7"
+                                                    }
+                                                  ],
+                                                  "hash": "a759b4f6eb7b7a4e0cb3dc09cf4ac33825bb4538"
+                                                }
+                                              ],
+                                              "hash": "de6b89164e97704fc24ac53451a40ee2662187dd"
+                                            }
+                                          ],
+                                          "hash": "62e368f53a12e35048e6ee040637104b907682c4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt",
+                                          "hash": "83b32fdc2e974ade0debc784dc287c4302fdd8c1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ModalScreenViewManager.kt",
+                                          "hash": "27778eb1cc58dfcab27807b3f93d81836c0215b1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt",
+                                          "hash": "65387323b28e1fdf2aa7c405eb3c01165253ce3e"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt",
+                                          "hash": "4372adbbcaf09b1f7ab02a135fe259b6474e22bc"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/EdgeInsets.kt",
+                                              "hash": "fc266969a7f207dac59d7adcb3688f5d136fbd53"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/InsetType.kt",
+                                              "hash": "867303d5c36b7ce6748ddeb8bf766c3dde131b2b"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaProvider.kt",
+                                              "hash": "8c34052ee29f5443454994a28fbbe5d25f6060a5"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaView.kt",
+                                              "hash": "33731736b9b3894bc58f8dd8768c6b0f1fe795be"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaViewEdges.kt",
+                                              "hash": "41a90ef53cdd8f4aae687bbabe77e86449d5ca0e"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaViewManager.kt",
+                                              "hash": "65aed46aeaf7700b5b13b6d1181f13b9176619dc"
+                                            }
+                                          ],
+                                          "hash": "70d15d3a24224d388e4e56251347b8ca5df39b48"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/Screen.kt",
+                                          "hash": "c9adcd91fc46b4e0b7934a91af673dc0f8a2adae"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt",
+                                          "hash": "b2722dec4607713d8c66bb89689926583d628570"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.kt",
+                                          "hash": "37e53a70eea508e466316d807d43e3c6eabfb609"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContentWrapper.kt",
+                                          "hash": "17027d1c3148f19c433f51e2a6330cc5db06494d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContentWrapperManager.kt",
+                                          "hash": "15435eb6b3173183352d3df665ba5fbd64c2022b"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenEventDispatcher.kt",
+                                          "hash": "1c1ccac7e9f7e22edf9047a743252749e9a627dd"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFooter.kt",
+                                          "hash": "b570f62f46a09c0ab8e3208ea3a76cac08c6dd84"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFooterManager.kt",
+                                          "hash": "8b36c5addfda852960a075ba2fa14e31732150c0"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt",
+                                          "hash": "7cbf1280a84d258b7a4ff4ffbd2998a6c546757f"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt",
+                                          "hash": "e4595f5ff5ed831878f699a20c794215e2e43ced"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenModalFragment.kt",
+                                          "hash": "3e7316a293ce8a110ecfeb528d5b8697587009e0"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt",
+                                          "hash": "2c3602444ea63abe41bc330631ecebbd6a0ff966"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt",
+                                          "hash": "53477119696dd2447f17c037c7832c5978e6e773"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt",
+                                          "hash": "f37c3f8ca88711e170252dee860ece615938e1a2"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragmentWrapper.kt",
+                                          "hash": "db037412ffbe8620f28d52e8ecf4e051ba316920"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt",
+                                          "hash": "d35361d63632849fc6b76333f975a1d1f74763b4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt",
+                                          "hash": "72524b6b70a87ec0c67fd1ec18ae3f817f58574c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderHeightUpdateProxy.kt",
+                                          "hash": "ef9b838580507c7acae54be2162ae03c1c0b80a1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt",
+                                          "hash": "a179a78c0d8d3ada5f688f01ce1b2f914a37d452"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt",
+                                          "hash": "a5b16992866128b9735db19d9cc0c3f815750646"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt",
+                                          "hash": "99af70bd5093b2f36f57ba3a81f3f3f7fe90d2af"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt",
+                                          "hash": "9833717758bc26720abed2c1b93cd6213d01516c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt",
+                                          "hash": "1eb06de6411e7d5d77bd1470dc2c7545477a8b7e"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt",
+                                          "hash": "b582e95c809ea115d65c9b11de94df7285d10069"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt",
+                                          "hash": "f556943edcf6abedf965cded7f8575f5a3836d7b"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchViewFormatter.kt",
+                                          "hash": "b2355a75e2d16cae509b9d27a8f3b36b1605fb33"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/anim",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/anim/ScreensAnimation.kt",
+                                                  "hash": "4943c1dfcb9acb9efa65c18975790384a02fdce8"
+                                                }
+                                              ],
+                                              "hash": "2546eb210b25b2dfe91c2f138fa7ee8cbd829fae"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildDrawingOrderStrategyImpl.kt",
+                                                  "hash": "9db34227e3b2afdf743f1202dc4b6d02ece93988"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildrenDrawingOrderStrategy.kt",
+                                                  "hash": "5b1d865592864ecef35cc68fa8acb554e8f3c467"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt",
+                                                  "hash": "368a06fa4a01690341e4105349a27aa742d786be"
+                                                }
+                                              ],
+                                              "hash": "7b73057a0a1c504d55a3fe3036092b83966f362d"
+                                            }
+                                          ],
+                                          "hash": "65d384b13e1feb507e0717fb9b2d0ac568a0f3ea"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/transition",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/transition/ExternalBoundaryValuesEvaluator.kt",
+                                              "hash": "52ae4442238c3c55eba505ce70931dcc99f476df"
+                                            }
+                                          ],
+                                          "hash": "bc9b7afd6d9e99f3a6becac63968c220636d3985"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ColorUtils.kt",
+                                              "hash": "afa166a89c7e419d2ab58b3980eddead272b65a6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DecorViewInsetsUtils.kt",
+                                              "hash": "9342c881fdbc74870d55793a47eaf217bdcd306a"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DeviceUtils.kt",
+                                              "hash": "625fed11e715d2a3bec0e7a5e15bf30574cf1da2"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt",
+                                              "hash": "a028a4bf98dcb4d639e45f47d0d27c915e628792"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DrawableUtils.kt",
+                                              "hash": "b7a83a5c70ffeedd2863643d83049c399759cafd"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/FragmentTransactionKt.kt",
+                                              "hash": "6fe3b475132a2cde6f94922d6826adef716c0713"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/InsetsKt.kt",
+                                              "hash": "a761166e4420420d3f42952a6f7b55447df0ce31"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/RNSLog.kt",
+                                              "hash": "dc993e0a7c750ad502c43756c08e55c69a2178db"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt",
+                                              "hash": "62301957e29e3e0fdf1b43b553e1bb4d55f95ccc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ViewBackgroundUtils.kt",
+                                              "hash": "38a038c8c64a383deaa7e9b78a8fa786f1a4bc14"
+                                            }
+                                          ],
+                                          "hash": "8afb7e80631d761d2d7d85c7636ba59c66fb325b"
+                                        }
+                                      ],
+                                      "hash": "be735e8fa5330235763fdea39e0b410de3d73b86"
+                                    }
+                                  ],
+                                  "hash": "f6c18fd6721a7345b1f9ecb947e8b2f3c58003c7"
+                                }
+                              ],
+                              "hash": "10a55c1e5f157e742dcb97eac334eac3e1f55df0"
+                            }
+                          ],
+                          "hash": "d6b78a91ed02991b9ecf9c5cfe568645a89daac7"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/jni",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/CMakeLists.txt",
+                              "hash": "2a5189163c0d5dd11937848c0fe350443ffc1c5e"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/rnscreens.cpp",
+                              "hash": "5d19bab488500223d09053d7f3b346519caae5cc"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/rnscreens.h",
+                              "hash": "d37edde0694f3db5e5f861562ee3455a816d9b14"
+                            }
+                          ],
+                          "hash": "0818374af2dbec8e0b5091f763a6f019c6fde05f"
+                        }
+                      ],
+                      "hash": "0d2e334829841e89a25db96f0159b8d8a9e45529"
+                    }
+                  ],
+                  "hash": "de920d783e84544635ecff1f10bcfe31b4873165"
+                }
+              ],
+              "hash": "b2e0c27d21961094fc4b1d3fafd6ba1a2fe449ea"
+            },
+            {
+              "path": "node_modules/react-native-screens/common",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/common/cpp",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/common/cpp/react",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/common/cpp/react/renderer",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/common/cpp/react/renderer/components",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/FrameCorrectionModes.h",
+                                      "hash": "13ec35de6952efac6470a88c3eb8ea439edc5a89"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h",
+                                      "hash": "0b14243cecaa826d529140505cd1f3d3d832a3b7"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp",
+                                      "hash": "041bf80cccf8c5ef46e1e501c24929756e3e8ea0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h",
+                                      "hash": "93a9cd713a9a784dd079f6efe0ab2a8732a52fd0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h",
+                                      "hash": "7aab1e4035184bf3e68eb7ac0ddd641d695bc55b"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenComponentDescriptor.h",
+                                      "hash": "6e2fc6fe3e4f078f74fdebfabce4b1e44beb7d4f"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenShadowNode.cpp",
+                                      "hash": "005f0299895ca9eb58e91ee77a83595e1a0301db"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenShadowNode.h",
+                                      "hash": "aa5d6d2e4842a01bad6e3657761b3d94346ca927"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewComponentDescriptor.h",
+                                      "hash": "aef68a0cf234f2ce7165c134cbaac86d1e300cee"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewShadowNode.cpp",
+                                      "hash": "8c02252e129932c38373dfca56e39f4b57229886"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewShadowNode.h",
+                                      "hash": "c058290b66305035f8941014b140c8ce3dab9325"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewState.cpp",
+                                      "hash": "9ecb94d180f3cc56adcfe9182eec2b63290f3cd9"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewState.h",
+                                      "hash": "d0e265905cc1449f9f106492884af1a80bf2c2af"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h",
+                                      "hash": "c5bc83170c4c5b918ce9547b074368ad8dde1b36"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp",
+                                      "hash": "f9572ceb2751febf9ed216cfa1b0e6c216dd39e0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.h",
+                                      "hash": "56538ef1fca15a7a6febaf7a782c0e5dca5a7e0c"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp",
+                                      "hash": "a43f46c44d7f9a28a37790674da1972ed434f50e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h",
+                                      "hash": "f8c8ae883900404cd173a08d039f6e726d8506f6"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h",
+                                      "hash": "22f56f8e0e1796c94348fd40f136c5b1e6a11f79"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp",
+                                      "hash": "4aa65e83d5470a3f77215de9d67459dbb0e5d474"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h",
+                                      "hash": "0ad7dcab9ec2a69f9098769f3cab14e29e30fa53"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp",
+                                      "hash": "3829a8937310bc181cd689b5875beeb5a19b36a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h",
+                                      "hash": "0564ae287939c82d6698c1d71a5ddc4b5535f0da"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h",
+                                      "hash": "bb0ed25bcac8a0c92735a14fbdfaf5b68739f224"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp",
+                                      "hash": "99637813bbcc18ee65837ee60f78c60dac304d39"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.h",
+                                      "hash": "63af47aab1ee5ddf14e6d1dbddfa9656645c151c"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.cpp",
+                                      "hash": "951e3e2b9d9f92020f908ecc94ac409b7bb46bd8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h",
+                                      "hash": "9b032605af38d15088f545f612ac2e2c1454e679"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenState.cpp",
+                                      "hash": "a891406cd1890ac26e2173d56c5b8f4f528850a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h",
+                                      "hash": "bc1b4b977215228a7a89e121fec47d70b63979b6"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenComponentDescriptor.h",
+                                      "hash": "870e263a1f7205ffe177428acfa412b0785894f4"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenShadowNode.cpp",
+                                      "hash": "75fabdc370f3dba8ba2eb6eea95880d9393823fb"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenShadowNode.h",
+                                      "hash": "b1d7285aeec517a427f1ff0e58b3603543fd55b3"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenState.h",
+                                      "hash": "62e9c5f71d4d8d6f1f98b857f1b3f25754696f62"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigComponentDescriptor.h",
+                                      "hash": "39e83f85a7322e13f257ad32fbc591dc77c2df23"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigShadowNode.cpp",
+                                      "hash": "6e1bb131d1988234fa003febb7100ac0580c661d"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigShadowNode.h",
+                                      "hash": "373405b86f81d465a3c653e59904b6214ed66cc4"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigState.cpp",
+                                      "hash": "dda4e92f5d3631f9752a2e7db03c7ee9f7b8052b"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigState.h",
+                                      "hash": "0b60c3ffbe6c0c533ac09a21ca22c8c5f0de65a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewComponentDescriptor.h",
+                                      "hash": "002ac19d53cced07e598eac085cb7f6b9b2eccf1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewShadowNode.cpp",
+                                      "hash": "eb8f6dd62b94571698ea16952552614b9aee00f8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewShadowNode.h",
+                                      "hash": "d7d6ca9b94e13e3698a77f092124737afffe33fd"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewState.cpp",
+                                      "hash": "2b237416bb56d820d88d46cff5657762a30bec22"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewState.h",
+                                      "hash": "4c7aacfed431740ed467d426d0917c67fc47a3da"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenComponentDescriptor.h",
+                                      "hash": "460da7113d6f14cd8bac6f3236b86f324e320013"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenShadowNode.cpp",
+                                      "hash": "86f1962bc959b05d477d6156028c646e4a5b2a12"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenShadowNode.h",
+                                      "hash": "5cb813a0acf251e15145607ebd4ffe694fde22b3"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenState.cpp",
+                                      "hash": "72ee359c6e58a4408cac267a22ec10164aa4f39e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenState.h",
+                                      "hash": "02b3ae38fc00de7b2ba464d28d201ba9951e5392"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryComponentDescriptor.h",
+                                      "hash": "0e05789da89ea6871dc3bdb8efcf97d545fcd912"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryShadowNode.cpp",
+                                      "hash": "90eb4568c48bd1f56f884bceaee041ecfad3d596"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryShadowNode.h",
+                                      "hash": "3435e5f05763f36663fbc5b62983b8f18dc71595"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryState.h",
+                                      "hash": "10aa704e068d4fa98866a4ef4a0308938f286218"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostComponentDescriptor.h",
+                                      "hash": "fda3435c68d89afdd86b24eb22cd507d809e234e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostShadowNode.cpp",
+                                      "hash": "7aa7572e2e50e5198bc67f1d25b3cb40611684d5"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostShadowNode.h",
+                                      "hash": "44838960668138b6a64ff8f07ea197d05b03e75f"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostState.cpp",
+                                      "hash": "9811b540b3400f5e9b4cdce2afa82d5b2c040abe"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostState.h",
+                                      "hash": "f3c0fb09939a85d387cb227b69efe7d43bc896f9"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/utils",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h",
+                                          "hash": "df0fece316063e3024464f0f86ece31d8c9a0dbc"
+                                        }
+                                      ],
+                                      "hash": "8c2e7b684fad4eb641d356ef4989835f779d9021"
+                                    }
+                                  ],
+                                  "hash": "bd9d459597da053b3f9532c4d41afc8a96bace5d"
+                                }
+                              ],
+                              "hash": "287358b7d49bc81a2229ea18f8be19f666676eb4"
+                            }
+                          ],
+                          "hash": "5c016ca6596c861413398aad0b89c7aa0c8f80fd"
+                        }
+                      ],
+                      "hash": "61876839748f2c9669c0d9f589a106a03c6a1f5b"
+                    }
+                  ],
+                  "hash": "1939c4dbb904b9fd859c31518804ff2f06792062"
+                }
+              ],
+              "hash": "62af203be42b4f785edc1f1c7495c85bb9dd6737"
+            },
+            {
+              "path": "node_modules/react-native-screens/cpp",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNScreensTurboModule.cpp",
+                  "hash": "de2709a495342f522c0f1c62fc6e21db5c5d8145"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNScreensTurboModule.h",
+                  "hash": "337249afab580c96c18d66e7de5746ede29ef691"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNSScreenRemovalListener.cpp",
+                  "hash": "207db03c4a9df1d209d4274aab7592ee78c1cbc0"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNSScreenRemovalListener.h",
+                  "hash": "4e929d15d09a1a783a0278d781816f9547de4712"
+                }
+              ],
+              "hash": "af777b4278b08c25581dc02bc49aad0a70928ecb"
+            },
+            {
+              "path": "node_modules/react-native-screens/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/ios/bridging",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/RNSReactBaseView.h",
+                      "hash": "c27d8f00bcc310ae7dbbf3d0498e34164be67ed3"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/RNSReactBaseView.mm",
+                      "hash": "3a7500246d9dd5b259b29361c91701b6d06093af"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/Swift-Bridging.h",
+                      "hash": "78980455e0d16439af28ed8d884b3a7d47c394cd"
+                    }
+                  ],
+                  "hash": "65bebc41a56b178009fefa66d52d5ca03fe92f42"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/conversion",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/always_false.h",
+                      "hash": "f27cfa159168d5dc21d3a29e1c382093527d153e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Fabric.mm",
+                      "hash": "c9a42c91958957b4e650032d576029de6d5f58e5"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-ScrollViewMarker.h",
+                      "hash": "099fbce1b29847497a314144199d5fc72823f0b6"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-ScrollViewMarker.mm",
+                      "hash": "ab3fdc8967865725f870bb75de92e8acd5d626f3"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-SplitView.mm",
+                      "hash": "5071f38921c18151b66989b49f2a2b7200a95a44"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Stack.h",
+                      "hash": "b2db93781fb7327ec767ef20bb632ad744f42142"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Stack.mm",
+                      "hash": "26281381f76dc12aa859aa260e7d50c5681c8aef"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Tabs.mm",
+                      "hash": "827469eaec0485966205dbfb46ab9fcb60e4f806"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions.h",
+                      "hash": "e6eeb6802e51e7db0ff3aa633c42175e1fb247da"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions.mm",
+                      "hash": "01f1b3979a15bdbafb40ee372c21c07c3cc83ece"
+                    }
+                  ],
+                  "hash": "15c3f06f839f369e6186ca968f6f237600ee211d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/events",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSHeaderHeightChangeEvent.h",
+                      "hash": "75110afdd804f971d89b0a0b7acb9a31c6986722"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSHeaderHeightChangeEvent.mm",
+                      "hash": "f3ce690ced0babbeacd80a22f1324f7658c7f1bd"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSScreenViewEvent.h",
+                      "hash": "8f04bbec44b32b94ad042e91fa23478571cecc7e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSScreenViewEvent.mm",
+                      "hash": "6c033a2a80e67a6d340167c0b32715bc1fb426c3"
+                    }
+                  ],
+                  "hash": "18e86f7540d76e4b8ecde8b2b201f0519970c72d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/gamma",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/orientation",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/orientation/RNSOrientationProviding.swift",
+                          "hash": "8657e7bb02cad6b6015ab05712b5f072520e82aa"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/orientation/RNSOrientationSwift.swift",
+                          "hash": "e43343eba7726f5275bec9a174f0da347d2f2e22"
+                        }
+                      ],
+                      "hash": "1edd6da9916827cb187b9c4f8014c30af4342a80"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/ReactMountingTransactionObserving.swift",
+                      "hash": "12765683eeabd943535e8f4f3498a2043572c2ac"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h",
+                          "hash": "51442f944ca19006d3aea53b371f3604acf88033"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm",
+                          "hash": "67f0c30d18072ae799d455a5df73b20a7552790b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewSeeking.h",
+                          "hash": "97f42a0d040bb8ab41da6c4c309e78d9a15b4533"
+                        }
+                      ],
+                      "hash": "62065573b9bedab0a57c6608cf0c16455e073418"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/split",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceApplicator.swift",
+                          "hash": "a890c89df427bef6deb9d0e24532b4f11caa4372"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceCoordinator.swift",
+                          "hash": "5d2fbcb5ecd4f4f09085a45d8f9ca990f8f970c8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift",
+                          "hash": "5dfdb31c2a50703ea30e1698293a93579331a45d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentEventEmitter.h",
+                          "hash": "b4365d5fe0d027b83f344e9503329ae8c15adf96"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentEventEmitter.mm",
+                          "hash": "723f7b327e756ee39101de6c4d62c8914d75b0a0"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentView.h",
+                          "hash": "e8d68bded7716089629b76056fb6351c08b0429b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentView.mm",
+                          "hash": "e673ee3889dc7d5d1a641b3c1fec9baf8ac8677f"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentViewManager.h",
+                          "hash": "358e39dfe2bf26a651b1935e0293751c875580b7"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentViewManager.mm",
+                          "hash": "24ae4e54977326e6aaf7b0a8a941a992c46945cd"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostController.swift",
+                          "hash": "21df833cf3d9984b9b27d2f6d0b38ee02b4fa480"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitNavigationController.swift",
+                          "hash": "3e8aaf8ea8147976b701506ca21804366b6b2318"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentEventEmitter.h",
+                          "hash": "9d73e2bf5ebe7df7d1cecf04acb5622c1a43cf8a"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentEventEmitter.mm",
+                          "hash": "96285fd583326020caed83587e152b682119999b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentView.h",
+                          "hash": "cc6d795a063936f60a4624366bc5e0fcebedc08c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentView.mm",
+                          "hash": "175efcd01b34b92eca82fc1b020e44c6616b7c1d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentViewManager.h",
+                          "hash": "2b3360f0c45d579ca16391d3a68fa52be86bfd73"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentViewManager.mm",
+                          "hash": "3af77c69862e125c1ab31af5008f7e15fc27d5b1"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenController.swift",
+                          "hash": "3b9af3a19fbe32cac31e7e1a216a02688b573b8c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenShadowStateProxy.h",
+                          "hash": "8c0d13059b168b217733894f7ea71755ae2b527f"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm",
+                          "hash": "d45a99ad1a91bc0c477bdf4eec4ba38a3e9af28b"
+                        }
+                      ],
+                      "hash": "d78f809a30239a675bb281a27bcc17ceb644c115"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/stack",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/stack/host",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentView.h",
+                              "hash": "e8c9560e013f6b05770b6f1ee9d3595e98299f3a"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentView.mm",
+                              "hash": "8817f18b84c1a3d4a19192247814e86cd850cb70"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentViewManager.h",
+                              "hash": "5e6f763b44d1d3322487098131cbf1cc26beedf8"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentViewManager.mm",
+                              "hash": "9aab3adad7b32e8d4160670b110b3bc2ae1f76a0"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackNavigationController.h",
+                              "hash": "3601c4a73934594eeab5f2d8bcb41da8fdaf87cc"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackNavigationController.mm",
+                              "hash": "96e87e2549727812343292dca6bd58b4026bbe45"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperation.h",
+                              "hash": "0c438dbab6ed30cb328d1bf1fbdf2a82d7b7a514"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperation.mm",
+                              "hash": "2e56336793e2aa6d45fbf79176f705f92055bb98"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperationCoordinator.h",
+                              "hash": "0b1d80e401e464170803416979e0e0a1300d3c3c"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperationCoordinator.mm",
+                              "hash": "7fce2712e84e84b2a08260eb0d3bea114b7ab8e0"
+                            }
+                          ],
+                          "hash": "4dc559a2ac51b3913a1b5ff90c04409a37b9e347"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/stack/screen",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentEventEmitter.h",
+                              "hash": "fd5198000e324c2e5d54753cfcd0ea75463463bd"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentEventEmitter.mm",
+                              "hash": "4157295bbc6a929f7910faf59407437c0067d4fd"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentView.h",
+                              "hash": "871add2575fa992eb524083f82dff938b3de162c"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentView.mm",
+                              "hash": "c75ea34506964b599581ea62aef11d7e478492e0"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentViewManager.h",
+                              "hash": "236502e7840f16edce8c8d7e30c4bc565d665308"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentViewManager.mm",
+                              "hash": "4cde2a0827925e338e4ea1a747a4db63482f2b9f"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenController.h",
+                              "hash": "efa25696f5303c46c95d477eb070312a25bb5cc7"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenController.mm",
+                              "hash": "87f6908ee0dfe28d920d341deaae7ce5615920d4"
+                            }
+                          ],
+                          "hash": "ebf3f8c0e532a4ad96bb1bac5c348cc79336c5d5"
+                        }
+                      ],
+                      "hash": "6879361970790fd4d55712f6f57898b1adfeabde"
+                    }
+                  ],
+                  "hash": "da725ddfb139288cb905b0e7e36d9f8626f9b289"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/helpers",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/image",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/image/RNSImageLoadingHelper.h",
+                          "hash": "054a27ae25d8590c267f6ea166016cd7060561e5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/image/RNSImageLoadingHelper.mm",
+                          "hash": "d6badfd1ac6baf625f19d7200693bd49272f5c8a"
+                        }
+                      ],
+                      "hash": "49e3c911bfaceb1fc843e270c5df4b3347889103"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionAware.h",
+                      "hash": "5bad0b6824f574c8fe058cabb43fd88c6ba0255b"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionManager.h",
+                      "hash": "a6b417ae17b5cdf00eff70a9c8eb5887000faf73"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionManager.mm",
+                      "hash": "a3305172c75536f4971ccb0df7d8853485d5272e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/scroll-view",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSContentScrollViewProviding.h",
+                          "hash": "fa697a6ed91bfb6ad181ed1f3c281bfa43c12d71"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.h",
+                          "hash": "51e1f1da40cd59fa12a68f40980dd9c69f099f8c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.mm",
+                          "hash": "270eacb438022cfd1ff31ea5c73d0c7440e31a9c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewFinder.h",
+                          "hash": "4a8de3c7b5735b38c36f4c83c70e4d575924fdf9"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewFinder.mm",
+                          "hash": "25c7845563761898dd60c83555c58dcad4fdb57b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewHelper.h",
+                          "hash": "df1eb9c3c6dc588f15794a8e61c82befc9081f38"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewHelper.mm",
+                          "hash": "21867737ba546faee34e7a7d2247dfc002b24c94"
+                        }
+                      ],
+                      "hash": "c24490c2fcaee141b79b3897bc8af437df728d87"
+                    }
+                  ],
+                  "hash": "cbdee47f361aaa97df051807bb0ccc784218a230"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/integrations",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/integrations/RNSDismissibleModalProtocol.h",
+                      "hash": "db330aeef91b9cbd7c3b80d852295f4a1c0b78be"
+                    }
+                  ],
+                  "hash": "4a90b85b715e3e7166bd5725acd84c6718791a83"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTConvert+RNScreens.h",
+                  "hash": "e2463b42549ae33845eed83f489f761929bab83c"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTConvert+RNScreens.mm",
+                  "hash": "29203359a39253e77f89fc7b61763073c7d02803"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h",
+                  "hash": "909fbec14f438e34fc35d10769ec758a2f10d8e6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm",
+                  "hash": "e10cd9f826cc6fee91bfa3ce86205a1b43b5a81d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSBarButtonItem.h",
+                  "hash": "9790f5f46b83b8e34c733d8739f1f0d44be65b4f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSBarButtonItem.mm",
+                  "hash": "127c7d0798a87640947ed58b81cb44e436f2444e"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSConvert.h",
+                  "hash": "733ab0a0568d1d19c78ce1a71ee06ef26d69e0f3"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSConvert.mm",
+                  "hash": "8959b0d5a8607860b61051dc45606350de28c3bb"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNScreens-Bridging-Header.h",
+                  "hash": "34da9799185a9debe5c4242a96b45de0b243d37e"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSEnums.h",
+                  "hash": "a15931ff66797583f0e3f0978fc33b11973d51b1"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSFullWindowOverlay.h",
+                  "hash": "39571c7075fc7be6ce105ac4fcf4cda1b108bd32"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSFullWindowOverlay.mm",
+                  "hash": "a176bec39701d6208daae7753139312be7e5de50"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModalScreen.h",
+                  "hash": "5db0f5e1ff04e9ccfd0ae6ac43ee6efd1693bf59"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModalScreen.mm",
+                  "hash": "fb862d10f073d555647f358488c17230e7957d55"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModule.h",
+                  "hash": "165145e788aa0f7810117363528e91c786b9eb64"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModule.mm",
+                  "hash": "427c378121bd7cf2b66f385ed3ea36cf06612c79"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSOrientationProviding.h",
+                  "hash": "3ea8b8827d3ae843266a0e880ef69ccdc58acca1"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSPercentDrivenInteractiveTransition.h",
+                  "hash": "463a896ae735abd9a9ecd10881afce9c45561149"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSPercentDrivenInteractiveTransition.mm",
+                  "hash": "12d904ed4caa06930e0fac020a23b1ac6ba94c36"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreen.h",
+                  "hash": "0281ac3c2135ac5213e5972578300a0fdc561b16"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreen.mm",
+                  "hash": "ebca2e5579b6e0579f9a08232c8c2aa0b42bba5f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContainer.h",
+                  "hash": "5f726d571706aed6abc785a31a787c06c9b0de5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContainer.mm",
+                  "hash": "bbf7dbc57406dbe991e8174f2e7bb67342382d5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContentWrapper.h",
+                  "hash": "69c97c710061e56f14ebb7b4cd17312f169e86b5"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm",
+                  "hash": "78ddf2ad501033c5eb4dd0ac2af03f4eca6e1f68"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenFooter.h",
+                  "hash": "ab24c448f262a43d8153c954292cf83f0b0785c6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenFooter.mm",
+                  "hash": "29b64d15466bb14d136a81b74c27ac61728aad5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenNavigationContainer.h",
+                  "hash": "8c30d12549f9dee917aa58302b076af63f889a5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenNavigationContainer.mm",
+                  "hash": "273e4c8fd04bfe754c8204f35b2e30346b3d0732"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStack.h",
+                  "hash": "23a0886e848bd7d902a068f3700de56b3719bd08"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStack.mm",
+                  "hash": "4571a937a2eedd7314873b20c7988f016d12ffd9"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackAnimator.h",
+                  "hash": "4b23709e7c11ccc6dc3b4ccc75e4b4ae352c8c66"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackAnimator.mm",
+                  "hash": "be5ea6139332ae7215f9087514314188fd7230ee"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.h",
+                  "hash": "8a5720125aa0594bd23a56f3fcfb9e4b1e3a064a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm",
+                  "hash": "882f891989a90f3bd2c3c697be6dd4d682377b77"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.h",
+                  "hash": "949919ec5e8d0cfbb31e973c0a50e299b0a281b8"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.mm",
+                  "hash": "26b67d967197de564a6ccfacd7a54bd2dd8c2342"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenWindowTraits.h",
+                  "hash": "07204f1be665c232266002166053b10d33bd4b23"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenWindowTraits.mm",
+                  "hash": "f0240729776a10957ab619ef47360da8c998dc2f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScrollViewBehaviorOverriding.h",
+                  "hash": "8d5fcd65c62fe3be5b0b76154c9c42b9bf7fb624"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSSearchBar.h",
+                  "hash": "24d3cf23f4765bbb78b98e29509f614ce91d2ab6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSSearchBar.mm",
+                  "hash": "0cfe00e24f2127d17a60c302adfe78479ce9f68a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/safe-area",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaProviding.h",
+                      "hash": "67770dc50d4523ef378caa26a497fd03689e2f95"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewComponentView.h",
+                      "hash": "1675a37ca574fa81f41bb299fa3a431284449686"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewComponentView.mm",
+                      "hash": "6d93a6b96e3a020d87e56197978d1e95ddad386c"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewNotifications.h",
+                      "hash": "1c4b99d3d87b1ff07fa7494b41abac6291972ae2"
+                    }
+                  ],
+                  "hash": "d29cf3f464023c810679fecccf864e6982f9d951"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/stubs",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/stubs/RNSGammaStubs.h",
+                      "hash": "5c152f8dc57a26bb7366e9af2ee75a663165f3f7"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/stubs/RNSGammaStubs.mm",
+                      "hash": "2bb9b2457b10d5c0b1d5c9e238e5c4b3f2956eb2"
+                    }
+                  ],
+                  "hash": "3bf63a938adab8e6ded5b71eee2fc9b245ee0105"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/tabs",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.h",
+                          "hash": "70c24ef7c7fac1a6a46d9b67a15097b4f9e4bd28"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm",
+                          "hash": "ed2355f6da64d0c87aad5fcafa3fd06316683621"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentViewManager.h",
+                          "hash": "2a6e622d3a91fe57e842f43d16a75249454f9c2a"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentViewManager.mm",
+                          "hash": "1a8827b22258c944740796b71da0d89a64ac10ae"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h",
+                          "hash": "a51ee7b10fb63047af2a52189ae85fed2aa60b1c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm",
+                          "hash": "deb81c1e49ea377df7ecb0e3623f5c43fdc9bbda"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryEventEmitter.h",
+                          "hash": "bb6a92d6689b3dc8b299419a0ad62ea052c28aba"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryEventEmitter.mm",
+                          "hash": "8ab8ef0b7e980f7e269d0a4f5717ff75f0c2c9ac"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h",
+                          "hash": "26fba656671fb99ea0b347c65b0f8c1287481cff"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm",
+                          "hash": "edd5aaea568632bcd3237f70d8fc0ebf7318f346"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.h",
+                          "hash": "f31832fbcf71a1f5c99fbaa388f5015e1c9f0a7d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm",
+                          "hash": "9e44c9990b0499bbd955abc8d1e081094891126b"
+                        }
+                      ],
+                      "hash": "d755c4ba2747f66e9fa0a8f84e5ebbba3486a57f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/extensions",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/extensions/RNSTabsHostComponentView+RNSImageLoader.h",
+                          "hash": "f5cb255823d72e6ae8bbb7a22adb397e39b3f4a9"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/extensions/RNSTabsHostComponentView+RNSImageLoader.mm",
+                          "hash": "eb02f7fff3b039617cdacee5edec8e966814f909"
+                        }
+                      ],
+                      "hash": "d527863f014f799e7db83ef0e1092f662c47caf2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/host",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabBarController.h",
+                          "hash": "68a37a32e59e5a8134ac752d96f4e86abc41e163"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabBarController.mm",
+                          "hash": "160af83bb1a3b6c67b577ea23adb836a29a0c0b5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentView.h",
+                          "hash": "b25515a4cecd5e5c3e821c208ae0b1dfdf6f70a8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentView.mm",
+                          "hash": "24f5e0d27301270c596be83d34489bd9f660e977"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentViewManager.h",
+                          "hash": "005ab769719756d6cae8ba454b7cd0349505d312"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentViewManager.mm",
+                          "hash": "998ef73404e2b8f89c35a88cbfaaea13846e1dd5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostEventEmitter.h",
+                          "hash": "6b54b53827f64ad0ec4577e7c9d4c8b1a57659be"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostEventEmitter.mm",
+                          "hash": "44b7a587323d22abfe0dc816acaccd06bca0f382"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationState.h",
+                          "hash": "548c653230acc14b20442f06f32aed1239286218"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationState.mm",
+                          "hash": "e2814862989cb87eca687c45ab8ca2599c6987ef"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h",
+                          "hash": "8271ef879283232579b42b99bb3cfeb1ba60d3a8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm",
+                          "hash": "9e38de661008be27915e3465afe106035197ce0f"
+                        }
+                      ],
+                      "hash": "ab4719b804bbfa267da948eae7ff4c0af58d73ac"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RCTConvert+RNSTabs.h",
+                      "hash": "cfa12c8c56337b04003858b6ea426df483591a08"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RCTConvert+RNSTabs.mm",
+                      "hash": "8d7d4b93852cf2b45c1571a03cac3743a3d54bfe"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabBarAppearanceCoordinator.h",
+                      "hash": "539786bffbf514e03ce0cfc9bb40867249c4a494"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabBarAppearanceCoordinator.mm",
+                      "hash": "369292529fb19b5a612368479c6de035512d4eca"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabsSpecialEffectsSupporting.h",
+                      "hash": "11cfbb810c010bfa4e51e722115b351590330955"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/screen",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentView.h",
+                          "hash": "80b1edb4dc7bca78f73feca9e4839f97c8795238"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentView.mm",
+                          "hash": "857107b30a982eeb76e9b8da0c638bea695b2497"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentViewManager.h",
+                          "hash": "b1d3d0d8466ae227156b0b7489ea7a8f0ba12414"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentViewManager.mm",
+                          "hash": "cadd59f70ac376b8d7e96c466754f3c938107b38"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenEventEmitter.h",
+                          "hash": "4db4ef306fbdcf2260583734aaecec34856e55c1"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenEventEmitter.mm",
+                          "hash": "9c19430f10d41219ba6567f9f92eb9ae36f508c3"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenViewController.h",
+                          "hash": "77de31bb3141e2526e8e9c9d436046417a9a9798"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenViewController.mm",
+                          "hash": "92310b50598060b6083a4fbc971094a19d2335d1"
+                        }
+                      ],
+                      "hash": "c71a88dedc05535bea873cb1673fa268b614ed99"
+                    }
+                  ],
+                  "hash": "aac904c56de2a5541e2b92202b0c6f87487fc49a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIScrollView+RNScreens.h",
+                  "hash": "bedc4fa0db03d7a5da0c8794098402bed321ac9a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIScrollView+RNScreens.mm",
+                  "hash": "da7e519adea6bc75dd69409e94bcf2ae257b5800"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIViewController+RNScreens.h",
+                  "hash": "9f33b4ecc857d215e66398bdd62b7d14917dadef"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIViewController+RNScreens.mm",
+                  "hash": "b8ec172246c41a29faaad9395a59b4997f298859"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIWindow+RNScreens.h",
+                  "hash": "4f9511c28abb8be5ebba3f16b45fe4f4d849a7f9"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIWindow+RNScreens.mm",
+                  "hash": "c940a380d411dded1edb95fa7b8e0f5b8a17ce01"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/utils",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/extensions",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/utils/extensions/RCTImageSource+AccessHiddenMembers.h",
+                          "hash": "adf2fed09b9e23e56d4e810ccf10f39d28f28c75"
+                        }
+                      ],
+                      "hash": "2f22873e915a91bf645b060eb9a60a8f768c9332"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/NSString+RNSUtility.h",
+                      "hash": "53611c29c7d43f9365610213239450824c7c4ed9"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/NSString+RNSUtility.mm",
+                      "hash": "6d1534f745fcd2cad4eb8085cfe4542d6fe9f28e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTSurfaceTouchHandler+RNSUtility.h",
+                      "hash": "aa92ff9528eb80737c8f1335f33bea0accb59362"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTSurfaceTouchHandler+RNSUtility.mm",
+                      "hash": "96024226db2a8c3dfd0dd1ed168d2e5e467db8d4"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTTouchHandler+RNSUtility.h",
+                      "hash": "aaf2393a40b6353460a85f0de18bd9a67da48811"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTTouchHandler+RNSUtility.mm",
+                      "hash": "d1f893b279e0134e5759a1446b839f82dd8fd654"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSBackBarButtonItem.h",
+                      "hash": "765bcc05f13e17cabc9a3c0734e62e63ffbaaf7a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSBackBarButtonItem.mm",
+                      "hash": "464a544452c7a95820185cf44250d237b4e1fe35"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSDefines.h",
+                      "hash": "5601f1f96ffcbcdc23ca0b1f36ae2432f7d4243a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSLog.h",
+                      "hash": "038a63d6beb7fee759ed93a091bf7c207ced6b21"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSLog.swift",
+                      "hash": "e53e50cd9c635e3c54fef5a2f88843d3aa11703f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UINavigationBar+RNSUtility.h",
+                      "hash": "31fa0780cee543fdfd72881bd4284f096fa6f82e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UINavigationBar+RNSUtility.mm",
+                      "hash": "b4fe4c1280b6decb785e0f8acd3db225a69e2498"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UIView+RNSUtility.h",
+                      "hash": "f35d4bb6316d0c4ca7ef7b32ccce7f9bd9211e8e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UIView+RNSUtility.mm",
+                      "hash": "3b5aa2da6d621f56f53bf97bd5f316c40e1c48ae"
+                    }
+                  ],
+                  "hash": "033e17effb648c0f79f979ad9de0ef956725574b"
+                }
+              ],
+              "hash": "684d0f1a575c5d1333bd8754f649d08bf532abb1"
+            },
+            {
+              "path": "node_modules/react-native-screens/RNScreens.podspec",
+              "hash": "c50a07f05b0a167724d075e7a9599b6d4e5249f6"
+            },
+            {
+              "path": "node_modules/react-native-screens/windows",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/windows/RNScreens",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ModalScreenViewManager.cpp",
+                      "hash": "4aea5930729b4f0f3ee504a7a56a61a8b335b64e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ModalScreenViewManager.h",
+                      "hash": "50cca018c7835394a16aa4629409405ebc250c81"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/pch.cpp",
+                      "hash": "7e25a29ef977104140e7ce056e9a8ee2025a4390"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/pch.h",
+                      "hash": "f132ac7550ba9c57fe036b3875bb9d2b5d738c21"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ReactPackageProvider.cpp",
+                      "hash": "e005c253fe076a67a3097012461d0919afe5f97a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ReactPackageProvider.h",
+                      "hash": "db93a0d0e6a614497bc01ca1aae8a7e258c46d29"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/RNScreens.cpp",
+                      "hash": "578fbedbe5f1968f49ea3207fbe3398abade97e1"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/RNScreens.h",
+                      "hash": "29ea93af1792cfb101ce8edce1c4cd9dcce4dd4d"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/Screen.cpp",
+                      "hash": "22ebdd8f08382ecc1a0ed3a5ec27d23dc6f538af"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/Screen.h",
+                      "hash": "277f89dd527efcf6efa99d30936551e3a4dfb5b0"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainer.cpp",
+                      "hash": "1e070948b10edaf14ba7c3bdbf828b873f225aba"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainer.h",
+                      "hash": "ba7656c4076f2fc9da9415ec8395de44fdaf2243"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainerViewManager.cpp",
+                      "hash": "3e174cbb2b8f30ace8ecc93997df569746cb0f58"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainerViewManager.h",
+                      "hash": "c9c64690a226504275f7225d27b106df98761d92"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStack.cpp",
+                      "hash": "2d8e1140c3cb4dc150bf4276ba37c8aa88e9ca40"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStack.h",
+                      "hash": "ba19f3f983926796122952fc146f8b5eeeaa636c"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfig.cpp",
+                      "hash": "c3c5437080bf6233dd9c3493e5b65b16d51f0dfd"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfig.h",
+                      "hash": "c999fa61d08977d58844869a3ded6e9a23108013"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfigViewManager.cpp",
+                      "hash": "9112ac632e686f23b7fc1f50a3f0f7a6b4c00391"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfigViewManager.h",
+                      "hash": "2bcc9998f9a5c0074b369e0f6a34d25e6bdbeb00"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubview.cpp",
+                      "hash": "b438d6d57b32679be232476a9066be4ed66b9c89"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubview.h",
+                      "hash": "7e1025296118db982dfa7deb63f6494f2647ba2d"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp",
+                      "hash": "3047f9669a91ae871dd2d29aa76324cf95c37be7"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubviewViewManager.h",
+                      "hash": "24250e9d21e4c1fcc911c71c00f63e080e2e0fb2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackViewManager.cpp",
+                      "hash": "a9fec18d936f087b635107ab011d591ee66e3beb"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackViewManager.h",
+                      "hash": "02173396bda08d5f00374a14ea7429acf1395a27"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenViewManager.cpp",
+                      "hash": "e4c51437b7f2d39399afed0a54df3a7f0daf021e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenViewManager.h",
+                      "hash": "d60a6d516c2d8d88747933e3c112b4d26ac1af55"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBar.cpp",
+                      "hash": "a7f9ade7be9aaf66bb9855e1a9b3522b20d9f512"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBar.h",
+                      "hash": "f74dd7185083d4c6d0c32575db2617312b50b131"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBarViewManager.cpp",
+                      "hash": "f53df8576b03fa0cc3162e67789eb133f28160d2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBarViewManager.h",
+                      "hash": "b3739035d50241bdb7f79494225bc83837e3c126"
+                    }
+                  ],
+                  "hash": "fb467c3b2ea4bcaa73e0764db2e71e8ebe5261c2"
+                }
+              ],
+              "hash": "7bd6f7dcc686225143816171d37c774e8d71631a"
+            }
+          ],
+          "hash": "cebea40d794bc3c3b5c1726186e27e18e6212b77"
         }
       },
       {
         "type": "contents",
         "id": "package:react-native",
-        "contents": "{\"name\":\"react-native\",\"version\":\"0.81.0\",\"description\":\"A framework for building native apps using React\",\"license\":\"MIT\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/facebook/react-native.git\",\"directory\":\"packages/react-native\"},\"homepage\":\"https://reactnative.dev/\",\"keywords\":[\"react\",\"react-native\",\"android\",\"ios\",\"mobile\",\"cross-platform\",\"app-framework\",\"mobile-development\"],\"bugs\":\"https://github.com/facebook/react-native/issues\",\"engines\":{\"node\":\">= 20.19.4\"},\"bin\":{\"react-native\":\"cli.js\"},\"main\":\"./index.js\",\"types\":\"types\",\"exports\":{\".\":{\"react-native-strict-api\":\"./types_generated/index.d.ts\",\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/index.d.ts\",\"types\":\"./types/index.d.ts\",\"default\":\"./index.js\"},\"./*\":{\"react-native-strict-api\":null,\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/*.d.ts\",\"types\":\"./*.d.ts\",\"default\":\"./*.js\"},\"./*.js\":{\"react-native-strict-api\":null,\"default\":\"./*.js\"},\"./Libraries/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./Libraries/*.d.ts\"},\"./scripts/*\":\"./scripts/*\",\"./src/*\":{\"react-native-strict-api\":null,\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/src/*.d.ts\",\"default\":\"./src/*.js\"},\"./types/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./types/*.d.ts\"},\"./gradle/*\":null,\"./React/*\":null,\"./ReactAndroid/*\":null,\"./ReactApple/*\":null,\"./ReactCommon/*\":null,\"./sdks/*\":null,\"./src/fb_internal/*\":\"./src/fb_internal/*\",\"./third-party-podspecs/*\":null,\"./types/*\":null,\"./types_generated/*\":null,\"./package.json\":\"./package.json\"},\"jest-junit\":{\"outputDirectory\":\"reports/junit\",\"outputName\":\"js-test-results.xml\"},\"files\":[\"build.gradle.kts\",\"cli.js\",\"flow\",\"gradle.properties\",\"gradle/libs.versions.toml\",\"index.js\",\"index.js.flow\",\"interface.js\",\"jest-preset.js\",\"jest\",\"Libraries\",\"LICENSE\",\"React-Core.podspec\",\"React-Core-prebuilt.podspec\",\"react-native.config.js\",\"React.podspec\",\"React\",\"!React/Fabric/RCTThirdPartyFabricComponentsProvider.*\",\"ReactAndroid\",\"!ReactAndroid/.cxx\",\"!ReactAndroid/build\",\"!ReactAndroid/external-artifacts/artifacts\",\"!ReactAndroid/external-artifacts/build\",\"!ReactAndroid/hermes-engine/.cxx\",\"!ReactAndroid/hermes-engine/build\",\"!ReactAndroid/src/main/third-party\",\"!ReactAndroid/src/test\",\"ReactApple\",\"ReactCommon\",\"README.md\",\"rn-get-polyfills.js\",\"scripts/replace-rncore-version.js\",\"scripts/bundle.js\",\"scripts/cocoapods\",\"scripts/codegen\",\"scripts/compose-source-maps.js\",\"scripts/find-node-for-xcode.sh\",\"scripts/generate-codegen-artifacts.js\",\"scripts/generate-provider-cli.js\",\"scripts/generate-specs-cli.js\",\"scripts/hermes/hermes-utils.js\",\"scripts/hermes/prepare-hermes-for-build.js\",\"scripts/ios-configure-glog.sh\",\"scripts/native_modules.rb\",\"scripts/node-binary.sh\",\"scripts/packager-reporter.js\",\"scripts/packager.sh\",\"scripts/react_native_pods_utils/script_phases.rb\",\"scripts/react_native_pods_utils/script_phases.sh\",\"scripts/react_native_pods.rb\",\"scripts/react-native-xcode.sh\",\"scripts/xcode/ccache-clang.sh\",\"scripts/xcode/ccache-clang++.sh\",\"scripts/xcode/ccache.conf\",\"scripts/xcode/with-environment.sh\",\"sdks/.hermesversion\",\"sdks/hermes-engine\",\"sdks/hermesc\",\"settings.gradle.kts\",\"src\",\"!src/private/testing\",\"third-party-podspecs\",\"types\",\"types_generated\",\"!**/__docs__/**\",\"!**/__fixtures__/**\",\"!**/__flowtests__/**\",\"!**/__mocks__/**\",\"!**/__tests__/**\",\"!**/__typetests__/**\"],\"scripts\":{\"prepack\":\"node ./scripts/prepack.js\",\"featureflags\":\"node ./scripts/featureflags/index.js\"},\"peerDependencies\":{\"@types/react\":\"^19.1.0\",\"react\":\"^19.1.0\"},\"peerDependenciesMeta\":{\"@types/react\":{\"optional\":true}},\"dependencies\":{\"@jest/create-cache-key-function\":\"^29.7.0\",\"@react-native/assets-registry\":\"0.81.0\",\"@react-native/codegen\":\"0.81.0\",\"@react-native/community-cli-plugin\":\"0.81.0\",\"@react-native/gradle-plugin\":\"0.81.0\",\"@react-native/js-polyfills\":\"0.81.0\",\"@react-native/normalize-colors\":\"0.81.0\",\"@react-native/virtualized-lists\":\"0.81.0\",\"abort-controller\":\"^3.0.0\",\"anser\":\"^1.4.9\",\"ansi-regex\":\"^5.0.0\",\"babel-jest\":\"^29.7.0\",\"babel-plugin-syntax-hermes-parser\":\"0.29.1\",\"base64-js\":\"^1.5.1\",\"commander\":\"^12.0.0\",\"flow-enums-runtime\":\"^0.0.6\",\"glob\":\"^7.1.1\",\"invariant\":\"^2.2.4\",\"jest-environment-node\":\"^29.7.0\",\"memoize-one\":\"^5.0.0\",\"metro-runtime\":\"^0.83.1\",\"metro-source-map\":\"^0.83.1\",\"nullthrows\":\"^1.1.1\",\"pretty-format\":\"^29.7.0\",\"promise\":\"^8.3.0\",\"react-devtools-core\":\"^6.1.5\",\"react-refresh\":\"^0.14.0\",\"regenerator-runtime\":\"^0.13.2\",\"scheduler\":\"0.26.0\",\"semver\":\"^7.1.3\",\"stacktrace-parser\":\"^0.1.10\",\"whatwg-fetch\":\"^3.0.0\",\"ws\":\"^6.2.3\",\"yargs\":\"^17.6.2\"},\"codegenConfig\":{\"libraries\":[{\"name\":\"FBReactNativeSpec\",\"type\":\"all\",\"ios\":{\"modules\":{\"AccessibilityManager\":{\"unstableRequiresMainQueueSetup\":true},\"Appearance\":{\"unstableRequiresMainQueueSetup\":true},\"AppState\":{\"unstableRequiresMainQueueSetup\":true},\"DeviceInfo\":{\"unstableRequiresMainQueueSetup\":true},\"PlatformConstants\":{\"unstableRequiresMainQueueSetup\":true},\"StatusBarManager\":{\"unstableRequiresMainQueueSetup\":true}}},\"android\":{},\"jsSrcsDir\":\"src\"}]}}",
+        "contents": "{\"name\":\"react-native\",\"version\":\"0.85.2\",\"description\":\"A framework for building native apps using React\",\"license\":\"MIT\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/facebook/react-native.git\",\"directory\":\"packages/react-native\"},\"homepage\":\"https://reactnative.dev/\",\"keywords\":[\"react\",\"react-native\",\"android\",\"ios\",\"mobile\",\"cross-platform\",\"app-framework\",\"mobile-development\"],\"bugs\":\"https://github.com/facebook/react-native/issues\",\"engines\":{\"node\":\"^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0\"},\"bin\":{\"react-native\":\"cli.js\"},\"main\":\"./index.js\",\"types\":\"types\",\"exports\":{\".\":{\"react-native-strict-api\":\"./types_generated/index.d.ts\",\"types\":\"./types/index.d.ts\",\"default\":\"./index.js\"},\"./*\":{\"react-native-strict-api\":null,\"types\":\"./*.d.ts\",\"default\":\"./*.js\"},\"./*.js\":{\"react-native-strict-api\":null,\"default\":\"./*.js\"},\"./Libraries/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./Libraries/*.d.ts\"},\"./scripts/*\":\"./scripts/*\",\"./src/*\":{\"react-native-strict-api\":null,\"default\":\"./src/*.js\"},\"./types/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./types/*.d.ts\"},\"./gradle/*\":null,\"./React/*\":null,\"./ReactAndroid/*\":null,\"./ReactApple/*\":null,\"./ReactCommon/*\":null,\"./sdks/*\":null,\"./src/fb_internal/*\":\"./src/fb_internal/*\",\"./third-party-podspecs/*\":null,\"./types/*\":null,\"./types_generated/*\":null,\"./package.json\":\"./package.json\"},\"jest-junit\":{\"outputDirectory\":\"reports/junit\",\"outputName\":\"js-test-results.xml\"},\"files\":[\"build.gradle.kts\",\"cli.js\",\"flow\",\"gradle.properties\",\"gradle/libs.versions.toml\",\"index.js\",\"index.js.flow\",\"interface.js\",\"jest-preset.js\",\"Libraries\",\"LICENSE\",\"React-Core.podspec\",\"React-Core-prebuilt.podspec\",\"react-native.config.js\",\"React.podspec\",\"React\",\"!React/Fabric/RCTThirdPartyFabricComponentsProvider.*\",\"ReactAndroid\",\"!ReactAndroid/.cxx\",\"!ReactAndroid/build\",\"!ReactAndroid/external-artifacts/artifacts\",\"!ReactAndroid/external-artifacts/build\",\"!ReactAndroid/hermes-engine/.cxx\",\"!ReactAndroid/hermes-engine/build\",\"!ReactAndroid/src/main/third-party\",\"!ReactAndroid/src/test\",\"ReactApple\",\"ReactCommon\",\"README.md\",\"rn-get-polyfills.js\",\"scripts/replace-rncore-version.js\",\"scripts/bundle.js\",\"scripts/cocoapods\",\"scripts/codegen\",\"scripts/compose-source-maps.js\",\"scripts/find-node-for-xcode.sh\",\"scripts/generate-codegen-artifacts.js\",\"scripts/generate-provider-cli.js\",\"scripts/generate-specs-cli.js\",\"scripts/hermes/hermes-utils.js\",\"scripts/hermes/prepare-hermes-for-build.js\",\"scripts/ios-configure-glog.sh\",\"scripts/native_modules.rb\",\"scripts/node-binary.sh\",\"scripts/packager-reporter.js\",\"scripts/packager.sh\",\"scripts/react_native_pods_utils/script_phases.rb\",\"scripts/react_native_pods_utils/script_phases.sh\",\"scripts/react_native_pods.rb\",\"scripts/react-native-xcode.sh\",\"scripts/xcode/ccache-clang.sh\",\"scripts/xcode/ccache-clang++.sh\",\"scripts/xcode/ccache.conf\",\"scripts/xcode/with-environment.sh\",\"sdks/.hermesversion\",\"sdks/.hermesv1version\",\"sdks/hermes-engine\",\"sdks/hermesc\",\"settings.gradle.kts\",\"src\",\"!src/private/testing\",\"third-party-podspecs\",\"types\",\"types_generated\",\"!**/__docs__/**\",\"!**/__fixtures__/**\",\"!**/__flowtests__/**\",\"!**/__mocks__/**\",\"!**/__tests__/**\",\"!**/__typetests__/**\"],\"scripts\":{\"prepack\":\"node ./scripts/prepack.js\",\"featureflags\":\"node ./scripts/featureflags/index.js\"},\"peerDependencies\":{\"@react-native/jest-preset\":\"0.85.2\",\"@types/react\":\"^19.1.1\",\"react\":\"^19.2.3\"},\"peerDependenciesMeta\":{\"@types/react\":{\"optional\":true},\"@react-native/jest-preset\":{\"optional\":true}},\"dependencies\":{\"@react-native/assets-registry\":\"0.85.2\",\"@react-native/codegen\":\"0.85.2\",\"@react-native/community-cli-plugin\":\"0.85.2\",\"@react-native/gradle-plugin\":\"0.85.2\",\"@react-native/js-polyfills\":\"0.85.2\",\"@react-native/normalize-colors\":\"0.85.2\",\"@react-native/virtualized-lists\":\"0.85.2\",\"abort-controller\":\"^3.0.0\",\"anser\":\"^1.4.9\",\"ansi-regex\":\"^5.0.0\",\"babel-plugin-syntax-hermes-parser\":\"0.33.3\",\"base64-js\":\"^1.5.1\",\"commander\":\"^12.0.0\",\"flow-enums-runtime\":\"^0.0.6\",\"hermes-compiler\":\"250829098.0.10\",\"invariant\":\"^2.2.4\",\"memoize-one\":\"^5.0.0\",\"metro-runtime\":\"^0.84.0\",\"metro-source-map\":\"^0.84.0\",\"nullthrows\":\"^1.1.1\",\"pretty-format\":\"^29.7.0\",\"promise\":\"^8.3.0\",\"react-devtools-core\":\"^6.1.5\",\"react-refresh\":\"^0.14.0\",\"regenerator-runtime\":\"^0.13.2\",\"scheduler\":\"0.27.0\",\"semver\":\"^7.1.3\",\"stacktrace-parser\":\"^0.1.10\",\"tinyglobby\":\"^0.2.15\",\"whatwg-fetch\":\"^3.0.0\",\"ws\":\"^7.5.10\",\"yargs\":\"^17.6.2\"},\"codegenConfig\":{\"libraries\":[{\"name\":\"FBReactNativeSpec\",\"type\":\"all\",\"ios\":{\"modules\":{\"AccessibilityManager\":{\"unstableRequiresMainQueueSetup\":true},\"Appearance\":{\"unstableRequiresMainQueueSetup\":true},\"AppState\":{\"unstableRequiresMainQueueSetup\":true},\"DeviceInfo\":{\"unstableRequiresMainQueueSetup\":true},\"PlatformConstants\":{\"unstableRequiresMainQueueSetup\":true},\"StatusBarManager\":{\"unstableRequiresMainQueueSetup\":true}}},\"android\":{},\"jsSrcsDir\":\"src\"}]}}",
         "reasons": [
           "package:react-native"
         ],
-        "hash": "cbec4d5b6c0b5eea0f0d3a5064fdf2b0418e5750",
+        "hash": "606bf938348eb462743a98a75160c803610abd88",
         "debugInfo": {
-          "hash": "cbec4d5b6c0b5eea0f0d3a5064fdf2b0418e5750"
+          "hash": "606bf938348eb462743a98a75160c803610abd88"
         }
       },
       {
         "type": "contents",
-        "id": "rncoreAutolinkingConfig:ios",
-        "contents": "{\"@hot-updater/react-native\":{\"root\":\"node_modules/@hot-updater/react-native\",\"name\":\"@hot-updater/react-native\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/@hot-updater/react-native/HotUpdater.podspec\",\"version\":\"0.24.5\",\"configurations\":[],\"scriptPhases\":[]}}},\"react-native-safe-area-context\":{\"root\":\"node_modules/react-native-safe-area-context\",\"name\":\"react-native-safe-area-context\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-safe-area-context/react-native-safe-area-context.podspec\",\"version\":\"5.6.0\",\"configurations\":[],\"scriptPhases\":[]}}}}",
+        "id": "rncoreAutolinkingConfig",
+        "contents": "{\"@callstack/repack\":{\"root\":\"node_modules/@callstack/repack\",\"name\":\"@callstack/repack\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/@callstack/repack/callstack-repack.podspec\",\"version\":\"5.2.5\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/@callstack/repack/android\",\"packageImportPath\":\"import com.callstack.repack.ScriptManagerPackage;\",\"packageInstance\":\"new ScriptManagerPackage()\",\"buildTypes\":[],\"libraryName\":\"RNScriptManagerSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/@callstack/repack/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"@hot-updater/react-native\":{\"root\":\"node_modules/@hot-updater/react-native\",\"name\":\"@hot-updater/react-native\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/@hot-updater/react-native/HotUpdater.podspec\",\"version\":\"0.36.3\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/@hot-updater/react-native/android\",\"packageImportPath\":\"import com.hotupdater.HotUpdaterPackage;\",\"packageInstance\":\"new HotUpdaterPackage()\",\"buildTypes\":[],\"libraryName\":\"HotUpdaterSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/@hot-updater/react-native/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-bootsplash\":{\"root\":\"node_modules/react-native-bootsplash\",\"name\":\"react-native-bootsplash\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-bootsplash/RNBootSplash.podspec\",\"version\":\"7.1.0\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-bootsplash/android\",\"packageImportPath\":\"import com.zoontek.rnbootsplash.RNBootSplashPackage;\",\"packageInstance\":\"new RNBootSplashPackage()\",\"buildTypes\":[],\"libraryName\":\"RNBootSplashSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/react-native-bootsplash/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-launch-arguments\":{\"root\":\"node_modules/react-native-launch-arguments\",\"name\":\"react-native-launch-arguments\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-launch-arguments/react-native-launch-arguments.podspec\",\"version\":\"4.1.1\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-launch-arguments/android\",\"packageImportPath\":\"import com.reactnativelauncharguments.LaunchArgumentsPackage;\",\"packageInstance\":\"new LaunchArgumentsPackage()\",\"buildTypes\":[],\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/react-native-launch-arguments/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-safe-area-context\":{\"root\":\"node_modules/react-native-safe-area-context\",\"name\":\"react-native-safe-area-context\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-safe-area-context/react-native-safe-area-context.podspec\",\"version\":\"5.8.0\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-safe-area-context/android\",\"packageImportPath\":\"import com.th3rdwave.safeareacontext.SafeAreaContextPackage;\",\"packageInstance\":\"new SafeAreaContextPackage()\",\"buildTypes\":[],\"libraryName\":\"safeareacontext\",\"componentDescriptors\":[\"RNCSafeAreaProviderComponentDescriptor\",\"RNCSafeAreaViewComponentDescriptor\"],\"cmakeListsPath\":\"node_modules/react-native-safe-area-context/android/src/main/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-screens\":{\"root\":\"node_modules/react-native-screens\",\"name\":\"react-native-screens\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-screens/RNScreens.podspec\",\"version\":\"4.25.2\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-screens/android\",\"packageImportPath\":\"import com.swmansion.rnscreens.RNScreensPackage;\",\"packageInstance\":\"new RNScreensPackage()\",\"buildTypes\":[],\"libraryName\":\"rnscreens\",\"componentDescriptors\":[\"RNSFullWindowOverlayComponentDescriptor\",\"RNSScreenContainerComponentDescriptor\",\"RNSScreenNavigationContainerComponentDescriptor\",\"RNSScreenStackHeaderConfigComponentDescriptor\",\"RNSScreenStackHeaderSubviewComponentDescriptor\",\"RNSScreenStackComponentDescriptor\",\"RNSSearchBarComponentDescriptor\",\"RNSScreenComponentDescriptor\",\"RNSScreenFooterComponentDescriptor\",\"RNSScreenContentWrapperComponentDescriptor\",\"RNSModalScreenComponentDescriptor\",\"RNSTabsHostComponentDescriptor\",\"RNSSafeAreaViewComponentDescriptor\",\"RNSStackScreenComponentDescriptor\",\"RNSStackHeaderConfigComponentDescriptor\",\"RNSStackHeaderSubviewComponentDescriptor\"],\"cmakeListsPath\":\"node_modules/react-native-screens/android/src/main/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}}}",
         "reasons": [
-          "rncoreAutolinkingIos"
+          "rncoreAutolinking"
         ],
-        "hash": "97411996ddc58c80248718a525e27c9a345b6185",
+        "hash": "fbab7f83229870bffac18c6d2b68762aa9976d6f",
         "debugInfo": {
-          "hash": "97411996ddc58c80248718a525e27c9a345b6185"
+          "hash": "fbab7f83229870bffac18c6d2b68762aa9976d6f"
         }
       }
     ],
-    "hash": "375ccd5f2d85d8cb55d7ccf3991032cca7e3c51d"
+    "hash": "8993a59e7bed3c6788e1e612b272100625773d0d"
   },
   "android": {
     "sources": [
@@ -776,11 +3756,247 @@
       },
       {
         "type": "dir",
+        "filePath": "node_modules/@callstack/repack",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "dc3acea09d7a8fcfc69288fdd7ca7f0770fcc2ab",
+        "debugInfo": {
+          "path": "node_modules/@callstack/repack",
+          "children": [
+            {
+              "path": "node_modules/@callstack/repack/android",
+              "children": [
+                {
+                  "path": "node_modules/@callstack/repack/android/build.gradle",
+                  "hash": "a89f20f0090f61f07b66615f4ad5c51857dade6f"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/android/CMakeLists.txt",
+                  "hash": "836a27e7d9fb769014724131f023869cd9c3a271"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/NativeScriptLoader.cpp",
+                              "hash": "ff41bccda571e81fbf98aa05a957d0d3a732a02c"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/NativeScriptLoader.h",
+                              "hash": "485a50f6b0d596e081c0280bb5b0945946497f69"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/cpp/OnLoad.cpp",
+                              "hash": "050534575fa518719ef4aceb2712f18d14fe9e18"
+                            }
+                          ],
+                          "hash": "eff7db109fc285484022d838000d76d466206516"
+                        },
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt",
+                                          "hash": "177d09d6cfd5965d740cd6efc53cc28a7f387e29"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt",
+                                          "hash": "3544923fdb98c4decff87c1e1b80dc8b704cf520"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt",
+                                          "hash": "c9ee5f4a659f6813b90f24ae58edd34c870ea125"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt",
+                                          "hash": "eb79f0fa044a0308e66508bbec2ea3c8943927e3"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptLoadingError.kt",
+                                          "hash": "9d9771e159b442e40a233403615be4177cd20e9a"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt",
+                                          "hash": "6348861f19208b5aaab8b340a73f39ea4b025970"
+                                        },
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/main/java/com/callstack/repack/ScriptManagerPackage.kt",
+                                          "hash": "196f5631ce0877a19c7d56b5f753a62c23b9c101"
+                                        }
+                                      ],
+                                      "hash": "70bbb6cd50be70a1b690e683f31b89896b3dc31b"
+                                    }
+                                  ],
+                                  "hash": "78f30092efd79effceb160212cf0837e937f2ae4"
+                                }
+                              ],
+                              "hash": "af58469aefb97e9d1a62bbb7d1a72cf7856ef13f"
+                            }
+                          ],
+                          "hash": "8aba5e06dcc1b6f9693d40c5c543fb95e27a520e"
+                        }
+                      ],
+                      "hash": "5d421d3eb70f8865c3d798aa253600161d8e5cc2"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/newarch",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/newarch/ScriptManagerSpec.kt",
+                          "hash": "676b44a5546b0ef72d105c54de5cf8582b3197c8"
+                        }
+                      ],
+                      "hash": "8b40f3dc9493ef2c209c947fe9e18d760d626bae"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/oldarch",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/oldarch/ScriptManagerSpec.kt",
+                          "hash": "73a6659b6ba2984173f2b6f38269712a57ae89bf"
+                        }
+                      ],
+                      "hash": "c619e02c412472284c904f6038fabebf9cf5e5ea"
+                    },
+                    {
+                      "path": "node_modules/@callstack/repack/android/src/versioned",
+                      "children": [
+                        {
+                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker",
+                          "children": [
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack/repack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/73/com/callstack/repack/NativeScriptLoader.kt",
+                                              "hash": "95894468ba5ffb8a0c64d0788b8d4606f4e216e2"
+                                            }
+                                          ],
+                                          "hash": "414da8506f8b3a90f022a445fe0372ac61c0b5d7"
+                                        }
+                                      ],
+                                      "hash": "18a0532df8ffa3d411bb9c6448fca5e28c6bad81"
+                                    }
+                                  ],
+                                  "hash": "5691b7581b286cc18ee97cfd63174c765ebd633f"
+                                }
+                              ],
+                              "hash": "c69dd92b641c2fb200d4e94806c0629caae3fe9f"
+                            },
+                            {
+                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest",
+                              "children": [
+                                {
+                                  "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack/repack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/@callstack/repack/android/src/versioned/CallInvoker/latest/com/callstack/repack/NativeScriptLoader.kt",
+                                              "hash": "b3107a1227fa43612a0040e40104cdae6516e5cb"
+                                            }
+                                          ],
+                                          "hash": "3b95b541d155e6f0a41b4f893ad5f8245e41e69d"
+                                        }
+                                      ],
+                                      "hash": "a2edbb85d6c9296eb3f0c1b445002a891bc9c85b"
+                                    }
+                                  ],
+                                  "hash": "8177159ae2c907b6db6d81a9ffbb7bc43206a136"
+                                }
+                              ],
+                              "hash": "196e17a89f158997ea40640c54422b2459fa460c"
+                            }
+                          ],
+                          "hash": "719d44357a148216a90e759e0b65808880e6b2f2"
+                        }
+                      ],
+                      "hash": "622e290a06eed467162ef146943fe6cabab42271"
+                    }
+                  ],
+                  "hash": "7b09a87d60ae5512e63ba04688f9c7347c0a5369"
+                }
+              ],
+              "hash": "12cdaff4ed7aa640dce14af86b342a43ce1da21e"
+            },
+            {
+              "path": "node_modules/@callstack/repack/callstack-repack.podspec",
+              "hash": "c61f4e2b2979d246e6dc94df9e74e2a879f720e8"
+            },
+            {
+              "path": "node_modules/@callstack/repack/ios",
+              "children": [
+                {
+                  "path": "node_modules/@callstack/repack/ios/CodeSigningErrors.swift",
+                  "hash": "c6db9f01818c88534166033c34fd5d4a443d2c5f"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/CodeSigningUtils.swift",
+                  "hash": "300dab18d58b0a5b0f7b9c28b64c117dfe11292e"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ErrorCodes.h",
+                  "hash": "6c272a5cce8e91ee7ac4b7d6feffdc80839a67e2"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptConfig.h",
+                  "hash": "0ac1df0b2a6089dfc296d58ef31ce37b92e82ff2"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptConfig.mm",
+                  "hash": "ffefd4264cd9cf85c91a017e99e2fe043d259c9b"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptManager.h",
+                  "hash": "96f5a4544fe03c183d49c50bd7bd6101c8dc3c11"
+                },
+                {
+                  "path": "node_modules/@callstack/repack/ios/ScriptManager.mm",
+                  "hash": "93b0633775d040f3b6b75750a4af395f622e4fb4"
+                }
+              ],
+              "hash": "8648e04123f14796515fa95a152edb54bb4900ee"
+            }
+          ],
+          "hash": "dc3acea09d7a8fcfc69288fdd7ca7f0770fcc2ab"
+        }
+      },
+      {
+        "type": "dir",
         "filePath": "node_modules/@hot-updater/react-native",
         "reasons": [
-          "rncoreAutolinkingAndroid"
+          "rncoreAutolinking"
         ],
-        "hash": "d91000a070c9f9ab83c0585714aca5356e6dd26d",
+        "hash": "a72cb93a3847dfaa05e17fe9044ea1c8f84f9283",
         "debugInfo": {
           "path": "node_modules/@hot-updater/react-native",
           "children": [
@@ -789,15 +4005,15 @@
               "children": [
                 {
                   "path": "node_modules/@hot-updater/react-native/android/build.gradle",
-                  "hash": "78d6e231d72d4cff9def556dd871d4f2f77f131a"
+                  "hash": "82ce1dac836ccb3b26ed0c92b04dfa36854bab83"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/proguard-rules.pro",
-                  "hash": "62e423236bd393540d4876356b997ab01325fab6"
+                  "hash": "6e369fa0f1da0ba0d99fde4a00d8df8b55aa3b24"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/react-native-helpers.gradle",
-                  "hash": "fa2094af6b8dd1d41aec725e16baee598b5ccf48"
+                  "hash": "85cff141aab7c15aa5672c97fa17522c7d3d1080"
                 },
                 {
                   "path": "node_modules/@hot-updater/react-native/android/src",
@@ -805,6 +4021,20 @@
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/main",
                       "children": [
+                        {
+                          "path": "node_modules/@hot-updater/react-native/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/main/cpp/CMakeLists.txt",
+                              "hash": "d7c6e7d34d838fe9b3514b98dbf8ef59a0f536dc"
+                            },
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/main/cpp/HotUpdaterRecovery.cpp",
+                              "hash": "ec33ebcbac32bf9d49577f95fbb8f83854274a87"
+                            }
+                          ],
+                          "hash": "341f58e19183ec5ecd928c5cd8f3135050740971"
+                        },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/main/java",
                           "children": [
@@ -815,12 +4045,20 @@
                                   "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater",
                                   "children": [
                                     {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BsdiffPatch.kt",
+                                      "hash": "0185ffbffba3862768ed0ef94588e09dfc5d60e2"
+                                    },
+                                    {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt",
-                                      "hash": "8641999f74a80c9e7c3645d81b35173a73fa7102"
+                                      "hash": "a4b06b73fe861fd221a6cbb8c94646f4f02fc543"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleMetadata.kt",
-                                      "hash": "73c398ec847910cb9323a9261457f45950d58f5d"
+                                      "hash": "e8d617586f0dec0bcb3446e4a987de692f276b3f"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/CohortService.kt",
+                                      "hash": "32d97f9971458ce85361e5be17ce7b073d1c7131"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/DecompressionStrategy.kt",
@@ -828,51 +4066,79 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/DecompressService.kt",
-                                      "hash": "b960c59e3bfc5aa9beace8a960e9ded135b33a49"
+                                      "hash": "fac169137d4c633045d45493c167c88194b2d2bd"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/FileManagerService.kt",
-                                      "hash": "69860dcb3f4ce5e6dafb06f27dddffe1fa62a515"
+                                      "hash": "1bc609ce2261ca821cb1be21ed0ed27fa4d49797"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HashUtils.kt",
                                       "hash": "c441a04536a87f930dde20e6a18e2389dc1e3907"
                                     },
                                     {
-                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdater.kt",
-                                      "hash": "dbfc5f03e97e8f4291038e34a1690a44f25f3ad0"
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterConfig.kt",
+                                      "hash": "6e5b57306d58b449b8edd582f02b1b7dfe1d3e45"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterException.kt",
-                                      "hash": "abbc8b846c4332e2e07521fd33c9a763ebbd0d65"
+                                      "hash": "d92c2c55f0660fb13530dbfce9a42c45e5419914"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterImpl.kt",
-                                      "hash": "ed203df8caa43aac771cefb99ec3cb542d622b20"
+                                      "hash": "bb216b18cb6f324c3401249cba8537fb21c2c2b5"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRecoveryManager.kt",
+                                      "hash": "fa20ed9fa2da632a05d6b4f14b068cfddf14a358"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRecoveryReceiver.kt",
+                                      "hash": "06dc026004041af8cbd9cedaddd9f30d2ffc4de2"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/HotUpdaterRestartActivity.kt",
+                                      "hash": "0363d655ab9652261fe2d19bc05a305354640f7d"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/NativeConfigUtils.kt",
+                                      "hash": "99f79b46d10fb7820eb5b6d9b202d5f92f3ef7fd"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/OkHttpDownloadService.kt",
-                                      "hash": "c997a6aff6ab359992079977613930403b5674af"
+                                      "hash": "3dcd2f16868afe310986fb7b2f2a737cb2d9c4e5"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ReactIntegrationManagerBase.kt",
                                       "hash": "edc166023f86025e71584993c7f5b38654fbce41"
                                     },
                                     {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ReactNativeValueConverters.kt",
+                                      "hash": "e1d2aed44ba20d3b9c133dc9e22bdb6ba6dd61c0"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/RelativePathResolver.kt",
+                                      "hash": "609ac569ca61e5495e235cf12bd2c02477cbfec0"
+                                    },
+                                    {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/SignatureVerifier.kt",
-                                      "hash": "e31eed019170f898f4278f91edc9c9e60528df11"
+                                      "hash": "8440cc497dbaeaf6349491f8bef4c763cbf0768d"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/StringResourceUtils.kt",
+                                      "hash": "7b632931e5fea501a3dda45734fc9f30055c91b6"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarArchiveInputStream.kt",
-                                      "hash": "ba5f1a48bdf8cb2f1962ebe6c7ccb408b94f0ae7"
+                                      "hash": "9f509ee5633269151e157d287977c7e061489ed4"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarBrDecompressionStrategy.kt",
-                                      "hash": "9f571ddac577a596ee00668c96b96c686e5e1094"
+                                      "hash": "e0ce9f6b1195c1a66503c711763b15590f244eb5"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/TarGzDecompressionStrategy.kt",
-                                      "hash": "f5dfce60b18333b442049f5d357ad3832702644f"
+                                      "hash": "dfd05ced7bb9740a499fec2e039faecb5169bc79"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/VersionedPreferencesService.kt",
@@ -880,26 +4146,30 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/ZipDecompressionStrategy.kt",
-                                      "hash": "e30536e08dca22b95714a088f95c4605634a15ef"
+                                      "hash": "37887140bb6a2909fa0f8b214b33fb9299854361"
                                     }
                                   ],
-                                  "hash": "fda4026ada6dd17c45ab18502c92f7f797c25db1"
+                                  "hash": "09cb7a7225af03f95c4ad508c08c78e2a0af6af4"
                                 }
                               ],
-                              "hash": "cb228dab273ed1f22a1f3e29853ba0a27d6d9a1d"
+                              "hash": "676007ada277bd78b51a4a63bab0707d5e534615"
                             }
                           ],
-                          "hash": "7f064addf5c994ea06733bf0fe98f6a28b5a8d0d"
+                          "hash": "9c712ec8cad4c2bf8595bfd1455dbb891d0ebb3d"
                         }
                       ],
-                      "hash": "2d9c5e8976ae804c0a75c3f1665d5dbc82f725a5"
+                      "hash": "4e14c9cc93e6d73553370780c4ea5f8e28011cf6"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/newarch",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdater.kt",
+                          "hash": "09b480efc63a70bdc6c8b6a5463c4a4c97d4a45c"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdaterModule.kt",
-                          "hash": "64566e2c6c53cf59ba7e96e861c3bcab8cfe8bbd"
+                          "hash": "d1e0cf5d376970927ae9cdc9ab233cfb24c49300"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/HotUpdaterPackage.kt",
@@ -910,18 +4180,26 @@
                           "hash": "e7c1f793e0c67767bdac1bc8ef25e49525f31f70"
                         },
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/newarch/ReactHostHolder.kt",
+                          "hash": "9a3d61f4b340bf8d7304b6a008c37ed79658adaa"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/newarch/ReactIntegrationManager.kt",
-                          "hash": "396d0992b8bacee2d277a412ea62ced950ec78ee"
+                          "hash": "cbafabc415e79f898caa22478db8725729135068"
                         }
                       ],
-                      "hash": "4b4d5136d3c88643fb4500071ad831d4b7e2b4a0"
+                      "hash": "60a8af5ee52d2cb62875deda875aea0dc309d372"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/oldarch",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdater.kt",
+                          "hash": "a7f9b6d8813189d6eb2b57469998b79feaad08fc"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterModule.kt",
-                          "hash": "b5c14e6596d5cc5107956839682f3155c7f74793"
+                          "hash": "46bcf7f012412562d436934ee7ae3c9bef909ebc"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterPackage.kt",
@@ -929,24 +4207,72 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/HotUpdaterSpec.kt",
-                          "hash": "6ce0075cb888f878409ef077fd4f0f192d26a1fd"
+                          "hash": "98f0ffbcb03a8e5e5127a1a8b12dbb08c266cb5d"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/android/src/oldarch/ReactIntegrationManager.kt",
-                          "hash": "f21e4efde4031d73b16381199e58a991243533c1"
+                          "hash": "3a43affdface6224cb16d675e3d9cf8437eb28a7"
                         }
                       ],
-                      "hash": "104671261be6d324eabd629caa643d096ae83558"
+                      "hash": "005e75c80b2fe53f0053e42ce4893125397a4010"
+                    },
+                    {
+                      "path": "node_modules/@hot-updater/react-native/android/src/test",
+                      "children": [
+                        {
+                          "path": "node_modules/@hot-updater/react-native/android/src/test/java",
+                          "children": [
+                            {
+                              "path": "node_modules/@hot-updater/react-native/android/src/test/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BsdiffPatchTest.kt",
+                                      "hash": "478e6fc46dca958db7ed7e812436b69786ec3091"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt",
+                                      "hash": "ad2de262a349c896374a4bfca70970fcebc1d334"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/HotUpdaterImplTest.kt",
+                                      "hash": "dd33ba327dff1595bf09dc353868e1c0450d1072"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/NativeConfigUtilsTest.kt",
+                                      "hash": "8ba3106d7c65fc60913d3eb8b1ec296c8428d3af"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/OkHttpDownloadServiceTest.kt",
+                                      "hash": "1562feb1879dd2321be46698102156f70d0573be"
+                                    },
+                                    {
+                                      "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/TarArchiveInputStreamTest.kt",
+                                      "hash": "ce7276d44a1978121e2128edcd9278ce7aa52bd4"
+                                    }
+                                  ],
+                                  "hash": "a855169ae5c29dae5204545bfc3a4b9bdb84cd5d"
+                                }
+                              ],
+                              "hash": "cdb25757dc119aef5e71e6f4d34569d8618d71ee"
+                            }
+                          ],
+                          "hash": "33d29c74e671e742ab50f2d013759e9cbeef46a5"
+                        }
+                      ],
+                      "hash": "b111dd09b5f860b00bf7c40d552420b3a051a599"
                     }
                   ],
-                  "hash": "a49851e35f663a4cd2140aefba0474bc2b606e0d"
+                  "hash": "e43a7ec58de195f4f8bb3b18556aab43f402deac"
                 }
               ],
-              "hash": "3f175c34f306556f52c32ca2c2e5a59aa3f7a263"
+              "hash": "f278621d2670d4448af70782726dca6d908df331"
             },
             {
               "path": "node_modules/@hot-updater/react-native/HotUpdater.podspec",
-              "hash": "ccd5e76d8a20d2f99e72abe2df81f71ee96246ad"
+              "hash": "f3d12124616dce2f101435a7b195b848f7a1266f"
             },
             {
               "path": "node_modules/@hot-updater/react-native/ios",
@@ -958,12 +4284,28 @@
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal",
                       "children": [
                         {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ArchiveExtractionUtilities.swift",
+                          "hash": "28a89f474d87c258e6a8502c2e71265841f49993"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BsdiffPatchBridge.h",
+                          "hash": "345d32891e87b349ffc25df0d0e20a9a6746f293"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BsdiffPatchBridge.mm",
+                          "hash": "503b86b2df26eb512935fa7b48a679ae853de8d5"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift",
-                          "hash": "ac581014ce0aad7194e5f8a8eb6e040aafd38da2"
+                          "hash": "699394246a0d7cd68d3c65943697a0462953ac0f"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleMetadata.swift",
-                          "hash": "19e81827ae242920e21e5520780a66bf88169432"
+                          "hash": "ffdd34407e94619adae076acfaf02534323a736b"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/CohortService.swift",
+                          "hash": "d93d2e0183b97994d566a35a037e1b218e954cef"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/DecompressionStrategy.swift",
@@ -971,7 +4313,7 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/DecompressService.swift",
-                          "hash": "367af8e4940336777ab843139ebacae7a928e04f"
+                          "hash": "59cd0e74865f55087f37c553a0128374534b71ba"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/FileManagerService.swift",
@@ -983,88 +4325,354 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdater-Bridging-Header.h",
-                          "hash": "3250415134e6b9ef79bdf41a4ee947674c31e155"
+                          "hash": "53caff96ed2c510f2332636f368591bd3f203b15"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdater.mm",
-                          "hash": "053c4462b3e854274bae68e50b7efef5207eb3fa"
+                          "hash": "c9fa6eae1e7983c0dfdbeaa6bf56d5a22d843546"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterConfig.swift",
+                          "hash": "58de094fe85f0d0418b09dbdd650929792350b03"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterCrashHandler.h",
+                          "hash": "ef03e14974e02c2ea07c6c26baef3debe5711a70"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterCrashHandler.mm",
+                          "hash": "e9e1e5a4f578eaa97f72c58716769eef8c6d17d6"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/HotUpdaterImpl.swift",
-                          "hash": "60f64166bc77017eb72fe6dcc51924aee13f1922"
+                          "hash": "ec00e2160062318a8cb96672ff5e2b86e0376d95"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/NotificationExtension.swift",
-                          "hash": "47d7a97efcbe1b0c1bfe0bcb25143516a6b54d6c"
+                          "hash": "df1fccf112d9d5283292d11617ce4a6194828ec1"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/SignatureVerifier.swift",
-                          "hash": "f4bc7d76c6b611c3d63ae10d8ba33db6c3b8fd7e"
+                          "hash": "371232a8c622b57948949246476bb7cc4091e18a"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/StreamingTarArchiveExtractor.swift",
+                          "hash": "bab395b8f7f1c7e3fdfb10bc0a89c3a981bd8c70"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarArchiveExtractor.swift",
+                          "hash": "d0e091858190bf71feb81aadeb86964d355c5e22"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarBrDecompressionStrategy.swift",
-                          "hash": "5c9b3087aeb00b9a4e2a7a0522035ed5a8fb5997"
+                          "hash": "c2170852ab98cca72e109b3a39a8b4a83f4f556d"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/TarGzDecompressionStrategy.swift",
-                          "hash": "c4185dcdbfeaacef413b388b27501283864bceb2"
+                          "hash": "57f070f40a3546d7d88b1399ca63f13f6b6f165b"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/URLSessionDownloadService.swift",
-                          "hash": "e2f4ed722fc40837b681f3617d392cfc1f2d2e8a"
+                          "hash": "424bf417fe5ac0ee80d20c33d5cb2c9a89f4dbe8"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/VersionedPreferencesService.swift",
                           "hash": "11ede903c1b4e7d8caff8df2785e770c2d0451bb"
                         },
                         {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ZipArchiveExtractor.swift",
+                          "hash": "8584221bbd3be1aff935a6ac94e0fc65ec7f4b10"
+                        },
+                        {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/ZipDecompressionStrategy.swift",
-                          "hash": "3ceb9e7ffe85a591f482a247ec96cb9bbb1a6bca"
+                          "hash": "1819cbfc897319e45aeac88691ea325ae7a99d58"
                         }
                       ],
-                      "hash": "25d2b7885ae2ebe691357c7caf8c687316065b0e"
+                      "hash": "7c49d7859faa18ad0c4240a03d2cb627a1bb3e91"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Package.swift",
-                      "hash": "73f973b0ff9ab004d7010414e0d22edc9b5624bd"
+                      "hash": "368b68a5a4ee5ed44ec139e5d324e51093fe2ee4"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Public",
                       "children": [
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Public/HotUpdater.h",
-                          "hash": "c836f779ed1b7a65a2f286539f6d7e1769d582d5"
+                          "hash": "d57e6a6f6aeb746d737954c3c40fa4074c1ae11e"
                         }
                       ],
-                      "hash": "a4593f7ab9ba903d02694cb8a31675ea385452c3"
+                      "hash": "7fe52522dca6e3f2488e4c6e224031879c05dc4b"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test",
                       "children": [
                         {
-                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/TempTest.swift",
-                          "hash": "adeb43fe8e8c510cc48a779ce0038d83b8969a7d"
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ArchiveExtractionTests.swift",
+                          "hash": "2827d86f6dc61b014c12ac2466df982386093822"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ArchiveExtractionXCTestFallback.swift",
+                          "hash": "0bb86b753281edf0d7a28a80dd481859142914b2"
+                        },
+                        {
+                          "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift",
+                          "hash": "1b3f8aad854d493ea86d6d8c6909cf8b0172dca6"
                         }
                       ],
-                      "hash": "70e11214e1f054d0a80d669f5d6e1c34b22d8f05"
+                      "hash": "5dab09e737339fffba28642d58f240834b67229f"
                     }
                   ],
-                  "hash": "e6cf44e1ada2811ba4b5dac0d7d65db0f8651b73"
+                  "hash": "150d6d00df531ffa1eb1b1f5b2a73f207d385b9b"
                 }
               ],
-              "hash": "bb987ec257378184dea04da293eaae0b96c3e986"
+              "hash": "a8e70fee0b213511b704f13b0e1adb69da7e32df"
             }
           ],
-          "hash": "d91000a070c9f9ab83c0585714aca5356e6dd26d"
+          "hash": "a72cb93a3847dfaa05e17fe9044ea1c8f84f9283"
+        }
+      },
+      {
+        "type": "dir",
+        "filePath": "node_modules/react-native-bootsplash",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "35536164716c88f7c7be14e1ae5413022409240a",
+        "debugInfo": {
+          "path": "node_modules/react-native-bootsplash",
+          "children": [
+            {
+              "path": "node_modules/react-native-bootsplash/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-bootsplash/android/build.gradle",
+                  "hash": "a73762aecef135cf5b55524afd6b53f08a58f1f8"
+                },
+                {
+                  "path": "node_modules/react-native-bootsplash/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.kt",
+                                          "hash": "e1ce2e5a63b59628558a86da826c8e3431e7b14c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashDialog.kt",
+                                          "hash": "57993c1e2c06439d8020744786612ab4b8adfee4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.kt",
+                                          "hash": "45ba6379677abbffb677d133474ee909989dd19d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashPackage.kt",
+                                          "hash": "07194523fd2082468cb80687ba68fb794b9488fe"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-bootsplash/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashQueue.kt",
+                                          "hash": "51390acbc0c4fbcb54889d3507c66094184fceaa"
+                                        }
+                                      ],
+                                      "hash": "9265c2e46b97d36708e4c656d64800cb36ce30a1"
+                                    }
+                                  ],
+                                  "hash": "ab2ca2fb3e6b15a0cbeddb6615341592840fff96"
+                                }
+                              ],
+                              "hash": "f43c8cef1d2aff6da79062a33b6a2680907235ba"
+                            }
+                          ],
+                          "hash": "a31d69cded92a01e3907658e3d89275b8551bdb6"
+                        }
+                      ],
+                      "hash": "8bfe34e2db53aa46d719a90871726f0858acbe60"
+                    },
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/newarch",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/newarch/com",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek/rnbootsplash",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/newarch/com/zoontek/rnbootsplash/RNBootSplashModule.kt",
+                                      "hash": "7ab6c029c57e088d2b90a7240e877a575ac5ec67"
+                                    }
+                                  ],
+                                  "hash": "e671163e059c501691d7689bde184317a3c1f75b"
+                                }
+                              ],
+                              "hash": "f1783f798a984c0612f1ebf7a642e63e17b76c6f"
+                            }
+                          ],
+                          "hash": "e1491620fb6cdc3a69521834eaf02fb32bb0ec78"
+                        }
+                      ],
+                      "hash": "8a2a5fff7851f6e3ae1840298a197c354b39c4ec"
+                    },
+                    {
+                      "path": "node_modules/react-native-bootsplash/android/src/oldarch",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-bootsplash/android/src/oldarch/com",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek/rnbootsplash",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-bootsplash/android/src/oldarch/com/zoontek/rnbootsplash/RNBootSplashModule.kt",
+                                      "hash": "f07da75230af4592043eb505031364e1e6ec14b6"
+                                    }
+                                  ],
+                                  "hash": "545c4e0b7badd9dd327d598a2cd066cbf3b096cd"
+                                }
+                              ],
+                              "hash": "6707620fa7c9414448c64a3261979a2caadebc23"
+                            }
+                          ],
+                          "hash": "42cec3e9587ae5455a9e415e60fed33619236e97"
+                        }
+                      ],
+                      "hash": "fed1422876439df1c192e793576ab69cb6d1d601"
+                    }
+                  ],
+                  "hash": "db88382b2b2ddd3f2bb5e576d80e8b43e6e19777"
+                }
+              ],
+              "hash": "324c57c1d5135cd41c9a4bdc263447e1d9bf5439"
+            },
+            {
+              "path": "node_modules/react-native-bootsplash/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-bootsplash/ios/RNBootSplash.h",
+                  "hash": "70376f79433f8d78c7f4233ccc9a87d94c6b7b25"
+                },
+                {
+                  "path": "node_modules/react-native-bootsplash/ios/RNBootSplash.mm",
+                  "hash": "932e02b76b6298aff0182f474001a8bd95a8eb5e"
+                }
+              ],
+              "hash": "949456a0fc953f67129ec62f36ccbf865b45d2d4"
+            },
+            {
+              "path": "node_modules/react-native-bootsplash/RNBootSplash.podspec",
+              "hash": "01111b3d01e7158ece80f3be49ce105c03738c35"
+            }
+          ],
+          "hash": "35536164716c88f7c7be14e1ae5413022409240a"
+        }
+      },
+      {
+        "type": "dir",
+        "filePath": "node_modules/react-native-launch-arguments",
+        "reasons": [
+          "rncoreAutolinking"
+        ],
+        "hash": "84678b09037a1e7f35d78938f9afeff3f8a4279b",
+        "debugInfo": {
+          "path": "node_modules/react-native-launch-arguments",
+          "children": [
+            {
+              "path": "node_modules/react-native-launch-arguments/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-launch-arguments/android/build.gradle",
+                  "hash": "e6b4f83705581a7519a01dad3483063993a567a3"
+                },
+                {
+                  "path": "node_modules/react-native-launch-arguments/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-launch-arguments/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-launch-arguments/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-launch-arguments/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java",
+                                      "hash": "c6de38f2b17ca01cb1f8520d72248ad7b1b05ce8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-launch-arguments/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsPackage.java",
+                                      "hash": "74a3e7f14f7303b6f1e1ca3779685f9873271df1"
+                                    }
+                                  ],
+                                  "hash": "31ad9696e8fb0845c8ab00559bba9466edf424b7"
+                                }
+                              ],
+                              "hash": "7cd1f96fec59c5a7241d13e4bd109a47aa8b5445"
+                            }
+                          ],
+                          "hash": "9caa598f548a15da1035d01582d468105508bb2f"
+                        }
+                      ],
+                      "hash": "1b1c98dce6a4ef8d097ee1fae2292f723050d531"
+                    }
+                  ],
+                  "hash": "768ebe72570e72badeca3c3e2b04fac68c952a96"
+                }
+              ],
+              "hash": "6f6f49f88e0b8dbdb478050e1766eb6a31265e32"
+            },
+            {
+              "path": "node_modules/react-native-launch-arguments/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-launch-arguments/ios/LaunchArguments.h",
+                  "hash": "90228301258b813b7c745f512760a2a874a8da28"
+                },
+                {
+                  "path": "node_modules/react-native-launch-arguments/ios/LaunchArguments.m",
+                  "hash": "5f5bc81165f42c59bad7b256598812688d5d2184"
+                }
+              ],
+              "hash": "f03d12f79d3dab304a987a5886c92082c0e4dcc6"
+            },
+            {
+              "path": "node_modules/react-native-launch-arguments/react-native-launch-arguments.podspec",
+              "hash": "84da4e71be0739299484accec986a3252101fc6f"
+            }
+          ],
+          "hash": "84678b09037a1e7f35d78938f9afeff3f8a4279b"
         }
       },
       {
         "type": "dir",
         "filePath": "node_modules/react-native-safe-area-context",
         "reasons": [
-          "rncoreAutolinkingAndroid"
+          "rncoreAutolinking"
         ],
-        "hash": "e031acae2aadfce18f9e0b4c5e91a8f6dfc75c09",
+        "hash": "872e7ecfe93e702cafb1e8cbe9e8524bd90ff25e",
         "debugInfo": {
           "path": "node_modules/react-native-safe-area-context",
           "children": [
@@ -1165,7 +4773,7 @@
                                         },
                                         {
                                           "path": "node_modules/react-native-safe-area-context/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.kt",
-                                          "hash": "ff1054b7a5293e161b2740b958834034b1a65533"
+                                          "hash": "e5e6b3af1e5f14a0a143410edac629adb05dc77a"
                                         },
                                         {
                                           "path": "node_modules/react-native-safe-area-context/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewEdges.kt",
@@ -1192,16 +4800,16 @@
                                           "hash": "073b88ec5f57125d9091abe303c455124777cee5"
                                         }
                                       ],
-                                      "hash": "97b0b14a89d38c1377406b3671d4ca8518558fcd"
+                                      "hash": "827382474eaf9fbca3c417a2985e84344aecc448"
                                     }
                                   ],
-                                  "hash": "7c0a97caa3653154872cc7ea08e30ba6e1408ff7"
+                                  "hash": "c22270e0acc856486d550dc65c19e4a4c1157567"
                                 }
                               ],
-                              "hash": "748d3a71b0626dfe87d9da353f36592627b6c7c1"
+                              "hash": "e28c9d6d2c1ae5c72c58a4c49820236a1b36cf8d"
                             }
                           ],
-                          "hash": "47928e93a85a9f434fe5ad61180d4c1b0a629bb3"
+                          "hash": "76f9a948d7816e2d7cf5829e29aea67d41f425a0"
                         },
                         {
                           "path": "node_modules/react-native-safe-area-context/android/src/main/jni",
@@ -1218,7 +4826,7 @@
                           "hash": "75301d1c17281162eb24d71f21a16ca53bcba541"
                         }
                       ],
-                      "hash": "60580f1a5b43012c5620e5a571e303b050c97a9c"
+                      "hash": "50cd1e539b5301888eeee1d0bbf0ce6230400fde"
                     },
                     {
                       "path": "node_modules/react-native-safe-area-context/android/src/paper",
@@ -1297,10 +4905,10 @@
                       "hash": "cc8e28811027625fce15e328444f68aeb317c7ce"
                     }
                   ],
-                  "hash": "6fc5333f4d8b70cfceb282b8eedc8255ab194089"
+                  "hash": "1b373c52d0d9bd87f4cee422f38ce5659bafafec"
                 }
               ],
-              "hash": "31c4c77b37508fa58d1d9ce6651b816e3bad4eb5"
+              "hash": "333f517550cb5fd08422966e5f39fe2b3ba23804"
             },
             {
               "path": "node_modules/react-native-safe-area-context/common",
@@ -1405,7 +5013,7 @@
                 },
                 {
                   "path": "node_modules/react-native-safe-area-context/ios/RNCSafeAreaProvider.m",
-                  "hash": "f39079a1dee7f529db7f68fa7e2ecfcfbac982a4"
+                  "hash": "228bf9a5f44c7bec4c7b0a32c88d8c532c0aff32"
                 },
                 {
                   "path": "node_modules/react-native-safe-area-context/ios/RNCSafeAreaProviderManager.h",
@@ -1480,53 +5088,2405 @@
                   "hash": "f0534b50c6299da7ee011d5b7369ab0720bb04e6"
                 }
               ],
-              "hash": "c044599e861f888edddd4b0c3254b14742aec27e"
+              "hash": "2cd1398ce0cd5065f9620e5e1f2826d7565e00bc"
             },
             {
               "path": "node_modules/react-native-safe-area-context/react-native-safe-area-context.podspec",
-              "hash": "fef1ca82be2c4f1107c5e284728b8c0327d6743e"
+              "hash": "2bfce6ed1a27a637a5ba554c0f986a4bfa9f91ad"
             }
           ],
-          "hash": "e031acae2aadfce18f9e0b4c5e91a8f6dfc75c09"
+          "hash": "872e7ecfe93e702cafb1e8cbe9e8524bd90ff25e"
         }
       },
       {
-        "type": "contents",
-        "id": "expoAutolinkingConfig:android",
-        "contents": "{\"extraDependencies\":[],\"modules\":[]}",
+        "type": "dir",
+        "filePath": "node_modules/react-native-screens",
         "reasons": [
-          "expoAutolinkingAndroid"
+          "rncoreAutolinking"
         ],
-        "hash": "a11c4dfdbf37b1bdcc11fcac45a79dc9228dcb0f",
+        "hash": "cebea40d794bc3c3b5c1726186e27e18e6212b77",
         "debugInfo": {
-          "hash": "a11c4dfdbf37b1bdcc11fcac45a79dc9228dcb0f"
+          "path": "node_modules/react-native-screens",
+          "children": [
+            {
+              "path": "node_modules/react-native-screens/android",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/android/build.gradle",
+                  "hash": "97921c17ae33f0f49d8fd318b0a66b9afea1aa72"
+                },
+                {
+                  "path": "node_modules/react-native-screens/android/CMakeLists.txt",
+                  "hash": "d7b32d6d6b89187a31c14d8d815f5c1727dbd036"
+                },
+                {
+                  "path": "node_modules/react-native-screens/android/src",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/android/src/fabric",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/android/src/fabric/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/fabric/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt",
+                                          "hash": "287536a4c90f9dc6c706af25bcab02ee2731d025"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt",
+                                          "hash": "7df1f99a691d492c87b31ae6f7ce9febec87fb93"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt",
+                                          "hash": "79869775c4e6ad47026884f72baae8ae631773f5"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt",
+                                          "hash": "5b4e5598643790c36b0f21455525ecabe52bdb8b"
+                                        }
+                                      ],
+                                      "hash": "4767e305595ff21912478ef443d48565133f78be"
+                                    }
+                                  ],
+                                  "hash": "7de5d16dc2961073a61ede6a0bd4bc606918f09b"
+                                }
+                              ],
+                              "hash": "2651820bf02cdaf7bad3bed752ed37234fecdbef"
+                            }
+                          ],
+                          "hash": "6ed80249e1eab198e18a3299cf70d73896e9668c"
+                        }
+                      ],
+                      "hash": "f5540136b635d3922dd5fc1eb14a4be68ffeb74f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/android/src/main",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/cpp",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/jni-adapter.cpp",
+                              "hash": "7e15ab3a692933f36e0962b85f924596200d211b"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/NativeProxy.cpp",
+                              "hash": "8be561505be8c9bf5a0c19436232c0cf23511001"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/NativeProxy.h",
+                              "hash": "857256053c2823e87c78951852e310a8eded2b2f"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/cpp/OnLoad.cpp",
+                              "hash": "2de272c2e66e1c16aff335e9ca4121252104b999"
+                            }
+                          ],
+                          "hash": "3928c3d6e9a47c79ab470dda7f1a6d7544904240"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/java",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/java/com",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetBehaviorExt.kt",
+                                              "hash": "608568ef57b0a96e238e49e28d7fcd89fc57d982"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetDialogRootView.kt",
+                                              "hash": "036245a41814f7ed9366d305580948a4ff454a95"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetDialogScreen.kt",
+                                              "hash": "0e55d0c9fbde36d342e5443390a2e1da65899bcb"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt",
+                                              "hash": "06a396c5ffd52bf444e8c67247bb9ce1ac7969be"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetWindowInsetListenerChain.kt",
+                                              "hash": "a6b08b6110f4cac39ee9612274d37e99c2edeede"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt",
+                                              "hash": "05118a529e3e91df5a49b2b08632a85721ff6d42"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt",
+                                              "hash": "a0b5a14a28cc33a0f0b6422b84830d0a80aa2254"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewPointerEvents.kt",
+                                              "hash": "d71edd5ccc4c4ab8d19a02a060245fe558912297"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt",
+                                              "hash": "3f9c91bf3ebba8462fa68add19563b90221b01d4"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt",
+                                              "hash": "04c3fc910ace76a40773672d61572ae59bc06622"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDetents.kt",
+                                              "hash": "63ba4f687ff4a9758f3e5f7dace36160fa105872"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt",
+                                              "hash": "bce7f59d2a55ab9e6cc257af5519d5ecb321a1ac"
+                                            }
+                                          ],
+                                          "hash": "95cd0885e485a29e6866631febe08b251bdea10f"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/CustomSearchView.kt",
+                                          "hash": "6d5fd8d80810d896d99e1a8a97c3f2c1ed0ad2cc"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt",
+                                          "hash": "3284f1d8fa23ca900d33d0af2732b7f40d427289"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt",
+                                              "hash": "e4e6c670eea3ada1d6a1a55ca8e715d032c3b029"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt",
+                                              "hash": "501b8d9c72e7274c8c8498daf5a721cd6ff549bc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt",
+                                              "hash": "9c3304aae7d572282c8a5fc5a36ca7a0adfed5d6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt",
+                                              "hash": "1a3411f947d191145202338d86453fd80b110dcf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenAnimationDelegate.kt",
+                                              "hash": "22dc3f1cddfb4bf47732d9e41ad20ca7b04df981"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenAppearEvent.kt",
+                                              "hash": "5d9dd52444298e70d5732828c869935c2a8307ec"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt",
+                                              "hash": "ddb4a286fd5da6b7eb69ef906e129bf25297cacf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenDismissedEvent.kt",
+                                              "hash": "05c5af5d71567d293163840c41698c84a16ed752"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt",
+                                              "hash": "db838ed6e37bfe34acbdc0614c79678eecdb8490"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt",
+                                              "hash": "6a69fff09c65f835f982752ed0a6c89f3f29c738"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillAppearEvent.kt",
+                                              "hash": "0fff5cf9166c4b549e8ce16b689cade46833cb59"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillDisappearEvent.kt",
+                                              "hash": "84bc7a76588b03e7eca147662b3c4db1602e5441"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt",
+                                              "hash": "ac6e8e9023627c3b68c69a82e87eae689fa9f721"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt",
+                                              "hash": "7bab111a6587ba76c24a30e03477228e6dcd6a8d"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt",
+                                              "hash": "9b41faed4c175d52774ceccad1b6e1fe15edd257"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt",
+                                              "hash": "41a3561edea27e5b0c1588b819710ee2e8318c1f"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt",
+                                              "hash": "4e06b0c4117c151cf4ebf4a295086eb2c85c82e6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt",
+                                              "hash": "7476325ccc3173e4d96583290ec398f5532d9d34"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/SheetDetentChangedEvent.kt",
+                                              "hash": "9ba9bb10095a53f8f213ab853c8e4a140d0c6d6c"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/StackFinishTransitioningEvent.kt",
+                                              "hash": "1961be8dfad2b31e7f17b16fae5c2a56809f2628"
+                                            }
+                                          ],
+                                          "hash": "eb4dabe35e402c3124d86c30e50df87749a35a6d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/FragmentExt.kt",
+                                              "hash": "ce319a9d0c5427733dcc3a298381384a58baed6b"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/NumericExt.kt",
+                                              "hash": "1a52014a4bdda3e7d9a80d0ab4d99fe23c948cfd"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt",
+                                              "hash": "6c0d3bd1a98dd71682b536e14bb83bfcfcc3df1b"
+                                            }
+                                          ],
+                                          "hash": "858c54f6ee62aab70145eca102a330de9d3ff8d7"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/AutoRemovingFragment.kt",
+                                                  "hash": "dd901bb482d3d6d02b2a3be96e02f50968617415"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt",
+                                                  "hash": "13ec8ad8b79230177a0773acb32a115bf460ec55"
+                                                }
+                                              ],
+                                              "hash": "8817e30678e78720c57d3286750f7f62472ff7a0"
+                                            }
+                                          ],
+                                          "hash": "aff3531e8370e8f4c6784634aaf28053072bd1e9"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/FragmentBackPressOverrider.kt",
+                                          "hash": "2517db4275d8cb377b7d42013ac8d2e1068a73d5"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/FragmentHolder.kt",
+                                          "hash": "9b0fb079c524c78e7207a12b456fece87e1c7528"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorScheme.kt",
+                                                      "hash": "065c39f5c1040bec00582e3059702a4840dd5eea"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeCoordinator.kt",
+                                                      "hash": "75ebc3de9cd60002e2036f9bb42cc0e1ef4d8cd4"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeListener.kt",
+                                                      "hash": "d8ded388da33cdf95d73425e2201a3054f423218"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/colorscheme/ColorSchemeProviding.kt",
+                                                      "hash": "c394d1891eb2f631703fadee72c7808c35da75de"
+                                                    }
+                                                  ],
+                                                  "hash": "f04d58711363d587f8b7c7a0c06a2cd507931cbd"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/BaseEventEmitter.kt",
+                                                      "hash": "e324e6eeee280f1dbf0f9bb8a65c8b043c3ea789"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/NamingAwareEventType.kt",
+                                                      "hash": "07e11b698b55109c1427d864e44513e13819fe42"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/event/ViewAppearanceEventEmitter.kt",
+                                                      "hash": "740d6b0fead67e37f32358bcc3e8f295ddb81a0f"
+                                                    }
+                                                  ],
+                                                  "hash": "a7cbff3eb6927b1a995ac349f859c0b2ad41043f"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt",
+                                                  "hash": "9e92148c4dd3afab4c16426b2e3444896223bf51"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/common/ShadowStateProxy.kt",
+                                                  "hash": "aca7ab2ac38614a35e447bdab64b49379a99154a"
+                                                }
+                                              ],
+                                              "hash": "c579ed19603e49a45ec34e8f60aed3d89714b788"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/EventHelpers.kt",
+                                                  "hash": "b8debe37713994e9a95c601c34feeeec0dccbed0"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt",
+                                                  "hash": "c3dff7ed709c23ce68414fe697673410a0357ad7"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt",
+                                                  "hash": "12103a7b915f68c231a431b58c4919c0526d1b11"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/SystemDrawable.kt",
+                                                  "hash": "622846dc57bc714daa3adda63efa5bce6fff2f22"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/UIManagerHelperExt.kt",
+                                                  "hash": "ceac9e883f3609b4a09ee655f298333623dfae53"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewFinder.kt",
+                                                  "hash": "796beedb5db8e7e4f16adc9c83af7b50e3df7f0b"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt",
+                                                  "hash": "5580e1fb049e9f4014d2b473ca68e312b4bf6609"
+                                                }
+                                              ],
+                                              "hash": "08e94d2ae70bdaedde844e0abd1902e117929bbf"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarker.kt",
+                                                  "hash": "49780ddbea103d429940428944c7d92ba7668db5"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt",
+                                                  "hash": "c25f2370550b2f275fcfd56280821a31537c12bb"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewSeeking.kt",
+                                                  "hash": "bd94a5fd7b48f0a419c27f2f9ce8287de68af3e0"
+                                                }
+                                              ],
+                                              "hash": "b6412e579a5d175223fa08682003a42fc54647fc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/OnHeaderConfigAttachListener.kt",
+                                                          "hash": "446364ae4cbcd19d963e4ffb7daeda97d76e1aee"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/OnHeaderConfigChangeListener.kt",
+                                                          "hash": "a008c90c488c9351d904708feae8b31a880d8cbb"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt",
+                                                          "hash": "8be6097398b0f2f2caf204a37ec51df1c3d761f2"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt",
+                                                          "hash": "3e2f91ee893f803c533eb90a0144912863369ea0"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt",
+                                                          "hash": "c9f1b7c40aae7de1914230ea4c401d5c8590c6ac"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderType.kt",
+                                                          "hash": "a6de4d8471c91bdf90fccddff1a87262e32720b8"
+                                                        }
+                                                      ],
+                                                      "hash": "3bcdc4f2d7cfe47333625301113c87af78a97d26"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt",
+                                                      "hash": "e5697959c519a41ba21d08182e5b4d04d590039e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt",
+                                                      "hash": "f0c31f8eff9cf775abaf3177373e3aa7f22fabea"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt",
+                                                      "hash": "802ab2ea84cab86ec23cf1683cc5ce1898bdbcd2"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt",
+                                                      "hash": "5d1d57a8107da29b84fd7870cd0f62e408cc0cbb"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderScrollingViewBehavior.kt",
+                                                      "hash": "3e9b81f31e32c21fd3774953e1d4d12063d376a3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/OnStackHeaderSubviewChangeListener.kt",
+                                                          "hash": "f01afb06becf237860359ad35973f7f3a69e026c"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt",
+                                                          "hash": "b2b60af38f15e9778a51938d0eb3624496806dac"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewCollapseMode.kt",
+                                                          "hash": "9838d3ea3e7a0d849720f8d70acd73e92a166a1f"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewProviding.kt",
+                                                          "hash": "886dfa45f765bb554c1d9e7313eeb14e5b48a343"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewType.kt",
+                                                          "hash": "322355d25c921be7055b4de7acc7685fb6aeebfa"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubviewViewManager.kt",
+                                                          "hash": "ebc6e5881a8478f508b5e0f813eff2f052c22a2d"
+                                                        }
+                                                      ],
+                                                      "hash": "a4d2bb8b0be4f9c918dcd33992556468d44931d2"
+                                                    }
+                                                  ],
+                                                  "hash": "cb3093ac1ecf55ea4a16f4c810f6ed2d3cb59f0b"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/FragmentOperation.kt",
+                                                      "hash": "a68d46443afe7719466a2ccc024b109a7f40312e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/FragmentOperationExecutor.kt",
+                                                      "hash": "757d7d086bbef69f850189893feda079e2b572d3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt",
+                                                      "hash": "1819e4948921a1b6a66451d1b348498eec6a7986"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerDelegate.kt",
+                                                      "hash": "7da1cac5b0926c1a7ba21427062d9fa264358043"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerParent.kt",
+                                                      "hash": "d0d87d312a970086a1f6ba9dc2c20eac45b8d5f0"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainerUpdateCoordinator.kt",
+                                                      "hash": "6f3362c276bdf539105d8454b0ffd4cc2cf113d9"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHost.kt",
+                                                      "hash": "ed410178a797ae7b840fc21a5b6bcd0cd7a9a1e8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHostViewManager.kt",
+                                                      "hash": "d5356f106ac8735061cf3dddb91f4de53b57d62c"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackOperation.kt",
+                                                      "hash": "79f3fc609c71dec4c59d2ca3d0eeb021287e3241"
+                                                    }
+                                                  ],
+                                                  "hash": "472c6eae977a925f434a1da1e5acb2b2f1613ac9"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDidAppearEvent.kt",
+                                                          "hash": "dd4a3521c2fa33e73bbb6fdd656ad7b8a8f2ed0a"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDidDisappearEvent.kt",
+                                                          "hash": "990e6f915c609da4b5778ae824c8e20c7159eefe"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenDismissEvent.kt",
+                                                          "hash": "48f66220d4be83452b813a4e518b123227030661"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenLifecycleEvent.kt",
+                                                          "hash": "525d22f69f4e129607febddda4eb1cb7ee26b667"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenNativeDismissPreventedEvent.kt",
+                                                          "hash": "654af77363f1b827a70e22cc5fb12d9c26506f3e"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenWillAppearEvent.kt",
+                                                          "hash": "b3a6cb8e791ae86a0615879107146170b7cca2ae"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/event/StackScreenWillDisappearEvent.kt",
+                                                          "hash": "e05074ee898f69543247d11c36b077451a43bc2e"
+                                                        }
+                                                      ],
+                                                      "hash": "ba34d26c5443b2e14f15a58b67284ee62a1691eb"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/PreventNativeDismissCallback.kt",
+                                                      "hash": "b331720144c16cf4137dff2c658d5418b1610573"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/PreventNativeDismissChangeObserver.kt",
+                                                      "hash": "0a3464f23c64a3773c01cc9438d5fe927b570aa8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt",
+                                                      "hash": "11bf5fdff39f3f57579eeafdf68f9a25ebffc3e8"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenAppearanceEventsEmitter.kt",
+                                                      "hash": "92f19255283601f84b6d085a8507761161e0f136"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenEventEmitter.kt",
+                                                      "hash": "d38d428a4dd095862ec555bd8262997687bdc482"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenFragment.kt",
+                                                      "hash": "22c06f876c264d4c7b104e8873123805ca276d31"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenViewManager.kt",
+                                                      "hash": "772d27c3915cd9877ac0148e0b0f194f4b38b6e3"
+                                                    }
+                                                  ],
+                                                  "hash": "e7dfcbef2d5667f3b37ea8ca7bd17dad948702b3"
+                                                }
+                                              ],
+                                              "hash": "24d43172bd85469c8b1cb81c66b4c4bdbe0bcd00"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceApplicator.kt",
+                                                      "hash": "0d98d3d89f476993933383002fe24d97b5155d80"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceCoordinator.kt",
+                                                      "hash": "d61eb52d547f20469e56fdc1e41946fbfd9a71e2"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceModel.kt",
+                                                      "hash": "2038ab2e61eced8988559fe74a86d6921bbe1165"
+                                                    }
+                                                  ],
+                                                  "hash": "f739b745561beacb1cd2a9559329911e75ab97d1"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/CustomBottomNavigationView.kt",
+                                                      "hash": "09670d02d6aa4e6f5d881e406f7f34ce3733b5d3"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/MenuHelpers.kt",
+                                                      "hash": "cb6cf987d4f4933e9085849b453ece948889398e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsActionOrigin.kt",
+                                                      "hash": "6194f0570c687370968a4ae043ad6ba82bd42584"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt",
+                                                      "hash": "f5d516975c7ead6f360691d843f299a78137f499"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationState.kt",
+                                                      "hash": "38b24a4c393e1b1fe8880c9e4c04b50ab5ceec17"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserver.kt",
+                                                      "hash": "821b39bf9da7a04f2b4b3ba504610e0d56dca4f7"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt",
+                                                      "hash": "d0999378ca922236e5c035ea5415922dcc9e2e28"
+                                                    }
+                                                  ],
+                                                  "hash": "ba0bc67052b5d3f30efbe5e4376683ae30271a92"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectedEvent.kt",
+                                                          "hash": "48d8bac77729c6c65250adfc49cd7f58fe53272a"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt",
+                                                          "hash": "0e06036b3da0245baca8f6e36c485f5ef764a34e"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt",
+                                                          "hash": "bb62696153dab0c918a78ab1410bc3ce80f718da"
+                                                        }
+                                                      ],
+                                                      "hash": "73ece090b9011ad44f7bdfbfbd38dc4af3426007"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt",
+                                                      "hash": "f21ada8dbfa35833a13ac90f2adf12dd4b5825d1"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostA11yCoordinator.kt",
+                                                      "hash": "dff00edd01ff5ee77151b595764eaad5018de26f"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt",
+                                                      "hash": "09d36833a6f0cdc0fb0c26a7c4fa3d79b0b36b2f"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt",
+                                                      "hash": "838bc711cd927a0c5ff931f5d217d26da01bcf73"
+                                                    }
+                                                  ],
+                                                  "hash": "8541a662c2a0514c1d3c6cde26550883253dc939"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen",
+                                                  "children": [
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event",
+                                                      "children": [
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenDidAppearEvent.kt",
+                                                          "hash": "337a1356c467bbef84ebf4033e72009803f75d9d"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenDidDisappearEvent.kt",
+                                                          "hash": "351e51f03f65acf0d5b0423b2bc42aa2be5d2073"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenWillAppearEvent.kt",
+                                                          "hash": "efa74526aa8c046b76079fef3b09bf3ccc4fefd1"
+                                                        },
+                                                        {
+                                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/event/TabsScreenWillDisappearEvent.kt",
+                                                          "hash": "aaf896f80806309525753ef8a6703f274eafb9c0"
+                                                        }
+                                                      ],
+                                                      "hash": "388fcd45f12c56d4f6d24cfe6e872c37c78a7f7b"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt",
+                                                      "hash": "4132946e699fa678cbd23228bb289cc4d89c612b"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenDelegate.kt",
+                                                      "hash": "2718ae4b5f93c78ac224a69dc4d704751f2ce573"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenEventEmitter.kt",
+                                                      "hash": "30010d8b3f7ba8966f031f4d3889912fc9133368"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt",
+                                                      "hash": "3aa990519d5265e47a415f82c665445b3e54617e"
+                                                    },
+                                                    {
+                                                      "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt",
+                                                      "hash": "2006d7a624a01d07feead3dc936f0f2cd4a7a3c7"
+                                                    }
+                                                  ],
+                                                  "hash": "a759b4f6eb7b7a4e0cb3dc09cf4ac33825bb4538"
+                                                }
+                                              ],
+                                              "hash": "de6b89164e97704fc24ac53451a40ee2662187dd"
+                                            }
+                                          ],
+                                          "hash": "62e368f53a12e35048e6ee040637104b907682c4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt",
+                                          "hash": "83b32fdc2e974ade0debc784dc287c4302fdd8c1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ModalScreenViewManager.kt",
+                                          "hash": "27778eb1cc58dfcab27807b3f93d81836c0215b1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt",
+                                          "hash": "65387323b28e1fdf2aa7c405eb3c01165253ce3e"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt",
+                                          "hash": "4372adbbcaf09b1f7ab02a135fe259b6474e22bc"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/EdgeInsets.kt",
+                                              "hash": "fc266969a7f207dac59d7adcb3688f5d136fbd53"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/InsetType.kt",
+                                              "hash": "867303d5c36b7ce6748ddeb8bf766c3dde131b2b"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaProvider.kt",
+                                              "hash": "8c34052ee29f5443454994a28fbbe5d25f6060a5"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaView.kt",
+                                              "hash": "33731736b9b3894bc58f8dd8768c6b0f1fe795be"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaViewEdges.kt",
+                                              "hash": "41a90ef53cdd8f4aae687bbabe77e86449d5ca0e"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaViewManager.kt",
+                                              "hash": "65aed46aeaf7700b5b13b6d1181f13b9176619dc"
+                                            }
+                                          ],
+                                          "hash": "70d15d3a24224d388e4e56251347b8ca5df39b48"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/Screen.kt",
+                                          "hash": "c9adcd91fc46b4e0b7934a91af673dc0f8a2adae"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt",
+                                          "hash": "b2722dec4607713d8c66bb89689926583d628570"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.kt",
+                                          "hash": "37e53a70eea508e466316d807d43e3c6eabfb609"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContentWrapper.kt",
+                                          "hash": "17027d1c3148f19c433f51e2a6330cc5db06494d"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContentWrapperManager.kt",
+                                          "hash": "15435eb6b3173183352d3df665ba5fbd64c2022b"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenEventDispatcher.kt",
+                                          "hash": "1c1ccac7e9f7e22edf9047a743252749e9a627dd"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFooter.kt",
+                                          "hash": "b570f62f46a09c0ab8e3208ea3a76cac08c6dd84"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFooterManager.kt",
+                                          "hash": "8b36c5addfda852960a075ba2fa14e31732150c0"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt",
+                                          "hash": "7cbf1280a84d258b7a4ff4ffbd2998a6c546757f"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt",
+                                          "hash": "e4595f5ff5ed831878f699a20c794215e2e43ced"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenModalFragment.kt",
+                                          "hash": "3e7316a293ce8a110ecfeb528d5b8697587009e0"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt",
+                                          "hash": "2c3602444ea63abe41bc330631ecebbd6a0ff966"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt",
+                                          "hash": "53477119696dd2447f17c037c7832c5978e6e773"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt",
+                                          "hash": "f37c3f8ca88711e170252dee860ece615938e1a2"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragmentWrapper.kt",
+                                          "hash": "db037412ffbe8620f28d52e8ecf4e051ba316920"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt",
+                                          "hash": "d35361d63632849fc6b76333f975a1d1f74763b4"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt",
+                                          "hash": "72524b6b70a87ec0c67fd1ec18ae3f817f58574c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderHeightUpdateProxy.kt",
+                                          "hash": "ef9b838580507c7acae54be2162ae03c1c0b80a1"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt",
+                                          "hash": "a179a78c0d8d3ada5f688f01ce1b2f914a37d452"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt",
+                                          "hash": "a5b16992866128b9735db19d9cc0c3f815750646"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt",
+                                          "hash": "99af70bd5093b2f36f57ba3a81f3f3f7fe90d2af"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt",
+                                          "hash": "9833717758bc26720abed2c1b93cd6213d01516c"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt",
+                                          "hash": "1eb06de6411e7d5d77bd1470dc2c7545477a8b7e"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt",
+                                          "hash": "b582e95c809ea115d65c9b11de94df7285d10069"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt",
+                                          "hash": "f556943edcf6abedf965cded7f8575f5a3836d7b"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchViewFormatter.kt",
+                                          "hash": "b2355a75e2d16cae509b9d27a8f3b36b1605fb33"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/anim",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/anim/ScreensAnimation.kt",
+                                                  "hash": "4943c1dfcb9acb9efa65c18975790384a02fdce8"
+                                                }
+                                              ],
+                                              "hash": "2546eb210b25b2dfe91c2f138fa7ee8cbd829fae"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views",
+                                              "children": [
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildDrawingOrderStrategyImpl.kt",
+                                                  "hash": "9db34227e3b2afdf743f1202dc4b6d02ece93988"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildrenDrawingOrderStrategy.kt",
+                                                  "hash": "5b1d865592864ecef35cc68fa8acb554e8f3c467"
+                                                },
+                                                {
+                                                  "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt",
+                                                  "hash": "368a06fa4a01690341e4105349a27aa742d786be"
+                                                }
+                                              ],
+                                              "hash": "7b73057a0a1c504d55a3fe3036092b83966f362d"
+                                            }
+                                          ],
+                                          "hash": "65d384b13e1feb507e0717fb9b2d0ac568a0f3ea"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/transition",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/transition/ExternalBoundaryValuesEvaluator.kt",
+                                              "hash": "52ae4442238c3c55eba505ce70931dcc99f476df"
+                                            }
+                                          ],
+                                          "hash": "bc9b7afd6d9e99f3a6becac63968c220636d3985"
+                                        },
+                                        {
+                                          "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils",
+                                          "children": [
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ColorUtils.kt",
+                                              "hash": "afa166a89c7e419d2ab58b3980eddead272b65a6"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DecorViewInsetsUtils.kt",
+                                              "hash": "9342c881fdbc74870d55793a47eaf217bdcd306a"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DeviceUtils.kt",
+                                              "hash": "625fed11e715d2a3bec0e7a5e15bf30574cf1da2"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt",
+                                              "hash": "a028a4bf98dcb4d639e45f47d0d27c915e628792"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/DrawableUtils.kt",
+                                              "hash": "b7a83a5c70ffeedd2863643d83049c399759cafd"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/FragmentTransactionKt.kt",
+                                              "hash": "6fe3b475132a2cde6f94922d6826adef716c0713"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/InsetsKt.kt",
+                                              "hash": "a761166e4420420d3f42952a6f7b55447df0ce31"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/RNSLog.kt",
+                                              "hash": "dc993e0a7c750ad502c43756c08e55c69a2178db"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt",
+                                              "hash": "62301957e29e3e0fdf1b43b553e1bb4d55f95ccc"
+                                            },
+                                            {
+                                              "path": "node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/utils/ViewBackgroundUtils.kt",
+                                              "hash": "38a038c8c64a383deaa7e9b78a8fa786f1a4bc14"
+                                            }
+                                          ],
+                                          "hash": "8afb7e80631d761d2d7d85c7636ba59c66fb325b"
+                                        }
+                                      ],
+                                      "hash": "be735e8fa5330235763fdea39e0b410de3d73b86"
+                                    }
+                                  ],
+                                  "hash": "f6c18fd6721a7345b1f9ecb947e8b2f3c58003c7"
+                                }
+                              ],
+                              "hash": "10a55c1e5f157e742dcb97eac334eac3e1f55df0"
+                            }
+                          ],
+                          "hash": "d6b78a91ed02991b9ecf9c5cfe568645a89daac7"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/android/src/main/jni",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/CMakeLists.txt",
+                              "hash": "2a5189163c0d5dd11937848c0fe350443ffc1c5e"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/rnscreens.cpp",
+                              "hash": "5d19bab488500223d09053d7f3b346519caae5cc"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/android/src/main/jni/rnscreens.h",
+                              "hash": "d37edde0694f3db5e5f861562ee3455a816d9b14"
+                            }
+                          ],
+                          "hash": "0818374af2dbec8e0b5091f763a6f019c6fde05f"
+                        }
+                      ],
+                      "hash": "0d2e334829841e89a25db96f0159b8d8a9e45529"
+                    }
+                  ],
+                  "hash": "de920d783e84544635ecff1f10bcfe31b4873165"
+                }
+              ],
+              "hash": "b2e0c27d21961094fc4b1d3fafd6ba1a2fe449ea"
+            },
+            {
+              "path": "node_modules/react-native-screens/common",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/common/cpp",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/common/cpp/react",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/common/cpp/react/renderer",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/common/cpp/react/renderer/components",
+                              "children": [
+                                {
+                                  "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens",
+                                  "children": [
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/FrameCorrectionModes.h",
+                                      "hash": "13ec35de6952efac6470a88c3eb8ea439edc5a89"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h",
+                                      "hash": "0b14243cecaa826d529140505cd1f3d3d832a3b7"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp",
+                                      "hash": "041bf80cccf8c5ef46e1e501c24929756e3e8ea0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h",
+                                      "hash": "93a9cd713a9a784dd079f6efe0ab2a8732a52fd0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h",
+                                      "hash": "7aab1e4035184bf3e68eb7ac0ddd641d695bc55b"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenComponentDescriptor.h",
+                                      "hash": "6e2fc6fe3e4f078f74fdebfabce4b1e44beb7d4f"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenShadowNode.cpp",
+                                      "hash": "005f0299895ca9eb58e91ee77a83595e1a0301db"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSModalScreenShadowNode.h",
+                                      "hash": "aa5d6d2e4842a01bad6e3657761b3d94346ca927"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewComponentDescriptor.h",
+                                      "hash": "aef68a0cf234f2ce7165c134cbaac86d1e300cee"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewShadowNode.cpp",
+                                      "hash": "8c02252e129932c38373dfca56e39f4b57229886"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewShadowNode.h",
+                                      "hash": "c058290b66305035f8941014b140c8ce3dab9325"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewState.cpp",
+                                      "hash": "9ecb94d180f3cc56adcfe9182eec2b63290f3cd9"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSafeAreaViewState.h",
+                                      "hash": "d0e265905cc1449f9f106492884af1a80bf2c2af"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h",
+                                      "hash": "c5bc83170c4c5b918ce9547b074368ad8dde1b36"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp",
+                                      "hash": "f9572ceb2751febf9ed216cfa1b0e6c216dd39e0"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.h",
+                                      "hash": "56538ef1fca15a7a6febaf7a782c0e5dca5a7e0c"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp",
+                                      "hash": "a43f46c44d7f9a28a37790674da1972ed434f50e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h",
+                                      "hash": "f8c8ae883900404cd173a08d039f6e726d8506f6"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h",
+                                      "hash": "22f56f8e0e1796c94348fd40f136c5b1e6a11f79"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp",
+                                      "hash": "4aa65e83d5470a3f77215de9d67459dbb0e5d474"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h",
+                                      "hash": "0ad7dcab9ec2a69f9098769f3cab14e29e30fa53"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp",
+                                      "hash": "3829a8937310bc181cd689b5875beeb5a19b36a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h",
+                                      "hash": "0564ae287939c82d6698c1d71a5ddc4b5535f0da"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h",
+                                      "hash": "bb0ed25bcac8a0c92735a14fbdfaf5b68739f224"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp",
+                                      "hash": "99637813bbcc18ee65837ee60f78c60dac304d39"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.h",
+                                      "hash": "63af47aab1ee5ddf14e6d1dbddfa9656645c151c"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.cpp",
+                                      "hash": "951e3e2b9d9f92020f908ecc94ac409b7bb46bd8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h",
+                                      "hash": "9b032605af38d15088f545f612ac2e2c1454e679"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenState.cpp",
+                                      "hash": "a891406cd1890ac26e2173d56c5b8f4f528850a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h",
+                                      "hash": "bc1b4b977215228a7a89e121fec47d70b63979b6"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenComponentDescriptor.h",
+                                      "hash": "870e263a1f7205ffe177428acfa412b0785894f4"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenShadowNode.cpp",
+                                      "hash": "75fabdc370f3dba8ba2eb6eea95880d9393823fb"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenShadowNode.h",
+                                      "hash": "b1d7285aeec517a427f1ff0e58b3603543fd55b3"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSSplitScreenState.h",
+                                      "hash": "62e9c5f71d4d8d6f1f98b857f1b3f25754696f62"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigComponentDescriptor.h",
+                                      "hash": "39e83f85a7322e13f257ad32fbc591dc77c2df23"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigShadowNode.cpp",
+                                      "hash": "6e1bb131d1988234fa003febb7100ac0580c661d"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigShadowNode.h",
+                                      "hash": "373405b86f81d465a3c653e59904b6214ed66cc4"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigState.cpp",
+                                      "hash": "dda4e92f5d3631f9752a2e7db03c7ee9f7b8052b"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderConfigState.h",
+                                      "hash": "0b60c3ffbe6c0c533ac09a21ca22c8c5f0de65a1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewComponentDescriptor.h",
+                                      "hash": "002ac19d53cced07e598eac085cb7f6b9b2eccf1"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewShadowNode.cpp",
+                                      "hash": "eb8f6dd62b94571698ea16952552614b9aee00f8"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewShadowNode.h",
+                                      "hash": "d7d6ca9b94e13e3698a77f092124737afffe33fd"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewState.cpp",
+                                      "hash": "2b237416bb56d820d88d46cff5657762a30bec22"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackHeaderSubviewState.h",
+                                      "hash": "4c7aacfed431740ed467d426d0917c67fc47a3da"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenComponentDescriptor.h",
+                                      "hash": "460da7113d6f14cd8bac6f3236b86f324e320013"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenShadowNode.cpp",
+                                      "hash": "86f1962bc959b05d477d6156028c646e4a5b2a12"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenShadowNode.h",
+                                      "hash": "5cb813a0acf251e15145607ebd4ffe694fde22b3"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenState.cpp",
+                                      "hash": "72ee359c6e58a4408cac267a22ec10164aa4f39e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSStackScreenState.h",
+                                      "hash": "02b3ae38fc00de7b2ba464d28d201ba9951e5392"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryComponentDescriptor.h",
+                                      "hash": "0e05789da89ea6871dc3bdb8efcf97d545fcd912"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryShadowNode.cpp",
+                                      "hash": "90eb4568c48bd1f56f884bceaee041ecfad3d596"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryShadowNode.h",
+                                      "hash": "3435e5f05763f36663fbc5b62983b8f18dc71595"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsBottomAccessoryState.h",
+                                      "hash": "10aa704e068d4fa98866a4ef4a0308938f286218"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostComponentDescriptor.h",
+                                      "hash": "fda3435c68d89afdd86b24eb22cd507d809e234e"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostShadowNode.cpp",
+                                      "hash": "7aa7572e2e50e5198bc67f1d25b3cb40611684d5"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostShadowNode.h",
+                                      "hash": "44838960668138b6a64ff8f07ea197d05b03e75f"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostState.cpp",
+                                      "hash": "9811b540b3400f5e9b4cdce2afa82d5b2c040abe"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/RNSTabsHostState.h",
+                                      "hash": "f3c0fb09939a85d387cb227b69efe7d43bc896f9"
+                                    },
+                                    {
+                                      "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/utils",
+                                      "children": [
+                                        {
+                                          "path": "node_modules/react-native-screens/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h",
+                                          "hash": "df0fece316063e3024464f0f86ece31d8c9a0dbc"
+                                        }
+                                      ],
+                                      "hash": "8c2e7b684fad4eb641d356ef4989835f779d9021"
+                                    }
+                                  ],
+                                  "hash": "bd9d459597da053b3f9532c4d41afc8a96bace5d"
+                                }
+                              ],
+                              "hash": "287358b7d49bc81a2229ea18f8be19f666676eb4"
+                            }
+                          ],
+                          "hash": "5c016ca6596c861413398aad0b89c7aa0c8f80fd"
+                        }
+                      ],
+                      "hash": "61876839748f2c9669c0d9f589a106a03c6a1f5b"
+                    }
+                  ],
+                  "hash": "1939c4dbb904b9fd859c31518804ff2f06792062"
+                }
+              ],
+              "hash": "62af203be42b4f785edc1f1c7495c85bb9dd6737"
+            },
+            {
+              "path": "node_modules/react-native-screens/cpp",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNScreensTurboModule.cpp",
+                  "hash": "de2709a495342f522c0f1c62fc6e21db5c5d8145"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNScreensTurboModule.h",
+                  "hash": "337249afab580c96c18d66e7de5746ede29ef691"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNSScreenRemovalListener.cpp",
+                  "hash": "207db03c4a9df1d209d4274aab7592ee78c1cbc0"
+                },
+                {
+                  "path": "node_modules/react-native-screens/cpp/RNSScreenRemovalListener.h",
+                  "hash": "4e929d15d09a1a783a0278d781816f9547de4712"
+                }
+              ],
+              "hash": "af777b4278b08c25581dc02bc49aad0a70928ecb"
+            },
+            {
+              "path": "node_modules/react-native-screens/ios",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/ios/bridging",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/RNSReactBaseView.h",
+                      "hash": "c27d8f00bcc310ae7dbbf3d0498e34164be67ed3"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/RNSReactBaseView.mm",
+                      "hash": "3a7500246d9dd5b259b29361c91701b6d06093af"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/bridging/Swift-Bridging.h",
+                      "hash": "78980455e0d16439af28ed8d884b3a7d47c394cd"
+                    }
+                  ],
+                  "hash": "65bebc41a56b178009fefa66d52d5ca03fe92f42"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/conversion",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/always_false.h",
+                      "hash": "f27cfa159168d5dc21d3a29e1c382093527d153e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Fabric.mm",
+                      "hash": "c9a42c91958957b4e650032d576029de6d5f58e5"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-ScrollViewMarker.h",
+                      "hash": "099fbce1b29847497a314144199d5fc72823f0b6"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-ScrollViewMarker.mm",
+                      "hash": "ab3fdc8967865725f870bb75de92e8acd5d626f3"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-SplitView.mm",
+                      "hash": "5071f38921c18151b66989b49f2a2b7200a95a44"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Stack.h",
+                      "hash": "b2db93781fb7327ec767ef20bb632ad744f42142"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Stack.mm",
+                      "hash": "26281381f76dc12aa859aa260e7d50c5681c8aef"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions-Tabs.mm",
+                      "hash": "827469eaec0485966205dbfb46ab9fcb60e4f806"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions.h",
+                      "hash": "e6eeb6802e51e7db0ff3aa633c42175e1fb247da"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/conversion/RNSConversions.mm",
+                      "hash": "01f1b3979a15bdbafb40ee372c21c07c3cc83ece"
+                    }
+                  ],
+                  "hash": "15c3f06f839f369e6186ca968f6f237600ee211d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/events",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSHeaderHeightChangeEvent.h",
+                      "hash": "75110afdd804f971d89b0a0b7acb9a31c6986722"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSHeaderHeightChangeEvent.mm",
+                      "hash": "f3ce690ced0babbeacd80a22f1324f7658c7f1bd"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSScreenViewEvent.h",
+                      "hash": "8f04bbec44b32b94ad042e91fa23478571cecc7e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/events/RNSScreenViewEvent.mm",
+                      "hash": "6c033a2a80e67a6d340167c0b32715bc1fb426c3"
+                    }
+                  ],
+                  "hash": "18e86f7540d76e4b8ecde8b2b201f0519970c72d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/gamma",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/orientation",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/orientation/RNSOrientationProviding.swift",
+                          "hash": "8657e7bb02cad6b6015ab05712b5f072520e82aa"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/orientation/RNSOrientationSwift.swift",
+                          "hash": "e43343eba7726f5275bec9a174f0da347d2f2e22"
+                        }
+                      ],
+                      "hash": "1edd6da9916827cb187b9c4f8014c30af4342a80"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/ReactMountingTransactionObserving.swift",
+                      "hash": "12765683eeabd943535e8f4f3498a2043572c2ac"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h",
+                          "hash": "51442f944ca19006d3aea53b371f3604acf88033"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm",
+                          "hash": "67f0c30d18072ae799d455a5df73b20a7552790b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/scroll-view-marker/RNSScrollViewSeeking.h",
+                          "hash": "97f42a0d040bb8ab41da6c4c309e78d9a15b4533"
+                        }
+                      ],
+                      "hash": "62065573b9bedab0a57c6608cf0c16455e073418"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/split",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceApplicator.swift",
+                          "hash": "a890c89df427bef6deb9d0e24532b4f11caa4372"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceCoordinator.swift",
+                          "hash": "5d2fbcb5ecd4f4f09085a45d8f9ca990f8f970c8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift",
+                          "hash": "5dfdb31c2a50703ea30e1698293a93579331a45d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentEventEmitter.h",
+                          "hash": "b4365d5fe0d027b83f344e9503329ae8c15adf96"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentEventEmitter.mm",
+                          "hash": "723f7b327e756ee39101de6c4d62c8914d75b0a0"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentView.h",
+                          "hash": "e8d68bded7716089629b76056fb6351c08b0429b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentView.mm",
+                          "hash": "e673ee3889dc7d5d1a641b3c1fec9baf8ac8677f"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentViewManager.h",
+                          "hash": "358e39dfe2bf26a651b1935e0293751c875580b7"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostComponentViewManager.mm",
+                          "hash": "24ae4e54977326e6aaf7b0a8a941a992c46945cd"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitHostController.swift",
+                          "hash": "21df833cf3d9984b9b27d2f6d0b38ee02b4fa480"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitNavigationController.swift",
+                          "hash": "3e8aaf8ea8147976b701506ca21804366b6b2318"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentEventEmitter.h",
+                          "hash": "9d73e2bf5ebe7df7d1cecf04acb5622c1a43cf8a"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentEventEmitter.mm",
+                          "hash": "96285fd583326020caed83587e152b682119999b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentView.h",
+                          "hash": "cc6d795a063936f60a4624366bc5e0fcebedc08c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentView.mm",
+                          "hash": "175efcd01b34b92eca82fc1b020e44c6616b7c1d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentViewManager.h",
+                          "hash": "2b3360f0c45d579ca16391d3a68fa52be86bfd73"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenComponentViewManager.mm",
+                          "hash": "3af77c69862e125c1ab31af5008f7e15fc27d5b1"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenController.swift",
+                          "hash": "3b9af3a19fbe32cac31e7e1a216a02688b573b8c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenShadowStateProxy.h",
+                          "hash": "8c0d13059b168b217733894f7ea71755ae2b527f"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm",
+                          "hash": "d45a99ad1a91bc0c477bdf4eec4ba38a3e9af28b"
+                        }
+                      ],
+                      "hash": "d78f809a30239a675bb281a27bcc17ceb644c115"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/gamma/stack",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/stack/host",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentView.h",
+                              "hash": "e8c9560e013f6b05770b6f1ee9d3595e98299f3a"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentView.mm",
+                              "hash": "8817f18b84c1a3d4a19192247814e86cd850cb70"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentViewManager.h",
+                              "hash": "5e6f763b44d1d3322487098131cbf1cc26beedf8"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackHostComponentViewManager.mm",
+                              "hash": "9aab3adad7b32e8d4160670b110b3bc2ae1f76a0"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackNavigationController.h",
+                              "hash": "3601c4a73934594eeab5f2d8bcb41da8fdaf87cc"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackNavigationController.mm",
+                              "hash": "96e87e2549727812343292dca6bd58b4026bbe45"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperation.h",
+                              "hash": "0c438dbab6ed30cb328d1bf1fbdf2a82d7b7a514"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperation.mm",
+                              "hash": "2e56336793e2aa6d45fbf79176f705f92055bb98"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperationCoordinator.h",
+                              "hash": "0b1d80e401e464170803416979e0e0a1300d3c3c"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/host/RNSStackOperationCoordinator.mm",
+                              "hash": "7fce2712e84e84b2a08260eb0d3bea114b7ab8e0"
+                            }
+                          ],
+                          "hash": "4dc559a2ac51b3913a1b5ff90c04409a37b9e347"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/gamma/stack/screen",
+                          "children": [
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentEventEmitter.h",
+                              "hash": "fd5198000e324c2e5d54753cfcd0ea75463463bd"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentEventEmitter.mm",
+                              "hash": "4157295bbc6a929f7910faf59407437c0067d4fd"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentView.h",
+                              "hash": "871add2575fa992eb524083f82dff938b3de162c"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentView.mm",
+                              "hash": "c75ea34506964b599581ea62aef11d7e478492e0"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentViewManager.h",
+                              "hash": "236502e7840f16edce8c8d7e30c4bc565d665308"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenComponentViewManager.mm",
+                              "hash": "4cde2a0827925e338e4ea1a747a4db63482f2b9f"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenController.h",
+                              "hash": "efa25696f5303c46c95d477eb070312a25bb5cc7"
+                            },
+                            {
+                              "path": "node_modules/react-native-screens/ios/gamma/stack/screen/RNSStackScreenController.mm",
+                              "hash": "87f6908ee0dfe28d920d341deaae7ce5615920d4"
+                            }
+                          ],
+                          "hash": "ebf3f8c0e532a4ad96bb1bac5c348cc79336c5d5"
+                        }
+                      ],
+                      "hash": "6879361970790fd4d55712f6f57898b1adfeabde"
+                    }
+                  ],
+                  "hash": "da725ddfb139288cb905b0e7e36d9f8626f9b289"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/helpers",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/image",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/image/RNSImageLoadingHelper.h",
+                          "hash": "054a27ae25d8590c267f6ea166016cd7060561e5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/image/RNSImageLoadingHelper.mm",
+                          "hash": "d6badfd1ac6baf625f19d7200693bd49272f5c8a"
+                        }
+                      ],
+                      "hash": "49e3c911bfaceb1fc843e270c5df4b3347889103"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionAware.h",
+                      "hash": "5bad0b6824f574c8fe058cabb43fd88c6ba0255b"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionManager.h",
+                      "hash": "a6b417ae17b5cdf00eff70a9c8eb5887000faf73"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/RNSViewInteractionManager.mm",
+                      "hash": "a3305172c75536f4971ccb0df7d8853485d5272e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/helpers/scroll-view",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSContentScrollViewProviding.h",
+                          "hash": "fa697a6ed91bfb6ad181ed1f3c281bfa43c12d71"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.h",
+                          "hash": "51e1f1da40cd59fa12a68f40980dd9c69f099f8c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.mm",
+                          "hash": "270eacb438022cfd1ff31ea5c73d0c7440e31a9c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewFinder.h",
+                          "hash": "4a8de3c7b5735b38c36f4c83c70e4d575924fdf9"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewFinder.mm",
+                          "hash": "25c7845563761898dd60c83555c58dcad4fdb57b"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewHelper.h",
+                          "hash": "df1eb9c3c6dc588f15794a8e61c82befc9081f38"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/helpers/scroll-view/RNSScrollViewHelper.mm",
+                          "hash": "21867737ba546faee34e7a7d2247dfc002b24c94"
+                        }
+                      ],
+                      "hash": "c24490c2fcaee141b79b3897bc8af437df728d87"
+                    }
+                  ],
+                  "hash": "cbdee47f361aaa97df051807bb0ccc784218a230"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/integrations",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/integrations/RNSDismissibleModalProtocol.h",
+                      "hash": "db330aeef91b9cbd7c3b80d852295f4a1c0b78be"
+                    }
+                  ],
+                  "hash": "4a90b85b715e3e7166bd5725acd84c6718791a83"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTConvert+RNScreens.h",
+                  "hash": "e2463b42549ae33845eed83f489f761929bab83c"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTConvert+RNScreens.mm",
+                  "hash": "29203359a39253e77f89fc7b61763073c7d02803"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h",
+                  "hash": "909fbec14f438e34fc35d10769ec758a2f10d8e6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm",
+                  "hash": "e10cd9f826cc6fee91bfa3ce86205a1b43b5a81d"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSBarButtonItem.h",
+                  "hash": "9790f5f46b83b8e34c733d8739f1f0d44be65b4f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSBarButtonItem.mm",
+                  "hash": "127c7d0798a87640947ed58b81cb44e436f2444e"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSConvert.h",
+                  "hash": "733ab0a0568d1d19c78ce1a71ee06ef26d69e0f3"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSConvert.mm",
+                  "hash": "8959b0d5a8607860b61051dc45606350de28c3bb"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNScreens-Bridging-Header.h",
+                  "hash": "34da9799185a9debe5c4242a96b45de0b243d37e"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSEnums.h",
+                  "hash": "a15931ff66797583f0e3f0978fc33b11973d51b1"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSFullWindowOverlay.h",
+                  "hash": "39571c7075fc7be6ce105ac4fcf4cda1b108bd32"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSFullWindowOverlay.mm",
+                  "hash": "a176bec39701d6208daae7753139312be7e5de50"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModalScreen.h",
+                  "hash": "5db0f5e1ff04e9ccfd0ae6ac43ee6efd1693bf59"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModalScreen.mm",
+                  "hash": "fb862d10f073d555647f358488c17230e7957d55"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModule.h",
+                  "hash": "165145e788aa0f7810117363528e91c786b9eb64"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSModule.mm",
+                  "hash": "427c378121bd7cf2b66f385ed3ea36cf06612c79"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSOrientationProviding.h",
+                  "hash": "3ea8b8827d3ae843266a0e880ef69ccdc58acca1"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSPercentDrivenInteractiveTransition.h",
+                  "hash": "463a896ae735abd9a9ecd10881afce9c45561149"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSPercentDrivenInteractiveTransition.mm",
+                  "hash": "12d904ed4caa06930e0fac020a23b1ac6ba94c36"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreen.h",
+                  "hash": "0281ac3c2135ac5213e5972578300a0fdc561b16"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreen.mm",
+                  "hash": "ebca2e5579b6e0579f9a08232c8c2aa0b42bba5f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContainer.h",
+                  "hash": "5f726d571706aed6abc785a31a787c06c9b0de5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContainer.mm",
+                  "hash": "bbf7dbc57406dbe991e8174f2e7bb67342382d5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContentWrapper.h",
+                  "hash": "69c97c710061e56f14ebb7b4cd17312f169e86b5"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm",
+                  "hash": "78ddf2ad501033c5eb4dd0ac2af03f4eca6e1f68"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenFooter.h",
+                  "hash": "ab24c448f262a43d8153c954292cf83f0b0785c6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenFooter.mm",
+                  "hash": "29b64d15466bb14d136a81b74c27ac61728aad5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenNavigationContainer.h",
+                  "hash": "8c30d12549f9dee917aa58302b076af63f889a5b"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenNavigationContainer.mm",
+                  "hash": "273e4c8fd04bfe754c8204f35b2e30346b3d0732"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStack.h",
+                  "hash": "23a0886e848bd7d902a068f3700de56b3719bd08"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStack.mm",
+                  "hash": "4571a937a2eedd7314873b20c7988f016d12ffd9"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackAnimator.h",
+                  "hash": "4b23709e7c11ccc6dc3b4ccc75e4b4ae352c8c66"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackAnimator.mm",
+                  "hash": "be5ea6139332ae7215f9087514314188fd7230ee"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.h",
+                  "hash": "8a5720125aa0594bd23a56f3fcfb9e4b1e3a064a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm",
+                  "hash": "882f891989a90f3bd2c3c697be6dd4d682377b77"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.h",
+                  "hash": "949919ec5e8d0cfbb31e973c0a50e299b0a281b8"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.mm",
+                  "hash": "26b67d967197de564a6ccfacd7a54bd2dd8c2342"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenWindowTraits.h",
+                  "hash": "07204f1be665c232266002166053b10d33bd4b23"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScreenWindowTraits.mm",
+                  "hash": "f0240729776a10957ab619ef47360da8c998dc2f"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSScrollViewBehaviorOverriding.h",
+                  "hash": "8d5fcd65c62fe3be5b0b76154c9c42b9bf7fb624"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSSearchBar.h",
+                  "hash": "24d3cf23f4765bbb78b98e29509f614ce91d2ab6"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/RNSSearchBar.mm",
+                  "hash": "0cfe00e24f2127d17a60c302adfe78479ce9f68a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/safe-area",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaProviding.h",
+                      "hash": "67770dc50d4523ef378caa26a497fd03689e2f95"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewComponentView.h",
+                      "hash": "1675a37ca574fa81f41bb299fa3a431284449686"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewComponentView.mm",
+                      "hash": "6d93a6b96e3a020d87e56197978d1e95ddad386c"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/safe-area/RNSSafeAreaViewNotifications.h",
+                      "hash": "1c4b99d3d87b1ff07fa7494b41abac6291972ae2"
+                    }
+                  ],
+                  "hash": "d29cf3f464023c810679fecccf864e6982f9d951"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/stubs",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/stubs/RNSGammaStubs.h",
+                      "hash": "5c152f8dc57a26bb7366e9af2ee75a663165f3f7"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/stubs/RNSGammaStubs.mm",
+                      "hash": "2bb9b2457b10d5c0b1d5c9e238e5c4b3f2956eb2"
+                    }
+                  ],
+                  "hash": "3bf63a938adab8e6ded5b71eee2fc9b245ee0105"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/tabs",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.h",
+                          "hash": "70c24ef7c7fac1a6a46d9b67a15097b4f9e4bd28"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm",
+                          "hash": "ed2355f6da64d0c87aad5fcafa3fd06316683621"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentViewManager.h",
+                          "hash": "2a6e622d3a91fe57e842f43d16a75249454f9c2a"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentViewManager.mm",
+                          "hash": "1a8827b22258c944740796b71da0d89a64ac10ae"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h",
+                          "hash": "a51ee7b10fb63047af2a52189ae85fed2aa60b1c"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm",
+                          "hash": "deb81c1e49ea377df7ecb0e3623f5c43fdc9bbda"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryEventEmitter.h",
+                          "hash": "bb6a92d6689b3dc8b299419a0ad62ea052c28aba"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryEventEmitter.mm",
+                          "hash": "8ab8ef0b7e980f7e269d0a4f5717ff75f0c2c9ac"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h",
+                          "hash": "26fba656671fb99ea0b347c65b0f8c1287481cff"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm",
+                          "hash": "edd5aaea568632bcd3237f70d8fc0ebf7318f346"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.h",
+                          "hash": "f31832fbcf71a1f5c99fbaa388f5015e1c9f0a7d"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm",
+                          "hash": "9e44c9990b0499bbd955abc8d1e081094891126b"
+                        }
+                      ],
+                      "hash": "d755c4ba2747f66e9fa0a8f84e5ebbba3486a57f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/extensions",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/extensions/RNSTabsHostComponentView+RNSImageLoader.h",
+                          "hash": "f5cb255823d72e6ae8bbb7a22adb397e39b3f4a9"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/extensions/RNSTabsHostComponentView+RNSImageLoader.mm",
+                          "hash": "eb02f7fff3b039617cdacee5edec8e966814f909"
+                        }
+                      ],
+                      "hash": "d527863f014f799e7db83ef0e1092f662c47caf2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/host",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabBarController.h",
+                          "hash": "68a37a32e59e5a8134ac752d96f4e86abc41e163"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabBarController.mm",
+                          "hash": "160af83bb1a3b6c67b577ea23adb836a29a0c0b5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentView.h",
+                          "hash": "b25515a4cecd5e5c3e821c208ae0b1dfdf6f70a8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentView.mm",
+                          "hash": "24f5e0d27301270c596be83d34489bd9f660e977"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentViewManager.h",
+                          "hash": "005ab769719756d6cae8ba454b7cd0349505d312"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostComponentViewManager.mm",
+                          "hash": "998ef73404e2b8f89c35a88cbfaaea13846e1dd5"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostEventEmitter.h",
+                          "hash": "6b54b53827f64ad0ec4577e7c9d4c8b1a57659be"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsHostEventEmitter.mm",
+                          "hash": "44b7a587323d22abfe0dc816acaccd06bca0f382"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationState.h",
+                          "hash": "548c653230acc14b20442f06f32aed1239286218"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationState.mm",
+                          "hash": "e2814862989cb87eca687c45ab8ca2599c6987ef"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h",
+                          "hash": "8271ef879283232579b42b99bb3cfeb1ba60d3a8"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm",
+                          "hash": "9e38de661008be27915e3465afe106035197ce0f"
+                        }
+                      ],
+                      "hash": "ab4719b804bbfa267da948eae7ff4c0af58d73ac"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RCTConvert+RNSTabs.h",
+                      "hash": "cfa12c8c56337b04003858b6ea426df483591a08"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RCTConvert+RNSTabs.mm",
+                      "hash": "8d7d4b93852cf2b45c1571a03cac3743a3d54bfe"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabBarAppearanceCoordinator.h",
+                      "hash": "539786bffbf514e03ce0cfc9bb40867249c4a494"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabBarAppearanceCoordinator.mm",
+                      "hash": "369292529fb19b5a612368479c6de035512d4eca"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/RNSTabsSpecialEffectsSupporting.h",
+                      "hash": "11cfbb810c010bfa4e51e722115b351590330955"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/tabs/screen",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentView.h",
+                          "hash": "80b1edb4dc7bca78f73feca9e4839f97c8795238"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentView.mm",
+                          "hash": "857107b30a982eeb76e9b8da0c638bea695b2497"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentViewManager.h",
+                          "hash": "b1d3d0d8466ae227156b0b7489ea7a8f0ba12414"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenComponentViewManager.mm",
+                          "hash": "cadd59f70ac376b8d7e96c466754f3c938107b38"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenEventEmitter.h",
+                          "hash": "4db4ef306fbdcf2260583734aaecec34856e55c1"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenEventEmitter.mm",
+                          "hash": "9c19430f10d41219ba6567f9f92eb9ae36f508c3"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenViewController.h",
+                          "hash": "77de31bb3141e2526e8e9c9d436046417a9a9798"
+                        },
+                        {
+                          "path": "node_modules/react-native-screens/ios/tabs/screen/RNSTabsScreenViewController.mm",
+                          "hash": "92310b50598060b6083a4fbc971094a19d2335d1"
+                        }
+                      ],
+                      "hash": "c71a88dedc05535bea873cb1673fa268b614ed99"
+                    }
+                  ],
+                  "hash": "aac904c56de2a5541e2b92202b0c6f87487fc49a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIScrollView+RNScreens.h",
+                  "hash": "bedc4fa0db03d7a5da0c8794098402bed321ac9a"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIScrollView+RNScreens.mm",
+                  "hash": "da7e519adea6bc75dd69409e94bcf2ae257b5800"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIViewController+RNScreens.h",
+                  "hash": "9f33b4ecc857d215e66398bdd62b7d14917dadef"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIViewController+RNScreens.mm",
+                  "hash": "b8ec172246c41a29faaad9395a59b4997f298859"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIWindow+RNScreens.h",
+                  "hash": "4f9511c28abb8be5ebba3f16b45fe4f4d849a7f9"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/UIWindow+RNScreens.mm",
+                  "hash": "c940a380d411dded1edb95fa7b8e0f5b8a17ce01"
+                },
+                {
+                  "path": "node_modules/react-native-screens/ios/utils",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/extensions",
+                      "children": [
+                        {
+                          "path": "node_modules/react-native-screens/ios/utils/extensions/RCTImageSource+AccessHiddenMembers.h",
+                          "hash": "adf2fed09b9e23e56d4e810ccf10f39d28f28c75"
+                        }
+                      ],
+                      "hash": "2f22873e915a91bf645b060eb9a60a8f768c9332"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/NSString+RNSUtility.h",
+                      "hash": "53611c29c7d43f9365610213239450824c7c4ed9"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/NSString+RNSUtility.mm",
+                      "hash": "6d1534f745fcd2cad4eb8085cfe4542d6fe9f28e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTSurfaceTouchHandler+RNSUtility.h",
+                      "hash": "aa92ff9528eb80737c8f1335f33bea0accb59362"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTSurfaceTouchHandler+RNSUtility.mm",
+                      "hash": "96024226db2a8c3dfd0dd1ed168d2e5e467db8d4"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTTouchHandler+RNSUtility.h",
+                      "hash": "aaf2393a40b6353460a85f0de18bd9a67da48811"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RCTTouchHandler+RNSUtility.mm",
+                      "hash": "d1f893b279e0134e5759a1446b839f82dd8fd654"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSBackBarButtonItem.h",
+                      "hash": "765bcc05f13e17cabc9a3c0734e62e63ffbaaf7a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSBackBarButtonItem.mm",
+                      "hash": "464a544452c7a95820185cf44250d237b4e1fe35"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSDefines.h",
+                      "hash": "5601f1f96ffcbcdc23ca0b1f36ae2432f7d4243a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSLog.h",
+                      "hash": "038a63d6beb7fee759ed93a091bf7c207ced6b21"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/RNSLog.swift",
+                      "hash": "e53e50cd9c635e3c54fef5a2f88843d3aa11703f"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UINavigationBar+RNSUtility.h",
+                      "hash": "31fa0780cee543fdfd72881bd4284f096fa6f82e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UINavigationBar+RNSUtility.mm",
+                      "hash": "b4fe4c1280b6decb785e0f8acd3db225a69e2498"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UIView+RNSUtility.h",
+                      "hash": "f35d4bb6316d0c4ca7ef7b32ccce7f9bd9211e8e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/ios/utils/UIView+RNSUtility.mm",
+                      "hash": "3b5aa2da6d621f56f53bf97bd5f316c40e1c48ae"
+                    }
+                  ],
+                  "hash": "033e17effb648c0f79f979ad9de0ef956725574b"
+                }
+              ],
+              "hash": "684d0f1a575c5d1333bd8754f649d08bf532abb1"
+            },
+            {
+              "path": "node_modules/react-native-screens/RNScreens.podspec",
+              "hash": "c50a07f05b0a167724d075e7a9599b6d4e5249f6"
+            },
+            {
+              "path": "node_modules/react-native-screens/windows",
+              "children": [
+                {
+                  "path": "node_modules/react-native-screens/windows/RNScreens",
+                  "children": [
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ModalScreenViewManager.cpp",
+                      "hash": "4aea5930729b4f0f3ee504a7a56a61a8b335b64e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ModalScreenViewManager.h",
+                      "hash": "50cca018c7835394a16aa4629409405ebc250c81"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/pch.cpp",
+                      "hash": "7e25a29ef977104140e7ce056e9a8ee2025a4390"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/pch.h",
+                      "hash": "f132ac7550ba9c57fe036b3875bb9d2b5d738c21"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ReactPackageProvider.cpp",
+                      "hash": "e005c253fe076a67a3097012461d0919afe5f97a"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ReactPackageProvider.h",
+                      "hash": "db93a0d0e6a614497bc01ca1aae8a7e258c46d29"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/RNScreens.cpp",
+                      "hash": "578fbedbe5f1968f49ea3207fbe3398abade97e1"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/RNScreens.h",
+                      "hash": "29ea93af1792cfb101ce8edce1c4cd9dcce4dd4d"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/Screen.cpp",
+                      "hash": "22ebdd8f08382ecc1a0ed3a5ec27d23dc6f538af"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/Screen.h",
+                      "hash": "277f89dd527efcf6efa99d30936551e3a4dfb5b0"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainer.cpp",
+                      "hash": "1e070948b10edaf14ba7c3bdbf828b873f225aba"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainer.h",
+                      "hash": "ba7656c4076f2fc9da9415ec8395de44fdaf2243"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainerViewManager.cpp",
+                      "hash": "3e174cbb2b8f30ace8ecc93997df569746cb0f58"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenContainerViewManager.h",
+                      "hash": "c9c64690a226504275f7225d27b106df98761d92"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStack.cpp",
+                      "hash": "2d8e1140c3cb4dc150bf4276ba37c8aa88e9ca40"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStack.h",
+                      "hash": "ba19f3f983926796122952fc146f8b5eeeaa636c"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfig.cpp",
+                      "hash": "c3c5437080bf6233dd9c3493e5b65b16d51f0dfd"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfig.h",
+                      "hash": "c999fa61d08977d58844869a3ded6e9a23108013"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfigViewManager.cpp",
+                      "hash": "9112ac632e686f23b7fc1f50a3f0f7a6b4c00391"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderConfigViewManager.h",
+                      "hash": "2bcc9998f9a5c0074b369e0f6a34d25e6bdbeb00"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubview.cpp",
+                      "hash": "b438d6d57b32679be232476a9066be4ed66b9c89"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubview.h",
+                      "hash": "7e1025296118db982dfa7deb63f6494f2647ba2d"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp",
+                      "hash": "3047f9669a91ae871dd2d29aa76324cf95c37be7"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackHeaderSubviewViewManager.h",
+                      "hash": "24250e9d21e4c1fcc911c71c00f63e080e2e0fb2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackViewManager.cpp",
+                      "hash": "a9fec18d936f087b635107ab011d591ee66e3beb"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenStackViewManager.h",
+                      "hash": "02173396bda08d5f00374a14ea7429acf1395a27"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenViewManager.cpp",
+                      "hash": "e4c51437b7f2d39399afed0a54df3a7f0daf021e"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/ScreenViewManager.h",
+                      "hash": "d60a6d516c2d8d88747933e3c112b4d26ac1af55"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBar.cpp",
+                      "hash": "a7f9ade7be9aaf66bb9855e1a9b3522b20d9f512"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBar.h",
+                      "hash": "f74dd7185083d4c6d0c32575db2617312b50b131"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBarViewManager.cpp",
+                      "hash": "f53df8576b03fa0cc3162e67789eb133f28160d2"
+                    },
+                    {
+                      "path": "node_modules/react-native-screens/windows/RNScreens/SearchBarViewManager.h",
+                      "hash": "b3739035d50241bdb7f79494225bc83837e3c126"
+                    }
+                  ],
+                  "hash": "fb467c3b2ea4bcaa73e0764db2e71e8ebe5261c2"
+                }
+              ],
+              "hash": "7bd6f7dcc686225143816171d37c774e8d71631a"
+            }
+          ],
+          "hash": "cebea40d794bc3c3b5c1726186e27e18e6212b77"
         }
       },
       {
         "type": "contents",
         "id": "package:react-native",
-        "contents": "{\"name\":\"react-native\",\"version\":\"0.81.0\",\"description\":\"A framework for building native apps using React\",\"license\":\"MIT\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/facebook/react-native.git\",\"directory\":\"packages/react-native\"},\"homepage\":\"https://reactnative.dev/\",\"keywords\":[\"react\",\"react-native\",\"android\",\"ios\",\"mobile\",\"cross-platform\",\"app-framework\",\"mobile-development\"],\"bugs\":\"https://github.com/facebook/react-native/issues\",\"engines\":{\"node\":\">= 20.19.4\"},\"bin\":{\"react-native\":\"cli.js\"},\"main\":\"./index.js\",\"types\":\"types\",\"exports\":{\".\":{\"react-native-strict-api\":\"./types_generated/index.d.ts\",\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/index.d.ts\",\"types\":\"./types/index.d.ts\",\"default\":\"./index.js\"},\"./*\":{\"react-native-strict-api\":null,\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/*.d.ts\",\"types\":\"./*.d.ts\",\"default\":\"./*.js\"},\"./*.js\":{\"react-native-strict-api\":null,\"default\":\"./*.js\"},\"./Libraries/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./Libraries/*.d.ts\"},\"./scripts/*\":\"./scripts/*\",\"./src/*\":{\"react-native-strict-api\":null,\"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS\":\"./types_generated/src/*.d.ts\",\"default\":\"./src/*.js\"},\"./types/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./types/*.d.ts\"},\"./gradle/*\":null,\"./React/*\":null,\"./ReactAndroid/*\":null,\"./ReactApple/*\":null,\"./ReactCommon/*\":null,\"./sdks/*\":null,\"./src/fb_internal/*\":\"./src/fb_internal/*\",\"./third-party-podspecs/*\":null,\"./types/*\":null,\"./types_generated/*\":null,\"./package.json\":\"./package.json\"},\"jest-junit\":{\"outputDirectory\":\"reports/junit\",\"outputName\":\"js-test-results.xml\"},\"files\":[\"build.gradle.kts\",\"cli.js\",\"flow\",\"gradle.properties\",\"gradle/libs.versions.toml\",\"index.js\",\"index.js.flow\",\"interface.js\",\"jest-preset.js\",\"jest\",\"Libraries\",\"LICENSE\",\"React-Core.podspec\",\"React-Core-prebuilt.podspec\",\"react-native.config.js\",\"React.podspec\",\"React\",\"!React/Fabric/RCTThirdPartyFabricComponentsProvider.*\",\"ReactAndroid\",\"!ReactAndroid/.cxx\",\"!ReactAndroid/build\",\"!ReactAndroid/external-artifacts/artifacts\",\"!ReactAndroid/external-artifacts/build\",\"!ReactAndroid/hermes-engine/.cxx\",\"!ReactAndroid/hermes-engine/build\",\"!ReactAndroid/src/main/third-party\",\"!ReactAndroid/src/test\",\"ReactApple\",\"ReactCommon\",\"README.md\",\"rn-get-polyfills.js\",\"scripts/replace-rncore-version.js\",\"scripts/bundle.js\",\"scripts/cocoapods\",\"scripts/codegen\",\"scripts/compose-source-maps.js\",\"scripts/find-node-for-xcode.sh\",\"scripts/generate-codegen-artifacts.js\",\"scripts/generate-provider-cli.js\",\"scripts/generate-specs-cli.js\",\"scripts/hermes/hermes-utils.js\",\"scripts/hermes/prepare-hermes-for-build.js\",\"scripts/ios-configure-glog.sh\",\"scripts/native_modules.rb\",\"scripts/node-binary.sh\",\"scripts/packager-reporter.js\",\"scripts/packager.sh\",\"scripts/react_native_pods_utils/script_phases.rb\",\"scripts/react_native_pods_utils/script_phases.sh\",\"scripts/react_native_pods.rb\",\"scripts/react-native-xcode.sh\",\"scripts/xcode/ccache-clang.sh\",\"scripts/xcode/ccache-clang++.sh\",\"scripts/xcode/ccache.conf\",\"scripts/xcode/with-environment.sh\",\"sdks/.hermesversion\",\"sdks/hermes-engine\",\"sdks/hermesc\",\"settings.gradle.kts\",\"src\",\"!src/private/testing\",\"third-party-podspecs\",\"types\",\"types_generated\",\"!**/__docs__/**\",\"!**/__fixtures__/**\",\"!**/__flowtests__/**\",\"!**/__mocks__/**\",\"!**/__tests__/**\",\"!**/__typetests__/**\"],\"scripts\":{\"prepack\":\"node ./scripts/prepack.js\",\"featureflags\":\"node ./scripts/featureflags/index.js\"},\"peerDependencies\":{\"@types/react\":\"^19.1.0\",\"react\":\"^19.1.0\"},\"peerDependenciesMeta\":{\"@types/react\":{\"optional\":true}},\"dependencies\":{\"@jest/create-cache-key-function\":\"^29.7.0\",\"@react-native/assets-registry\":\"0.81.0\",\"@react-native/codegen\":\"0.81.0\",\"@react-native/community-cli-plugin\":\"0.81.0\",\"@react-native/gradle-plugin\":\"0.81.0\",\"@react-native/js-polyfills\":\"0.81.0\",\"@react-native/normalize-colors\":\"0.81.0\",\"@react-native/virtualized-lists\":\"0.81.0\",\"abort-controller\":\"^3.0.0\",\"anser\":\"^1.4.9\",\"ansi-regex\":\"^5.0.0\",\"babel-jest\":\"^29.7.0\",\"babel-plugin-syntax-hermes-parser\":\"0.29.1\",\"base64-js\":\"^1.5.1\",\"commander\":\"^12.0.0\",\"flow-enums-runtime\":\"^0.0.6\",\"glob\":\"^7.1.1\",\"invariant\":\"^2.2.4\",\"jest-environment-node\":\"^29.7.0\",\"memoize-one\":\"^5.0.0\",\"metro-runtime\":\"^0.83.1\",\"metro-source-map\":\"^0.83.1\",\"nullthrows\":\"^1.1.1\",\"pretty-format\":\"^29.7.0\",\"promise\":\"^8.3.0\",\"react-devtools-core\":\"^6.1.5\",\"react-refresh\":\"^0.14.0\",\"regenerator-runtime\":\"^0.13.2\",\"scheduler\":\"0.26.0\",\"semver\":\"^7.1.3\",\"stacktrace-parser\":\"^0.1.10\",\"whatwg-fetch\":\"^3.0.0\",\"ws\":\"^6.2.3\",\"yargs\":\"^17.6.2\"},\"codegenConfig\":{\"libraries\":[{\"name\":\"FBReactNativeSpec\",\"type\":\"all\",\"ios\":{\"modules\":{\"AccessibilityManager\":{\"unstableRequiresMainQueueSetup\":true},\"Appearance\":{\"unstableRequiresMainQueueSetup\":true},\"AppState\":{\"unstableRequiresMainQueueSetup\":true},\"DeviceInfo\":{\"unstableRequiresMainQueueSetup\":true},\"PlatformConstants\":{\"unstableRequiresMainQueueSetup\":true},\"StatusBarManager\":{\"unstableRequiresMainQueueSetup\":true}}},\"android\":{},\"jsSrcsDir\":\"src\"}]}}",
+        "contents": "{\"name\":\"react-native\",\"version\":\"0.85.2\",\"description\":\"A framework for building native apps using React\",\"license\":\"MIT\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/facebook/react-native.git\",\"directory\":\"packages/react-native\"},\"homepage\":\"https://reactnative.dev/\",\"keywords\":[\"react\",\"react-native\",\"android\",\"ios\",\"mobile\",\"cross-platform\",\"app-framework\",\"mobile-development\"],\"bugs\":\"https://github.com/facebook/react-native/issues\",\"engines\":{\"node\":\"^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0\"},\"bin\":{\"react-native\":\"cli.js\"},\"main\":\"./index.js\",\"types\":\"types\",\"exports\":{\".\":{\"react-native-strict-api\":\"./types_generated/index.d.ts\",\"types\":\"./types/index.d.ts\",\"default\":\"./index.js\"},\"./*\":{\"react-native-strict-api\":null,\"types\":\"./*.d.ts\",\"default\":\"./*.js\"},\"./*.js\":{\"react-native-strict-api\":null,\"default\":\"./*.js\"},\"./Libraries/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./Libraries/*.d.ts\"},\"./scripts/*\":\"./scripts/*\",\"./src/*\":{\"react-native-strict-api\":null,\"default\":\"./src/*.js\"},\"./types/*.d.ts\":{\"react-native-strict-api\":null,\"default\":\"./types/*.d.ts\"},\"./gradle/*\":null,\"./React/*\":null,\"./ReactAndroid/*\":null,\"./ReactApple/*\":null,\"./ReactCommon/*\":null,\"./sdks/*\":null,\"./src/fb_internal/*\":\"./src/fb_internal/*\",\"./third-party-podspecs/*\":null,\"./types/*\":null,\"./types_generated/*\":null,\"./package.json\":\"./package.json\"},\"jest-junit\":{\"outputDirectory\":\"reports/junit\",\"outputName\":\"js-test-results.xml\"},\"files\":[\"build.gradle.kts\",\"cli.js\",\"flow\",\"gradle.properties\",\"gradle/libs.versions.toml\",\"index.js\",\"index.js.flow\",\"interface.js\",\"jest-preset.js\",\"Libraries\",\"LICENSE\",\"React-Core.podspec\",\"React-Core-prebuilt.podspec\",\"react-native.config.js\",\"React.podspec\",\"React\",\"!React/Fabric/RCTThirdPartyFabricComponentsProvider.*\",\"ReactAndroid\",\"!ReactAndroid/.cxx\",\"!ReactAndroid/build\",\"!ReactAndroid/external-artifacts/artifacts\",\"!ReactAndroid/external-artifacts/build\",\"!ReactAndroid/hermes-engine/.cxx\",\"!ReactAndroid/hermes-engine/build\",\"!ReactAndroid/src/main/third-party\",\"!ReactAndroid/src/test\",\"ReactApple\",\"ReactCommon\",\"README.md\",\"rn-get-polyfills.js\",\"scripts/replace-rncore-version.js\",\"scripts/bundle.js\",\"scripts/cocoapods\",\"scripts/codegen\",\"scripts/compose-source-maps.js\",\"scripts/find-node-for-xcode.sh\",\"scripts/generate-codegen-artifacts.js\",\"scripts/generate-provider-cli.js\",\"scripts/generate-specs-cli.js\",\"scripts/hermes/hermes-utils.js\",\"scripts/hermes/prepare-hermes-for-build.js\",\"scripts/ios-configure-glog.sh\",\"scripts/native_modules.rb\",\"scripts/node-binary.sh\",\"scripts/packager-reporter.js\",\"scripts/packager.sh\",\"scripts/react_native_pods_utils/script_phases.rb\",\"scripts/react_native_pods_utils/script_phases.sh\",\"scripts/react_native_pods.rb\",\"scripts/react-native-xcode.sh\",\"scripts/xcode/ccache-clang.sh\",\"scripts/xcode/ccache-clang++.sh\",\"scripts/xcode/ccache.conf\",\"scripts/xcode/with-environment.sh\",\"sdks/.hermesversion\",\"sdks/.hermesv1version\",\"sdks/hermes-engine\",\"sdks/hermesc\",\"settings.gradle.kts\",\"src\",\"!src/private/testing\",\"third-party-podspecs\",\"types\",\"types_generated\",\"!**/__docs__/**\",\"!**/__fixtures__/**\",\"!**/__flowtests__/**\",\"!**/__mocks__/**\",\"!**/__tests__/**\",\"!**/__typetests__/**\"],\"scripts\":{\"prepack\":\"node ./scripts/prepack.js\",\"featureflags\":\"node ./scripts/featureflags/index.js\"},\"peerDependencies\":{\"@react-native/jest-preset\":\"0.85.2\",\"@types/react\":\"^19.1.1\",\"react\":\"^19.2.3\"},\"peerDependenciesMeta\":{\"@types/react\":{\"optional\":true},\"@react-native/jest-preset\":{\"optional\":true}},\"dependencies\":{\"@react-native/assets-registry\":\"0.85.2\",\"@react-native/codegen\":\"0.85.2\",\"@react-native/community-cli-plugin\":\"0.85.2\",\"@react-native/gradle-plugin\":\"0.85.2\",\"@react-native/js-polyfills\":\"0.85.2\",\"@react-native/normalize-colors\":\"0.85.2\",\"@react-native/virtualized-lists\":\"0.85.2\",\"abort-controller\":\"^3.0.0\",\"anser\":\"^1.4.9\",\"ansi-regex\":\"^5.0.0\",\"babel-plugin-syntax-hermes-parser\":\"0.33.3\",\"base64-js\":\"^1.5.1\",\"commander\":\"^12.0.0\",\"flow-enums-runtime\":\"^0.0.6\",\"hermes-compiler\":\"250829098.0.10\",\"invariant\":\"^2.2.4\",\"memoize-one\":\"^5.0.0\",\"metro-runtime\":\"^0.84.0\",\"metro-source-map\":\"^0.84.0\",\"nullthrows\":\"^1.1.1\",\"pretty-format\":\"^29.7.0\",\"promise\":\"^8.3.0\",\"react-devtools-core\":\"^6.1.5\",\"react-refresh\":\"^0.14.0\",\"regenerator-runtime\":\"^0.13.2\",\"scheduler\":\"0.27.0\",\"semver\":\"^7.1.3\",\"stacktrace-parser\":\"^0.1.10\",\"tinyglobby\":\"^0.2.15\",\"whatwg-fetch\":\"^3.0.0\",\"ws\":\"^7.5.10\",\"yargs\":\"^17.6.2\"},\"codegenConfig\":{\"libraries\":[{\"name\":\"FBReactNativeSpec\",\"type\":\"all\",\"ios\":{\"modules\":{\"AccessibilityManager\":{\"unstableRequiresMainQueueSetup\":true},\"Appearance\":{\"unstableRequiresMainQueueSetup\":true},\"AppState\":{\"unstableRequiresMainQueueSetup\":true},\"DeviceInfo\":{\"unstableRequiresMainQueueSetup\":true},\"PlatformConstants\":{\"unstableRequiresMainQueueSetup\":true},\"StatusBarManager\":{\"unstableRequiresMainQueueSetup\":true}}},\"android\":{},\"jsSrcsDir\":\"src\"}]}}",
         "reasons": [
           "package:react-native"
         ],
-        "hash": "cbec4d5b6c0b5eea0f0d3a5064fdf2b0418e5750",
+        "hash": "606bf938348eb462743a98a75160c803610abd88",
         "debugInfo": {
-          "hash": "cbec4d5b6c0b5eea0f0d3a5064fdf2b0418e5750"
+          "hash": "606bf938348eb462743a98a75160c803610abd88"
         }
       },
       {
         "type": "contents",
-        "id": "rncoreAutolinkingConfig:android",
-        "contents": "{\"@hot-updater/react-native\":{\"root\":\"node_modules/@hot-updater/react-native\",\"name\":\"@hot-updater/react-native\",\"platforms\":{\"android\":{\"sourceDir\":\"node_modules/@hot-updater/react-native/android\",\"packageImportPath\":\"import com.hotupdater.HotUpdaterPackage;\",\"packageInstance\":\"new HotUpdaterPackage()\",\"buildTypes\":[],\"libraryName\":\"HotUpdaterSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/@hot-updater/react-native/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null}}},\"react-native-safe-area-context\":{\"root\":\"node_modules/react-native-safe-area-context\",\"name\":\"react-native-safe-area-context\",\"platforms\":{\"android\":{\"sourceDir\":\"node_modules/react-native-safe-area-context/android\",\"packageImportPath\":\"import com.th3rdwave.safeareacontext.SafeAreaContextPackage;\",\"packageInstance\":\"new SafeAreaContextPackage()\",\"buildTypes\":[],\"libraryName\":\"safeareacontext\",\"componentDescriptors\":[\"RNCSafeAreaProviderComponentDescriptor\",\"RNCSafeAreaViewComponentDescriptor\"],\"cmakeListsPath\":\"node_modules/react-native-safe-area-context/android/src/main/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null}}}}",
+        "id": "rncoreAutolinkingConfig",
+        "contents": "{\"@callstack/repack\":{\"root\":\"node_modules/@callstack/repack\",\"name\":\"@callstack/repack\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/@callstack/repack/callstack-repack.podspec\",\"version\":\"5.2.5\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/@callstack/repack/android\",\"packageImportPath\":\"import com.callstack.repack.ScriptManagerPackage;\",\"packageInstance\":\"new ScriptManagerPackage()\",\"buildTypes\":[],\"libraryName\":\"RNScriptManagerSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/@callstack/repack/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"@hot-updater/react-native\":{\"root\":\"node_modules/@hot-updater/react-native\",\"name\":\"@hot-updater/react-native\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/@hot-updater/react-native/HotUpdater.podspec\",\"version\":\"0.36.3\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/@hot-updater/react-native/android\",\"packageImportPath\":\"import com.hotupdater.HotUpdaterPackage;\",\"packageInstance\":\"new HotUpdaterPackage()\",\"buildTypes\":[],\"libraryName\":\"HotUpdaterSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/@hot-updater/react-native/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-bootsplash\":{\"root\":\"node_modules/react-native-bootsplash\",\"name\":\"react-native-bootsplash\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-bootsplash/RNBootSplash.podspec\",\"version\":\"7.1.0\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-bootsplash/android\",\"packageImportPath\":\"import com.zoontek.rnbootsplash.RNBootSplashPackage;\",\"packageInstance\":\"new RNBootSplashPackage()\",\"buildTypes\":[],\"libraryName\":\"RNBootSplashSpec\",\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/react-native-bootsplash/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-launch-arguments\":{\"root\":\"node_modules/react-native-launch-arguments\",\"name\":\"react-native-launch-arguments\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-launch-arguments/react-native-launch-arguments.podspec\",\"version\":\"4.1.1\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-launch-arguments/android\",\"packageImportPath\":\"import com.reactnativelauncharguments.LaunchArgumentsPackage;\",\"packageInstance\":\"new LaunchArgumentsPackage()\",\"buildTypes\":[],\"componentDescriptors\":[],\"cmakeListsPath\":\"node_modules/react-native-launch-arguments/android/build/generated/source/codegen/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-safe-area-context\":{\"root\":\"node_modules/react-native-safe-area-context\",\"name\":\"react-native-safe-area-context\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-safe-area-context/react-native-safe-area-context.podspec\",\"version\":\"5.8.0\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-safe-area-context/android\",\"packageImportPath\":\"import com.th3rdwave.safeareacontext.SafeAreaContextPackage;\",\"packageInstance\":\"new SafeAreaContextPackage()\",\"buildTypes\":[],\"libraryName\":\"safeareacontext\",\"componentDescriptors\":[\"RNCSafeAreaProviderComponentDescriptor\",\"RNCSafeAreaViewComponentDescriptor\"],\"cmakeListsPath\":\"node_modules/react-native-safe-area-context/android/src/main/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}},\"react-native-screens\":{\"root\":\"node_modules/react-native-screens\",\"name\":\"react-native-screens\",\"platforms\":{\"ios\":{\"podspecPath\":\"node_modules/react-native-screens/RNScreens.podspec\",\"version\":\"4.25.2\",\"configurations\":[],\"scriptPhases\":[]},\"android\":{\"sourceDir\":\"node_modules/react-native-screens/android\",\"packageImportPath\":\"import com.swmansion.rnscreens.RNScreensPackage;\",\"packageInstance\":\"new RNScreensPackage()\",\"buildTypes\":[],\"libraryName\":\"rnscreens\",\"componentDescriptors\":[\"RNSFullWindowOverlayComponentDescriptor\",\"RNSScreenContainerComponentDescriptor\",\"RNSScreenNavigationContainerComponentDescriptor\",\"RNSScreenStackHeaderConfigComponentDescriptor\",\"RNSScreenStackHeaderSubviewComponentDescriptor\",\"RNSScreenStackComponentDescriptor\",\"RNSSearchBarComponentDescriptor\",\"RNSScreenComponentDescriptor\",\"RNSScreenFooterComponentDescriptor\",\"RNSScreenContentWrapperComponentDescriptor\",\"RNSModalScreenComponentDescriptor\",\"RNSTabsHostComponentDescriptor\",\"RNSSafeAreaViewComponentDescriptor\",\"RNSStackScreenComponentDescriptor\",\"RNSStackHeaderConfigComponentDescriptor\",\"RNSStackHeaderSubviewComponentDescriptor\"],\"cmakeListsPath\":\"node_modules/react-native-screens/android/src/main/jni/CMakeLists.txt\",\"cxxModuleCMakeListsModuleName\":null,\"cxxModuleCMakeListsPath\":null,\"cxxModuleHeaderName\":null,\"isPureCxxDependency\":false}}}}",
         "reasons": [
-          "rncoreAutolinkingAndroid"
+          "rncoreAutolinking"
         ],
-        "hash": "2281fd4bf2f5df3d74410475b29e306b1d40b883",
+        "hash": "fbab7f83229870bffac18c6d2b68762aa9976d6f",
         "debugInfo": {
-          "hash": "2281fd4bf2f5df3d74410475b29e306b1d40b883"
+          "hash": "fbab7f83229870bffac18c6d2b68762aa9976d6f"
         }
       }
     ],
-    "hash": "64edb00dbbb1d97b7289937d39f5dd6d9ea5cacb"
+    "hash": "8993a59e7bed3c6788e1e612b272100625773d0d"
   }
 }

--- a/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
+++ b/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
@@ -34,7 +34,7 @@
 		<key>CFBundleVersion</key>
 		<string>$(CURRENT_PROJECT_VERSION)</string>
 		<key>HOT_UPDATER_FINGERPRINT_HASH</key>
-		<string>375ccd5f2d85d8cb55d7ccf3991032cca7e3c51d</string>
+		<string>8993a59e7bed3c6788e1e612b272100625773d0d</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>NSAppTransportSecurity</key>

--- a/packages/cli-tools/src/createTarGz.spec.ts
+++ b/packages/cli-tools/src/createTarGz.spec.ts
@@ -1,0 +1,49 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import * as tar from "tar";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createTarGzTargetFiles } from "./createTarGz";
+
+const createdDirectories: string[] = [];
+
+describe("createTarGzTargetFiles", () => {
+  afterEach(async () => {
+    await Promise.all(
+      createdDirectories.map((directory) =>
+        fs.rm(directory, { recursive: true, force: true }),
+      ),
+    );
+    createdDirectories.length = 0;
+  });
+
+  it("preserves a POSIX PAX path in a gzip-compressed TAR archive", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-tar-gz-"),
+    );
+    createdDirectories.push(directory);
+
+    const sourcePath = path.join(directory, "asset.bmp");
+    const archivePath = path.join(directory, "bundle.tar.gz");
+    const extractPath = path.join(directory, "extract");
+    const targetName = `assets/${"long-name-".repeat(14)}asset.bmp`;
+    await fs.writeFile(sourcePath, "pax asset");
+
+    await createTarGzTargetFiles({
+      outfile: archivePath,
+      targetFiles: [{ name: targetName, path: sourcePath }],
+    });
+    await fs.mkdir(extractPath, { recursive: true });
+    await tar.extract({
+      cwd: extractPath,
+      file: archivePath,
+      gzip: true,
+    });
+
+    await expect(
+      fs.readFile(path.join(extractPath, targetName), "utf8"),
+    ).resolves.toBe("pax asset");
+  });
+});

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -560,7 +560,8 @@ class BundleFileStorageService(
 
             val resolvedAssets =
                 manifest.assets.keys.associateWith { assetPath ->
-                    RelativePathResolver.resolveInside(bundleDir, assetPath)
+                    RelativePathResolver
+                        .resolveInside(bundleDir, assetPath)
                         ?.takeIf { it.isFile }
                         ?: return null
                 }

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -547,34 +547,27 @@ class BundleFileStorageService(
         return regex.find(currentUrl)?.groupValues?.get(1)
     }
 
-    private fun resolveBundleFile(bundleDir: File): File? {
-        val manifest = readManifestFromBundleDir(bundleDir)
-        val manifestBundlePath =
-            (manifest?.get("assets") as? Map<*, *>)
-                ?.keys
-                ?.mapNotNull { key ->
-                    (key as? String)
-                        ?.trim()
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.takeIf { File(it).name.endsWith(".android.bundle") }
-                }?.singleOrNull()
-
-        if (manifestBundlePath != null) {
-            try {
-                val canonicalBundleDir = bundleDir.canonicalFile
-                val canonicalBundleFile = File(bundleDir, manifestBundlePath).canonicalFile
-                val canonicalBundleDirPath = canonicalBundleDir.path
-                val canonicalBundleFilePath = canonicalBundleFile.path
-                val isWithinBundleDir =
-                    canonicalBundleFilePath == canonicalBundleDirPath ||
-                        canonicalBundleFilePath.startsWith("$canonicalBundleDirPath${File.separator}")
-
-                if (isWithinBundleDir && canonicalBundleFile.isFile) {
-                    return canonicalBundleFile
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to resolve manifest bundle file from ${bundleDir.absolutePath}: ${e.message}")
+    private fun resolveBundleFile(
+        bundleDir: File,
+        expectedBundleId: String? = null,
+    ): File? {
+        val manifestFile = File(bundleDir, "manifest.json")
+        if (manifestFile.exists()) {
+            val manifest = parseBundleManifestFromFile(manifestFile) ?: return null
+            if (expectedBundleId != null && manifest.bundleId != expectedBundleId) {
+                return null
             }
+
+            val resolvedAssets =
+                manifest.assets.keys.associateWith { assetPath ->
+                    RelativePathResolver.resolveInside(bundleDir, assetPath)
+                        ?.takeIf { it.isFile }
+                        ?: return null
+                }
+            return resolvedAssets
+                .filterKeys { assetPath -> File(assetPath).name.endsWith(".android.bundle") }
+                .values
+                .singleOrNull()
         }
 
         return File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
@@ -582,7 +575,7 @@ class BundleFileStorageService(
 
     private fun findBundleFile(bundleId: String): File? {
         val bundleDir = File(getBundleStoreDir(), bundleId)
-        return resolveBundleFile(bundleDir)
+        return resolveBundleFile(bundleDir, bundleId)
     }
 
     private fun getBundleUrlForId(bundleId: String): String? = findBundleFile(bundleId)?.absolutePath
@@ -1090,15 +1083,21 @@ class BundleFileStorageService(
             return null
         }
 
-        val file = File(urlString)
-        val exists = file.exists()
-        Log.d(TAG, "getCachedBundleURL: file exists = $exists at path: $urlString")
-        if (!exists) {
+        val cachedBundleId = extractBundleIdFromCurrentURL()
+        val resolvedBundle = cachedBundleId?.let(::findBundleFile)
+        val isValid =
+            if (cachedBundleId == null) {
+                File(urlString).isFile
+            } else {
+                resolvedBundle != null
+            }
+        Log.d(TAG, "getCachedBundleURL: cached bundle valid = $isValid at path: $urlString")
+        if (!isValid) {
             preferences.setItem("HotUpdaterBundleURL", null)
-            Log.d(TAG, "getCachedBundleURL: file doesn't exist, cleared preference")
+            Log.d(TAG, "getCachedBundleURL: cached bundle is invalid, cleared preference")
             return null
         }
-        return urlString
+        return resolvedBundle?.absolutePath ?: urlString
     }
 
     override fun getFallbackBundleURL(): String = "assets://index.android.bundle"
@@ -1180,7 +1179,7 @@ class BundleFileStorageService(
         val finalBundleDir = File(bundleStoreDir, bundleId)
         if (finalBundleDir.exists()) {
             Log.d(TAG, "Bundle for bundleId $bundleId already exists. Using cached bundle.")
-            val existingBundleFile = resolveBundleFile(finalBundleDir)
+            val existingBundleFile = resolveBundleFile(finalBundleDir, bundleId)
             if (existingBundleFile != null) {
                 // Update last modified time
                 finalBundleDir.setLastModified(System.currentTimeMillis())
@@ -1364,7 +1363,7 @@ class BundleFileStorageService(
                     }
 
                     // 4) Resolve the extracted Android bundle file.
-                    val extractedBundleFile = resolveBundleFile(tmpDir)
+                    val extractedBundleFile = resolveBundleFile(tmpDir, bundleId)
                     if (extractedBundleFile == null) {
                         Log.d("BundleStorage", "Android bundle file could not be resolved in tmpDir.")
                         tempDir.deleteRecursively()
@@ -1403,7 +1402,7 @@ class BundleFileStorageService(
                     }
 
                     // 8) Verify the Android bundle file exists inside finalBundleDir.
-                    val finalBundleFile = resolveBundleFile(finalBundleDir)
+                    val finalBundleFile = resolveBundleFile(finalBundleDir, bundleId)
                     if (finalBundleFile == null) {
                         Log.d("BundleStorage", "Android bundle file could not be resolved in realDir.")
                         tempDir.deleteRecursively()

--- a/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
@@ -48,29 +48,29 @@ class BundleFileStorageServiceTest {
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has no android bundle candidate`() {
+    fun `resolveBundleFile rejects a manifest with missing assets even when root index exists`() {
         val rootDir = temporaryFolder.newFolder("no-android-candidate")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-no-candidate")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeManifest(bundleDir, listOf("index.ios.bundle", "assets/image.png"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has multiple android bundle candidates`() {
+    fun `resolveBundleFile rejects a manifest with multiple android bundle candidates`() {
         val rootDir = temporaryFolder.newFolder("multiple-android-candidates")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-multiple-candidates")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeFile(bundleDir, "foo.android.bundle")
         writeFile(bundleDir, "dist/bar.android.bundle")
         writeManifest(bundleDir, listOf("foo.android.bundle", "dist/bar.android.bundle"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
@@ -122,7 +122,14 @@ class BundleFileStorageServiceTest {
         val service = createService(rootDir, preferences)
 
         val stagingDir = createBundleDir(rootDir, "staging-bundle")
-        writeManifest(stagingDir, listOf("dist/missing.android.bundle"))
+        writeFile(stagingDir, "dist/staging.android.bundle")
+        writeManifest(
+            stagingDir,
+            listOf(
+                "dist/staging.android.bundle",
+                "assets/missing.png",
+            ),
+        )
 
         val stableDir = createBundleDir(rootDir, "stable-bundle")
         val stableBundleFile = writeFile(stableDir, "dist/stable.android.bundle")
@@ -141,7 +148,7 @@ class BundleFileStorageServiceTest {
         val selection = service.prepareLaunch(null)
         val report = service.notifyAppReady()
 
-        assertEquals(stableBundleFile.canonicalFile.absolutePath, selection.bundleUrl)
+        assertEquals(stableBundleFile.absolutePath, selection.bundleUrl)
         assertEquals(stableDir.name, selection.launchedBundleId)
         assertFalse(selection.shouldRollbackOnCrash)
         assertFalse(stagingDir.exists())
@@ -153,7 +160,7 @@ class BundleFileStorageServiceTest {
         assertEquals(stableDir.name, metadata?.stagingBundleId)
         assertNull(metadata?.stableBundleId)
         assertFalse(metadata?.verificationPending ?: true)
-        assertEquals(stableBundleFile.canonicalFile.absolutePath, preferences.getItem("HotUpdaterBundleURL"))
+        assertEquals(stableBundleFile.absolutePath, preferences.getItem("HotUpdaterBundleURL"))
     }
 
     @Test
@@ -416,9 +423,10 @@ class BundleFileStorageServiceTest {
             BundleFileStorageService::class.java.getDeclaredMethod(
                 "resolveBundleFile",
                 File::class.java,
+                String::class.java,
             )
         method.isAccessible = true
-        return method.invoke(service, bundleDir) as File?
+        return method.invoke(service, bundleDir, bundleDir.name) as File?
     }
 
     private fun invokeCanUseManifestDrivenInstall(service: BundleFileStorageService): Boolean {

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -1141,7 +1141,10 @@ class BundleFileStorageService: BundleStorageService {
         let fallbackBundleId = metadata.stableBundleId.flatMap { candidate in
             if case .success(let storeDir) = bundleStoreDir() {
                 let stableBundleDir = (storeDir as NSString).appendingPathComponent(candidate)
-                if case .success(let bundlePath) = findBundleFile(in: stableBundleDir), bundlePath != nil {
+                if case .success(let bundlePath) = findBundleFile(
+                    in: stableBundleDir,
+                    expectedBundleId: candidate
+                ), bundlePath != nil {
                     return candidate
                 }
             }
@@ -1163,7 +1166,10 @@ class BundleFileStorageService: BundleStorageService {
         if let fallbackBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let fallbackBundleDir = (storeDir as NSString).appendingPathComponent(fallbackBundleId)
-            if case .success(let bundlePath) = findBundleFile(in: fallbackBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: fallbackBundleDir,
+                expectedBundleId: fallbackBundleId
+            ), let bundlePath {
                 let _ = setBundleURL(localPath: bundlePath)
             }
         } else {
@@ -1278,8 +1284,44 @@ class BundleFileStorageService: BundleStorageService {
      * @param directoryPath Directory to search in
      * @return Result with path to bundle file or error
      */
-    func findBundleFile(in directoryPath: String) -> Result<String?, Error> {
+    func findBundleFile(
+        in directoryPath: String,
+        expectedBundleId: String? = nil
+    ) -> Result<String?, Error> {
         NSLog("[BundleStorage] Searching for bundle file in directory: \(directoryPath)")
+
+        let manifestPath = (directoryPath as NSString).appendingPathComponent("manifest.json")
+        if fileSystem.fileExists(atPath: manifestPath) {
+            guard let manifest = readManifest(in: directoryPath),
+                  let parsedManifest = parseBundleManifest(from: manifest),
+                  expectedBundleId == nil || parsedManifest.bundleId == expectedBundleId else {
+                return .success(nil)
+            }
+
+            do {
+                var bundlePaths: [String] = []
+                for assetPath in parsedManifest.assets.keys {
+                    let assetURL = try ArchiveExtractionUtilities.extractionURL(
+                        for: assetPath,
+                        destinationRoot: directoryPath
+                    )
+                    guard fileSystem.fileExists(atPath: assetURL.path),
+                          let attributes = try? fileSystem.attributesOfItem(atPath: assetURL.path),
+                          attributes[.type] as? FileAttributeType == .typeRegular else {
+                        return .success(nil)
+                    }
+
+                    let fileName = assetURL.lastPathComponent
+                    if fileName.hasSuffix(".bundle") || fileName == "main.jsbundle" {
+                        bundlePaths.append(assetURL.path)
+                    }
+                }
+
+                return .success(bundlePaths.count == 1 ? bundlePaths[0] : nil)
+            } catch {
+                return .failure(error)
+            }
+        }
 
         let iosBundlePath = (directoryPath as NSString).appendingPathComponent("index.ios.bundle")
         if self.fileSystem.fileExists(atPath: iosBundlePath) {
@@ -1421,12 +1463,39 @@ class BundleFileStorageService: BundleStorageService {
      */
     func getCachedBundleURL() -> URL? {
         do {
-            guard let savedURLString = try self.preferences.getItem(forKey: "HotUpdaterBundleURL"),
-                  let bundleURL = URL(string: savedURLString),
-                  self.fileSystem.fileExists(atPath: bundleURL.path) else {
+            guard let savedURLString = try self.preferences.getItem(forKey: "HotUpdaterBundleURL") else {
                 return nil
             }
-            return bundleURL
+
+            let savedURL = URL(string: savedURLString)
+            let bundleURL = (
+                (savedURL?.isFileURL == true ? savedURL : nil)
+                    ?? URL(fileURLWithPath: savedURLString)
+            ).standardizedFileURL
+            guard self.fileSystem.fileExists(atPath: bundleURL.path),
+                  case .success(let storeDir) = bundleStoreDir() else {
+                return nil
+            }
+
+            let storeURL = URL(fileURLWithPath: storeDir, isDirectory: true).standardizedFileURL
+            let storePrefix = storeURL.path + "/"
+            guard bundleURL.path.hasPrefix(storePrefix),
+                  let bundleId = bundleURL.path
+                    .dropFirst(storePrefix.count)
+                    .split(separator: "/")
+                    .first
+                    .map(String.init) else {
+                return nil
+            }
+
+            let bundleDirectory = storeURL.appendingPathComponent(bundleId).path
+            guard case .success(let resolvedBundlePath) = findBundleFile(
+                in: bundleDirectory,
+                expectedBundleId: bundleId
+            ), let resolvedBundlePath else {
+                return nil
+            }
+            return URL(fileURLWithPath: resolvedBundlePath)
         } catch {
             NSLog("[BundleStorage] Error getting cached bundle URL: \(error.localizedDescription)")
             return nil
@@ -1454,7 +1523,10 @@ class BundleFileStorageService: BundleStorageService {
         if let stagingId = metadata.stagingBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let stagingBundleDir = (storeDir as NSString).appendingPathComponent(stagingId)
-            if case .success(let bundlePath) = findBundleFile(in: stagingBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: stagingBundleDir,
+                expectedBundleId: stagingId
+            ), let bundlePath {
                 return LaunchSelection(
                     bundleURL: URL(fileURLWithPath: bundlePath),
                     launchedBundleId: stagingId,
@@ -1470,7 +1542,10 @@ class BundleFileStorageService: BundleStorageService {
         if let stableId = metadata.stableBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let stableBundleDir = (storeDir as NSString).appendingPathComponent(stableId)
-            if case .success(let bundlePath) = findBundleFile(in: stableBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: stableBundleDir,
+                expectedBundleId: stableId
+            ), let bundlePath {
                 return LaunchSelection(
                     bundleURL: URL(fileURLWithPath: bundlePath),
                     launchedBundleId: stableId,
@@ -1552,7 +1627,10 @@ class BundleFileStorageService: BundleStorageService {
             let finalBundleDir = (storeDir as NSString).appendingPathComponent(bundleId)
             
             if self.fileSystem.fileExists(atPath: finalBundleDir) {
-                let findResult = self.findBundleFile(in: finalBundleDir)
+                let findResult = self.findBundleFile(
+                    in: finalBundleDir,
+                    expectedBundleId: bundleId
+                )
                 switch findResult {
                 case .success(let existingBundlePath):
                     if let bundlePath = existingBundlePath {
@@ -1969,7 +2047,7 @@ class BundleFileStorageService: BundleStorageService {
             let manifestDestination = (tmpDir as NSString).appendingPathComponent("manifest.json")
             try writeManifestFile(targetManifest, to: manifestDestination)
 
-            switch self.findBundleFile(in: tmpDir) {
+            switch self.findBundleFile(in: tmpDir, expectedBundleId: bundleId) {
             case .success(let maybeBundlePath):
                 guard let bundlePathInTmp = maybeBundlePath else {
                     throw BundleStorageError.invalidBundle
@@ -2289,7 +2367,7 @@ class BundleFileStorageService: BundleStorageService {
                 progressHandler: progressHandler,
                 progress: UpdateProgress.bundleValidation
             )
-            switch self.findBundleFile(in: tmpDir) {
+            switch self.findBundleFile(in: tmpDir, expectedBundleId: bundleId) {
             case .success(let maybeBundlePath):
                 if let bundlePathInTmp = maybeBundlePath {
                     NSLog("[BundleStorage] Found valid bundle in tmpDir: \(bundlePathInTmp)")

--- a/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
@@ -54,7 +54,11 @@ struct BundleFileStorageServiceTests {
             bundleId: "stable-bundle"
         )
         try writeBundle(in: stableDirectory, bundleFileName: "main.jsbundle")
-        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+        try writeManifest(
+            in: stableDirectory,
+            bundleId: "stable-bundle",
+            assetPaths: ["main.jsbundle"]
+        )
 
         let stagingDirectory = try createBundleDirectory(
             documentsDirectory: workingDirectory,
@@ -89,6 +93,80 @@ struct BundleFileStorageServiceTests {
         let service = makeStorageService(documentsDirectory: workingDirectory)
 
         #expect(service.canUseManifestDrivenInstall() == false)
+    }
+
+    @Test
+    func prepareLaunchRollsBackBundleWithMissingManifestAsset() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let stableDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "stable-bundle"
+        )
+        try writeBundle(in: stableDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+
+        let stagingDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "staging-bundle"
+        )
+        try writeBundle(in: stagingDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(
+            in: stagingDirectory,
+            bundleId: "staging-bundle",
+            assetPaths: ["index.ios.bundle", "assets/missing.png"]
+        )
+        try writeMetadata(
+            documentsDirectory: workingDirectory,
+            BundleMetadata(
+                isolationKey: testIsolationKey,
+                stableBundleId: "stable-bundle",
+                stagingBundleId: "staging-bundle",
+                verificationPending: true
+            )
+        )
+
+        let selection = service.prepareLaunch(bundle: .main, pendingRecovery: nil)
+
+        #expect(selection.launchedBundleId == "stable-bundle")
+        #expect(FileManager.default.fileExists(atPath: stagingDirectory.path) == false)
+    }
+
+    @Test
+    func getCachedBundleURLValidatesNestedManifestBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let preferences = InMemoryPreferencesService()
+        let service = makeStorageService(
+            documentsDirectory: workingDirectory,
+            preferences: preferences
+        )
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "nested-bundle"
+        )
+        let nestedDirectory = bundleDirectory.appendingPathComponent("dist", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: nestedDirectory,
+            withIntermediateDirectories: true
+        )
+        try writeBundle(in: nestedDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(
+            in: bundleDirectory,
+            bundleId: "nested-bundle",
+            assetPaths: ["dist/index.ios.bundle"]
+        )
+        let bundleURL = nestedDirectory.appendingPathComponent("index.ios.bundle")
+        try preferences.setItem(bundleURL.path, forKey: "HotUpdaterBundleURL")
+
+        #expect(service.getCachedBundleURL() == bundleURL)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1185.\n\n## Summary\n\n- validate the manifest bundle ID and every declared asset before install or launch\n- reject ambiguous platform bundle candidates while retaining legacy no-manifest fallback\n- validate cached nested bundle paths on Android and iOS\n- add native regression tests and TAR.GZ PAX writer coverage\n- run Android JVM unit tests in CI\n\n## Verification\n\n- Full local FixCI: build, type, lint, 2,153 unit tests, 1,455 integration tests\n- Android JVM tests: 40 passed\n- Swift tests: 22 passed