### PR TITLE
fix(doctor): accept matching prerelease channels

### DIFF
--- a/.changeset/calm-doctors-agree.md
+++ b/.changeset/calm-doctors-agree.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Allow Doctor to accept package increments within the same prerelease channel.

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -165,6 +165,12 @@ describe("areVersionsCompatible", () => {
     expect(areVersionsCompatible("^1.0.0-alpha.1", "1.0.0")).toBe(true);
     expect(areVersionsCompatible("2.0.0-alpha.1", "^1.0.0")).toBe(false);
   });
+
+  it("should accept increments within the same pre-release channel", () => {
+    expect(areVersionsCompatible("1.0.0-rc.1", "1.0.0-rc.0")).toBe(true);
+    expect(areVersionsCompatible("1.0.0-rc.0", "1.0.0-rc.1")).toBe(true);
+    expect(areVersionsCompatible("1.0.1-rc.0", "1.0.0-rc.0")).toBe(false);
+  });
 });
 
 describe("infrastructure version helpers", () => {
@@ -515,6 +521,23 @@ describe("doctor", () => {
         dependencies: {
           "hot-updater": "1.0.0",
           "@hot-updater/core": "1.0.1",
+        },
+      },
+      path: "/mock/cwd/package.json",
+    });
+
+    const result = await doctor();
+    expect(result).toBe(true);
+  });
+
+  it("should accept independently released packages in the same RC", async () => {
+    mockReadPackageUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          "hot-updater": "1.0.0-rc.0",
+          "@hot-updater/cloudflare": "1.0.0-rc.0",
+          "@hot-updater/expo": "1.0.0-rc.1",
+          "@hot-updater/react-native": "1.0.0-rc.1",
         },
       },
       path: "/mock/cwd/package.json",

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -166,6 +166,20 @@ export function areVersionsCompatible(
     : null;
   const parsedVersionA = comparableVersionA ? parse(comparableVersionA) : null;
   const parsedVersionB = comparableVersionB ? parse(comparableVersionB) : null;
+  const prereleaseChannelA = parsedVersionA?.prerelease?.[0];
+  const prereleaseChannelB = parsedVersionB?.prerelease?.[0];
+
+  if (
+    parsedVersionA &&
+    parsedVersionB &&
+    parsedVersionA.major === parsedVersionB.major &&
+    parsedVersionA.minor === parsedVersionB.minor &&
+    parsedVersionA.patch === parsedVersionB.patch &&
+    prereleaseChannelA !== undefined &&
+    prereleaseChannelA === prereleaseChannelB
+  ) {
+    return true;
+  }
 
   if (
     parsedVersionA &&


### PR DESCRIPTION
## Summary

- treat increments within the same prerelease channel and base version as compatible
- keep different prerelease channels and different base versions incompatible
- cover the official rc.0 CLI/cloudflare plus rc.1 Expo/React Native release combination

## Reproduction

After #1221, Doctor reports Expo and React Native 1.0.0-rc.1 as mismatches against hot-updater 1.0.0-rc.0 even though those packages are independently versioned in the same RC.

## Validation

- pnpm exec nx run hot-updater:build
- pnpm exec vitest run packages/hot-updater/src/commands/doctor.spec.ts --project=unit:default
- pnpm --filter hot-updater test:type
- pnpm test (276 files, 2457 tests)
- pnpm lint
- pnpm exec changeset status