### PR TITLE
fix(test-utils): keep package private

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@hot-updater/test-utils",
+  "private": true,
   "version": "1.0.0-rc.0",
   "type": "module",
   "description": "Test utilities for Hot Updater packages",
@@ -35,9 +36,6 @@
   },
   "repository": "https://github.com/gronxb/hot-updater",
   "author": "gronxb <gron1gh1@gmail.com> (https://github.com/gronxb)",
-  "publishConfig": {
-    "access": "public"
-  },
   "peerDependencies": {
     "@hot-updater/core": "*",
     "@hot-updater/plugin-core": "*",

--- a/packages/test-utils/src/package.spec.ts
+++ b/packages/test-utils/src/package.spec.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 import packageJson from "../package.json" with { type: "json" };
 
 describe("@hot-updater/test-utils package", () => {
-  it("is publishable as a public package", () => {
-    expect(Object.hasOwn(packageJson, "private")).toBe(false);
-    expect(packageJson.publishConfig).toEqual({ access: "public" });
+  it("is private so release tooling cannot publish it", () => {
+    expect(packageJson.private).toBe(true);
+    expect(Object.hasOwn(packageJson, "publishConfig")).toBe(false);
   });
 
   it("advertises the Vitest-dependent root as ESM-only", () => {


### PR DESCRIPTION
## Summary

- mark `@hot-updater/test-utils` as a private workspace-only package
- remove its public npm publish configuration
- add a regression assertion that release tooling must not publish it

## Root cause

The package was configured as publishable (`publishConfig.access: public`) and was not marked private, so Nx included it in the release publish set. The release then failed when npm attempted to create/publish the internal package.

Failed release: https://github.com/gronxb/hot-updater/actions/runs/33346740462/job/99352184053

## Verification

- `pnpm exec vitest run packages/test-utils/src/package.spec.ts --project='unit:*'`
- `pnpm nx release publish --dry-run --tag rc --outputStyle=static` — 23 publishable projects; `@hot-updater/test-utils` excluded
- `pnpm changeset publish-plan` — `@hot-updater/test-utils` excluded
- full FixCI passed: build, typecheck, lint, unit (2,453), integration (295)

No release or registry write was performed.