### PR TITLE
fix(aws): apply Lambda@Edge memory size on every deploy

### DIFF
--- a/.changeset/lambda-edge-memory-size.md
+++ b/.changeset/lambda-edge-memory-size.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/aws": patch
+---
+
+Apply the Lambda@Edge memory size on every deploy: `createFunction` now sets `MemorySize`, and updates publish a version only after the configuration change is applied.

--- a/plugins/aws/iac/lambdaAsset.ts
+++ b/plugins/aws/iac/lambdaAsset.ts
@@ -1,0 +1,9 @@
+import path from "path";
+
+/**
+ * Resolves the directory holding the bundled Lambda@Edge runtime.
+ * Kept in its own module so it can be mocked in tests without requiring a
+ * built `dist/`.
+ */
+export const resolveLambdaDir = () =>
+  path.dirname(require.resolve("@hot-updater/aws/lambda"));

--- a/plugins/aws/iac/lambdaEdge.spec.ts
+++ b/plugins/aws/iac/lambdaEdge.spec.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLambda = vi.hoisted(() => ({
+  createFunction: vi.fn(),
+  updateFunctionCode: vi.fn(),
+  updateFunctionConfiguration: vi.fn(),
+  publishVersion: vi.fn(),
+  getFunctionConfiguration: vi.fn(),
+}));
+
+const mockPrompt = vi.hoisted(() => ({
+  log: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+  tasks: vi.fn(
+    async (
+      tasks: {
+        title: string;
+        task: (message: (s: string) => void) => unknown;
+      }[],
+    ) => {
+      for (const task of tasks) {
+        await task.task(() => {});
+      }
+    },
+  ),
+}));
+
+vi.mock("@aws-sdk/client-lambda", () => ({
+  Lambda: vi.fn(function Lambda() {
+    return mockLambda;
+  }),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    writeFile: vi.fn(),
+    readFile: vi.fn(async () => Buffer.from("zip")),
+    rm: vi.fn(),
+  },
+}));
+
+vi.mock("./lambdaAsset", () => ({
+  resolveLambdaDir: () => "/node_modules/@hot-updater/aws/lambda",
+}));
+
+vi.mock("@hot-updater/cli-tools", () => ({
+  p: mockPrompt,
+  getCwd: () => "/cwd",
+  copyDirToTmp: async () => ({ tmpDir: "/tmp/lambda", removeTmpDir: vi.fn() }),
+  createZip: vi.fn(),
+  transformEnv: () => "code",
+}));
+
+import { LambdaEdgeDeployer } from "./lambdaEdge";
+
+const config = {
+  bucketName: "bucket",
+  publicKeyId: "key-id",
+  ssmParameterName: "/param",
+  ssmRegion: "us-east-1",
+};
+
+const deploy = () =>
+  new LambdaEdgeDeployer({
+    accessKeyId: "access-key",
+    secretAccessKey: "secret-key",
+  }).deploy("role-arn", "hot-updater-edge", config);
+
+describe("LambdaEdgeDeployer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLambda.getFunctionConfiguration.mockResolvedValue({
+      LastUpdateStatus: "Successful",
+      State: "Active",
+    });
+  });
+
+  it("creates the function with the Lambda@Edge memory size", async () => {
+    mockLambda.createFunction.mockResolvedValue({
+      FunctionArn: "arn:aws:lambda:us-east-1:1:function:hot-updater-edge",
+      Version: "1",
+    });
+
+    const result = await deploy();
+
+    expect(mockLambda.createFunction).toHaveBeenCalledWith(
+      expect.objectContaining({ MemorySize: 256, Timeout: 10 }),
+    );
+    expect(result.functionArn).toBe(
+      "arn:aws:lambda:us-east-1:1:function:hot-updater-edge:1",
+    );
+  });
+
+  it("publishes a version only after the configuration is applied", async () => {
+    const conflict = new Error("Function already exist");
+    conflict.name = "ResourceConflictException";
+    mockLambda.createFunction.mockRejectedValue(conflict);
+    mockLambda.updateFunctionCode.mockResolvedValue({
+      FunctionArn: "arn:aws:lambda:us-east-1:1:function:hot-updater-edge",
+    });
+    mockLambda.updateFunctionConfiguration.mockResolvedValue({});
+    mockLambda.publishVersion.mockResolvedValue({
+      FunctionArn: "arn:aws:lambda:us-east-1:1:function:hot-updater-edge:7",
+      Version: "7",
+    });
+
+    const result = await deploy();
+
+    // The code update must not publish: a published version is an immutable
+    // snapshot and would capture the previous deploy's configuration.
+    expect(mockLambda.updateFunctionCode).toHaveBeenCalledWith(
+      expect.objectContaining({ Publish: false }),
+    );
+    expect(mockLambda.updateFunctionConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({ MemorySize: 256, Timeout: 10 }),
+    );
+    expect(
+      mockLambda.updateFunctionConfiguration.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockLambda.publishVersion.mock.invocationCallOrder[0]);
+    expect(result.functionArn).toBe(
+      "arn:aws:lambda:us-east-1:1:function:hot-updater-edge:7",
+    );
+  });
+
+  it("fails the deploy when the configuration update fails", async () => {
+    const conflict = new Error("Function already exist");
+    conflict.name = "ResourceConflictException";
+    mockLambda.createFunction.mockRejectedValue(conflict);
+    mockLambda.updateFunctionCode.mockResolvedValue({});
+    mockLambda.updateFunctionConfiguration.mockRejectedValue(
+      new Error("InvalidParameterValueException"),
+    );
+
+    await expect(deploy()).rejects.toThrow("InvalidParameterValueException");
+    expect(mockLambda.publishVersion).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/aws/iac/lambdaEdge.ts
+++ b/plugins/aws/iac/lambdaEdge.ts
@@ -10,6 +10,37 @@ import {
   transformEnv,
 } from "@hot-updater/cli-tools";
 
+import { resolveLambdaDir } from "./lambdaAsset";
+
+const LAMBDA_EDGE_MEMORY_SIZE = 256;
+const LAMBDA_EDGE_TIMEOUT = 10;
+
+const waitForFunctionUpdate = async (
+  lambdaClient: Lambda,
+  lambdaName: string,
+) => {
+  while (true) {
+    try {
+      const status = await lambdaClient.getFunctionConfiguration({
+        FunctionName: lambdaName,
+      });
+      if (status.LastUpdateStatus === "Successful") {
+        return;
+      }
+      if (status.LastUpdateStatus === "Failed") {
+        throw new Error(
+          `Lambda update failed: ${status.LastUpdateStatusReason}`,
+        );
+      }
+    } catch (err) {
+      if (!(err instanceof Error && err.name === "ResourceConflictException")) {
+        throw err;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+};
+
 export class LambdaEdgeDeployer {
   private credentials: { accessKeyId: string; secretAccessKey: string };
 
@@ -29,8 +60,7 @@ export class LambdaEdgeDeployer {
   ): Promise<{ lambdaName: string; functionArn: string }> {
     const cwd = getCwd();
 
-    const lambdaPath = require.resolve("@hot-updater/aws/lambda");
-    const lambdaDir = path.dirname(lambdaPath);
+    const lambdaDir = resolveLambdaDir();
     const { tmpDir, removeTmpDir } = await copyDirToTmp(lambdaDir);
 
     // Transform Lambda code with CloudFront key pair details and SSM config
@@ -79,7 +109,8 @@ export class LambdaEdgeDeployer {
               Code: { ZipFile: await fs.readFile(zipFilePath) },
               Description: "Hot Updater Lambda@Edge function",
               Publish: true,
-              Timeout: 10,
+              MemorySize: LAMBDA_EDGE_MEMORY_SIZE,
+              Timeout: LAMBDA_EDGE_TIMEOUT,
             });
             functionArn.arn = createResp.FunctionArn || null;
             functionArn.version = createResp.Version || "1";
@@ -92,51 +123,30 @@ export class LambdaEdgeDeployer {
               message(
                 `Function "${lambdaName}" already exists. Updating function code...`,
               );
-              const updateResp = await lambdaClient.updateFunctionCode({
+              // Publish only after the configuration is applied: a published
+              // version is an immutable snapshot, so publishing here would pin
+              // the previous deploy's memory/timeout.
+              await lambdaClient.updateFunctionCode({
                 FunctionName: lambdaName,
                 ZipFile: await fs.readFile(zipFilePath),
-                Publish: true,
+                Publish: false,
               });
               message("Waiting for Lambda function update to complete...");
-              let isUpdateComplete = false;
-              while (!isUpdateComplete) {
-                try {
-                  const status = await lambdaClient.getFunctionConfiguration({
-                    FunctionName: lambdaName,
-                  });
-                  if (status.LastUpdateStatus === "Successful") {
-                    isUpdateComplete = true;
-                  } else if (status.LastUpdateStatus === "Failed") {
-                    throw new Error(
-                      `Lambda update failed: ${status.LastUpdateStatusReason}`,
-                    );
-                  } else {
-                    await new Promise((resolve) => setTimeout(resolve, 2000));
-                  }
-                } catch (err) {
-                  if (
-                    err instanceof Error &&
-                    err.name === "ResourceConflictException"
-                  ) {
-                    await new Promise((resolve) => setTimeout(resolve, 2000));
-                  } else {
-                    throw err;
-                  }
-                }
-              }
-              try {
-                await lambdaClient.updateFunctionConfiguration({
-                  FunctionName: lambdaName,
-                  MemorySize: 256,
-                  Timeout: 10,
-                });
-              } catch (error) {
-                p.log.error(
-                  `Failed to update Lambda configuration: ${error instanceof Error ? error.message : String(error)}`,
-                );
-              }
-              functionArn.arn = updateResp.FunctionArn || null;
-              functionArn.version = updateResp.Version || "1";
+              await waitForFunctionUpdate(lambdaClient, lambdaName);
+
+              await lambdaClient.updateFunctionConfiguration({
+                FunctionName: lambdaName,
+                MemorySize: LAMBDA_EDGE_MEMORY_SIZE,
+                Timeout: LAMBDA_EDGE_TIMEOUT,
+              });
+              message("Waiting for Lambda configuration update to complete...");
+              await waitForFunctionUpdate(lambdaClient, lambdaName);
+
+              const publishResp = await lambdaClient.publishVersion({
+                FunctionName: lambdaName,
+              });
+              functionArn.arn = publishResp.FunctionArn || null;
+              functionArn.version = publishResp.Version || "1";
             } else {
               if (error instanceof Error) {
                 p.log.error(


### PR DESCRIPTION
Context: I noticed our lambda downgraded back to 128MB, and it's constantly reaching that limit, getting slowed down by constant GC attempts. `createFunction` never passed `MemorySize`, so when I upgraded from 0.29 it created new lambda and it used 128MB by default

Claude:
That branch also published before it reconfigured: `updateFunctionCode` ran with `Publish: true` and `updateFunctionConfiguration` came after. A published version is an immutable snapshot of the configuration at publish time and `updateFunctionConfiguration` only mutates `$LATEST`, so the version handed to CloudFront always carried the previous deploy's memory size. Combined, 256 MB took three deploys to reach traffic