### PR TITLE
fix(react-native): handle archive directory entries

### DIFF
--- a/.changeset/calm-tars-rest.md
+++ b/.changeset/calm-tars-rest.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Handle standard trailing slashes on Android archive directory entries without treating them as malicious paths.

--- a/packages/react-native/android/src/main/java/com/hotupdater/RelativePathResolver.kt
+++ b/packages/react-native/android/src/main/java/com/hotupdater/RelativePathResolver.kt
@@ -12,7 +12,8 @@ internal object RelativePathResolver {
             return null
         }
 
-        val components = path.split("/")
+        // Archive directory entries conventionally end with one slash.
+        val components = path.removeSuffix("/").split("/")
         if (components.any { it.isEmpty() || it == "." || it == ".." }) {
             return null
         }

--- a/packages/react-native/android/src/test/java/com/hotupdater/RelativePathResolverTest.kt
+++ b/packages/react-native/android/src/test/java/com/hotupdater/RelativePathResolverTest.kt
@@ -1,0 +1,41 @@
+package com.hotupdater
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class RelativePathResolverTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `resolves a standard archive directory entry ending in a slash`() {
+        val root = temporaryFolder.root
+
+        val resolved = RelativePathResolver.resolveInside(root, "drawable-mdpi/")
+
+        assertEquals(
+            File(root, "drawable-mdpi").canonicalFile,
+            resolved?.canonicalFile,
+        )
+    }
+
+    @Test
+    fun `rejects unsafe archive directory paths ending in a slash`() {
+        val root = temporaryFolder.root
+        val unsafePaths =
+            listOf(
+                "/",
+                "../",
+                "drawable-mdpi/../",
+                "drawable-mdpi//",
+            )
+
+        unsafePaths.forEach { path ->
+            assertNull(path, RelativePathResolver.resolveInside(root, path))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- normalize the single trailing slash used by standard Android archive directory entries
- preserve rejection of absolute paths, traversal components, backslashes, and repeated separators
- add focused regression coverage for valid and unsafe directory paths

## Root cause

TAR directory entries conventionally end in a slash. RelativePathResolver treated the resulting final empty component as unsafe, so tar.br and tar.gz extraction logged normal directory entries as potentially malicious. File entries still extracted because their parent directories were created lazily.

The shared resolver now removes exactly one trailing slash before applying the existing path checks. This also handles ZIP directory entries without relaxing internal empty-component or traversal validation.

Closes #1191

## Verification

- ./gradlew :hot-updater_react-native:testReleaseUnitTest
- pnpm -w lint
- pnpm -w test (164 files, 2152 tests)