### PR TITLE
fix(react-native): reject incomplete bundle manifests

### DIFF
--- a/.changeset/calm-bundles-check.md
+++ b/.changeset/calm-bundles-check.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Reject incomplete manifest-driven bundles before installing or launching them.

--- a/.github/workflows/integration-android.yml
+++ b/.github/workflows/integration-android.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Library Build
         run: pnpm build
 
+      - name: Android Unit Tests
+        run: cd examples/v0.85.0/android && ./gradlew :hot-updater_react-native:testDebugUnitTest --build-cache
+
       - name: Build Android
         run: cd examples/v0.76.1-new-arch/android && ./gradlew assembleDebug --build-cache && cd ../..
         env:

--- a/e2e/detox/scenario-contract.spec.ts
+++ b/e2e/detox/scenario-contract.spec.ts
@@ -1830,6 +1830,14 @@ describe("Detox scenario contract", () => {
       "assert archive diff marker",
       "assert archive diff stable launch",
     ]);
+    expect(
+      (
+        await controlStepBody(
+          "bspatch-archive-to-diff-ota",
+          "deploy archive base bundle",
+        )
+      ).compressStrategy,
+    ).toBe("tar.gz");
   });
 
   it("keeps bsdiff install phases aligned with Maestro metadata-first assertions", async () => {

--- a/e2e/detox/scenarios/bspatch-archive-to-diff-ota.ts
+++ b/e2e/detox/scenarios/bspatch-archive-to-diff-ota.ts
@@ -8,6 +8,7 @@ export const bspatchArchiveToDiffOtaScenario: DetoxScenarioDefinition = {
       "/e2e/jobs/deploy-bundle",
       {
         channel: "production",
+        compressStrategy: "tar.gz",
         marker: "archive-base-detox",
         mode: "reset",
         safeBundleIds: [],

--- a/examples/v0.85.0/android/app/src/androidTest/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,6 @@
         <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity" android:exported="true"/>
         <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity" android:exported="true"/>
         <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity" android:exported="true"/>
-        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="2f24804ae39e663516c06cc51ca4f987c1bf299b"/>
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="21191dab0da498f9a99e7277c093502d1647686c"/>
     </application>
 </manifest>

--- a/examples/v0.85.0/android/app/src/debug/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning">
-        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="2f24804ae39e663516c06cc51ca4f987c1bf299b"/>
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="21191dab0da498f9a99e7277c093502d1647686c"/>
     </application>
 </manifest>

--- a/examples/v0.85.0/android/app/src/main/AndroidManifest.xml
+++ b/examples/v0.85.0/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,6 @@
                 <data android:scheme="hotupdaterexample"/>
             </intent-filter>
         </activity>
-        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="2f24804ae39e663516c06cc51ca4f987c1bf299b"/>
+        <meta-data android:name="com.hotupdater.FINGERPRINT_HASH" android:value="21191dab0da498f9a99e7277c093502d1647686c"/>
     </application>
 </manifest>

--- a/examples/v0.85.0/fingerprint.json
+++ b/examples/v0.85.0/fingerprint.json
@@ -251,7 +251,7 @@
         "reasons": [
           "rncoreAutolinking"
         ],
-        "hash": "d05ccc290e436a2051f6577b6576c861f5440177",
+        "hash": "7cc28ff7b012230b7b5e85eac206bce70c12d278",
         "debugInfo": {
           "path": "node_modules/@hot-updater/react-native",
           "children": [
@@ -305,7 +305,7 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt",
-                                      "hash": "0d538dad5ff8c758e76ee53a1dfaebc09c814e35"
+                                      "hash": "684dd5c40fcc10fab84f6c0205a946e187565feb"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleMetadata.kt",
@@ -404,16 +404,16 @@
                                       "hash": "37887140bb6a2909fa0f8b214b33fb9299854361"
                                     }
                                   ],
-                                  "hash": "4e4051a591a938dbc8cf3d044eb5cdf2ba87372c"
+                                  "hash": "e0fbd5810b985fc8c49cecd63d8d222603eb675d"
                                 }
                               ],
-                              "hash": "8829baf89671298ad76936c99b191b4e8b0f605f"
+                              "hash": "31ccd3e14bd7fd8b6ed96c2dee39679ed6e1023a"
                             }
                           ],
-                          "hash": "5e7007f1fec2df7293a71f57a2a39ea538422551"
+                          "hash": "f05c079477d9122e6188b04628b6d7acb7e2bfe9"
                         }
                       ],
-                      "hash": "0013dfdf031fd3c3a6b93927d6298ce975391a4c"
+                      "hash": "a3d17aa781a87d37443e7956a9a0954c17c31593"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/newarch",
@@ -489,7 +489,7 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt",
-                                      "hash": "ef6b62b4bf1208b93e78266f6b336178cbea7881"
+                                      "hash": "4bd1fc7a8bb6553dae0f2837917d6615b2e0854a"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/HotUpdaterImplTest.kt",
@@ -512,22 +512,22 @@
                                       "hash": "ce7276d44a1978121e2128edcd9278ce7aa52bd4"
                                     }
                                   ],
-                                  "hash": "5f5945bd356bf49d58c1f55aadec7f9b02bd2735"
+                                  "hash": "ae1202e1da9ed5b601c479b2cf3a24c4039e5099"
                                 }
                               ],
-                              "hash": "e19ce3229d37f2bb8000317b17866164a0932ab1"
+                              "hash": "fed6d7796a44dbf7199f11da5f30488fd845c40f"
                             }
                           ],
-                          "hash": "17a6cdf7abcb2c49b8f980e357cee8b37b36db57"
+                          "hash": "7d8656b35213913d9b5624cc24cb8060dbaa58ac"
                         }
                       ],
-                      "hash": "58e51cac1eb3e9621e7e573472844d017d0b65ec"
+                      "hash": "41023424a10bfc17ff47effc49e2cab149c16ef1"
                     }
                   ],
-                  "hash": "f8fd8f2e54638acb2f1cdf8b1460e4b51ede18dd"
+                  "hash": "3e6bac538c062ab7a7a9c52bbb8cba27b3540353"
                 }
               ],
-              "hash": "144c0855442ca1b581d6e2584e599ab12aeb1a70"
+              "hash": "1ca3adedc50642a16c428325d6500c3cf9dbdc7e"
             },
             {
               "path": "node_modules/@hot-updater/react-native/HotUpdater.podspec",
@@ -556,7 +556,7 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift",
-                          "hash": "e238772f242b5aa69d5ff82865e8808162a8c4c1"
+                          "hash": "0391b673442394b30539c4aa49a3997e56ed9565"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleMetadata.swift",
@@ -643,7 +643,7 @@
                           "hash": "1819cbfc897319e45aeac88691ea325ae7a99d58"
                         }
                       ],
-                      "hash": "4ea770da3f004fa32f2dea8e4fd47a3dc4fa1750"
+                      "hash": "3a90e2c00c23f66b8c78eb72244d836b712afdd1"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Package.swift",
@@ -672,23 +672,23 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift",
-                          "hash": "c55a37bc42f002bf109237705ea1f806ab2819cc"
+                          "hash": "652d56e19b60f83d7efe6158ab23048904ef2daa"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ReleaseCatalogCacheServiceTests.swift",
                           "hash": "2fda0e2e5b61bf19a0e86fa4a7bdaeb12dcf8b92"
                         }
                       ],
-                      "hash": "ed27eb6034cccc19392466a468781640ae38f2d7"
+                      "hash": "12dcb323f967e7ecc695cc855257b1011845c376"
                     }
                   ],
-                  "hash": "1e36de494da10e9f8b43594d358ae018c6ea520b"
+                  "hash": "a9eb02693aa738b1314d02e5d29a2dcfbea3bdf9"
                 }
               ],
-              "hash": "ee496488b8d151e17dfac01d2b400b56b6c5d7c6"
+              "hash": "97b6c7865cc6f9a743e76ba4d6e18fdc08a516c0"
             }
           ],
-          "hash": "d05ccc290e436a2051f6577b6576c861f5440177"
+          "hash": "7cc28ff7b012230b7b5e85eac206bce70c12d278"
         }
       },
       {
@@ -3746,7 +3746,7 @@
         }
       }
     ],
-    "hash": "2f24804ae39e663516c06cc51ca4f987c1bf299b"
+    "hash": "21191dab0da498f9a99e7277c093502d1647686c"
   },
   "android": {
     "sources": [
@@ -4000,7 +4000,7 @@
         "reasons": [
           "rncoreAutolinking"
         ],
-        "hash": "d05ccc290e436a2051f6577b6576c861f5440177",
+        "hash": "7cc28ff7b012230b7b5e85eac206bce70c12d278",
         "debugInfo": {
           "path": "node_modules/@hot-updater/react-native",
           "children": [
@@ -4054,7 +4054,7 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt",
-                                      "hash": "0d538dad5ff8c758e76ee53a1dfaebc09c814e35"
+                                      "hash": "684dd5c40fcc10fab84f6c0205a946e187565feb"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/main/java/com/hotupdater/BundleMetadata.kt",
@@ -4153,16 +4153,16 @@
                                       "hash": "37887140bb6a2909fa0f8b214b33fb9299854361"
                                     }
                                   ],
-                                  "hash": "4e4051a591a938dbc8cf3d044eb5cdf2ba87372c"
+                                  "hash": "e0fbd5810b985fc8c49cecd63d8d222603eb675d"
                                 }
                               ],
-                              "hash": "8829baf89671298ad76936c99b191b4e8b0f605f"
+                              "hash": "31ccd3e14bd7fd8b6ed96c2dee39679ed6e1023a"
                             }
                           ],
-                          "hash": "5e7007f1fec2df7293a71f57a2a39ea538422551"
+                          "hash": "f05c079477d9122e6188b04628b6d7acb7e2bfe9"
                         }
                       ],
-                      "hash": "0013dfdf031fd3c3a6b93927d6298ce975391a4c"
+                      "hash": "a3d17aa781a87d37443e7956a9a0954c17c31593"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/android/src/newarch",
@@ -4238,7 +4238,7 @@
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt",
-                                      "hash": "ef6b62b4bf1208b93e78266f6b336178cbea7881"
+                                      "hash": "4bd1fc7a8bb6553dae0f2837917d6615b2e0854a"
                                     },
                                     {
                                       "path": "node_modules/@hot-updater/react-native/android/src/test/java/com/hotupdater/HotUpdaterImplTest.kt",
@@ -4261,22 +4261,22 @@
                                       "hash": "ce7276d44a1978121e2128edcd9278ce7aa52bd4"
                                     }
                                   ],
-                                  "hash": "5f5945bd356bf49d58c1f55aadec7f9b02bd2735"
+                                  "hash": "ae1202e1da9ed5b601c479b2cf3a24c4039e5099"
                                 }
                               ],
-                              "hash": "e19ce3229d37f2bb8000317b17866164a0932ab1"
+                              "hash": "fed6d7796a44dbf7199f11da5f30488fd845c40f"
                             }
                           ],
-                          "hash": "17a6cdf7abcb2c49b8f980e357cee8b37b36db57"
+                          "hash": "7d8656b35213913d9b5624cc24cb8060dbaa58ac"
                         }
                       ],
-                      "hash": "58e51cac1eb3e9621e7e573472844d017d0b65ec"
+                      "hash": "41023424a10bfc17ff47effc49e2cab149c16ef1"
                     }
                   ],
-                  "hash": "f8fd8f2e54638acb2f1cdf8b1460e4b51ede18dd"
+                  "hash": "3e6bac538c062ab7a7a9c52bbb8cba27b3540353"
                 }
               ],
-              "hash": "144c0855442ca1b581d6e2584e599ab12aeb1a70"
+              "hash": "1ca3adedc50642a16c428325d6500c3cf9dbdc7e"
             },
             {
               "path": "node_modules/@hot-updater/react-native/HotUpdater.podspec",
@@ -4305,7 +4305,7 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift",
-                          "hash": "e238772f242b5aa69d5ff82865e8808162a8c4c1"
+                          "hash": "0391b673442394b30539c4aa49a3997e56ed9565"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Internal/BundleMetadata.swift",
@@ -4392,7 +4392,7 @@
                           "hash": "1819cbfc897319e45aeac88691ea325ae7a99d58"
                         }
                       ],
-                      "hash": "4ea770da3f004fa32f2dea8e4fd47a3dc4fa1750"
+                      "hash": "3a90e2c00c23f66b8c78eb72244d836b712afdd1"
                     },
                     {
                       "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Package.swift",
@@ -4421,23 +4421,23 @@
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift",
-                          "hash": "c55a37bc42f002bf109237705ea1f806ab2819cc"
+                          "hash": "652d56e19b60f83d7efe6158ab23048904ef2daa"
                         },
                         {
                           "path": "node_modules/@hot-updater/react-native/ios/HotUpdater/Test/ReleaseCatalogCacheServiceTests.swift",
                           "hash": "2fda0e2e5b61bf19a0e86fa4a7bdaeb12dcf8b92"
                         }
                       ],
-                      "hash": "ed27eb6034cccc19392466a468781640ae38f2d7"
+                      "hash": "12dcb323f967e7ecc695cc855257b1011845c376"
                     }
                   ],
-                  "hash": "1e36de494da10e9f8b43594d358ae018c6ea520b"
+                  "hash": "a9eb02693aa738b1314d02e5d29a2dcfbea3bdf9"
                 }
               ],
-              "hash": "ee496488b8d151e17dfac01d2b400b56b6c5d7c6"
+              "hash": "97b6c7865cc6f9a743e76ba4d6e18fdc08a516c0"
             }
           ],
-          "hash": "d05ccc290e436a2051f6577b6576c861f5440177"
+          "hash": "7cc28ff7b012230b7b5e85eac206bce70c12d278"
         }
       },
       {
@@ -7495,6 +7495,6 @@
         }
       }
     ],
-    "hash": "2f24804ae39e663516c06cc51ca4f987c1bf299b"
+    "hash": "21191dab0da498f9a99e7277c093502d1647686c"
   }
 }

--- a/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
+++ b/examples/v0.85.0/ios/HotUpdaterExample/Info.plist
@@ -34,7 +34,7 @@
 		<key>CFBundleVersion</key>
 		<string>$(CURRENT_PROJECT_VERSION)</string>
 		<key>HOT_UPDATER_FINGERPRINT_HASH</key>
-		<string>2f24804ae39e663516c06cc51ca4f987c1bf299b</string>
+		<string>21191dab0da498f9a99e7277c093502d1647686c</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>NSAppTransportSecurity</key>

--- a/packages/cli-tools/src/createTarGz.spec.ts
+++ b/packages/cli-tools/src/createTarGz.spec.ts
@@ -1,0 +1,49 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import * as tar from "tar";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createTarGzTargetFiles } from "./createTarGz";
+
+const createdDirectories: string[] = [];
+
+describe("createTarGzTargetFiles", () => {
+  afterEach(async () => {
+    await Promise.all(
+      createdDirectories.map((directory) =>
+        fs.rm(directory, { recursive: true, force: true }),
+      ),
+    );
+    createdDirectories.length = 0;
+  });
+
+  it("preserves a POSIX PAX path in a gzip-compressed TAR archive", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "hot-updater-tar-gz-"),
+    );
+    createdDirectories.push(directory);
+
+    const sourcePath = path.join(directory, "asset.bmp");
+    const archivePath = path.join(directory, "bundle.tar.gz");
+    const extractPath = path.join(directory, "extract");
+    const targetName = `assets/${"long-name-".repeat(14)}asset.bmp`;
+    await fs.writeFile(sourcePath, "pax asset");
+
+    await createTarGzTargetFiles({
+      outfile: archivePath,
+      targetFiles: [{ name: targetName, path: sourcePath }],
+    });
+    await fs.mkdir(extractPath, { recursive: true });
+    await tar.extract({
+      cwd: extractPath,
+      file: archivePath,
+      gzip: true,
+    });
+
+    await expect(
+      fs.readFile(path.join(extractPath, targetName), "utf8"),
+    ).resolves.toBe("pax asset");
+  });
+});

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -652,7 +652,8 @@ class BundleFileStorageService(
 
             val resolvedAssets =
                 manifest.assets.keys.associateWith { assetPath ->
-                    RelativePathResolver.resolveInside(bundleDir, assetPath)
+                    RelativePathResolver
+                        .resolveInside(bundleDir, assetPath)
                         ?.takeIf { it.isFile }
                         ?: return null
                 }

--- a/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/BundleFileStorageService.kt
@@ -639,34 +639,27 @@ class BundleFileStorageService(
         return regex.find(currentUrl)?.groupValues?.get(1)
     }
 
-    private fun resolveBundleFile(bundleDir: File): File? {
-        val manifest = readManifestFromBundleDir(bundleDir)
-        val manifestBundlePath =
-            (manifest?.get("assets") as? Map<*, *>)
-                ?.keys
-                ?.mapNotNull { key ->
-                    (key as? String)
-                        ?.trim()
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.takeIf { File(it).name.endsWith(".android.bundle") }
-                }?.singleOrNull()
-
-        if (manifestBundlePath != null) {
-            try {
-                val canonicalBundleDir = bundleDir.canonicalFile
-                val canonicalBundleFile = File(bundleDir, manifestBundlePath).canonicalFile
-                val canonicalBundleDirPath = canonicalBundleDir.path
-                val canonicalBundleFilePath = canonicalBundleFile.path
-                val isWithinBundleDir =
-                    canonicalBundleFilePath == canonicalBundleDirPath ||
-                        canonicalBundleFilePath.startsWith("$canonicalBundleDirPath${File.separator}")
-
-                if (isWithinBundleDir && canonicalBundleFile.isFile) {
-                    return canonicalBundleFile
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to resolve manifest bundle file from ${bundleDir.absolutePath}: ${e.message}")
+    private fun resolveBundleFile(
+        bundleDir: File,
+        expectedBundleId: String? = null,
+    ): File? {
+        val manifestFile = File(bundleDir, "manifest.json")
+        if (manifestFile.exists()) {
+            val manifest = parseBundleManifestFromFile(manifestFile) ?: return null
+            if (expectedBundleId != null && manifest.bundleId != expectedBundleId) {
+                return null
             }
+
+            val resolvedAssets =
+                manifest.assets.keys.associateWith { assetPath ->
+                    RelativePathResolver.resolveInside(bundleDir, assetPath)
+                        ?.takeIf { it.isFile }
+                        ?: return null
+                }
+            return resolvedAssets
+                .filterKeys { assetPath -> File(assetPath).name.endsWith(".android.bundle") }
+                .values
+                .singleOrNull()
         }
 
         return File(bundleDir, "index.android.bundle").absoluteFile.takeIf { it.isFile }
@@ -674,7 +667,7 @@ class BundleFileStorageService(
 
     private fun findBundleFile(bundleId: String): File? {
         val bundleDir = File(getBundleStoreDir(), bundleId)
-        return resolveBundleFile(bundleDir)
+        return resolveBundleFile(bundleDir, bundleId)
     }
 
     private fun getBundleUrlForId(bundleId: String): String? = findBundleFile(bundleId)?.absolutePath
@@ -1432,15 +1425,21 @@ class BundleFileStorageService(
             return null
         }
 
-        val file = File(urlString)
-        val exists = file.exists()
-        Log.d(TAG, "getCachedBundleURL: file exists = $exists at path: $urlString")
-        if (!exists) {
+        val cachedBundleId = extractBundleIdFromCurrentURL()
+        val resolvedBundle = cachedBundleId?.let(::findBundleFile)
+        val isValid =
+            if (cachedBundleId == null) {
+                File(urlString).isFile
+            } else {
+                resolvedBundle != null
+            }
+        Log.d(TAG, "getCachedBundleURL: cached bundle valid = $isValid at path: $urlString")
+        if (!isValid) {
             preferences.setItem("HotUpdaterBundleURL", null)
-            Log.d(TAG, "getCachedBundleURL: file doesn't exist, cleared preference")
+            Log.d(TAG, "getCachedBundleURL: cached bundle is invalid, cleared preference")
             return null
         }
-        return urlString
+        return resolvedBundle?.absolutePath ?: urlString
     }
 
     override fun getFallbackBundleURL(): String = "assets://index.android.bundle"
@@ -1526,7 +1525,7 @@ class BundleFileStorageService(
         val finalBundleDir = File(bundleStoreDir, bundleId)
         if (finalBundleDir.exists()) {
             Log.d(TAG, "Bundle for bundleId $bundleId already exists. Using cached bundle.")
-            val existingBundleFile = resolveBundleFile(finalBundleDir)
+            val existingBundleFile = resolveBundleFile(finalBundleDir, bundleId)
             if (existingBundleFile != null) {
                 // Update last modified time
                 finalBundleDir.setLastModified(System.currentTimeMillis())
@@ -1710,7 +1709,7 @@ class BundleFileStorageService(
                     }
 
                     // 4) Resolve the extracted Android bundle file.
-                    val extractedBundleFile = resolveBundleFile(tmpDir)
+                    val extractedBundleFile = resolveBundleFile(tmpDir, bundleId)
                     if (extractedBundleFile == null) {
                         Log.d("BundleStorage", "Android bundle file could not be resolved in tmpDir.")
                         tempDir.deleteRecursively()
@@ -1749,7 +1748,7 @@ class BundleFileStorageService(
                     }
 
                     // 8) Verify the Android bundle file exists inside finalBundleDir.
-                    val finalBundleFile = resolveBundleFile(finalBundleDir)
+                    val finalBundleFile = resolveBundleFile(finalBundleDir, bundleId)
                     if (finalBundleFile == null) {
                         Log.d("BundleStorage", "Android bundle file could not be resolved in realDir.")
                         tempDir.deleteRecursively()

--- a/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/BundleFileStorageServiceTest.kt
@@ -48,29 +48,29 @@ class BundleFileStorageServiceTest {
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has no android bundle candidate`() {
+    fun `resolveBundleFile rejects a manifest with missing assets even when root index exists`() {
         val rootDir = temporaryFolder.newFolder("no-android-candidate")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-no-candidate")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeManifest(bundleDir, listOf("index.ios.bundle", "assets/image.png"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
-    fun `resolveBundleFile falls back to root index when manifest has multiple android bundle candidates`() {
+    fun `resolveBundleFile rejects a manifest with multiple android bundle candidates`() {
         val rootDir = temporaryFolder.newFolder("multiple-android-candidates")
         val service = createService(rootDir)
         val bundleDir = createBundleDir(rootDir, "bundle-multiple-candidates")
-        val fallbackBundleFile = writeFile(bundleDir, "index.android.bundle")
+        writeFile(bundleDir, "index.android.bundle")
 
         writeFile(bundleDir, "foo.android.bundle")
         writeFile(bundleDir, "dist/bar.android.bundle")
         writeManifest(bundleDir, listOf("foo.android.bundle", "dist/bar.android.bundle"))
 
-        assertResolvedBundlePath(service, bundleDir, fallbackBundleFile)
+        assertNull(invokeResolveBundleFile(service, bundleDir))
     }
 
     @Test
@@ -122,7 +122,14 @@ class BundleFileStorageServiceTest {
         val service = createService(rootDir, preferences)
 
         val stagingDir = createBundleDir(rootDir, "staging-bundle")
-        writeManifest(stagingDir, listOf("dist/missing.android.bundle"))
+        writeFile(stagingDir, "dist/staging.android.bundle")
+        writeManifest(
+            stagingDir,
+            listOf(
+                "dist/staging.android.bundle",
+                "assets/missing.png",
+            ),
+        )
 
         val stableDir = createBundleDir(rootDir, "stable-bundle")
         val stableBundleFile = writeFile(stableDir, "dist/stable.android.bundle")
@@ -141,7 +148,7 @@ class BundleFileStorageServiceTest {
         val selection = service.prepareLaunch(null)
         val report = service.notifyAppReady()
 
-        assertEquals(stableBundleFile.canonicalFile.absolutePath, selection.bundleUrl)
+        assertEquals(stableBundleFile.absolutePath, selection.bundleUrl)
         assertEquals(stableDir.name, selection.launchedBundleId)
         assertFalse(selection.shouldRollbackOnCrash)
         assertFalse(stagingDir.exists())
@@ -155,7 +162,7 @@ class BundleFileStorageServiceTest {
         assertEquals(stableDir.name, metadata?.stagingBundleId)
         assertNull(metadata?.stableBundleId)
         assertFalse(metadata?.verificationPending ?: true)
-        assertEquals(stableBundleFile.canonicalFile.absolutePath, preferences.getItem("HotUpdaterBundleURL"))
+        assertEquals(stableBundleFile.absolutePath, preferences.getItem("HotUpdaterBundleURL"))
     }
 
     @Test
@@ -694,9 +701,10 @@ class BundleFileStorageServiceTest {
             BundleFileStorageService::class.java.getDeclaredMethod(
                 "resolveBundleFile",
                 File::class.java,
+                String::class.java,
             )
         method.isAccessible = true
-        return method.invoke(service, bundleDir) as File?
+        return method.invoke(service, bundleDir, bundleDir.name) as File?
     }
 
     private fun invokeCanUseManifestDrivenInstall(service: BundleFileStorageService): Boolean {

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -1326,7 +1326,10 @@ class BundleFileStorageService: BundleStorageService {
         let fallbackBundleId = metadata.stableBundleId.flatMap { candidate in
             if case .success(let storeDir) = bundleStoreDir() {
                 let stableBundleDir = (storeDir as NSString).appendingPathComponent(candidate)
-                if case .success(let bundlePath) = findBundleFile(in: stableBundleDir), bundlePath != nil {
+                if case .success(let bundlePath) = findBundleFile(
+                    in: stableBundleDir,
+                    expectedBundleId: candidate
+                ), bundlePath != nil {
                     return candidate
                 }
             }
@@ -1354,7 +1357,10 @@ class BundleFileStorageService: BundleStorageService {
         if let fallbackBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let fallbackBundleDir = (storeDir as NSString).appendingPathComponent(fallbackBundleId)
-            if case .success(let bundlePath) = findBundleFile(in: fallbackBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: fallbackBundleDir,
+                expectedBundleId: fallbackBundleId
+            ), let bundlePath {
                 let _ = setBundleURL(localPath: bundlePath)
             }
         } else {
@@ -1644,8 +1650,44 @@ class BundleFileStorageService: BundleStorageService {
      * @param directoryPath Directory to search in
      * @return Result with path to bundle file or error
      */
-    func findBundleFile(in directoryPath: String) -> Result<String?, Error> {
+    func findBundleFile(
+        in directoryPath: String,
+        expectedBundleId: String? = nil
+    ) -> Result<String?, Error> {
         NSLog("[BundleStorage] Searching for bundle file in directory: \(directoryPath)")
+
+        let manifestPath = (directoryPath as NSString).appendingPathComponent("manifest.json")
+        if fileSystem.fileExists(atPath: manifestPath) {
+            guard let manifest = readManifest(in: directoryPath),
+                  let parsedManifest = parseBundleManifest(from: manifest),
+                  expectedBundleId == nil || parsedManifest.bundleId == expectedBundleId else {
+                return .success(nil)
+            }
+
+            do {
+                var bundlePaths: [String] = []
+                for assetPath in parsedManifest.assets.keys {
+                    let assetURL = try ArchiveExtractionUtilities.extractionURL(
+                        for: assetPath,
+                        destinationRoot: directoryPath
+                    )
+                    guard fileSystem.fileExists(atPath: assetURL.path),
+                          let attributes = try? fileSystem.attributesOfItem(atPath: assetURL.path),
+                          attributes[.type] as? FileAttributeType == .typeRegular else {
+                        return .success(nil)
+                    }
+
+                    let fileName = assetURL.lastPathComponent
+                    if fileName.hasSuffix(".bundle") || fileName == "main.jsbundle" {
+                        bundlePaths.append(assetURL.path)
+                    }
+                }
+
+                return .success(bundlePaths.count == 1 ? bundlePaths[0] : nil)
+            } catch {
+                return .failure(error)
+            }
+        }
 
         let iosBundlePath = (directoryPath as NSString).appendingPathComponent("index.ios.bundle")
         if self.fileSystem.fileExists(atPath: iosBundlePath) {
@@ -1786,12 +1828,39 @@ class BundleFileStorageService: BundleStorageService {
      */
     func getCachedBundleURL() -> URL? {
         do {
-            guard let savedURLString = try self.preferences.getItem(forKey: "HotUpdaterBundleURL"),
-                  let bundleURL = URL(string: savedURLString),
-                  self.fileSystem.fileExists(atPath: bundleURL.path) else {
+            guard let savedURLString = try self.preferences.getItem(forKey: "HotUpdaterBundleURL") else {
                 return nil
             }
-            return bundleURL
+
+            let savedURL = URL(string: savedURLString)
+            let bundleURL = (
+                (savedURL?.isFileURL == true ? savedURL : nil)
+                    ?? URL(fileURLWithPath: savedURLString)
+            ).standardizedFileURL
+            guard self.fileSystem.fileExists(atPath: bundleURL.path),
+                  case .success(let storeDir) = bundleStoreDir() else {
+                return nil
+            }
+
+            let storeURL = URL(fileURLWithPath: storeDir, isDirectory: true).standardizedFileURL
+            let storePrefix = storeURL.path + "/"
+            guard bundleURL.path.hasPrefix(storePrefix),
+                  let bundleId = bundleURL.path
+                    .dropFirst(storePrefix.count)
+                    .split(separator: "/")
+                    .first
+                    .map(String.init) else {
+                return nil
+            }
+
+            let bundleDirectory = storeURL.appendingPathComponent(bundleId).path
+            guard case .success(let resolvedBundlePath) = findBundleFile(
+                in: bundleDirectory,
+                expectedBundleId: bundleId
+            ), let resolvedBundlePath else {
+                return nil
+            }
+            return URL(fileURLWithPath: resolvedBundlePath)
         } catch {
             NSLog("[BundleStorage] Error getting cached bundle URL: \(error.localizedDescription)")
             return nil
@@ -1819,7 +1888,10 @@ class BundleFileStorageService: BundleStorageService {
         if let stagingId = metadata.stagingBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let stagingBundleDir = (storeDir as NSString).appendingPathComponent(stagingId)
-            if case .success(let bundlePath) = findBundleFile(in: stagingBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: stagingBundleDir,
+                expectedBundleId: stagingId
+            ), let bundlePath {
                 return LaunchSelection(
                     bundleURL: URL(fileURLWithPath: bundlePath),
                     launchedBundleId: stagingId,
@@ -1835,7 +1907,10 @@ class BundleFileStorageService: BundleStorageService {
         if let stableId = metadata.stableBundleId,
            case .success(let storeDir) = bundleStoreDir() {
             let stableBundleDir = (storeDir as NSString).appendingPathComponent(stableId)
-            if case .success(let bundlePath) = findBundleFile(in: stableBundleDir), let bundlePath {
+            if case .success(let bundlePath) = findBundleFile(
+                in: stableBundleDir,
+                expectedBundleId: stableId
+            ), let bundlePath {
                 return LaunchSelection(
                     bundleURL: URL(fileURLWithPath: bundlePath),
                     launchedBundleId: stableId,
@@ -1925,7 +2000,10 @@ class BundleFileStorageService: BundleStorageService {
             let finalBundleDir = (storeDir as NSString).appendingPathComponent(bundleId)
             
             if self.fileSystem.fileExists(atPath: finalBundleDir) {
-                let findResult = self.findBundleFile(in: finalBundleDir)
+                let findResult = self.findBundleFile(
+                    in: finalBundleDir,
+                    expectedBundleId: bundleId
+                )
                 switch findResult {
                 case .success(let existingBundlePath):
                     if let bundlePath = existingBundlePath {
@@ -2349,7 +2427,7 @@ class BundleFileStorageService: BundleStorageService {
             let manifestDestination = (tmpDir as NSString).appendingPathComponent("manifest.json")
             try writeManifestFile(targetManifest, to: manifestDestination)
 
-            switch self.findBundleFile(in: tmpDir) {
+            switch self.findBundleFile(in: tmpDir, expectedBundleId: bundleId) {
             case .success(let maybeBundlePath):
                 guard let bundlePathInTmp = maybeBundlePath else {
                     throw BundleStorageError.invalidBundle
@@ -2677,7 +2755,7 @@ class BundleFileStorageService: BundleStorageService {
                 progressHandler: progressHandler,
                 progress: UpdateProgress.bundleValidation
             )
-            switch self.findBundleFile(in: tmpDir) {
+            switch self.findBundleFile(in: tmpDir, expectedBundleId: bundleId) {
             case .success(let maybeBundlePath):
                 if let bundlePathInTmp = maybeBundlePath {
                     NSLog("[BundleStorage] Found valid bundle in tmpDir: \(bundlePathInTmp)")

--- a/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
@@ -54,7 +54,11 @@ struct BundleFileStorageServiceTests {
             bundleId: "stable-bundle"
         )
         try writeBundle(in: stableDirectory, bundleFileName: "main.jsbundle")
-        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+        try writeManifest(
+            in: stableDirectory,
+            bundleId: "stable-bundle",
+            assetPaths: ["main.jsbundle"]
+        )
 
         let stagingDirectory = try createBundleDirectory(
             documentsDirectory: workingDirectory,
@@ -150,7 +154,11 @@ struct BundleFileStorageServiceTests {
             bundleId: "stable-bundle"
         )
         try writeBundle(in: stableDirectory, bundleFileName: "main.jsbundle")
-        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+        try writeManifest(
+            in: stableDirectory,
+            bundleId: "stable-bundle",
+            assetPaths: ["main.jsbundle"]
+        )
 
         let stagingDirectory = try createBundleDirectory(
             documentsDirectory: workingDirectory,
@@ -345,6 +353,80 @@ struct BundleFileStorageServiceTests {
         )
 
         #expect(service.canUseManifestDrivenInstall() == false)
+    }
+
+    @Test
+    func prepareLaunchRollsBackBundleWithMissingManifestAsset() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let stableDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "stable-bundle"
+        )
+        try writeBundle(in: stableDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(in: stableDirectory, bundleId: "stable-bundle")
+
+        let stagingDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "staging-bundle"
+        )
+        try writeBundle(in: stagingDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(
+            in: stagingDirectory,
+            bundleId: "staging-bundle",
+            assetPaths: ["index.ios.bundle", "assets/missing.png"]
+        )
+        try writeMetadata(
+            documentsDirectory: workingDirectory,
+            BundleMetadata(
+                isolationKey: testIsolationKey,
+                stableBundleId: "stable-bundle",
+                stagingBundleId: "staging-bundle",
+                verificationPending: true
+            )
+        )
+
+        let selection = service.prepareLaunch(bundle: .main, pendingRecovery: nil)
+
+        #expect(selection.launchedBundleId == "stable-bundle")
+        #expect(FileManager.default.fileExists(atPath: stagingDirectory.path) == false)
+    }
+
+    @Test
+    func getCachedBundleURLValidatesNestedManifestBundle() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let preferences = InMemoryPreferencesService()
+        let service = makeStorageService(
+            documentsDirectory: workingDirectory,
+            preferences: preferences
+        )
+        let bundleDirectory = try createBundleDirectory(
+            documentsDirectory: workingDirectory,
+            bundleId: "nested-bundle"
+        )
+        let nestedDirectory = bundleDirectory.appendingPathComponent("dist", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: nestedDirectory,
+            withIntermediateDirectories: true
+        )
+        try writeBundle(in: nestedDirectory, bundleFileName: "index.ios.bundle")
+        try writeManifest(
+            in: bundleDirectory,
+            bundleId: "nested-bundle",
+            assetPaths: ["dist/index.ios.bundle"]
+        )
+        let bundleURL = nestedDirectory.appendingPathComponent("index.ios.bundle")
+        try preferences.setItem(bundleURL.path, forKey: "HotUpdaterBundleURL")
+
+        #expect(service.getCachedBundleURL() == bundleURL)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1187.\n\n## Summary\n\n- validate the manifest bundle ID and every declared asset before install or launch\n- reject ambiguous platform bundle candidates while retaining legacy no-manifest fallback\n- validate cached nested bundle paths on Android and iOS\n- add native regression tests and TAR.GZ PAX writer coverage\n- run Android JVM unit tests in CI\n- exercise TAR.GZ in the archive-to-diff device E2E scenario\n\n## Verification\n\n- Full local FixCI: build, type, lint, 2,237 unit tests, 295 integration tests\n- Android JVM tests: 40 passed\n- Swift tests: 36 passed\n- Targeted E2E contracts: 79 passed