### PR TITLE
fix(react-native): preserve nested iOS bundle paths

### DIFF
--- a/.changeset/fuzzy-dots-rest.md
+++ b/.changeset/fuzzy-dots-rest.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Preserve nested iOS bundle paths when installing and resolving cached updates.

--- a/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
+++ b/packages/react-native/ios/HotUpdater/Internal/BundleFileStorageService.swift
@@ -791,7 +791,7 @@ class BundleFileStorageService: BundleStorageService {
     }
 
     private func createInitialMetadata() -> BundleMetadata {
-        let currentBundleId = getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent
+        let currentBundleId = getCachedBundleId()
         return BundleMetadata(
             isolationKey: isolationKey,
             stableBundleId: nil,
@@ -808,7 +808,7 @@ class BundleFileStorageService: BundleStorageService {
     }
 
     private func getActiveBundleId() -> String? {
-        if let cachedBundleId = getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent {
+        if let cachedBundleId = getCachedBundleId() {
             return cachedBundleId
         }
 
@@ -870,12 +870,11 @@ class BundleFileStorageService: BundleStorageService {
     }
 
     func canUseManifestDrivenInstall() -> Bool {
-        guard let currentBundleURL = getCachedBundleURL(),
+        guard let currentBundleId = getCachedBundleId(),
               case .success(let storeDir) = bundleStoreDir() else {
             return false
         }
 
-        let currentBundleId = currentBundleURL.deletingLastPathComponent().lastPathComponent
         let currentBundleDir = (storeDir as NSString).appendingPathComponent(currentBundleId)
         guard fileSystem.fileExists(atPath: currentBundleDir),
               let snapshot = getActiveBundleMetadataSnapshot(),
@@ -1457,6 +1456,58 @@ class BundleFileStorageService: BundleStorageService {
             return .failure(error)
         }
     }
+
+    private func bundleId(for bundleURL: URL, storeDir: String) -> String? {
+        let storeURL = URL(fileURLWithPath: storeDir, isDirectory: true).standardizedFileURL
+        let bundleURL = bundleURL.standardizedFileURL
+        let storePrefix = storeURL.path + "/"
+
+        guard bundleURL.path.hasPrefix(storePrefix) else {
+            return nil
+        }
+
+        return bundleURL.path
+            .dropFirst(storePrefix.count)
+            .split(separator: "/")
+            .first
+            .map(String.init)
+    }
+
+    private func getCachedBundleId() -> String? {
+        guard let bundleURL = getCachedBundleURL(),
+              case .success(let storeDir) = bundleStoreDir() else {
+            return nil
+        }
+
+        return bundleId(for: bundleURL, storeDir: storeDir)
+    }
+
+    func resolveBundlePathAfterMove(
+        _ bundlePath: String,
+        from sourceDirectory: String,
+        to destinationDirectory: String
+    ) throws -> String {
+        let sourceURL = URL(
+            fileURLWithPath: sourceDirectory,
+            isDirectory: true
+        ).standardizedFileURL
+        let bundleURL = URL(fileURLWithPath: bundlePath).standardizedFileURL
+        let sourcePrefix = sourceURL.path + "/"
+
+        guard bundleURL.path.hasPrefix(sourcePrefix) else {
+            throw BundleStorageError.invalidBundle
+        }
+
+        let relativePath = String(bundleURL.path.dropFirst(sourcePrefix.count))
+        guard ArchiveExtractionUtilities.normalizedRelativePath(from: relativePath) == relativePath else {
+            throw BundleStorageError.invalidBundle
+        }
+
+        return try ArchiveExtractionUtilities.extractionURL(
+            for: relativePath,
+            destinationRoot: destinationDirectory
+        ).path
+    }
     
     /**
      * Gets the URL to the cached bundle file if it exists.
@@ -1478,13 +1529,7 @@ class BundleFileStorageService: BundleStorageService {
             }
 
             let storeURL = URL(fileURLWithPath: storeDir, isDirectory: true).standardizedFileURL
-            let storePrefix = storeURL.path + "/"
-            guard bundleURL.path.hasPrefix(storePrefix),
-                  let bundleId = bundleURL.path
-                    .dropFirst(storePrefix.count)
-                    .split(separator: "/")
-                    .first
-                    .map(String.init) else {
+            guard let bundleId = bundleId(for: bundleURL, storeDir: storeDir) else {
                 return nil
             }
 
@@ -1515,7 +1560,7 @@ class BundleFileStorageService: BundleStorageService {
         guard let metadata = loadMetadataOrNull() else {
             return LaunchSelection(
                 bundleURL: getCachedBundleURL() ?? getFallbackBundleURL(bundle: bundle),
-                launchedBundleId: getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent,
+                launchedBundleId: getCachedBundleId(),
                 shouldRollbackOnCrash: false
             )
         }
@@ -1587,7 +1632,7 @@ class BundleFileStorageService: BundleStorageService {
         }
 
         // Get the current bundle ID from the cached bundle URL (exclude fallback bundles)
-        let currentBundleId = self.getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent
+        let currentBundleId = self.getCachedBundleId()
 
         guard let validFileUrl = fileUrl else {
             NSLog("[BundleStorage] fileUrl is nil, resetting bundle URL.")
@@ -1748,7 +1793,7 @@ class BundleFileStorageService: BundleStorageService {
             return
         }
 
-        let currentBundleId = self.getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent
+        let currentBundleId = self.getCachedBundleId()
         let currentBundleDir = currentBundleId.map {
             (storeDir as NSString).appendingPathComponent($0)
         }
@@ -2063,8 +2108,10 @@ class BundleFileStorageService: BundleStorageService {
                     throw BundleStorageError.moveOperationFailed(error)
                 }
 
-                let finalBundlePath = (realDir as NSString).appendingPathComponent(
-                    (bundlePathInTmp as NSString).lastPathComponent
+                let finalBundlePath = try resolveBundlePathAfterMove(
+                    bundlePathInTmp,
+                    from: tmpDir,
+                    to: realDir
                 )
                 switch self.setBundleURL(localPath: finalBundlePath) {
                 case .success:
@@ -2277,7 +2324,7 @@ class BundleFileStorageService: BundleStorageService {
         progressHandler: @escaping (UpdateProgressPayload) -> Void,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
-        let currentBundleId = self.getCachedBundleURL()?.deletingLastPathComponent().lastPathComponent
+        let currentBundleId = self.getCachedBundleId()
         NSLog("[BundleStorage] Processing downloaded file atPath: \(location.path)")
 
         // 1) Ensure the bundle file exists
@@ -2393,7 +2440,11 @@ class BundleFileStorageService: BundleStorageService {
                     }
 
                     // 11) Construct final bundlePath for preferences
-                    let finalBundlePath = (realDir as NSString).appendingPathComponent((bundlePathInTmp as NSString).lastPathComponent)
+                    let finalBundlePath = try resolveBundlePathAfterMove(
+                        bundlePathInTmp,
+                        from: tmpDir,
+                        to: realDir
+                    )
 
                     // 12) Set the bundle URL in preferences (for backwards compatibility)
                     let setResult = self.setBundleURL(localPath: finalBundlePath)

--- a/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
+++ b/packages/react-native/ios/HotUpdater/Test/BundleFileStorageServiceTests.swift
@@ -167,6 +167,39 @@ struct BundleFileStorageServiceTests {
         try preferences.setItem(bundleURL.path, forKey: "HotUpdaterBundleURL")
 
         #expect(service.getCachedBundleURL() == bundleURL)
+        #expect(service.getBundleId() == "nested-bundle")
+        #expect(service.canUseManifestDrivenInstall())
+    }
+
+    @Test
+    func preservesNestedBundlePathAfterDirectoryMove() throws {
+        let workingDirectory = try makeWorkingDirectory()
+        defer {
+            cleanupWorkingDirectory(workingDirectory)
+        }
+
+        let service = makeStorageService(documentsDirectory: workingDirectory)
+        let sourceDirectory = workingDirectory.appendingPathComponent("nested-bundle.tmp")
+        let destinationDirectory = workingDirectory.appendingPathComponent("nested-bundle")
+        let nestedDirectory = sourceDirectory.appendingPathComponent("dist", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: nestedDirectory,
+            withIntermediateDirectories: true
+        )
+        try writeBundle(in: nestedDirectory, bundleFileName: "index.ios.bundle")
+        let sourceBundleURL = nestedDirectory.appendingPathComponent("index.ios.bundle")
+
+        let resolvedPath = try service.resolveBundlePathAfterMove(
+            sourceBundleURL.path,
+            from: sourceDirectory.path,
+            to: destinationDirectory.path
+        )
+
+        #expect(
+            resolvedPath == destinationDirectory
+                .appendingPathComponent("dist/index.ios.bundle")
+                .path
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- resolve cached bundle IDs relative to the bundle store root
- preserve the full nested bundle path when moving staged updates into the bundle store
- cover nested cache identity, manifest-driven installs, and moved bundle paths
- add a patch changeset for `@hot-updater/react-native`

Follow-up to #1188.

## Testing

- `swift test --package-path packages/react-native/ios/HotUpdater` (23 tests, 2 suites)