### PR TITLE
fix(react-native): preserve null fingerprint in analytics events

### DIFF
--- a/.changeset/tidy-analytics-fingerprint.md
+++ b/.changeset/tidy-analytics-fingerprint.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/react-native": patch
+---
+
+Normalize an omitted native fingerprint constant to `null` so app-version analytics events keep the required payload field.

--- a/packages/react-native/src/native.spec.ts
+++ b/packages/react-native/src/native.spec.ts
@@ -728,6 +728,20 @@ describe("notifyAppReady", () => {
     expect(getInstallId()).toBe("install-123");
   });
 
+  it("normalizes an omitted native fingerprint constant to null", async () => {
+    nativeModuleMock.getConstants.mockReturnValue({
+      APP_VERSION: null,
+      CHANNEL: "production",
+      DEFAULT_CHANNEL: "production",
+      FINGERPRINT_HASH: undefined as unknown as null,
+      MIN_BUNDLE_ID: "min-bundle-id",
+    });
+
+    const { getFingerprintHash } = await import("./native");
+
+    expect(getFingerprintHash()).toBeNull();
+  });
+
   it("throws when native SDK does not expose getInstallId", async () => {
     const nativeModule = nativeModuleMock as typeof nativeModuleMock & {
       getInstallId?: typeof nativeModuleMock.getInstallId;

--- a/packages/react-native/src/native.ts
+++ b/packages/react-native/src/native.ts
@@ -687,7 +687,7 @@ export const isChannelSwitched = (): boolean => {
  */
 export const getFingerprintHash = (): string | null => {
   const constants = HotUpdaterNative.getConstants();
-  return constants.FINGERPRINT_HASH;
+  return constants.FINGERPRINT_HASH ?? null;
 };
 
 export const getInstallId = (): string => {


### PR DESCRIPTION
## Summary

- normalize an omitted native fingerprint constant to null
- keep the required fingerprintHash field in app-version analytics payloads on iOS New Architecture
- add regression coverage and a patch changeset

## Runtime evidence

With 1.0.0-rc.1 on an iOS Release build, the native typed constants omit an unset fingerprint. The SDK serialized a 316-byte /events payload and the v1 server returned 400 because fingerprintHash was absent. The expected payload is 339 bytes; removing exactly fingerprintHash:null produces 316 bytes. A direct event containing fingerprintHash:null returned 204.

## Validation

- pnpm --filter @hot-updater/react-native test:type
- pnpm --filter @hot-updater/react-native exec vitest run (118 passed)
- oxfmt check on changed files
- oxlint on changed files