### PR TITLE
fix(expo): escape Android public key newlines

### DIFF
--- a/.changeset/tidy-keys-escape.md
+++ b/.changeset/tidy-keys-escape.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/expo": patch
+---
+
+Escape bundle signing public key newlines when writing AndroidManifest metadata.

--- a/plugins/expo/plugin/src/withHotUpdater.spec.ts
+++ b/plugins/expo/plugin/src/withHotUpdater.spec.ts
@@ -3,10 +3,12 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import * as cliTools from "@hot-updater/cli-tools";
+import { XML } from "expo/config-plugins";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { transformAndroid, transformIOS } from "./transformers";
-import { getPublicKeyFromConfig } from "./withHotUpdater";
+import withHotUpdater, { getPublicKeyFromConfig } from "./withHotUpdater";
 
 const tempDirs: string[] = [];
 
@@ -25,6 +27,7 @@ const createKeyPair = () =>
 
 afterEach(async () => {
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
   );
@@ -207,6 +210,59 @@ describe("getPublicKeyFromConfig", () => {
 
 describe("withHotUpdater - Test Cases", () => {
   describe("Android", () => {
+    it("escapes signing key newlines in AndroidManifest metadata", async () => {
+      const { privateKey, publicKey } = createKeyPair();
+      vi.stubEnv("HOT_UPDATER_PRIVATE_KEY", privateKey);
+      vi.spyOn(cliTools, "loadConfig").mockResolvedValue({
+        signing: {
+          enabled: true,
+          privateKeyPath: "/missing/private-key.pem",
+        },
+        updateStrategy: "appVersion",
+      } as Awaited<ReturnType<typeof cliTools.loadConfig>>);
+
+      const config = withHotUpdater({
+        _internal: { projectRoot: "/tmp/hot-updater-test" },
+        name: "Hot Updater Test",
+        slug: "hot-updater-test",
+      });
+      const manifestMod = config.mods?.android?.manifest;
+      expect(manifestMod).toBeTypeOf("function");
+      if (!manifestMod) {
+        throw new Error("AndroidManifest mod was not registered");
+      }
+
+      const modResults = {
+        manifest: {
+          $: { "xmlns:android": "http://schemas.android.com/apk/res/android" },
+          application: [{}],
+        },
+      } as Parameters<typeof manifestMod>[0]["modResults"];
+      const result = await manifestMod({
+        ...config,
+        modRawConfig: config,
+        modRequest: {
+          introspect: true,
+          modName: "manifest",
+          platform: "android",
+          platformProjectRoot: "/tmp/hot-updater-test/android",
+          projectRoot: "/tmp/hot-updater-test",
+        },
+        modResults,
+      });
+      const publicKeyMetaData = result.modResults.manifest.application?.[0][
+        "meta-data"
+      ]?.find(
+        (item) => item.$?.["android:name"] === "com.hotupdater.PUBLIC_KEY",
+      );
+      const expectedValue = publicKey.trim().replaceAll("\n", "\\n");
+
+      expect(publicKeyMetaData?.$?.["android:value"]).toBe(expectedValue);
+      expect(XML.format(result.modResults)).toContain(
+        `android:value="${expectedValue}"`,
+      );
+    });
+
     it("RN 0.82+ Kotlin: input -> output", () => {
       // Input: Raw RN 0.82 template
       const _input = `package com.rndiffapp

--- a/plugins/expo/plugin/src/withHotUpdater.ts
+++ b/plugins/expo/plugin/src/withHotUpdater.ts
@@ -5,6 +5,7 @@ import path from "path";
 import type { SigningConfig } from "@hot-updater/plugin-core";
 import type { ExpoConfig } from "expo/config";
 import {
+  XML,
   createRunOncePlugin,
   withAndroidManifest,
   withAppDelegate,
@@ -282,7 +283,7 @@ const withHotUpdaterConfigAsync =
         upsertAndroidMetaData(
           application,
           ANDROID_META_DATA_KEYS.publicKey,
-          publicKey,
+          XML.escapeAndroidString(publicKey),
         );
       } else {
         removeAndroidMetaData(application, ANDROID_META_DATA_KEYS.publicKey);


### PR DESCRIPTION
## Summary

- escape bundle-signing PEM newlines before writing `com.hotupdater.PUBLIC_KEY` to AndroidManifest metadata
- cover the real Expo Android manifest mod and serialized XML with a regression test
- add a patch changeset for `@hot-updater/expo`

## Why

`@hot-updater/expo@1.0.0-rc.0` writes the PEM with literal line breaks into an Android manifest attribute. The generated Android trust anchor no longer matches the configured key, and `hot-updater doctor` reports `PUBLIC_KEY_MISMATCH` after Expo prebuild. The CLI's native key export already writes the Android value with escaped `\\n` sequences; this makes the Expo plugin use the same representation.

This blocks the v1 migration in gronxb/codex-relay#83 without an app-local config-plugin workaround.

## Validation

- `pnpm -w lint`
- `pnpm -w test` (2,454 tests)
- `pnpm -w test:type` (34 projects)
- `pnpm --filter @hot-updater/expo... build`
- `pnpm exec changeset status`
