### PR TITLE
fix(ci): wait for MySQL TCP readiness

### DIFF
--- a/examples-server/hono-kysely-mysql/docker-compose.yml
+++ b/examples-server/hono-kysely-mysql/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - mysql_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "hot_updater", "-phot_updater_dev"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "hot_updater", "-phot_updater_dev"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
The GitHub integration run for #1224 failed while setting up MySQL: the container was reported healthy, but schema initialization then lost its connection when the temporary initialization server shut down.

Change the MySQL example's Docker healthcheck host from `localhost` to `127.0.0.1` so it probes TCP. The [official MySQL image entrypoint](https://github.com/docker-library/mysql/blob/master/docker-entrypoint.sh) starts its temporary initialization server with networking disabled. The healthcheck now waits for the final server instead of accepting the temporary Unix socket.

This is a one-line test infrastructure fix. No application schema or runtime behavior changes, and no release changeset is needed for the ignored example package.

Validation:

- Reproduced the startup race in an isolated fresh MySQL container: during initialization the `localhost` probe exited 0 and the `127.0.0.1` probe exited 1; after initialization the TCP probe exited 0.
- `.agents/skills/fix-ci/scripts/run_fixci.sh all` passed with this fix: build, type check, lint, 2,457 unit tests, and 295 integration tests.
- The migration consolidation from #1224 is already merged; this PR contains only the MySQL readiness correction.
