### PR TITLE
fix(cli): restore portable shebang on the CLI entry

### DIFF
--- a/.changeset/portable-cli-shebang.md
+++ b/.changeset/portable-cli-shebang.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Restore the plain `#!/usr/bin/env node` shebang on the CLI entry so Yarn Classic generates a working `hot-updater.cmd` shim on Windows.

--- a/packages/hot-updater/src/cliShebang.spec.ts
+++ b/packages/hot-updater/src/cliShebang.spec.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+describe("cli entry shebang", () => {
+  // Yarn Classic's Windows cmd shim reads the first token after `env` as the
+  // interpreter, so any extra `env` argument becomes the program name.
+  it("passes no extra arguments to /usr/bin/env", () => {
+    const entryPath = path.join(__dirname, "index.ts");
+    const [firstLine] = fs.readFileSync(entryPath, "utf-8").split("\n");
+
+    expect(firstLine).toBe("#!/usr/bin/env node");
+  });
+});

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --
+#!/usr/bin/env node
 import {
   Command,
   InvalidArgumentError,


### PR DESCRIPTION
Fixes #1206

## Problem

`yarn hot-updater init` fails on Windows:

```
$ D:\...\node_modules\.bin\hot-updater init
'-S' is not recognized as an internal or external command,
operable program or batch file.
```

The generated `hot-updater.cmd` shim is malformed:

```
@IF EXIST "%~dp0\-S.exe" (
  "%~dp0\-S.exe"  node -- "%~dp0\..\hot-updater\dist\index.mjs" %*
) ELSE (
  ...
  -S  node -- "%~dp0\..\hot-updater\dist\index.mjs" %*
)
```

## Cause

`packages/hot-updater/src/index.ts` starts with `#!/usr/bin/env -S node --`, and `tsdown` copies that line into `dist/index.mjs` verbatim.

Yarn Classic's bundled cmd-shim parses shebangs with:

```js
/^#!\s*(?:\/usr\/bin\/env)?\s*([^ \t]+)(.*)$/
```

It has no `-S` branch, so it takes `-S` as the program and `node --` as the arguments, which is exactly the broken shim above.

```
"#!/usr/bin/env -S node --"  ->  prog="-S"    args=" node --"
"#!/usr/bin/env node"        ->  prog="node"  args=""
```

npm is unaffected: its cmd-shim has an explicit `(?:-S\s+)?` branch, which is why this only shows up for Yarn Classic users.

## Fix

Restore `#!/usr/bin/env node`. The entry used that form until #1100, where the `-S ...` variant came in alongside unrelated `init` work. Neither extra argument was needed: `-S` only matters when more than one argument follows `env`, and `--` is a no-op before a script path. The repo's other two shebangs (`packages/bsdiff/scripts/wasm-build/build-wasm.mjs`, `e2e/detox/scripts/run.ts`) already use the plain form.

Added `packages/hot-updater/src/cliShebang.spec.ts` so the portable form is not lost again.

## Verification

- `pnpm -w build`, `pnpm -w test` (167 files / 2157 tests), `pnpm -w lint`, and `tsc --noEmit` for `hot-updater` all pass.
- `dist/index.mjs` now emits `#!/usr/bin/env node`, and both `node dist/index.mjs --version` and `./dist/index.mjs --version` print `0.36.6`.
- Reverting only the shebang turns the new test red with the expected assertion failure.
