### PR TITLE
fix: centralize secure runtime dependencies

### DIFF
--- a/.changeset/secure-hono-runtimes.md
+++ b/.changeset/secure-hono-runtimes.md
@@ -1,0 +1,8 @@
+---
+"@hot-updater/aws": patch
+"@hot-updater/cloudflare": patch
+"@hot-updater/firebase": patch
+"@hot-updater/supabase": patch
+---
+
+Use patched Hono versions and pin the Supabase Edge Function runtime import.

--- a/examples-server/hono-dynamodb/package.json
+++ b/examples-server/hono-dynamodb/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "3.1066.0",
-    "@aws-sdk/client-s3": "3.1066.0",
+    "@aws-sdk/client-s3": "catalog:aws",
     "@aws-sdk/lib-dynamodb": "3.1066.0",
     "@hot-updater/core": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -64,7 +64,7 @@
     "jszip": "^3.10.1",
     "picocolors": "1.1.1",
     "tar": "^7.5.16",
-    "verkit": "0.3.2",
+    "verkit": "catalog:",
     "workspace-tools": "^0.41.7"
   },
   "inlinedDependencies": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -70,7 +70,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
     "tw-animate-css": "^1.4.0",
-    "verkit": "0.3.2"
+    "verkit": "catalog:"
   },
   "devDependencies": {
     "@hot-updater/cli-tools": "workspace:*",

--- a/packages/hot-updater/package.json
+++ b/packages/hot-updater/package.json
@@ -85,7 +85,7 @@
     "sql-formatter": "15.6.10",
     "@typescript/native": "npm:typescript@7.0.2",
     "typescript": "npm:@typescript/typescript6@6.0.2",
-    "verkit": "0.3.2"
+    "verkit": "catalog:"
   },
   "peerDependencies": {
     "@expo/fingerprint": "*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -58,7 +58,7 @@
     "@hot-updater/core": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
     "rou3": "0.7.9",
-    "verkit": "0.3.2"
+    "verkit": "catalog:"
   },
   "peerDependencies": {
     "@prisma/client": "*",
@@ -93,6 +93,6 @@
     "kysely-pglite-dialect": "catalog:db",
     "mongodb": "catalog:db",
     "msw": "^2.7.0",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   }
 }

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -61,7 +61,7 @@
     "@aws-sdk/client-dynamodb": "3.1066.0",
     "@aws-sdk/client-iam": "3.1066.0",
     "@aws-sdk/client-lambda": "3.1066.0",
-    "@aws-sdk/client-s3": "3.1066.0",
+    "@aws-sdk/client-s3": "catalog:aws",
     "@aws-sdk/cloudfront-signer": "3.1064.0",
     "@aws-sdk/client-ssm": "3.1066.0",
     "@aws-sdk/client-sts": "3.1066.0",

--- a/plugins/bare/package.json
+++ b/plugins/bare/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/plugins/cloudflare/package.json
+++ b/plugins/cloudflare/package.json
@@ -58,7 +58,7 @@
     "dev": "wrangler dev worker/src/index.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1066.0",
+    "@aws-sdk/client-s3": "catalog:aws",
     "@aws-sdk/lib-storage": "3.1008.0",
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/core": "workspace:*",
@@ -66,7 +66,7 @@
     "@hot-updater/server": "workspace:*",
     "cloudflare": "4.2.0",
     "hono": "catalog:hono",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.13.0",
@@ -79,7 +79,7 @@
     "toml": "^3.0.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "verkit": "0.3.2",
+    "verkit": "catalog:",
     "vitest": "catalog:",
     "wrangler": "^4.69.0",
     "xdg-app-paths": "^8.3.0"

--- a/plugins/expo/package.json
+++ b/plugins/expo/package.json
@@ -32,7 +32,7 @@
     "@hot-updater/bare": "workspace:*",
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/plugins/js/package.json
+++ b/plugins/js/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "verkit": "0.3.2"
+    "verkit": "catalog:"
   },
   "inlinedDependencies": {
     "verkit": "0.3.2"

--- a/plugins/plugin-core/package.json
+++ b/plugins/plugin-core/package.json
@@ -50,7 +50,7 @@
     "@hot-updater/core": "workspace:*",
     "es-toolkit": "^1.32.0",
     "mime": "^4.0.4",
-    "verkit": "0.3.2"
+    "verkit": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/plugins/rock/package.json
+++ b/plugins/rock/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hot-updater/cli-tools": "workspace:*",
     "@hot-updater/plugin-core": "workspace:*",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/plugins/standalone/package.json
+++ b/plugins/standalone/package.json
@@ -51,7 +51,7 @@
     "@types/mime": "^2.0.3",
     "@types/node": "catalog:",
     "msw": "^2.7.0",
-    "verkit": "0.3.2",
+    "verkit": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -954,6 +954,9 @@ describe("resolveEdgeFunctionDenoConfig", () => {
         mime: `npm:mime@${resolvePackageVersion("mime", {
           searchFrom: path.resolve("plugins/plugin-core"),
         })}`,
+        hono: `npm:hono@${resolvePackageVersion("hono", {
+          searchFrom: path.resolve("plugins/supabase"),
+        })}`,
       });
 
       await expect(

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -933,6 +933,10 @@ describe("resolveEdgeFunctionDenoConfig", () => {
       path.join(os.tmpdir(), "hot-updater-supabase-edge-"),
     );
     try {
+      await fs.copyFile(
+        path.resolve("plugins/supabase/supabase/edge-functions/index.ts"),
+        path.join(targetDir, "index.ts"),
+      );
       const result = await resolveEdgeFunctionDenoConfig(targetDir);
 
       expect(result.imports).toEqual({

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -435,6 +435,14 @@ const buildEdgeFunctionImports = async (targetDir: string) => {
     exportName: "./edge",
   });
 
+  const supabasePackageRoot = path.dirname(
+    require.resolve("@hot-updater/supabase/package.json"),
+  );
+  imports.hono = await resolveBareSpecifierImportTarget(
+    "hono",
+    supabasePackageRoot,
+  );
+
   return imports;
 };
 

--- a/plugins/supabase/iac/index.ts
+++ b/plugins/supabase/iac/index.ts
@@ -373,7 +373,10 @@ const resolveBareSpecifierImportTarget = async (
 
 const buildEdgeFunctionImports = async (targetDir: string) => {
   const imports: Record<string, string> = {};
-  const visitedWorkspacePackages = new Set<string>();
+  const vendoredWorkspacePackages = new Map<
+    string,
+    Awaited<ReturnType<typeof prepareVendoredPackageImport>>
+  >();
 
   const addWorkspacePackage = async ({
     importSpecifier,
@@ -385,16 +388,17 @@ const buildEdgeFunctionImports = async (targetDir: string) => {
     exportName: string;
   }) => {
     const visitKey = `${packageName}:${exportName}`;
-    if (visitedWorkspacePackages.has(visitKey)) {
-      return;
+    const existingPackage = vendoredWorkspacePackages.get(visitKey);
+    if (existingPackage) {
+      return existingPackage;
     }
-    visitedWorkspacePackages.add(visitKey);
 
     const vendoredPackage = await prepareVendoredPackageImport({
       targetDir,
       packageName,
       exportName,
     });
+    vendoredWorkspacePackages.set(visitKey, vendoredPackage);
 
     imports[importSpecifier] = vendoredPackage.importMapPath;
 
@@ -422,6 +426,8 @@ const buildEdgeFunctionImports = async (targetDir: string) => {
         vendoredPackage.packageRoot,
       );
     }
+
+    return vendoredPackage;
   };
 
   await addWorkspacePackage({
@@ -429,19 +435,27 @@ const buildEdgeFunctionImports = async (targetDir: string) => {
     packageName: "@hot-updater/server",
     exportName: ".",
   });
-  await addWorkspacePackage({
+  const supabasePackage = await addWorkspacePackage({
     importSpecifier: "@hot-updater/supabase/edge",
     packageName: "@hot-updater/supabase",
     exportName: "./edge",
   });
 
-  const supabasePackageRoot = path.dirname(
-    require.resolve("@hot-updater/supabase/package.json"),
-  );
-  imports.hono = await resolveBareSpecifierImportTarget(
-    "hono",
-    supabasePackageRoot,
-  );
+  const edgeFunctionEntryPath = path.join(targetDir, "index.ts");
+  if (await pathExists(edgeFunctionEntryPath)) {
+    const edgeFunctionSpecifiers = await collectBareImportSpecifiers(
+      edgeFunctionEntryPath,
+    );
+    for (const specifier of edgeFunctionSpecifiers) {
+      if (imports[specifier]) {
+        continue;
+      }
+      imports[specifier] = await resolveBareSpecifierImportTarget(
+        specifier,
+        supabasePackage.packageRoot,
+      );
+    }
+  }
 
   return imports;
 };
@@ -746,10 +760,9 @@ const deployEdgeFunction = async (
     );
   }
   await fs.mkdir(targetDir, { recursive: true });
-  const denoConfig = await resolveEdgeFunctionDenoConfig(targetDir);
-
   const targetPath = path.join(targetDir, "index.ts");
   await fs.writeFile(targetPath, edgeFunctionsCode);
+  const denoConfig = await resolveEdgeFunctionDenoConfig(targetDir);
   await fs.writeFile(
     path.join(targetDir, "deno.json"),
     `${JSON.stringify(denoConfig, null, 2)}\n`,

--- a/plugins/supabase/package.json
+++ b/plugins/supabase/package.json
@@ -61,7 +61,7 @@
     "@hot-updater/server": "workspace:*",
     "@supabase/supabase-js": "catalog:supabase",
     "hono": "catalog:hono",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "catalog:"
   },
   "devDependencies": {
     "@electric-sql/pglite": "catalog:db",

--- a/plugins/supabase/supabase/edge-functions/index.ts
+++ b/plugins/supabase/supabase/edge-functions/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createHotUpdater } from "@hot-updater/server";
 import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase/edge";
-import { Hono } from "npm:hono";
+import { Hono } from "hono";
 
 declare global {
   var HotUpdater: {

--- a/plugins/supabase/supabase/edge-functions/runtime.docker.integration.spec.ts
+++ b/plugins/supabase/supabase/edge-functions/runtime.docker.integration.spec.ts
@@ -13,7 +13,7 @@ import {
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { transformEnv } from "@hot-updater/cli-tools";
+import { resolvePackageVersion, transformEnv } from "@hot-updater/cli-tools";
 import {
   type Bundle,
   NIL_UUID,
@@ -1154,6 +1154,9 @@ const writeSupabaseRuntimeFiles = async ({
       "@hot-updater/supabase/edge": pathToFileURL(
         path.join(runtimeRoot, "hot-updater-supabase-edge.ts"),
       ).href,
+      hono: `npm:hono@${resolvePackageVersion("hono", {
+        searchFrom: path.join(WORKSPACE_ROOT, "plugins/supabase"),
+      })}`,
     },
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  aws:
+    '@aws-sdk/client-s3':
+      specifier: 3.1066.0
+      version: 3.1066.0
   db:
     '@electric-sql/pglite':
       specifier: 0.4.1
@@ -40,6 +44,12 @@ catalogs:
     '@types/node':
       specifier: ^20
       version: 20.19.43
+    uuidv7:
+      specifier: ^1.0.2
+      version: 1.2.1
+    verkit:
+      specifier: 0.3.2
+      version: 0.3.2
     vitest:
       specifier: 4.1.4
       version: 4.1.4
@@ -49,11 +59,8 @@ catalogs:
       version: 14.2.0
   hono:
     '@hono/node-server':
-      specifier: 1.19.11
-      version: 1.19.11
-    hono:
-      specifier: 4.12.9
-      version: 4.12.9
+      specifier: 1.19.17
+      version: 1.19.17
   supabase:
     '@supabase/supabase-js':
       specifier: 2.76.1
@@ -70,7 +77,9 @@ catalogs:
       version: 0.21.6
 
 overrides:
+  '@hono/node-server@1': 1.19.17
   '@smithy/types': 4.16.1
+  hono: 4.12.34
   recharts@3.8.0>es-toolkit: 1.46.0
 
 importers:
@@ -94,7 +103,7 @@ importers:
         version: 0.13.0(@cloudflare/workers-types@4.20260611.1)(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@nx/js':
         specifier: 22.6.3
         version: 22.6.3(@babel/traverse@7.29.7)(nx@22.6.3)
@@ -120,8 +129,8 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.9.3)(babel-plugin-macros@3.1.0)
@@ -362,7 +371,7 @@ importers:
         version: 0.4.1
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -397,8 +406,8 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       hot-updater:
         specifier: workspace:*
         version: link:../../packages/hot-updater
@@ -413,7 +422,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -427,14 +436,14 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
     devDependencies:
       '@aws-sdk/client-dynamodb':
         specifier: 3.1066.0
         version: 3.1066.0
       '@aws-sdk/client-s3':
-        specifier: 3.1066.0
+        specifier: catalog:aws
         version: 3.1066.0
       '@aws-sdk/lib-dynamodb':
         specifier: 3.1066.0
@@ -474,7 +483,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -491,8 +500,8 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       kysely:
         specifier: catalog:db
         version: 0.28.17
@@ -529,7 +538,7 @@ importers:
         version: 0.4.1
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -546,8 +555,8 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       kysely:
         specifier: catalog:db
         version: 0.28.17
@@ -581,7 +590,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -622,8 +631,8 @@ importers:
         specifier: catalog:firebase
         version: 14.2.0
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       hot-updater:
         specifier: workspace:*
         version: link:../../packages/hot-updater
@@ -641,7 +650,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:hono
-        version: 1.19.11(hono@4.12.9)
+        version: 1.19.17(hono@4.12.34)
       '@hot-updater/aws':
         specifier: workspace:*
         version: link:../../plugins/aws
@@ -676,8 +685,8 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       hot-updater:
         specifier: workspace:*
         version: link:../../packages/hot-updater
@@ -1450,7 +1459,7 @@ importers:
         specifier: ^7.5.16
         version: 7.5.16
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
       workspace-tools:
         specifier: ^0.41.7
@@ -1540,7 +1549,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
     devDependencies:
       '@hot-updater/cli-tools':
@@ -1725,7 +1734,7 @@ importers:
         specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
 
   packages/react-native:
@@ -1807,7 +1816,7 @@ importers:
         specifier: 0.7.9
         version: 0.7.9
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
     devDependencies:
       '@electric-sql/pglite':
@@ -1847,7 +1856,7 @@ importers:
         specifier: ^2.7.0
         version: 2.14.6(@types/node@20.19.43)(typescript@7.0.2)
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
 
   packages/test-utils:
@@ -1895,7 +1904,7 @@ importers:
         specifier: 3.1066.0
         version: 3.1066.0
       '@aws-sdk/client-s3':
-        specifier: 3.1066.0
+        specifier: catalog:aws
         version: 3.1066.0
       '@aws-sdk/client-ssm':
         specifier: 3.1066.0
@@ -1928,8 +1937,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
     devDependencies:
       '@hot-updater/core':
         specifier: workspace:*
@@ -1968,7 +1977,7 @@ importers:
         specifier: workspace:*
         version: link:../plugin-core
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
     devDependencies:
       '@types/node':
@@ -2000,7 +2009,7 @@ importers:
   plugins/cloudflare:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.1066.0
+        specifier: catalog:aws
         version: 3.1066.0
       '@aws-sdk/lib-storage':
         specifier: 3.1008.0
@@ -2021,10 +2030,10 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
     devDependencies:
       '@cloudflare/vitest-pool-workers':
@@ -2058,7 +2067,7 @@ importers:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
       vitest:
         specifier: 'catalog:'
@@ -2107,7 +2116,7 @@ importers:
         specifier: workspace:*
         version: link:../plugin-core
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
     devDependencies:
       '@types/node':
@@ -2141,8 +2150,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
     devDependencies:
       '@hot-updater/mock':
         specifier: workspace:*
@@ -2184,7 +2193,7 @@ importers:
         specifier: 'catalog:'
         version: 20.19.43
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
 
   plugins/mock:
@@ -2215,7 +2224,7 @@ importers:
         specifier: ^4.0.4
         version: 4.1.0
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
     devDependencies:
       '@types/node':
@@ -2274,7 +2283,7 @@ importers:
         specifier: workspace:*
         version: link:../plugin-core
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
     devDependencies:
       '@types/node':
@@ -2325,7 +2334,7 @@ importers:
         specifier: ^2.7.0
         version: 2.14.6(@types/node@20.19.43)(typescript@7.0.2)
       verkit:
-        specifier: 0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
       vitest:
         specifier: 'catalog:'
@@ -2349,10 +2358,10 @@ importers:
         specifier: catalog:supabase
         version: 2.76.1
       hono:
-        specifier: catalog:hono
-        version: 4.12.9
+        specifier: 4.12.34
+        version: 4.12.34
       uuidv7:
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.2.1
     devDependencies:
       '@electric-sql/pglite':
@@ -4907,23 +4916,17 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@hot-updater/react-native@file:packages/react-native':
     resolution: {directory: packages/react-native, type: directory}
@@ -12926,12 +12929,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -23273,17 +23272,13 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@1.19.11(hono@4.12.9)':
+  '@hono/node-server@1.19.17(hono@4.12.34)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.34
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
+  '@hono/node-server@2.0.4(hono@4.12.34)':
     dependencies:
-      hono: 4.12.25
-
-  '@hono/node-server@2.0.4(hono@4.12.25)':
-    dependencies:
-      hono: 4.12.25
+      hono: 4.12.34
 
   '@hot-updater/react-native@file:packages/react-native(react-native@0.80.1(@babel/core@7.26.0)(@react-native-community/cli@20.1.0(@typescript/typescript6@6.0.2))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -23969,7 +23964,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.17(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -23979,7 +23974,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -33626,9 +33621,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.25: {}
-
-  hono@4.12.9: {}
+  hono@4.12.34: {}
 
   hookable@6.1.1: {}
 
@@ -41798,11 +41791,11 @@ snapshots:
 
   waku@1.0.0-beta.1(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
-      '@hono/node-server': 2.0.4(hono@4.12.25)
+      '@hono/node-server': 2.0.4(hono@4.12.34)
       '@vitejs/plugin-react': 6.0.2(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitejs/plugin-rsc': 0.5.27(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       dotenv: 17.4.2
-      hono: 4.12.25
+      hono: 4.12.34
       magic-string: 0.30.21
       picocolors: 1.1.1
       react: 19.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ catalogs:
     '@hono/node-server':
       specifier: 1.19.17
       version: 1.19.17
+    hono:
+      specifier: 4.12.34
+      version: 4.12.34
   supabase:
     '@supabase/supabase-js':
       specifier: 2.76.1
@@ -77,9 +80,7 @@ catalogs:
       version: 0.21.6
 
 overrides:
-  '@hono/node-server@1': 1.19.17
   '@smithy/types': 4.16.1
-  hono: 4.12.34
   recharts@3.8.0>es-toolkit: 1.46.0
 
 importers:
@@ -129,7 +130,7 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       jest:
         specifier: ^29.7.0
@@ -406,7 +407,7 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       hot-updater:
         specifier: workspace:*
@@ -436,7 +437,7 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
     devDependencies:
       '@aws-sdk/client-dynamodb':
@@ -500,7 +501,7 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       kysely:
         specifier: catalog:db
@@ -555,7 +556,7 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       kysely:
         specifier: catalog:db
@@ -631,7 +632,7 @@ importers:
         specifier: catalog:firebase
         version: 14.2.0
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       hot-updater:
         specifier: workspace:*
@@ -685,7 +686,7 @@ importers:
         specifier: catalog:tools
         version: 9.5.2
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       hot-updater:
         specifier: workspace:*
@@ -1937,7 +1938,7 @@ importers:
         specifier: 1.0.7
         version: 1.0.7
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
     devDependencies:
       '@hot-updater/core':
@@ -2030,7 +2031,7 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       uuidv7:
         specifier: 'catalog:'
@@ -2150,7 +2151,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
     devDependencies:
       '@hot-updater/mock':
@@ -2358,7 +2359,7 @@ importers:
         specifier: catalog:supabase
         version: 2.76.1
       hono:
-        specifier: 4.12.34
+        specifier: catalog:hono
         version: 4.12.34
       uuidv7:
         specifier: 'catalog:'
@@ -4920,13 +4921,13 @@ packages:
     resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4
 
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4
 
   '@hot-updater/react-native@file:packages/react-native':
     resolution: {directory: packages/react-native, type: directory}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,9 +6,7 @@ packages:
   - examples-server/*
 
 overrides:
-  '@hono/node-server@1': catalog:hono
   '@smithy/types': 4.16.1
-  hono: catalog:hono
   recharts@3.8.0>es-toolkit: 1.46.0
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,9 @@ packages:
   - examples-server/*
 
 overrides:
+  '@hono/node-server@1': catalog:hono
   '@smithy/types': 4.16.1
+  hono: catalog:hono
   recharts@3.8.0>es-toolkit: 1.46.0
 
 allowBuilds:
@@ -31,8 +33,12 @@ allowBuilds:
 
 catalog:
   "@types/node": ^20
+  uuidv7: ^1.0.2
+  verkit: 0.3.2
   vitest: 4.1.4
 catalogs:
+  aws:
+    "@aws-sdk/client-s3": 3.1066.0
   db:
     "@electric-sql/pglite": 0.4.1
     "@libsql/client": 0.15.15
@@ -47,8 +53,8 @@ catalogs:
   firebase:
     firebase-admin: 14.2.0
   hono:
-    "@hono/node-server": 1.19.11
-    hono: 4.12.9
+    "@hono/node-server": 1.19.17
+    hono: 4.12.34
   supabase:
     "@supabase/supabase-js": 2.76.1
   tools:


### PR DESCRIPTION
## Summary

- update Hono to 4.12.34 and `@hono/node-server` 1.x to 1.19.17 through the workspace catalog
- keep the Supabase scaffold on a bare `hono` import and derive its exact `npm:hono@...` import-map target from the scaffold's actual imports
- resolve scaffold dependencies from the installed Supabase package root already discovered during vendoring, without self package lookup or global overrides
- centralize other repeated user-facing runtime dependencies (`uuidv7`, `verkit`, and `@aws-sdk/client-s3`) in catalogs
- leave copied standalone `package.json` manifests out of workspace catalogs

## Rationale

This keeps the `next` branch aligned with #1202. Hono 4.12.34 is the aggregate patched 4.x floor for the advisories affecting the previous catalog entry, and the generated Supabase Edge Function now deploys the exact installed Hono version.

Root overrides are intentionally not used: the published direct catalog entries and generated import map cover the user-facing boundary without changing unrelated MCP/Waku transitive resolution.

## Verification

- `pnpm -w lint`
- `pnpm -w build`
- `pnpm -w test:type`
- `pnpm -w test` (261 files, 2,314 tests)
- Supabase Docker integration tests (11 tests)
- built IAC output generates `npm:hono@4.12.34` from the actual scaffold source
- representative `pnpm pack` checks confirm published manifests contain concrete versions and no `catalog:` or `workspace:` protocols

The remaining `@hono/node-server` 2.x dependency is docs-only and intentionally outside this compatibility-scoped change.

Related to #1201
