### PR TITLE
fix(react-native): keep getMinBundleId public

### DIFF
--- a/.changeset/calm-bundles-stay.md
+++ b/.changeset/calm-bundles-stay.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Keep `HotUpdater.getMinBundleId()` as the public build-time bundle floor API.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -444,11 +444,9 @@ App-ready transition and Release adoption reporting use the configured
 `HotUpdater.wrap`; omission or `false` sends nothing. The server routes and
 backing model remain available regardless.
 
-The v0 `HotUpdater.getMinBundleId()` alias is removed; use
-`HotUpdater.getMinimumReleaseId()`. The deprecated positional
-`HotUpdater.updateBundle(bundleId, fileUrl)` overload is also removed. Pass the
-complete parameter object or call `updateInfo.updateBundle()` on the result of
-`HotUpdater.checkForUpdate()`.
+The deprecated positional `HotUpdater.updateBundle(bundleId, fileUrl)` overload
+is removed. Pass the complete parameter object or call
+`updateInfo.updateBundle()` on the result of `HotUpdater.checkForUpdate()`.
 
 ## Removed provider exports
 

--- a/docs/architecture/release-catalog-plan.md
+++ b/docs/architecture/release-catalog-plan.md
@@ -850,8 +850,9 @@ UUIDv7 timestamp floor generated with the native build. Backfilled Releases
 keep old Bundle IDs, and every post-build deploy receives a newer Release ID.
 Rollback disables a Release and reveals its predecessor. This preserves native
 compatibility without requiring the server to know the built-in Bundle ID.
-`getMinBundleId()` and native configuration names remain deprecated aliases;
-new selector/API language uses `getMinimumReleaseId()`.
+The public `getMinBundleId()` API and native configuration names remain
+unchanged. Release Catalog selection interprets that value internally as
+`minimumReleaseId`.
 
 The JavaScript selector evaluates Release descriptors in v0 order:
 

--- a/docs/release-catalog-plan.md
+++ b/docs/release-catalog-plan.md
@@ -810,8 +810,9 @@ UUIDv7 timestamp floor generated with the native build. Backfilled Releases
 keep old Bundle IDs, and every post-build deploy receives a newer Release ID.
 Rollback disables a Release and reveals its predecessor. This preserves native
 compatibility without requiring the server to know the built-in Bundle ID.
-`getMinBundleId()` and native configuration names remain deprecated aliases;
-new selector/API language uses `getMinimumReleaseId()`.
+The public `getMinBundleId()` API and native configuration names remain
+unchanged. Release Catalog selection interprets that value internally as
+`minimumReleaseId`.
 
 The JavaScript selector evaluates Release descriptors in v0 order:
 

--- a/packages/react-native/src/checkForUpdate.releaseCatalog.spec.ts
+++ b/packages/react-native/src/checkForUpdate.releaseCatalog.spec.ts
@@ -40,7 +40,7 @@ const mocks = vi.hoisted(() => ({
   getDefaultChannel: vi.fn(() => CHANNEL),
   getFingerprintHash: vi.fn(() => null),
   getInstallId: vi.fn(() => "install-id"),
-  getMinimumReleaseId: vi.fn(() => MINIMUM_RELEASE_ID),
+  getMinBundleId: vi.fn(() => MINIMUM_RELEASE_ID),
   getPersistedUserIdentity: vi.fn(() => ({})),
   isChannelSwitched: vi.fn(() => false),
   isReleaseSelectionCurrent: vi.fn(() => true),

--- a/packages/react-native/src/checkForUpdate.ts
+++ b/packages/react-native/src/checkForUpdate.ts
@@ -23,7 +23,7 @@ import {
   getDefaultChannel,
   getFingerprintHash,
   getInstallId,
-  getMinimumReleaseId,
+  getMinBundleId,
   getCrashHistory,
   getPersistedUserIdentity,
   isReleaseSelectionCurrent,
@@ -421,7 +421,7 @@ export async function checkForUpdate(
   const currentAppVersion = getAppVersion();
   const platform = Platform.OS as "ios" | "android";
   const currentBundleId = getBundleId();
-  const minimumReleaseId = getMinimumReleaseId();
+  const minimumReleaseId = getMinBundleId();
   const defaultChannel = getDefaultChannel();
   const isSwitched = isChannelSwitched();
   const currentChannel = isSwitched ? getChannel() : defaultChannel;

--- a/packages/react-native/src/index.spec.ts
+++ b/packages/react-native/src/index.spec.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => {
     getFingerprintHash: vi.fn(() => null),
     getInstallId: vi.fn(() => "install-id"),
     getManifest: vi.fn(() => null),
-    getMinimumReleaseId: vi.fn(() => "min-bundle-id"),
+    getMinBundleId: vi.fn(() => "min-bundle-id"),
     getReleaseId: vi.fn(async () => null),
     init: vi.fn(),
     isChannelSwitched: vi.fn(() => false),
@@ -67,7 +67,7 @@ vi.mock("./native", () => ({
   getFingerprintHash: mocks.getFingerprintHash,
   getInstallId: mocks.getInstallId,
   getManifest: mocks.getManifest,
-  getMinimumReleaseId: mocks.getMinimumReleaseId,
+  getMinBundleId: mocks.getMinBundleId,
   getReleaseId: mocks.getReleaseId,
   isChannelSwitched: mocks.isChannelSwitched,
   notifyAppReady: mocks.notifyAppReady,
@@ -283,7 +283,7 @@ describe("HotUpdater client initialization", () => {
     const HotUpdater = await importHotUpdater();
 
     expect(HotUpdater.getInstallId()).toBe("install-id");
-    expect(HotUpdater.getMinimumReleaseId()).toBe("min-bundle-id");
+    expect(HotUpdater.getMinBundleId()).toBe("min-bundle-id");
     HotUpdater.setUser({ userId: "user-123", username: "alice" });
     expect(mocks.setUser).toHaveBeenCalledWith({
       userId: "user-123",

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -18,7 +18,7 @@ import {
   getFingerprintHash,
   getInstallId,
   getManifest,
-  getMinimumReleaseId,
+  getMinBundleId,
   getReleaseId,
   isChannelSwitched,
   notifyAppReady,
@@ -337,8 +337,8 @@ function createHotUpdaterClient() {
      */
     getBundleId,
 
-    /** Preferred Release-catalog name for the build-time UUIDv7 floor. */
-    getMinimumReleaseId,
+    /** Returns the minimum bundle ID based on the native app build time. */
+    getMinBundleId,
 
     /** Returns the active Release identity, or null for BUILTIN/legacy state. */
     getReleaseId,

--- a/packages/react-native/src/native.ts
+++ b/packages/react-native/src/native.ts
@@ -215,7 +215,7 @@ const getNativeBundleId = (): string | null => {
 };
 
 const resolveBundleId = (bundleId: string | null): string => {
-  return !bundleId || bundleId === NIL_UUID ? getMinimumReleaseId() : bundleId;
+  return !bundleId || bundleId === NIL_UUID ? getMinBundleId() : bundleId;
 };
 
 const getFreshBundleId = (): string => {
@@ -588,11 +588,13 @@ export function setReloadBehavior(
 }
 
 /**
- * Fetches the build-time minimum Release id.
+ * Fetches the minimum bundle id created from the native app build time.
  *
- * @returns {string} The minimum Release id.
+ * Release Catalog selection uses this value as its minimum Release id.
+ *
+ * @returns {string} The minimum bundle id.
  */
-export const getMinimumReleaseId = (): string => {
+export const getMinBundleId = (): string => {
   const constants = HotUpdaterNative.getConstants();
   return constants.MIN_BUNDLE_ID;
 };


### PR DESCRIPTION
## Summary

- keep HotUpdater.getMinBundleId() as the sole public build-time bundle floor API
- use the existing API internally for Release Catalog selection
- align the breaking-change guide and architecture docs with the retained API

## Tests

- pnpm --filter @hot-updater/react-native exec vitest run src/index.spec.ts src/checkForUpdate.releaseCatalog.spec.ts src/native.spec.ts
- pnpm --filter @hot-updater/react-native test:type
- pnpm -w lint
- pnpm -w test