### PR TITLE
fix(expo): load config with dynamic imports

### DIFF
--- a/.changeset/fuzzy-expo-config.md
+++ b/.changeset/fuzzy-expo-config.md
@@ -2,5 +2,5 @@
 "@hot-updater/expo": patch
 ---
 
-Load `expo/config` from the target Expo project so the published build plugin
-resolves it in both ESM and CommonJS across supported Expo SDKs.
+Load the Expo config module through dynamic imports so the published build
+plugin resolves both the legacy and current Expo SDK layouts in ESM.

--- a/.changeset/fuzzy-expo-config.md
+++ b/.changeset/fuzzy-expo-config.md
@@ -1,0 +1,6 @@
+---
+"@hot-updater/expo": patch
+---
+
+Load `expo/config` from the target Expo project so the published build plugin
+resolves it in both ESM and CommonJS across supported Expo SDKs.

--- a/plugins/expo/src/expo.spec.ts
+++ b/plugins/expo/src/expo.spec.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   getConfig: vi.fn(),
 }));
 
-vi.mock("expo/config", () => ({
+vi.mock("./expoConfig", () => ({
   getConfig: mocks.getConfig,
 }));
 

--- a/plugins/expo/src/expo.spec.ts
+++ b/plugins/expo/src/expo.spec.ts
@@ -83,7 +83,7 @@ describe("getExpoFingerprintExtraSources", () => {
   it("includes the configured trust anchor in native fingerprints", async () => {
     const cwd = await createProject("keys/public-key.pem");
 
-    expect(getExpoFingerprintExtraSources(cwd)).toEqual([
+    await expect(getExpoFingerprintExtraSources(cwd)).resolves.toEqual([
       "keys/public-key.pem",
     ]);
   });
@@ -91,6 +91,6 @@ describe("getExpoFingerprintExtraSources", () => {
   it("adds no source when bundle signing is not configured", async () => {
     const cwd = await createProject();
 
-    expect(getExpoFingerprintExtraSources(cwd)).toEqual([]);
+    await expect(getExpoFingerprintExtraSources(cwd)).resolves.toEqual([]);
   });
 });

--- a/plugins/expo/src/expo.ts
+++ b/plugins/expo/src/expo.ts
@@ -9,9 +9,9 @@ import type {
   BuildPluginConfig,
 } from "@hot-updater/plugin-core";
 import { ExecaError, execa } from "execa";
-import { getConfig } from "expo/config";
 import { uuidv7 } from "uuidv7";
 
+import { getConfig } from "./expoConfig";
 import { resolveMain } from "./resolveMain";
 import { runExpoPrebuild } from "./util/prebuild";
 

--- a/plugins/expo/src/expo.ts
+++ b/plugins/expo/src/expo.ts
@@ -28,7 +28,7 @@ type HotUpdaterExpoPluginProps = {
 };
 
 const getHotUpdaterExpoPluginProps = (
-  plugins: ReturnType<typeof getConfig>["exp"]["plugins"],
+  plugins: Awaited<ReturnType<typeof getConfig>>["exp"]["plugins"],
 ): HotUpdaterExpoPluginProps | undefined => {
   const entry = plugins?.find(
     (plugin) =>
@@ -43,8 +43,10 @@ const getHotUpdaterExpoPluginProps = (
     : undefined;
 };
 
-export const getExpoFingerprintExtraSources = (cwd: string): string[] => {
-  const { exp } = getConfig(cwd, {
+export const getExpoFingerprintExtraSources = async (
+  cwd: string,
+): Promise<string[]> => {
+  const { exp } = await getConfig(cwd, {
     skipSDKVersionRequirement: true,
   });
   const publicKeyPath = getHotUpdaterExpoPluginProps(
@@ -62,7 +64,7 @@ export const getExpoFingerprintExtraSources = (cwd: string): string[] => {
 export const getExpoBundleSigningPublicKey = async (
   cwd: string,
 ): Promise<{ readonly publicKey: string } | null> => {
-  const { exp } = getConfig(cwd, {
+  const { exp } = await getConfig(cwd, {
     skipSDKVersionRequirement: true,
   });
   const publicKeyPath = getHotUpdaterExpoPluginProps(

--- a/plugins/expo/src/expoConfig.ts
+++ b/plugins/expo/src/expoConfig.ts
@@ -1,0 +1,13 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import type * as ExpoConfig from "expo/config";
+
+export const getConfig = (
+  ...args: Parameters<typeof ExpoConfig.getConfig>
+): ReturnType<typeof ExpoConfig.getConfig> => {
+  const [projectRoot] = args;
+  const require = createRequire(path.resolve(projectRoot, "package.json"));
+  const expoConfig = require("expo/config") as typeof ExpoConfig;
+  return expoConfig.getConfig(...args);
+};

--- a/plugins/expo/src/expoConfig.ts
+++ b/plugins/expo/src/expoConfig.ts
@@ -1,13 +1,33 @@
-import { createRequire } from "node:module";
-import path from "node:path";
-
 import type * as ExpoConfig from "expo/config";
 
-export const getConfig = (
+type ExpoConfigModule = Partial<typeof ExpoConfig> & {
+  default?: typeof ExpoConfig;
+};
+
+const importExpoConfigModule = (specifier: string) =>
+  import(specifier) as Promise<ExpoConfigModule>;
+
+const isMissingModule = (error: unknown, specifier: string): boolean =>
+  error instanceof Error &&
+  "code" in error &&
+  error.code === "ERR_MODULE_NOT_FOUND" &&
+  error.message.includes(specifier);
+
+const loadExpoConfig = async (): Promise<typeof ExpoConfig> => {
+  try {
+    const module = await importExpoConfigModule("expo/config.js");
+    return module.getConfig ? (module as typeof ExpoConfig) : module.default!;
+  } catch (error) {
+    if (!isMissingModule(error, "expo/config.js")) throw error;
+  }
+
+  const module = await importExpoConfigModule("expo/config/index.js");
+  return module.getConfig ? (module as typeof ExpoConfig) : module.default!;
+};
+
+export const getConfig = async (
   ...args: Parameters<typeof ExpoConfig.getConfig>
-): ReturnType<typeof ExpoConfig.getConfig> => {
-  const [projectRoot] = args;
-  const require = createRequire(path.resolve(projectRoot, "package.json"));
-  const expoConfig = require("expo/config") as typeof ExpoConfig;
+): Promise<ReturnType<typeof ExpoConfig.getConfig>> => {
+  const expoConfig = await loadExpoConfig();
   return expoConfig.getConfig(...args);
 };


### PR DESCRIPTION
## Summary

- dynamically import the Expo config entry for both legacy and current SDK layouts
- make fingerprint extra-source discovery async to keep the published plugin ESM-native
- add a patch changeset for `@hot-updater/expo`

`@hot-updater/expo@1.0.0-rc.2` bundles the SDK 50 `expo/config.js` resolution into its ESM build. Expo SDK 56 exposes `expo/config/index.js` instead, so importing the published plugin fails before the CLI can load its config. The loader now tries the explicit SDK entry points with `await import()` and preserves the async boundary already supported by the native-build hook.

## Validation

- `pnpm --filter @hot-updater/expo build`
- `pnpm --filter @hot-updater/expo test` (39 tests)
- `pnpm --filter @hot-updater/expo test:type`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`
- built ESM and CommonJS package imports
- built ESM and CommonJS calls into Expo SDK 50 config
- downstream Expo SDK 56 ESM and CommonJS calls through the rc.2 patch