### PR TITLE
docs: fix critical v1 setup and update guidance

### DIFF
--- a/docs/content/docs/(latest)/build-plugins/expo.mdx
+++ b/docs/content/docs/(latest)/build-plugins/expo.mdx
@@ -63,13 +63,11 @@ npx expo prebuild
 
 ## Expo DOM Components (`use dom`)
 
-> **Note**: This setup is only required for Expo SDK < 55. Expo SDK 55+ includes native `overrideUri` support ([PR #40397](https://github.com/expo/expo/pull/40397)).
-
 Expo DOM components are designed for EAS Update. Hot Updater uses `overrideUri` internally (via Babel plugin) to redirect DOM components to the correct bundle path.
 
 ### Babel plugin
 
-Add the Babel plugin only when you use Expo DOM components:
+Add the Babel plugin when you use Expo DOM components, including on Expo SDK 55+:
 
 ```package-install
 npx expo customize babel.config.js
@@ -89,6 +87,8 @@ module.exports = function (api) {
 ```
 
 ### Apply patch
+
+> **Note**: The patch and persistence steps below are only required for Expo SDK < 55. Expo SDK 55+ includes native `overrideUri` support ([PR #40397](https://github.com/expo/expo/pull/40397)), but still needs the Babel plugin above.
 
 Modify `node_modules/expo/src/dom/dom.types.ts`:
 

--- a/docs/content/docs/(latest)/custom/cli-configuration.mdx
+++ b/docs/content/docs/(latest)/custom/cli-configuration.mdx
@@ -11,13 +11,24 @@ Your CLI configuration (`hot-updater.config.ts`) connects your React Native proj
 
 ## Basic Configuration
 
-Create a `hot-updater.config.ts` file in your React Native project root:
+Install the CLI dependencies in your React Native project:
+
+```package-install
+npm install --save-dev @hot-updater/bare @hot-updater/aws @hot-updater/standalone hot-updater dotenv
+```
+
+Create `.env.hotupdater` in that project with the server's `R2_*` storage values
+and `HOT_UPDATER_ADMIN_TOKEN`, and add it to `.gitignore`. Then create
+`hot-updater.config.ts` in the same project root:
 
 ```typescript title="hot-updater.config.ts"
 import { bare } from "@hot-updater/bare";
 import { s3Storage } from "@hot-updater/aws";
 import { standaloneRepository } from "@hot-updater/standalone";
 import { defineConfig } from "hot-updater";
+import { config } from "dotenv";
+
+config({ path: ".env.hotupdater" });
 
 const adminToken = process.env.HOT_UPDATER_ADMIN_TOKEN;
 if (!adminToken) {
@@ -164,7 +175,7 @@ Mounting `hotUpdater.handlers.admin` exposes the admin contract used by
 
 A Channel referenced by a Release is not empty and cannot be deleted. For the
 complete request and response contract, use the canonical
-[Standalone Repository server contract](../database-plugins/standalone#server-contract).
+[Standalone Repository server contract](/docs/database-plugins/standalone#server-contract).
 The admin routes do not authenticate themselves; protect
 `/hot-updater/admin/*` before mounting `handlers.admin`.
 
@@ -172,12 +183,12 @@ The admin routes do not authenticate themselves; protect
 
 **Choose your build and storage plugins:**
 
-- [Build Plugins](../build-plugins/bare) - React Native CLI, Expo, Re.Pack
-- [Storage Plugins](../storage-plugins/supabase) - AWS S3, Supabase, Firebase, Cloudflare R2
+- [Build Plugins](/docs/build-plugins/bare) - React Native CLI, Expo, Re.Pack
+- [Storage Plugins](/docs/storage-plugins/supabase) - AWS S3, Supabase, Firebase, Cloudflare R2
 
 **Set up your server:**
 
-- [Quick Start Guide](./quick-start) - Set up a server in 5 minutes
-- [Database Adapters](./database/drizzle) - Drizzle, Prisma, Kysely, MongoDB
-- [Server Frameworks](./frameworks/hono) - Hono, Express, Elysia
-- [Overview](./overview) - Learn about the architecture
+- [Quick Start Guide](/docs/custom/quick-start) - Set up a server in 5 minutes
+- [Database Adapters](/docs/custom/database/drizzle) - Drizzle, Prisma, Kysely, MongoDB
+- [Server Frameworks](/docs/custom/frameworks/hono) - Hono, Express, Elysia
+- [Overview](/docs/custom/overview) - Learn about the architecture

--- a/docs/content/docs/(latest)/custom/database/drizzle.mdx
+++ b/docs/content/docs/(latest)/custom/database/drizzle.mdx
@@ -155,6 +155,6 @@ The configuration above enables the update-check routes:
 | GET    | `/hot-updater/artifacts/:targetBundleId/from/:currentBundleId`                                  | Resolve an artifact                    |
 
 `handlers.admin` owns the Bundle, Channel, Release, Release Catalog, and
-database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](../cli-configuration#api-endpoints) for their complete
+database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](/docs/custom/cli-configuration#api-endpoints) for their complete
 request and response contract. These admin routes do not authenticate themselves; keep the fail-closed
 framework middleware described above.

--- a/docs/content/docs/(latest)/custom/database/kysely.mdx
+++ b/docs/content/docs/(latest)/custom/database/kysely.mdx
@@ -147,6 +147,6 @@ The configuration above enables the update-check routes:
 | GET    | `/hot-updater/artifacts/:targetBundleId/from/:currentBundleId`                                  | Resolve an artifact                    |
 
 `handlers.admin` owns the Bundle, Channel, Release, Release Catalog, and
-database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](../cli-configuration#api-endpoints) for their complete
+database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](/docs/custom/cli-configuration#api-endpoints) for their complete
 request and response contract. These admin routes do not authenticate themselves; keep the fail-closed
 framework middleware described above.

--- a/docs/content/docs/(latest)/custom/database/mongodb.mdx
+++ b/docs/content/docs/(latest)/custom/database/mongodb.mdx
@@ -58,10 +58,10 @@ export const hotUpdater = createHotUpdater({
 });
 ```
 
-Set `transactions: true` when MongoDB runs as a replica set or sharded cluster.
-Hot Updater uses transactions to replace a bundle and its patch rows atomically.
-Leave the option disabled only when using a standalone MongoDB server; scalar
-bundle updates remain available, but patch replacement is rejected.
+Run MongoDB as a replica set or sharded cluster and set `transactions: true`.
+v1 Release and Release Catalog changes must commit atomically. With transactions
+disabled, commits with revision expectations or multiple changes are rejected,
+so a standalone MongoDB server cannot support the normal v1 deployment workflow.
 
 ## Schema Generation
 
@@ -130,6 +130,6 @@ The configuration above enables the update-check routes:
 | GET    | `/hot-updater/artifacts/:targetBundleId/from/:currentBundleId`                                  | Resolve an artifact                    |
 
 `handlers.admin` owns the Bundle, Channel, Release, Release Catalog, and
-database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](../cli-configuration#api-endpoints) for their complete
+database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](/docs/custom/cli-configuration#api-endpoints) for their complete
 request and response contract. These admin routes do not authenticate themselves; keep the fail-closed
 framework middleware described above.

--- a/docs/content/docs/(latest)/custom/database/prisma.mdx
+++ b/docs/content/docs/(latest)/custom/database/prisma.mdx
@@ -156,6 +156,6 @@ The configuration above enables the update-check routes:
 | GET    | `/hot-updater/artifacts/:targetBundleId/from/:currentBundleId`                                  | Resolve an artifact                    |
 
 `handlers.admin` owns the Bundle, Channel, Release, Release Catalog, and
-database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](../cli-configuration#api-endpoints) for their complete
+database-commit admin routes under `/hot-updater/admin/*`. See [CLI Configuration](/docs/custom/cli-configuration#api-endpoints) for their complete
 request and response contract. These admin routes do not authenticate themselves; keep the fail-closed
 framework middleware described above.

--- a/docs/content/docs/(latest)/custom/frameworks/elysia.mdx
+++ b/docs/content/docs/(latest)/custom/frameworks/elysia.mdx
@@ -15,7 +15,7 @@ npm install elysia @elysiajs/bearer
 
 ## Setup and Security
 
-Set up a [database adapter](../database/drizzle), generate its Hot Updater
+Set up a [database adapter](/docs/custom/database/drizzle), generate its Hot Updater
 schema, and apply the schema before starting the server.
 
 The recommended self-hosted client policy uses built-in API key authentication
@@ -106,18 +106,23 @@ their feature or storage provider is configured:
 | Admin   | `GET /hot-updater/admin/installations/*`  | Optional Analytics queries                       |
 
 Admin route groups exist only where `handlers.admin` is explicitly mounted.
-See the [Standalone Repository server contract](../../database-plugins/standalone#server-contract)
+See the [Standalone Repository server contract](/docs/database-plugins/standalone#server-contract)
 for the exact admin request and response shapes.
 
 ## React Native Setup
 
-Configure your React Native app to connect to this server.
+For `clientAccess: { type: "api-key" }`, first [create a client API key](/docs/custom/quick-start#bootstrap-the-schema-and-api-key)
+and send it as `x-api-key`. Omit this header only when the server explicitly
+uses `clientAccess: { type: "public" }`; never use the admin token in the app.
 
 ```typescript title="App.tsx"
 import { HotUpdater } from '@hot-updater/react-native';
 
 export default HotUpdater.wrap({
   baseURL: 'http://localhost:3000/hot-updater', // [!code ++]
+  requestHeaders: {
+    'x-api-key': '<API key printed by api-key create>',
+  },
   updateStrategy: 'appVersion', // or "fingerprint" // [!code ++]
   fallbackComponent: ({ progress, status }) => (
     // ... Custom loading UI

--- a/docs/content/docs/(latest)/custom/frameworks/express.mdx
+++ b/docs/content/docs/(latest)/custom/frameworks/express.mdx
@@ -16,7 +16,7 @@ npm install @types/express --save-dev
 
 ## Setup and Security
 
-Set up a [database adapter](../database/drizzle), generate its Hot Updater
+Set up a [database adapter](/docs/custom/database/drizzle), generate its Hot Updater
 schema, and apply the schema before starting the server.
 
 The recommended self-hosted client policy uses built-in API key authentication
@@ -117,18 +117,23 @@ their feature or storage provider is configured:
 | Admin   | `GET /hot-updater/admin/installations/*`  | Optional Analytics queries                       |
 
 Admin route groups exist only where `handlers.admin` is explicitly mounted.
-See the [Standalone Repository server contract](../../database-plugins/standalone#server-contract)
+See the [Standalone Repository server contract](/docs/database-plugins/standalone#server-contract)
 for the exact admin request and response shapes.
 
 ## React Native Setup
 
-Configure your React Native app to connect to this server.
+For `clientAccess: { type: "api-key" }`, first [create a client API key](/docs/custom/quick-start#bootstrap-the-schema-and-api-key)
+and send it as `x-api-key`. Omit this header only when the server explicitly
+uses `clientAccess: { type: "public" }`; never use the admin token in the app.
 
 ```typescript title="App.tsx"
 import { HotUpdater } from '@hot-updater/react-native';
 
 export default HotUpdater.wrap({
   baseURL: 'http://localhost:3000/hot-updater', // [!code ++]
+  requestHeaders: {
+    'x-api-key': '<API key printed by api-key create>',
+  },
   updateStrategy: 'appVersion', // or "fingerprint" // [!code ++]
   fallbackComponent: ({ progress, status }) => (
     // ... Custom loading UI

--- a/docs/content/docs/(latest)/custom/frameworks/hono.mdx
+++ b/docs/content/docs/(latest)/custom/frameworks/hono.mdx
@@ -15,7 +15,7 @@ npm install hono
 
 ## Setup and Security
 
-Set up a [database adapter](../database/drizzle), generate its Hot Updater
+Set up a [database adapter](/docs/custom/database/drizzle), generate its Hot Updater
 schema, and apply the schema before starting the server.
 
 The recommended self-hosted client policy uses built-in API key authentication
@@ -107,18 +107,23 @@ their feature or storage provider is configured:
 | Admin   | `GET /hot-updater/admin/installations/*`  | Optional Analytics queries                       |
 
 Admin route groups exist only where `handlers.admin` is explicitly mounted.
-See the [Standalone Repository server contract](../../database-plugins/standalone#server-contract)
+See the [Standalone Repository server contract](/docs/database-plugins/standalone#server-contract)
 for the exact admin request and response shapes.
 
 ## React Native Setup
 
-Configure your React Native app to connect to this server.
+For `clientAccess: { type: "api-key" }`, first [create a client API key](/docs/custom/quick-start#bootstrap-the-schema-and-api-key)
+and send it as `x-api-key`. Omit this header only when the server explicitly
+uses `clientAccess: { type: "public" }`; never use the admin token in the app.
 
 ```typescript title="App.tsx"
 import { HotUpdater } from '@hot-updater/react-native';
 
 export default HotUpdater.wrap({
   baseURL: 'http://localhost:3000/hot-updater', // [!code ++]
+  requestHeaders: {
+    'x-api-key': '<API key printed by api-key create>',
+  },
   updateStrategy: 'appVersion', // or "fingerprint" // [!code ++]
   fallbackComponent: ({ progress, status }) => (
     // ... Custom loading UI

--- a/docs/content/docs/(latest)/custom/hosting/docker.mdx
+++ b/docs/content/docs/(latest)/custom/hosting/docker.mdx
@@ -97,6 +97,7 @@ export const hotUpdater = createHotUpdater({
         secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
       },
       bucketName: process.env.R2_BUCKET_NAME!,
+      downloadUrlSigningKey: process.env.HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY!,
     }),
   ],
 });
@@ -141,7 +142,9 @@ both to deploy a client-only server.
 
 ## Schema Generation
 
-Generate the Drizzle schema for Hot Updater tables.
+Generate the Drizzle schema for Hot Updater tables. Run these commands in the
+server project with `DATABASE_URL` and the storage environment variables from
+the container configuration below available to the local process as well.
 
 ```bash
 npx hot-updater db generate src/hotUpdater.ts --yes
@@ -166,6 +169,10 @@ export default defineConfig({
 ```bash
 npx drizzle-kit push
 ```
+
+Because this server uses `clientAccess: { type: "api-key" }`, also
+[create a client API key and configure `x-api-key` in the app](/docs/custom/quick-start#bootstrap-the-schema-and-api-key)
+against this same database before the first update check.
 
 ## Dockerfile
 
@@ -220,6 +227,7 @@ Run the container with environment variables.
 docker run -p 3000:3000 \
   -e DATABASE_URL="postgresql://user:password@host:5432/dbname" \
   -e HOT_UPDATER_ADMIN_TOKEN="replace-with-a-secret" \
+  -e HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY="replace-with-a-separate-secret" \
   -e R2_ENDPOINT="https://<account-id>.r2.cloudflarestorage.com" \
   -e R2_ACCESS_KEY_ID="<access-key-id>" \
   -e R2_SECRET_ACCESS_KEY="<secret-access-key>" \
@@ -258,6 +266,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/hot_updater
       HOT_UPDATER_ADMIN_TOKEN: replace-with-a-secret
+      HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY: replace-with-a-separate-secret
       R2_ENDPOINT: https://<account-id>.r2.cloudflarestorage.com
       R2_ACCESS_KEY_ID: <access-key-id>
       R2_SECRET_ACCESS_KEY: <secret-access-key>

--- a/docs/content/docs/(latest)/custom/hosting/vercel.mdx
+++ b/docs/content/docs/(latest)/custom/hosting/vercel.mdx
@@ -43,6 +43,7 @@ your Vercel project settings:
 
 ```dotenv title=".env.local"
 HOT_UPDATER_ADMIN_TOKEN=replace-with-a-secret
+HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY=replace-with-a-separate-secret
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your-access-key-id
 R2_SECRET_ACCESS_KEY=your-secret-access-key
@@ -86,6 +87,7 @@ export const hotUpdater = createHotUpdater({
         secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
       },
       bucketName: process.env.R2_BUCKET_NAME!,
+      downloadUrlSigningKey: process.env.HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY!,
     }),
   ],
 });
@@ -124,7 +126,9 @@ the broader client mount. Omit both to deploy a client-only server.
 
 ## Schema Generation
 
-Generate the Drizzle schema for Hot Updater tables.
+Generate the Drizzle schema for Hot Updater tables. The local command process
+must have `DATABASE_URL` and the storage environment variables above available;
+`hot-updater` does not load `.env.local` automatically.
 
 ```bash
 npx hot-updater db generate src/hotUpdater.ts --yes
@@ -154,6 +158,10 @@ npx vercel env pull .env.local
 npx drizzle-kit push
 ```
 
+Because this server uses `clientAccess: { type: "api-key" }`, also
+[create a client API key and configure `x-api-key` in the app](/docs/custom/quick-start#bootstrap-the-schema-and-api-key)
+against the target Vercel environment's database before the first update check.
+
 ## Development
 
 Run the development server locally.
@@ -166,7 +174,7 @@ Server runs at `http://localhost:3000`.
 
 ## Deploy
 
-Set `HOT_UPDATER_ADMIN_TOKEN`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`,
+Set `HOT_UPDATER_ADMIN_TOKEN`, `HOT_UPDATER_STORAGE_DOWNLOAD_URL_KEY`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`,
 `R2_SECRET_ACCESS_KEY`, and `R2_BUCKET_NAME` in the target Vercel environment.
 
 Deploy to Vercel.

--- a/docs/content/docs/(latest)/custom/overview.mdx
+++ b/docs/content/docs/(latest)/custom/overview.mdx
@@ -15,7 +15,7 @@ npm install @hot-updater/server @hot-updater/aws
 ```
 
 ```package-install
-npm install --save-dev @hot-updater/bare @hot-updater/standalone hot-updater
+npm install --save-dev @hot-updater/bare @hot-updater/aws @hot-updater/standalone hot-updater dotenv
 ```
 
 ## Architecture
@@ -34,11 +34,17 @@ This approach gives you full control over metadata while leveraging reliable clo
 
 Configure your Hot Updater CLI to use the self-hosted database.
 
+In the React Native project, create `.env.hotupdater` with the server's `R2_*`
+storage values and `HOT_UPDATER_ADMIN_TOKEN`, and add it to `.gitignore`.
+
 ```typescript title="hot-updater.config.ts"
 import { bare } from "@hot-updater/bare";
 import { s3Storage } from "@hot-updater/aws";
 import { standaloneRepository } from "@hot-updater/standalone";
 import { defineConfig } from "hot-updater";
+import { config } from "dotenv";
+
+config({ path: ".env.hotupdater" });
 
 const adminToken = process.env.HOT_UPDATER_ADMIN_TOKEN;
 if (!adminToken) {
@@ -183,18 +189,18 @@ This ensures consistency and simplifies configuration. Only use multiple plugins
 
 **Available official plugins:**
 
-- [s3Storage](../storage-plugins/aws) - AWS S3 and Cloudflare R2
-- [supabaseStorage](../storage-plugins/supabase) - Supabase Storage
-- [firebaseStorage](../storage-plugins/firebase) - Firebase Cloud Storage
+- [s3Storage](/docs/storage-plugins/aws) - AWS S3 and Cloudflare R2
+- [supabaseStorage](/docs/storage-plugins/supabase) - Supabase Storage
+- [firebaseStorage](/docs/storage-plugins/firebase) - Firebase Cloud Storage
 
 ## Database Adapters
 
 Start by setting up your database adapter. Choose the ORM that fits your project:
 
-- [Drizzle](./database/drizzle) - TypeScript ORM with SQL-like syntax
-- [Prisma](./database/prisma) - Next-generation ORM with intuitive data modeling
-- [Kysely](./database/kysely) - Type-safe SQL query builder
-- [MongoDB](./database/mongodb) - Native MongoDB driver
+- [Drizzle](/docs/custom/database/drizzle) - TypeScript ORM with SQL-like syntax
+- [Prisma](/docs/custom/database/prisma) - Next-generation ORM with intuitive data modeling
+- [Kysely](/docs/custom/database/kysely) - Type-safe SQL query builder
+- [MongoDB](/docs/custom/database/mongodb) - Native MongoDB driver
 
 Generate and apply the adapter's schema before serving requests. The exact
 workflow differs by adapter: Kysely and MongoDB use `hot-updater db migrate`,
@@ -205,9 +211,9 @@ into `prisma/schema.prisma` before `prisma db push` applies them.
 
 After configuring your database, choose the framework that fits your stack:
 
-- [Hono](./frameworks/hono) - Lightweight Web Standard framework
-- [Express](./frameworks/express) - Popular Node.js framework
-- [Elysia](./frameworks/elysia) - Modern Bun-first framework
+- [Hono](/docs/custom/frameworks/hono) - Lightweight Web Standard framework
+- [Express](/docs/custom/frameworks/express) - Popular Node.js framework
+- [Elysia](/docs/custom/frameworks/elysia) - Modern Bun-first framework
 
 ## Key Features
 

--- a/docs/content/docs/(latest)/custom/quick-start.mdx
+++ b/docs/content/docs/(latest)/custom/quick-start.mdx
@@ -7,20 +7,24 @@ version: "v0.22.0"
 
 ## Installation
 
-Install all required dependencies at once.
+Install the server dependencies in your server project.
 
 ```package-install
 npm install @hot-updater/server @hot-updater/aws hono @hono/node-server kysely better-sqlite3 dotenv
 ```
 
 ```package-install
-npm install --save-dev @hot-updater/bare @hot-updater/standalone hot-updater @types/better-sqlite3 tsx
+npm install --save-dev hot-updater @types/better-sqlite3 tsx
 ```
 
-In your React Native app, install the client package separately:
+In your React Native project, install the client and CLI dependencies:
 
 ```package-install
 npm install @hot-updater/react-native
+```
+
+```package-install
+npm install --save-dev @hot-updater/bare @hot-updater/aws @hot-updater/standalone hot-updater dotenv
 ```
 
 ## Database Setup
@@ -44,7 +48,7 @@ export const db = new Kysely({
 
 ## Hot Updater Configuration
 
-Create the Hot Updater instance with your database adapter and storage plugin (see [Storage Plugins](./overview#storage-plugins)).
+Create the Hot Updater instance with your database adapter and storage plugin (see [Storage Plugins](/docs/custom/overview#storage-plugins)).
 
 ```typescript title="src/hotUpdater.ts"
 import { createHotUpdater } from "@hot-updater/server";
@@ -129,7 +133,7 @@ only where `handlers.admin` is explicitly mounted, and your framework
 middleware must protect every request before that mount. The server example
 above uses Bearer authentication for `/hot-updater/admin/*`.
 Create `.env.hotupdater` with the storage credentials, download URL signing
-key, and admin token used by this example:
+key, and admin token used by this example. Add this file to `.gitignore`:
 
 ```bash
 R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
@@ -176,11 +180,18 @@ Your Hot Updater server is now running at `http://localhost:3000/hot-updater`!
 
 Configure your Hot Updater CLI to connect to this self-hosted server.
 
+Create this configuration in the React Native project. Its `.env.hotupdater`
+must contain the same `R2_*` storage values and `HOT_UPDATER_ADMIN_TOKEN` as the
+server, and must also be excluded from Git.
+
 ```typescript title="hot-updater.config.ts"
 import { bare } from "@hot-updater/bare";
 import { s3Storage } from "@hot-updater/aws";
 import { standaloneRepository } from "@hot-updater/standalone";
 import { defineConfig } from "hot-updater";
+import { config } from "dotenv";
+
+config({ path: ".env.hotupdater" });
 
 const adminToken = process.env.HOT_UPDATER_ADMIN_TOKEN;
 if (!adminToken) {
@@ -272,6 +283,6 @@ its framework authentication remains required.
 
 ## Next Steps
 
-- Configure your CLI to use this server (see [Overview](./overview#cli-configuration))
-- Explore other [Database Adapters](./database/drizzle) (Drizzle, Prisma, MongoDB)
-- Try different [Server Frameworks](./frameworks/hono) (Express, Elysia)
+- Configure your CLI to use this server (see [Overview](/docs/custom/overview#cli-configuration))
+- Explore other [Database Adapters](/docs/custom/database/drizzle) (Drizzle, Prisma, MongoDB)
+- Try different [Server Frameworks](/docs/custom/frameworks/hono) (Express, Elysia)

--- a/docs/content/docs/(latest)/database-plugins/cloudflare.mdx
+++ b/docs/content/docs/(latest)/database-plugins/cloudflare.mdx
@@ -21,7 +21,10 @@ npx hot-updater init
 
 This interactive command will guide you through the setup process. For details on what the init command does, see the [Cloudflare](/docs/managed/cloudflare) documentation.
 
-For manual configuration, use the settings below.
+The settings below connect to an initialized v1 database; they do not create
+its schema. Complete `hot-updater init` first, or apply the SQL migrations in
+the installed `@hot-updater/cloudflare` package's `worker/migrations`
+directory in order. Do not apply v1 migrations to a v0 D1 database.
 
 ## Configuration
 

--- a/docs/content/docs/(latest)/database-plugins/standalone.mdx
+++ b/docs/content/docs/(latest)/database-plugins/standalone.mdx
@@ -13,7 +13,7 @@ connecting to your server.
 <Callout type="info">
 **Building a Self-Hosted Server?**
 
-See the [Self-Hosting (Custom) Guide](../custom/overview) for complete server implementation instructions using `@hot-updater/server` with database adapters (Drizzle, Prisma, Kysely, MongoDB) and frameworks (Hono, Express, Elysia).
+See the [Self-Hosting (Custom) Guide](/docs/custom/overview) for complete server implementation instructions using `@hot-updater/server` with database adapters (Drizzle, Prisma, Kysely, MongoDB) and frameworks (Hono, Express, Elysia).
 
 </Callout>
 
@@ -305,8 +305,8 @@ Releases.
 the console and `standaloneRepository`, and return a paginated JSON body.
 
 Cursor-based pagination is the official contract. `page` is an optional
-positive integer used alongside cursors when the caller needs stable page
-numbers.
+positive integer for page-aligned requests and cannot be combined with
+`after` or `before` in the same request.
 
 Supported query params:
 
@@ -432,8 +432,8 @@ routes are public or require an API key.
 
 ## Next Steps
 
-- [CLI Configuration](../custom/cli-configuration) - Complete CLI configuration guide
-- [Self-Hosting (Custom) Overview](../custom/overview) - Learn about the architecture
-- [Quick Start Guide](../custom/quick-start) - Set up a server in 5 minutes
-- [Database Adapters](../custom/database/drizzle) - Choose your ORM (Drizzle, Prisma, Kysely, MongoDB)
-- [Server Frameworks](../custom/frameworks/hono) - Choose your framework (Hono, Express, Elysia)
+- [CLI Configuration](/docs/custom/cli-configuration) - Complete CLI configuration guide
+- [Self-Hosting (Custom) Overview](/docs/custom/overview) - Learn about the architecture
+- [Quick Start Guide](/docs/custom/quick-start) - Set up a server in 5 minutes
+- [Database Adapters](/docs/custom/database/drizzle) - Choose your ORM (Drizzle, Prisma, Kysely, MongoDB)
+- [Server Frameworks](/docs/custom/frameworks/hono) - Choose your framework (Hono, Express, Elysia)

--- a/docs/content/docs/(latest)/database-plugins/supabase.mdx
+++ b/docs/content/docs/(latest)/database-plugins/supabase.mdx
@@ -20,7 +20,10 @@ npx hot-updater init
 
 This interactive command will guide you through the setup process. For details on what the init command does, see the [Supabase](/docs/managed/supabase) documentation.
 
-For manual configuration, use the settings below.
+The settings below connect to an initialized v1 database; they do not create
+its tables or RPC functions. Complete `hot-updater init` first, or apply the
+SQL migrations from the installed `@hot-updater/supabase` package's
+`supabase/migrations` directory to the selected project before using the plugin.
 
 ## Configuration
 

--- a/docs/content/docs/(latest)/get-started/basic-usage.mdx
+++ b/docs/content/docs/(latest)/get-started/basic-usage.mdx
@@ -93,8 +93,8 @@ export default defineConfig({
 </Callout>
 
 <Callout type="warn">
-  The environment variables in `.env.hotupdater` are used only during deployment, not in
-  your app bundle. However, if you're using `react-native-dotenv`, review the
+  Provider credentials in `.env.hotupdater` belong in the CLI/server configuration,
+  not in your app bundle. If you're using `react-native-dotenv`, review the
   [Security guidelines](/docs/policy/security#plugin-token-protection).
 </Callout>
 
@@ -118,7 +118,7 @@ export default HotUpdater.wrap({
   baseURL: "https://your-update-server-url", // [!code ++]
   updateStrategy: "appVersion", // or "fingerprint" // [!code ++]
   requestHeaders: {
-    // Optional: Add custom headers if needed
+    "x-api-key": "<HOT_UPDATER_API_KEY from init>", // Required for managed providers
   },
   fallbackComponent: ({ progress, status }) => (
     <View
@@ -146,7 +146,11 @@ export default HotUpdater.wrap({
 
 <Callout type="info">
   The update server URL will be provided after running `npx hot-updater init`.
-  Check your terminal output or provider console for the correct URL.
+  Check your terminal output or provider console for the correct URL. Managed
+  providers require the client API key saved as `HOT_UPDATER_API_KEY` in
+  `.env.hotupdater`; supply it through your app's build-time configuration.
+  That file is not automatically loaded into the app. Never use a provider,
+  service-role, or admin credential as the client API key.
 </Callout>
 
 The generated `authorityId` remains private deployment configuration. React

--- a/docs/content/docs/(latest)/get-started/introduction.mdx
+++ b/docs/content/docs/(latest)/get-started/introduction.mdx
@@ -33,7 +33,7 @@ Works with Metro, Re.Pack or any bundler through the plugin system.
 
 ## How It Works
 
-Hot Updater uses a [Plugin System](../concepts/plugin-system) that separates concerns:
+Hot Updater uses a [Plugin System](/docs/concepts/plugin-system) that separates concerns:
 - **Build Plugins**: Handle bundling (Metro, Re.Pack, Expo, Rock)
 - **Storage Plugins**: Store bundles anywhere (S3, R2, Supabase, Firebase)
 - **Database Plugins**: Manage metadata (PostgreSQL, D1, Firestore)

--- a/docs/content/docs/(latest)/guides/bundle-signing.mdx
+++ b/docs/content/docs/(latest)/guides/bundle-signing.mdx
@@ -48,7 +48,7 @@ import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
     npx hot-updater deploy -p ios
     ```
 
-    The Expo config plugin automatically extracts the public key from your private key during `expo prebuild`.
+    The Expo config plugin automatically embeds the public key during `expo prebuild`. The build can use `public-key.pem` without access to the private key.
   </Tab>
 </Tabs>
 
@@ -151,35 +151,25 @@ export default defineConfig({
 
 When you run `expo prebuild`, the plugin:
 1. Reads the signing config
-2. Loads `./keys/public-key.pem` (derived from `privateKeyPath`)
+2. Extracts the public key from the private key, or loads `./keys/public-key.pem` when the private key is unavailable
 3. Embeds it in native files automatically
 
 **No need to run `npx hot-updater keys export-public` manually for Expo projects.**
 
 ### EAS Build
 
-For EAS builds, the Expo plugin needs access to the private key to extract and embed the public key during prebuild. Store the private key as an environment variable:
+EAS prebuild only needs the public key. Keep the private key in the environment that runs `hot-updater deploy`; do not upload it just to build the native app.
 
-#### Using EAS Secrets
-
-```bash
-# Store private key in EAS Secrets
-eas env:create --name HOT_UPDATER_PRIVATE_KEY --value "$(cat keys/private-key.pem)"
-```
-
-The plugin automatically extracts the public key from `HOT_UPDATER_PRIVATE_KEY` during prebuild.
-
-#### Using .easignore (Alternative)
-
-For simpler setup, include the keys directory in EAS builds:
+For `privateKeyPath: "./keys/private-key.pem"`, include only `keys/public-key.pem` in the EAS upload. Copy your existing `.gitignore` rules into `.easignore`, then append these rules ([EAS ignore-file documentation](https://docs.expo.dev/build-reference/easignore/)):
 
 ```txt title=".easignore"
-!/keys
+# Keep your existing ignore rules above
+!/keys/
+/keys/*
+!/keys/public-key.pem
 ```
 
-This tells EAS to include the `keys/` directory even though it's in `.gitignore`. The plugin will use the private key file directly during prebuild.
-
-> **Note**: This approach is especially useful for local EAS builds (`eas build --local`) where you don't need to configure environment variables.
+Leave `signing.enabled: true` and `privateKeyPath` configured. With no `HOT_UPDATER_PRIVATE_KEY` environment variable or private key file in the build, the plugin loads the public key by replacing the `private-key.pem` filename with `public-key.pem`.
 
 #### How It Works
 
@@ -231,9 +221,13 @@ Store keys in:
 
 **Fix**:
 ```bash
-# Enable signing OR remove keys
+# Enable signing to update apps that already contain the public key.
+# To disable verification in a future native release:
 npx hot-updater keys remove
+# Rebuild and release the native app before targeting it with unsigned bundles.
 ```
+
+Removing the key from local native files does not change apps already installed on users' devices; those apps still require signed bundles.
 
 ### PublicKeyNotConfigured Error
 
@@ -257,8 +251,10 @@ npx hot-updater keys export-public --print-only
 
 ## Key Rotation
 
-1. Generate new key pair
+1. Generate a new key pair in a separate directory; retain the old private key while supporting existing native builds
 2. Update `privateKeyPath` in config
 3. Export new public key
 4. Release new app version
-5. Maintain compatibility until users update
+5. Deploy bundles separately for the old and new native builds, using their matching signing keys and non-overlapping app-version or fingerprint targets
+
+Each native build embeds one public key and rejects bundles signed with a different key. Replacing the key does not make existing installs trust the new key.

--- a/docs/content/docs/(latest)/guides/custom-update.mdx
+++ b/docs/content/docs/(latest)/guides/custom-update.mdx
@@ -60,17 +60,29 @@ Call `checkForUpdate` only when your app is ready for the decision.
 
 ```tsx
 async function checkForAppUpdate() {
+  let checkError: Error | null = null;
   const updateInfo = await HotUpdater.checkForUpdate({
     updateStrategy: "appVersion",
+    onError: (error) => {
+      checkError = error;
+    },
   });
 
+  if (checkError) {
+    throw checkError;
+  }
+
   if (!updateInfo) {
-    return { status: "UP_TO_DATE" as const };
+    return { status: "NO_UPDATE" as const };
   }
 
   return updateInfo;
 }
 ```
+
+`null` means no transition was selected, not necessarily that the check
+succeeded. Failed checks can call `onError` and return `null`; development
+checks are skipped. Capture callback errors as above before reporting a result.
 
 Common places to check:
 
@@ -82,8 +94,9 @@ Common places to check:
 
 ## Download and Apply
 
-The return value includes an `updateBundle` helper with all required update
-metadata pre-filled.
+The return value includes an `updateBundle` helper that resolves the artifact
+when needed and preserves the selected transition. Do not pass the result's
+`fileUrl` or `fileHash` to a direct call: both fields are `null` in v1.
 
 ```tsx
 const updateInfo = await HotUpdater.checkForUpdate({
@@ -146,9 +159,17 @@ function SettingsUpdateRow() {
 
     async function prepareUpdate() {
       try {
+        let checkError: Error | null = null;
         const updateInfo = await HotUpdater.checkForUpdate({
           updateStrategy: "appVersion",
+          onError: (error) => {
+            checkError = error;
+          },
         });
+
+        if (checkError) {
+          throw checkError;
+        }
 
         if (!isActive) {
           return;
@@ -203,7 +224,7 @@ function SettingsUpdateRow() {
     appUpdate.status === "checking"
       ? "checking"
       : appUpdate.status === "current"
-        ? "current"
+        ? "no update selected"
         : appUpdate.status === "downloading"
           ? `downloading ${Math.round(progress * 100)}%`
           : appUpdate.status === "ready"
@@ -295,15 +316,24 @@ if (reset) {
 
 ## Error Handling
 
-Wrap your custom flow in one boundary and keep the app usable when an update
-check fails.
+Capture `onError` as well as rejected promises: check failures can call the
+callback and return `null`, so `try/catch` alone does not report every failure.
+Keep the app usable when an update check fails.
 
 ```tsx
 async function runUpdateFlow() {
   try {
+    let checkError: Error | null = null;
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion",
+      onError: (error) => {
+        checkError = error;
+      },
     });
+
+    if (checkError) {
+      throw checkError;
+    }
 
     if (!updateInfo) {
       return;

--- a/docs/content/docs/(latest)/guides/upgrade-to-v1.mdx
+++ b/docs/content/docs/(latest)/guides/upgrade-to-v1.mdx
@@ -10,9 +10,9 @@ Catalogs. The v0 update-check protocol and database layout are not compatible
 with this model.
 
 <Callout type="warn">
-  There is no in-place v0 to v1 infrastructure upgrade. Do not point v1 init at
-  v0 resources. Create new provider resources and ship their endpoint in a new
-  native app build.
+  There is no in-place v0 database or protocol upgrade. Keep v0 metadata and
+  endpoints intact, scaffold v1 alongside them, and ship the v1 endpoint in a
+  new native app build.
 </Callout>
 
 ## Compatibility boundary
@@ -22,7 +22,7 @@ with this model.
 | v0 native app → v0 infrastructure     | Yes       | Keep the old endpoint running while those binaries need OTA updates. |
 | v0 native app → v1 infrastructure     | No        | v1 does not expose the v0 app-version or fingerprint routes.         |
 | v1 native app → v0 infrastructure     | No        | Release Catalog and artifact routes are required.                    |
-| v1 init → existing v0 resources       | No        | Init stops before changing detected v0 resources.                    |
+| v1 init → v0 database layout or endpoint | No      | Use a separate v1 database namespace and endpoint.                    |
 | v1 native app → new v1 infrastructure | Yes       | This is the supported target.                                        |
 
 Do not deliver v1 `@hot-updater/react-native` JavaScript to a v0 native binary
@@ -36,7 +36,7 @@ Record the v0 public endpoint, provider resource identifiers, configuration,
 and credentials. Back up its metadata database. Do not delete or repurpose the
 old resources: installed v0 binaries may still call that endpoint.
 
-### 2. Scaffold v1 with new resources
+### 2. Scaffold v1 alongside v0
 
 Upgrade all `hot-updater` and `@hot-updater/*` packages together, then run:
 
@@ -44,10 +44,16 @@ Upgrade all `hot-updater` and `@hot-updater/*` packages together, then run:
 npx hot-updater init
 ```
 
-Choose new database, storage, function/worker, and CDN resources. If init
-detects a v0 D1 database, Firestore database, Supabase schema, or AWS endpoint,
-it exits without modifying that infrastructure. Select or create different
-resources and rerun init.
+Use a separate v1 database namespace and endpoint. Firebase and Supabase can
+reuse the existing project: v1 uses `hot_updater_v1_*` collections or tables and
+a separate `hot-updater-v1` function. Their init checks the v1 namespace rather
+than rejecting a project merely because it contains v0 data. Cloudflare needs
+a separate D1 database; init rejects a v0 D1 database or an existing v0 endpoint
+instead of upgrading it.
+
+Storage buckets do not have to be new, but preserve the access policies and
+objects still needed by v0. Do not prune shared storage using only the v1
+database while v0 binaries still need those artifacts.
 
 The v1 scaffold starts with an empty Release history. Redeploy the releases you
 want to serve from their source artifacts; v0 policy is not backfilled.

--- a/docs/content/docs/(latest)/policy/app-review.mdx
+++ b/docs/content/docs/(latest)/policy/app-review.mdx
@@ -1,6 +1,6 @@
 ---
 title: "When to Submit Your App for Review"
-description: "`HotUpdater` enables seamless updates to JavaScript (JS) files and assets required by your app, bypassing the app store review process in many cases. However, certain changes, particularly those involving native code (e.g., written in Swift/Objective-C for iOS or Kotlin/Java for Android), require app store review. Below, we outline when you need to submit your app for review and when `HotUpdater` can handle updates independently."
+description: "`HotUpdater` updates JavaScript (JS) files and assets without replacing the native binary. Native changes require a new app build, and every update must comply with the applicable app store policies."
 icon: FileCheck
 ---
 
@@ -20,13 +20,23 @@ icon: FileCheck
    ```
 
 
-## Scenarios Compatible with HotUpdater (No App Store Review)
+## Scenarios Compatible with HotUpdater (No Native Code Changes)
 
-Certain updates can be performed entirely via HotUpdater, allowing you to bypass the app store review process:
+Certain updates can be performed entirely via HotUpdater when they remain compatible with the installed native binary. Technical compatibility does not guarantee that an update can bypass app store review.
+
+<Callout type="warn">
+  JavaScript-only updates are not exempt from store policies. Apple's
+  [App Review Guidelines, including section 2.5.2](https://developer.apple.com/app-store/review/guidelines/#software-requirements),
+  restrict downloaded code that introduces or changes app features or
+  functionality. Google's
+  [Device and Network Abuse policy](https://support.google.com/googleplay/android-developer/answer/16559646?hl=en)
+  also requires runtime-loaded interpreted code to comply with Google Play
+  policies. Review the applicable policies before distributing an OTA update.
+</Callout>
 
 ### JavaScript Code Updates
 
-Updates that only modify JS code can be handled by HotUpdater without review.
+Updates that only modify JS code can be handled by HotUpdater if they are compatible with the installed native binary and comply with store policies.
 
 ```tsx
    export default function App() {
@@ -61,23 +71,13 @@ Updates that involve only JS library changes are compatible with HotUpdater:
 
 ## Understanding HotUpdater Package Versioning
 
-The HotUpdater versioning system helps determine whether app store review is necessary:
-| **Version Type** | **Example**       | **Changes**                                                                 | **Review Required?**        |
-|-------------------|-------------------|-----------------------------------------------------------------------------|-----------------------------|
-| Patch Version     | `0.5.10 → 0.5.11` | Only JS logic is updated.                                                  | No                          |
-| Minor Version     | `0.5.10 → 0.6.0` | Updates include JS changes and minor optimizations in the native code.     | Yes                         |
-| Major Version     | `0.5.10 → 1.0.0` | Significant changes to native code, often involving feature enhancements.  | Yes                         |
+The package version number does not determine native compatibility or app store review requirements. Even a patch release of `@hot-updater/react-native` can include native changes.
 
-If the version change only affects the `0.5.x` part of the package (patch version), you can update the `hot-updater` package without requiring an app store review, as the updates are limited to JS logic. However, if the `0.x.0` portion changes (major or minor version), it indicates changes in the native code. In these cases, the app must go through the app store review process.
-
-### Key Notes on Versioning
--	Patch Versions (x.x.Patch): Updates limited to JS logic (e.g., bug fixes or performance improvements). No app store review required.
--	Minor Versions (x.Minor.x): May include minor changes to native code, requiring app store review.
--	Major Versions (Major.x.x): Introduce significant updates to native code, always requiring app store review.
+Check the release notes and native dependency changes before upgrading. Changes to the native runtime require a new native build distributed through the app store; an OTA bundle cannot install those changes. JS-only changes still need to be compatible with the installed runtime and comply with store policies.
 
 ### Summary
 
 To ensure a smooth update process:
--	Use HotUpdater for JS updates and asset changes to avoid app store reviews.
+-	Use HotUpdater for native-compatible JS updates and asset changes that comply with store policies.
 -	Submit your app for review when native code changes or third-party libraries affecting native code are integrated.
--	Follow HotUpdater versioning guidelines to determine when a review is required.
+-	Check actual native changes and current store policies, not only the package version number.

--- a/docs/content/docs/(latest)/policy/security.mdx
+++ b/docs/content/docs/(latest)/policy/security.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 
 ## Clarification
 
-The `hot-updater.config.ts` file is not included in the app’s build. Instead, it serves as a configuration layer specifically for communicating with the `hot-updater` CLI. As a result, sensitive tokens defined in this file are not part of the distributed application code.
+The `hot-updater.config.ts` file is not included in the app’s build. Instead, it serves as a configuration layer specifically for communicating with the `hot-updater` CLI. Sensitive tokens kept in this configuration are not part of the distributed application code unless you separately import or inject them into the app.
 
 What is actually included in the app’s build is as follows:
 ```ts
@@ -47,15 +47,18 @@ import { HotUpdater } from "@hot-updater/react-native";
 export default HotUpdater.wrap({
   baseURL: "https://<your-update-server-url>",
   updateStrategy: "appVersion", // or "fingerprint",
+  requestHeaders: {
+    "x-api-key": "<client API key>", // Required by managed providers
+  },
 });
 ```
 
-Here, the source URL is included in the app code, but sensitive environment variables, such as `HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY` tokens, are not bundled.
+Here, `baseURL` and the client API key are included in the app code. An embedded client API key can be extracted; it controls OTA reads and Analytics writes, not admin access. Provider credentials such as `HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY` must stay in the CLI/server configuration and must never be used as the client API key. See [API key authentication](/docs/custom/api-key-authentication#security-boundary).
 
 ## Potential Token Exposure
 
 <Callout type="warn">
-If you're **not** using react-native-dotenv, tokens won't be included in your app by default. This is a guideline for projects using react-native-dotenv.
+Hot Updater does not bundle CLI credentials by default, but any environment-variable inliner or native key manager can expose values that you include in the app. This risk is not limited to react-native-dotenv.
 
 Using tools like react-native-dotenv can expose sensitive tokens in your app build. To avoid this, only include non-sensitive or publicly safe variables in your configuration.
 </Callout>
@@ -87,4 +90,4 @@ module.exports = {
 1. Restrict Exposure: Only include environment variables that are safe for public access in your app build.
 2. Use Whitelists: Use tools like react-native-dotenv to define a whitelist of allowed environment variables.
 3. Keep Sensitive Data Out of Builds: Store sensitive data securely on your server or backend, and ensure it is only accessed during server-side operations.
-4. Use `react-native-keys` to manage keys.
+4. Do not rely on `react-native-keys` or another client-side key manager to keep provider credentials, admin tokens, or signing private keys secret in a distributed app.

--- a/docs/content/docs/(latest)/react-native-api/addListener.mdx
+++ b/docs/content/docs/(latest)/react-native-api/addListener.mdx
@@ -5,7 +5,7 @@ icon: Headphones
 ---
 
 <Callout type="warn">
-For progress UI, prefer [useHotUpdaterStore](./useHotUpdaterStore). Use
+For progress UI, prefer [useHotUpdaterStore](/docs/react-native-api/useHotUpdaterStore). Use
 `addListener` when you need the raw event, such as analytics, logs, or custom
 side effects.
 </Callout>

--- a/docs/content/docs/(latest)/react-native-api/checkForUpdate.mdx
+++ b/docs/content/docs/(latest)/react-native-api/checkForUpdate.mdx
@@ -21,20 +21,28 @@ HotUpdater.init({
 // Use checkForUpdate - it reuses the configured baseURL
 async function checkForAppUpdate() {
   try {
+    let checkError: Error | null = null;
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion",
       requestHeaders: {
         "x-api-key": "<your-api-key>",
       },
+      onError: (error) => {
+        checkError = error;
+      },
     });
+
+    if (checkError) {
+      throw checkError;
+    }
 
     if (!updateInfo) {
       return {
-        status: "UP_TO_DATE",
+        status: "NO_UPDATE",
       };
     }
 
-    // The returned helper includes all required update arguments.
+    // The helper resolves the artifact and preserves the selected transition.
     const didUpdate = await updateInfo.updateBundle();
 
     if (didUpdate && updateInfo.shouldForceUpdate) {
@@ -64,6 +72,9 @@ function App() {
       updateStrategy: "appVersion",
       requestHeaders: {
         "x-api-key": "<your-api-key>",
+      },
+      onError: (error) => {
+        console.error("Failed to check for update:", error);
       },
     })
       .then(async (updateInfo) => {
@@ -111,7 +122,7 @@ The `checkForUpdate` function accepts the following parameters:
 | `channel`        | `string`                          | ❌       | Channel to check. Defaults to the currently active channel. |
 | `requestHeaders` | `Record<string, string>`          | ❌       | Optional headers to include in the update request.          |
 | `requestTimeout` | `number`                          | ❌       | Request timeout in milliseconds (default: 5000).            |
-| `onError`        | `(error: Error) => void`          | ❌       | Error callback.                                             |
+| `onError`        | `(error: Error) => void`          | ❌       | Called when a check fails, including failures that return `null`. |
 
 The update source is always from `HotUpdater.wrap()` or `HotUpdater.init()`; it
 cannot be overridden in `checkForUpdate`.
@@ -122,8 +133,9 @@ successfully. If a different runtime channel is already active, call
 
 ## How It Works
 
-The client fetches a shared Release Catalog, evaluates it on the device, and
-resolves the selected artifact:
+The client fetches a shared Release Catalog and evaluates it on the device.
+When installation is needed, the returned `updateBundle()` helper resolves the
+selected artifact when called:
 
 - App version catalog: `GET {baseURL}/release-catalogs/app-version/:platform/:channelKey/:appVersion`
 - Fingerprint catalog: `GET {baseURL}/release-catalogs/fingerprint/:platform/:channelKey/:fingerprintHash`
@@ -134,6 +146,12 @@ server-owned and is not part of the React Native configuration or client URL.
 
 ## Return Value
 
-The function returns `null` when the app is up to date. Otherwise, it returns
-the selected bundle ID, status, message, nullable download URL and hash, and a
-pre-filled `updateBundle()` helper.
+The function returns `null` when no transition is selected, when checks are
+skipped in development, or after a check fails and calls `onError`. Do not
+interpret `null` alone as a successful up-to-date check. Use `onError` to track
+check failures and `try/catch` for rejected calls, such as a channel conflict.
+
+When a transition is selected, the result includes its bundle ID, status,
+message, and an `updateBundle()` helper. In v1, `fileUrl` and `fileHash` are
+`null` in this result: the helper resolves the artifact lazily when needed.
+Call the helper instead of copying these fields into `HotUpdater.updateBundle`.

--- a/docs/content/docs/(latest)/react-native-api/getCrashHistory.mdx
+++ b/docs/content/docs/(latest)/react-native-api/getCrashHistory.mdx
@@ -135,5 +135,5 @@ logCrashHistory();
 
 ## Related APIs
 
-- [`clearCrashHistory()`](./clearCrashHistory) - Clear the crash history to allow retrying bundles
-- [`wrap()`](./wrap) - Required for automatic crash detection and rollback
+- [`clearCrashHistory()`](/docs/react-native-api/clearCrashHistory) - Clear the crash history to allow retrying bundles
+- [`wrap()`](/docs/react-native-api/wrap) - Required for automatic crash detection and rollback

--- a/docs/content/docs/(latest)/react-native-api/reload.mdx
+++ b/docs/content/docs/(latest)/react-native-api/reload.mdx
@@ -10,7 +10,7 @@ icon: RefreshCw
 
 - If no new bundle is ready, it reloads the current app code
 - If a bundle was downloaded, that bundle becomes active immediately
-- The exact behavior depends on [`HotUpdater.setReloadBehavior()`](./setReloadBehavior)
+- The exact behavior depends on [`HotUpdater.setReloadBehavior()`](/docs/react-native-api/setReloadBehavior)
 
 ```tsx
 import { HotUpdater } from "@hot-updater/react-native";
@@ -39,7 +39,7 @@ By default, `HotUpdater.reload()` uses `processRestart`.
 - Android: cold process restart
 - iOS: behaves like normal React Native reload
 
-Use [`HotUpdater.setReloadBehavior("reload")`](./setReloadBehavior) only if you explicitly want the old in-process React Native reload path.
+Use [`HotUpdater.setReloadBehavior("reload")`](/docs/react-native-api/setReloadBehavior) only if you explicitly want the old in-process React Native reload path.
 
 ## Related APIs
 

--- a/docs/content/docs/(latest)/react-native-api/setReloadBehavior.mdx
+++ b/docs/content/docs/(latest)/react-native-api/setReloadBehavior.mdx
@@ -7,7 +7,7 @@ version: "0.27.0"
 
 ## Usage
 
-Use `HotUpdater.setReloadBehavior()` to control how [`HotUpdater.reload()`](./reload) is applied.
+Use `HotUpdater.setReloadBehavior()` to control how [`HotUpdater.reload()`](/docs/react-native-api/reload) is applied.
 
 The default is `processRestart`.
 This is a global setting, so calling it once during app startup is enough.

--- a/docs/content/docs/(latest)/react-native-api/updateBundle.mdx
+++ b/docs/content/docs/(latest)/react-native-api/updateBundle.mdx
@@ -20,20 +20,28 @@ HotUpdater.init({
 
 async function stageAppUpdate() {
   try {
+    let checkError: Error | null = null;
     const updateInfo = await HotUpdater.checkForUpdate({
       updateStrategy: "appVersion", // or "fingerprint"
       requestHeaders: {
         "x-api-key": "<your-api-key>",
       },
+      onError: (error) => {
+        checkError = error;
+      },
     });
+
+    if (checkError) {
+      throw checkError;
+    }
 
     if (!updateInfo) {
       return {
-        status: "UP_TO_DATE",
+        status: "NO_UPDATE",
       };
     }
 
-    // Recommended: use the helper with all update arguments pre-filled.
+    // Recommended: let the helper resolve the artifact and stage the selection.
     const didUpdate = await updateInfo.updateBundle();
 
     if (!didUpdate) {
@@ -59,21 +67,14 @@ The `updateBundle` function accepts the following parameters:
 | Parameter  | Type                     | Required | Description                                       |
 | ---------- | ------------------------ | -------- | ------------------------------------------------- |
 | `bundleId` | `string`                 | ✅       | Unique identifier of the update bundle.           |
-| `fileUrl`  | `string \| null`         | ✅       | Bundle archive URL, or `null` when none is used.  |
+| `fileUrl`  | `string \| null`         | ✅       | Bundle archive URL, or `null` to reset to the built-in bundle. |
 | `fileHash` | `string \| null`         | ✅       | SHA256 hash, `sig:<base64_signature>`, or `null`. |
 | `status`   | `"UPDATE" \| "ROLLBACK"` | ✅       | Update transition to apply.                       |
 
-For a direct rollback transition with no archive, pass the required nullable
-properties explicitly:
-
-```tsx
-await HotUpdater.updateBundle({
-  bundleId: "<rollback-bundle-id>",
-  fileUrl: null,
-  fileHash: null,
-  status: "ROLLBACK",
-});
-```
+Passing `fileUrl: null` resets to the built-in bundle; it does not roll back to
+the OTA bundle named by `bundleId`. For a catalog-selected rollback, call the
+returned `updateInfo.updateBundle()` helper so the selected release and artifact
+are preserved.
 
 ### Behavior
 
@@ -81,8 +82,9 @@ await HotUpdater.updateBundle({
 - When `fileHash` is a hexadecimal hash, verifies the downloaded file's SHA256
   hash. A `sig:` value verifies its RSA-SHA256 signature with the configured
   public key. A failed verification aborts the update and deletes the download.
-- A `null` URL or hash represents a transition that does not use that archive
-  value; the properties must still be present in the object.
+- A `null` URL resets the native bundle selection to the built-in bundle and
+  runs downloaded-bundle cleanup. The nullable properties must still be present
+  in the object.
 - Stages the selected bundle transition for the next React Native runtime start
   without replacing the code already running.
 - Never reloads the app by itself. Call `HotUpdater.reload()` explicitly to
@@ -93,15 +95,17 @@ await HotUpdater.updateBundle({
 
 ### Security Recommendation
 
-Use the `fileHash` returned by `checkForUpdate()` whenever an update has a
-bundle archive. A plain SHA256 hash checks integrity but does not authenticate
-the publisher; a `sig:` value also verifies publisher authenticity with the
-configured public key.
+Use `updateInfo.updateBundle()` to resolve the artifact and pass its verification
+hash to the native updater. The `fileUrl` and `fileHash` fields returned by
+`checkForUpdate()` are `null` in v1 and must not be copied into a direct call.
+A plain SHA256 hash checks integrity but does not authenticate the publisher;
+a `sig:` value also verifies publisher authenticity with the configured public key.
 
 #### Recommended Approach
 
-Use `updateInfo.updateBundle()` whenever possible. The helper preserves the
-complete update context selected by `checkForUpdate()` without manual copying.
+Use `updateInfo.updateBundle()` whenever possible. The helper resolves the
+artifact when needed and preserves the complete update context selected by
+`checkForUpdate()` without manual copying.
 
 ```tsx
 const updateInfo = await HotUpdater.checkForUpdate({


### PR DESCRIPTION
## Scope

Docs-only follow-up to the adversarial audit of `next` (base `c387b0bc`). Retains only confirmed P1 semantic errors that can break documented workflows, misreport update failures, or lead to unsafe operations. No P0 was confirmed.

Only 29 existing MDX files under `docs/content/docs/(latest)` change. Existing correct explanations are retained; there are no runtime, v0, release-label, dependency, generated-artifact, or formatting-only changes.

## Corrections

- Supply the required client API key in managed/basic and custom framework examples; distinguish extractable client credentials from provider/admin/signing secrets.
- Install CLI dependencies in the correct React Native project and explicitly load `.env.hotupdater`; add the server-side storage URL signing key missing from Docker/Vercel examples.
- Handle `checkForUpdate` callback failures before reporting no update. Explain lazy artifact resolution and use the returned helper instead of copying its null URL/hash into a direct call.
- Remove the direct-null rollback example that actually resets to the built-in bundle and cleans downloaded bundles.
- Keep signing private keys out of EAS native-build uploads; describe the existing public-key fallback and single-key native-build boundary during key rotation/removal.
- Require the Expo DOM Babel plugin on SDK 55+ too; limit the pre-55 condition to the patch steps.
- Clarify SQL/RPC provisioning prerequisites, MongoDB transaction requirements, and mutually exclusive standalone page/cursor pagination.
- Preserve the v0/v1 protocol boundary while accurately distinguishing shared provider projects/buckets from separate v1 namespaces/endpoints; warn against pruning shared v0 artifacts using only v1 metadata.
- Remove the false guarantees that JS-only updates or package patch versions imply no app-store review/native changes.
- Replace 44 existing broken relative links with canonical documentation URLs, plus use canonical URLs for five new prerequisite links. The old links resolve to nonexistent routes on the configured trailing-slash deployment.

## Review and verification

Five bounded implementation reviewers and an independent adversarial reviewer checked the changes against current implementation. Final cross-reviews found no remaining actionable P0/P1 issue in this diff. Cloudflare setup/routing assumptions and Apple/Google policy statements were checked against primary documentation.

- [x] `pnpm -w build` — 26 projects passed
- [x] `pnpm -w test:type` — 34 projects passed
- [x] `pnpm -w lint`
- [x] `pnpm -w test --reporter=dot` — 262 files, 2,330 tests passed
- [x] Final `pnpm --dir docs build` and `pnpm --dir docs test:type`
- [x] Generated HTML validation: all 78 latest pages; 2,201 internal links (including navigation), 1,159 fragment targets; zero missing targets
- [x] Extracted update-flow examples checked for callback failure, rejection, no update, and successful update
- [x] EAS ignore rules checked: public key included; private keys excluded
- [x] `git diff --check`

## Intentionally excluded

P2/P3 completeness, deduplication, prose cleanup, media refreshes, Elysia Node support expansion, link-checker redesign, npm release sequencing, and runtime implementation issues remain outside this PR. No changeset is needed for documentation-only changes.
