### PR TITLE
fix(release): support Changesets v3 prerelease state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,11 @@ jobs:
 
       - name: Create and publish versions
         if: steps.release-lane.outputs.enabled == 'true'
-        # Pinned from changesets/action@v1 to avoid mutable release action
+        # Pinned from changesets/action@v2 to avoid mutable release action
         # code running with repository write access.
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1
         with:
-          commit: ${{ steps.release-lane.outputs.title }}
-          title: ${{ steps.release-lane.outputs.title }}
-          publish: ${{ steps.release-lane.outputs.publish }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ${{ steps.release-lane.outputs.title }}
+          pr-title: ${{ steps.release-lane.outputs.title }}
+          publish-script: ${{ steps.release-lane.outputs.publish }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- upgrade the pinned Changesets action from v1.9.0 to v2.1.1
- migrate the renamed v2 inputs and pass the GitHub token explicitly
- preserve the Changesets v3 prerelease archive under .changeset/pre

## Root cause

Changesets CLI v3 moves consumed prerelease changesets into .changeset/pre. The v1 action bundles the v2-era reader, which treats that directory as a legacy folder changeset and attempts to open .changeset/pre/changes.md. The file does not exist, so the release job exits with ENOENT before publishing.

Changesets action v2 uses the v3-compatible reader and filters archived prerelease entries when selecting release mode.

Failed run: https://github.com/gronxb/hot-updater/actions/runs/33346065425/job/99350308473

## Verification

- reproduced the failure with @changesets/read 0.6.7 and verified @changesets/read 1.0.0 reads all 33 archived prerelease changesets
- verified Changesets v3 publish-plan selects the current RC packages for publishing
- validated release.yml as YAML and checked all configured inputs against the pinned action contract
- pnpm -w build
- pnpm -w test:type
- pnpm -w lint
- pnpm -w test (2,453 tests)
- pnpm -w test:integration (295 tests)