### PR TITLE
feat(docs): show all sponsors as weighted bubbles

### DIFF
--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -24,12 +24,15 @@ jobs:
           set -euo pipefail
           mkdir -p docs/public
 
+          # SPONSORS_TOKEN must be a classic PAT owned by the sponsorable
+          # account with read:user. Fine-grained PATs cannot read sponsor tiers.
           gh api graphql --paginate -f query='
             query($endCursor: String) {
               user(login: "gronxb") {
                 sponsorshipsAsMaintainer(
                   first: 100
                   after: $endCursor
+                  activeOnly: false
                   includePrivate: false
                 ) {
                   nodes {
@@ -46,9 +49,44 @@ jobs:
             .[].data.user.sponsorshipsAsMaintainer.nodes[]
             | select(.sponsorEntity != null)
             | .sponsorEntity
-          ]' > /tmp/active-sponsors.json
+          ]' > /tmp/public-sponsors.json
 
-          # Preserve historical sponsors and their last recorded tier amount
+          # Amounts remain in an ephemeral runner file. includePrivate is needed
+          # to recover the amount for sponsors that were public in git history
+          # but later changed visibility; private identities are never published.
+          gh api graphql --paginate -f query='
+            query($endCursor: String) {
+              user(login: "gronxb") {
+                sponsorshipsAsMaintainer(
+                  first: 100
+                  after: $endCursor
+                  activeOnly: false
+                  includePrivate: true
+                ) {
+                  nodes {
+                    tier { monthlyPriceInCents }
+                    sponsorEntity {
+                      ... on User { login }
+                      ... on Organization { login }
+                    }
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }
+          ' | jq -s '[
+            .[].data.user.sponsorshipsAsMaintainer.nodes[]
+            | select(
+                .sponsorEntity != null
+                and .tier.monthlyPriceInCents > 0
+              )
+            | {
+                login: .sponsorEntity.login,
+                amountInCents: .tier.monthlyPriceInCents
+              }
+          ]' > /tmp/sponsor-amounts.json
+
+          # Preserve every sponsor that was public in an earlier revision.
           git log --reverse --format=%H -- docs/public/sponsors.json |
             while read -r revision; do
               git show "$revision:docs/public/sponsors.json" | jq '.sponsors // []'
@@ -56,45 +94,52 @@ jobs:
             jq -s 'add // []' > /tmp/historical-sponsors.json
 
           jq -n \
-            --slurpfile activeSponsors /tmp/active-sponsors.json \
+            --slurpfile publicSponsors /tmp/public-sponsors.json \
+            --slurpfile sponsorAmounts /tmp/sponsor-amounts.json \
             --slurpfile historicalSponsors /tmp/historical-sponsors.json '
-              ($activeSponsors[0]
+              ($publicSponsors[0]
                 | map({
                     login,
                     avatarUrl,
                     name,
                     url
-                  })) as $active
-              | ($historicalSponsors[0] + $active)
-              | reduce .[] as $sponsor ({};
-                  .[$sponsor.login] as $existing
-                  |
-                  .[$sponsor.login] = (
-                    {
-                      login: $sponsor.login,
-                      avatarUrl: $sponsor.avatarUrl,
-                      name: $sponsor.name,
-                      url: $sponsor.url,
-                      amountInCents: (
-                        $sponsor.amountInCents
-                        // $existing.amountInCents
-                        // 0
-                      )
-                    }
-                    + (
-                      ($sponsor.displayWeight // $existing.displayWeight) as $displayWeight
-                      | if $displayWeight == null
-                        then {}
-                        else { displayWeight: $displayWeight }
+                  })) as $public
+              | ($historicalSponsors[0] + $public
+                  | reduce .[] as $sponsor ({};
+                      .[$sponsor.login | ascii_downcase] = {
+                        login: $sponsor.login,
+                        avatarUrl: $sponsor.avatarUrl,
+                        name: $sponsor.name,
+                        url: $sponsor.url
+                      }
+                    )
+                  | [.[]]) as $sponsors
+              | ($sponsorAmounts[0]
+                  | reduce .[] as $sponsorship ({};
+                      .[$sponsorship.login | ascii_downcase] =
+                        $sponsorship.amountInCents
+                    )) as $amounts
+              | ($sponsors
+                  | map($amounts[.login | ascii_downcase])
+                  | max // 0) as $maxAmount
+              | if $maxAmount <= 0 then
+                  error("SPONSORS_TOKEN cannot read sponsor tier amounts")
+                else
+                  $sponsors
+                  | map(
+                      ($amounts[.login | ascii_downcase]) as $amount
+                      | if $amount == null then
+                          error("Missing amount for historical sponsor: \(.login)")
+                        else
+                          . + {
+                            weight: (
+                              ($amount / $maxAmount * 1000) | round / 1000
+                            )
+                          }
                         end
                     )
-                  )
-                )
-              | [.[]]
-              | sort_by([
-                  -(.displayWeight // .amountInCents // 0),
-                  (.login | ascii_downcase)
-                ])
+                  | sort_by([-.weight, (.login | ascii_downcase)])
+                end
             ' > /tmp/sponsors.new.json
 
           # Extract the existing sponsors array (or use an empty array if missing)

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -32,6 +32,7 @@ jobs:
                   includePrivate: false
                 ) {
                   nodes {
+                    tier { monthlyPriceInCents }
                     sponsorEntity {
                       ... on User { login avatarUrl name url }
                       ... on Organization { login avatarUrl name url }
@@ -44,54 +45,33 @@ jobs:
           ' | jq -s '[
             .[].data.user.sponsorshipsAsMaintainer.nodes[]
             | select(.sponsorEntity != null)
-            | .sponsorEntity
+            | {
+                sponsor: .sponsorEntity,
+                amountInCents: (.tier.monthlyPriceInCents // 0)
+              }
           ]' > /tmp/public-sponsorships.json
 
-          gh api graphql --paginate -f query='
-            query($endCursor: String) {
-              user(login: "gronxb") {
-                lifetimeReceivedSponsorshipValues(
-                  first: 100
-                  after: $endCursor
-                  orderBy: { field: LIFETIME_VALUE, direction: DESC }
-                ) {
-                  nodes {
-                    amountInCents
-                    sponsor {
-                      ... on User { login }
-                      ... on Organization { login }
-                    }
-                  }
-                  pageInfo { hasNextPage endCursor }
-                }
-              }
-            }
-          ' | jq -s '[
-            .[].data.user.lifetimeReceivedSponsorshipValues.nodes[]
-            | select(. != null and .sponsor != null)
-          ]' > /tmp/lifetime-values.json
-
           jq -n \
-            --slurpfile sponsorships /tmp/public-sponsorships.json \
-            --slurpfile lifetimeValues /tmp/lifetime-values.json '
+            --slurpfile sponsorships /tmp/public-sponsorships.json '
               ($sponsorships[0]
-                | unique_by(.login)) as $publicSponsors
-              | (reduce $lifetimeValues[0][] as $value ({};
-                  .[$value.sponsor.login] = $value.amountInCents
-                )) as $amountByLogin
-              | ($publicSponsors
-                  | map(.login as $login | $amountByLogin[$login] // 0)
-                  | max // 1
-                ) as $maxAmount
+                | group_by(.sponsor.login)
+                | map(max_by(.amountInCents))) as $publicSponsors
+              | ($publicSponsors | map(.amountInCents) | max // 0) as $maxAmount
               | $publicSponsors
               | map(
-                  .login as $login
-                  | . + {
+                  {
+                    login: .sponsor.login,
+                    avatarUrl: .sponsor.avatarUrl,
+                    name: .sponsor.name,
+                    url: .sponsor.url,
                       weight: (
-                        (($amountByLogin[$login] // 0) / $maxAmount * 1000)
-                        | round / 1000
+                        if $maxAmount > 0 then
+                          ((.amountInCents / $maxAmount * 1000) | round / 1000)
+                        else
+                          1
+                        end
                       )
-                    }
+                  }
                 )
               | sort_by([-.weight, (.login | ascii_downcase)])
             ' > /tmp/sponsors.new.json

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -22,40 +22,93 @@ jobs:
           set -euo pipefail
           mkdir -p docs/public
 
-          # 1) Generate the new sponsors array (sorted for stable diffs)
-          gh api graphql -f query='
-            query {
+          gh api graphql --paginate -f query='
+            query($endCursor: String) {
               user(login: "gronxb") {
-                sponsorshipsAsMaintainer(first: 100, includePrivate: false) {
+                sponsorshipsAsMaintainer(
+                  first: 100
+                  after: $endCursor
+                  activeOnly: false
+                  includePrivate: false
+                ) {
                   nodes {
                     sponsorEntity {
                       ... on User { login avatarUrl name url }
                       ... on Organization { login avatarUrl name url }
                     }
                   }
+                  pageInfo { hasNextPage endCursor }
                 }
               }
             }
-          ' | jq '[
-            .data.user.sponsorshipsAsMaintainer.nodes[].sponsorEntity
-            | select(. != null)
-            | { login, avatarUrl, name, url }
-          ] | sort_by(.login)' > /tmp/sponsors.new.json
+          ' | jq -s '[
+            .[].data.user.sponsorshipsAsMaintainer.nodes[]
+            | select(.sponsorEntity != null)
+            | .sponsorEntity
+          ]' > /tmp/public-sponsorships.json
 
-          # 2) Extract the existing sponsors array (or use an empty array if missing)
+          gh api graphql --paginate -f query='
+            query($endCursor: String) {
+              user(login: "gronxb") {
+                lifetimeReceivedSponsorshipValues(
+                  first: 100
+                  after: $endCursor
+                  orderBy: { field: LIFETIME_VALUE, direction: DESC }
+                ) {
+                  nodes {
+                    amountInCents
+                    sponsor {
+                      ... on User { login }
+                      ... on Organization { login }
+                    }
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }
+          ' | jq -s '[
+            .[].data.user.lifetimeReceivedSponsorshipValues.nodes[]
+            | select(. != null and .sponsor != null)
+          ]' > /tmp/lifetime-values.json
+
+          jq -n \
+            --slurpfile sponsorships /tmp/public-sponsorships.json \
+            --slurpfile lifetimeValues /tmp/lifetime-values.json '
+              ($sponsorships[0]
+                | unique_by(.login)) as $publicSponsors
+              | (reduce $lifetimeValues[0][] as $value ({};
+                  .[$value.sponsor.login] = $value.amountInCents
+                )) as $amountByLogin
+              | ($publicSponsors
+                  | map(.login as $login | $amountByLogin[$login] // 0)
+                  | max // 1
+                ) as $maxAmount
+              | $publicSponsors
+              | map(
+                  .login as $login
+                  | . + {
+                      weight: (
+                        (($amountByLogin[$login] // 0) / $maxAmount * 1000)
+                        | round / 1000
+                      )
+                    }
+                )
+              | sort_by([-.weight, (.login | ascii_downcase)])
+            ' > /tmp/sponsors.new.json
+
+          # Extract the existing sponsors array (or use an empty array if missing)
           if [ -f docs/public/sponsors.json ]; then
-            jq '.sponsors // [] | sort_by(.login)' docs/public/sponsors.json > /tmp/sponsors.old.json
+            jq '.sponsors // []' docs/public/sponsors.json > /tmp/sponsors.old.json
           else
             echo '[]' > /tmp/sponsors.old.json
           fi
 
-          # 3) If sponsors did not change, do not touch the file (so updatedAt won't change)
+          # Keep updatedAt stable when the sponsor data has not changed
           if diff -q /tmp/sponsors.old.json /tmp/sponsors.new.json >/dev/null; then
             echo "No sponsor changes. Skipping update."
             exit 0
           fi
 
-          # 4) If sponsors changed, write a new sponsors.json with a fresh updatedAt timestamp
           jq -n --slurpfile sponsors /tmp/sponsors.new.json \
             '{ sponsors: $sponsors[0], updatedAt: (now | todate) }' \
             > docs/public/sponsors.json

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -52,17 +52,27 @@ jobs:
             | .sponsorEntity
           ]' > /tmp/public-sponsors.json
 
-          # Lifetime amounts remain in an ephemeral runner file. The separate
-          # public sponsorship query above controls which identities are published.
+          # GitHub withholds lifetime value nodes from API tokens, so derive each
+          # total from sponsorship starts, tier changes, and cancellations. The
+          # amounts remain in an ephemeral runner file; the public query above
+          # controls which identities are published.
           gh api graphql --paginate -f query='
             query($endCursor: String) {
               user(login: "gronxb") {
-                lifetimeReceivedSponsorshipValues(
+                sponsorsActivities(
                   first: 100
                   after: $endCursor
+                  period: ALL
+                  includePrivate: true
                 ) {
                   nodes {
-                    amountInCents
+                    action
+                    timestamp
+                    paymentSource
+                    sponsorsTier {
+                      monthlyPriceInCents
+                      isOneTime
+                    }
                     sponsor {
                       ... on User { login }
                       ... on Organization { login }
@@ -72,17 +82,113 @@ jobs:
                 }
               }
             }
-          ' | jq -s '[
-            .[].data.user.lifetimeReceivedSponsorshipValues.nodes[]
-            | select(
-                .sponsor != null
-                and .amountInCents > 0
+          ' | jq -s '
+            def billing_count($startedAt; $endedAt; $includeEnd):
+              ($startedAt | fromdateiso8601 | gmtime) as $started
+              | ($endedAt | fromdateiso8601 | gmtime) as $ended
+              | (($ended[0] - $started[0]) * 12
+                  + $ended[1] - $started[1]) as $months
+              | if $months < 0 then
+                  error("Sponsorship ended before it started")
+                else
+                  ([$ended[0], $ended[1] + 1, 0, 0, 0, 0, 0, 0]
+                    | mktime | gmtime | .[2]) as $lastDay
+                  | ([$started[2], $lastDay] | min) as $billingDay
+                  | $months + (
+                      if $ended[2] > $billingDay
+                        or ($includeEnd and $ended[2] == $billingDay)
+                      then 1 else 0 end
+                    )
+                end;
+
+            (now | todate) as $now
+            | [
+                .[].data.user.sponsorsActivities.nodes[]
+                | select(. != null and .sponsor != null)
+                | {
+                    login: .sponsor.login,
+                    action,
+                    timestamp,
+                    paymentSource,
+                    amountInCents: .sponsorsTier.monthlyPriceInCents,
+                    isOneTime: .sponsorsTier.isOneTime
+                  }
+              ]
+            | sort_by([(.login | ascii_downcase), .timestamp])
+            | group_by(.login | ascii_downcase)
+            | map(
+                . as $events
+                | reduce $events[] as $event (
+                    {
+                      login: $events[0].login,
+                      amountInCents: 0,
+                      recurring: null
+                    };
+                    if $event.paymentSource != "GITHUB" then
+                      error("Unsupported sponsorship payment source")
+                    elif $event.action == "NEW_SPONSORSHIP" then
+                      if ($event.amountInCents // 0) <= 0 then
+                        error("Missing amount for new sponsorship")
+                      elif $event.isOneTime then
+                        .amountInCents += $event.amountInCents
+                      elif .recurring != null then
+                        error("Overlapping recurring sponsorships")
+                      else
+                        .recurring = {
+                          startedAt: $event.timestamp,
+                          amountInCents: $event.amountInCents
+                        }
+                      end
+                    elif $event.action == "TIER_CHANGE" then
+                      if .recurring == null
+                        or ($event.amountInCents // 0) <= 0 then
+                        error("Invalid recurring tier change")
+                      else
+                        .amountInCents += (
+                          .recurring.amountInCents
+                          * billing_count(
+                              .recurring.startedAt;
+                              $event.timestamp;
+                              false
+                            )
+                        )
+                        | .recurring = {
+                            startedAt: $event.timestamp,
+                            amountInCents: $event.amountInCents
+                          }
+                      end
+                    elif $event.action == "CANCELLED_SPONSORSHIP" then
+                      if .recurring == null then
+                        error("Cancellation without recurring sponsorship")
+                      else
+                        .amountInCents += (
+                          .recurring.amountInCents
+                          * billing_count(
+                              .recurring.startedAt;
+                              $event.timestamp;
+                              false
+                            )
+                        )
+                        | .recurring = null
+                      end
+                    elif $event.action == "REFUND" then
+                      error("Refund amounts are unavailable from Sponsors API")
+                    elif $event.action == "PENDING_CHANGE"
+                      or $event.action == "SPONSOR_MATCH_DISABLED" then
+                      .
+                    else
+                      error("Unsupported sponsorship activity")
+                    end
+                  )
+                | if .recurring != null then
+                    .amountInCents += (
+                      .recurring.amountInCents
+                      * billing_count(.recurring.startedAt; $now; true)
+                    )
+                  else . end
+                | del(.recurring)
               )
-            | {
-                login: .sponsor.login,
-                amountInCents
-              }
-          ]' > /tmp/sponsor-amounts.json
+          ' > /tmp/sponsor-amounts.json
 
           # Preserve every sponsor that was public in an earlier revision.
           git log --reverse --format=%H -- docs/public/sponsors.json |
@@ -121,7 +227,7 @@ jobs:
                   | map($amounts[.login | ascii_downcase])
                   | max // 0) as $maxAmount
               | if $maxAmount <= 0 then
-                  error("SPONSORS_TOKEN cannot read lifetime sponsorship amounts")
+                  error("Could not calculate lifetime sponsorship amounts")
                 else
                   $sponsors
                   | map(

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -25,7 +25,8 @@ jobs:
           mkdir -p docs/public
 
           # SPONSORS_TOKEN must be a classic PAT owned by the sponsorable
-          # account with read:user. Fine-grained PATs cannot read sponsor tiers.
+          # account with read:user and read:org. Fine-grained PATs cannot read
+          # sponsor tiers.
           gh api graphql --paginate -f query='
             query($endCursor: String) {
               user(login: "gronxb") {

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -52,21 +52,18 @@ jobs:
             | .sponsorEntity
           ]' > /tmp/public-sponsors.json
 
-          # Amounts remain in an ephemeral runner file. includePrivate is needed
-          # to recover the amount for sponsors that were public in git history
-          # but later changed visibility; private identities are never published.
+          # Lifetime amounts remain in an ephemeral runner file. The separate
+          # public sponsorship query above controls which identities are published.
           gh api graphql --paginate -f query='
             query($endCursor: String) {
               user(login: "gronxb") {
-                sponsorshipsAsMaintainer(
+                lifetimeReceivedSponsorshipValues(
                   first: 100
                   after: $endCursor
-                  activeOnly: false
-                  includePrivate: true
                 ) {
                   nodes {
-                    tier { monthlyPriceInCents }
-                    sponsorEntity {
+                    amountInCents
+                    sponsor {
                       ... on User { login }
                       ... on Organization { login }
                     }
@@ -76,14 +73,14 @@ jobs:
               }
             }
           ' | jq -s '[
-            .[].data.user.sponsorshipsAsMaintainer.nodes[]
+            .[].data.user.lifetimeReceivedSponsorshipValues.nodes[]
             | select(
-                .sponsorEntity != null
-                and .tier.monthlyPriceInCents > 0
+                .sponsor != null
+                and .amountInCents > 0
               )
             | {
-                login: .sponsorEntity.login,
-                amountInCents: .tier.monthlyPriceInCents
+                login: .sponsor.login,
+                amountInCents
               }
           ]' > /tmp/sponsor-amounts.json
 
@@ -124,7 +121,7 @@ jobs:
                   | map($amounts[.login | ascii_downcase])
                   | max // 0) as $maxAmount
               | if $maxAmount <= 0 then
-                  error("SPONSORS_TOKEN cannot read sponsor tier amounts")
+                  error("SPONSORS_TOKEN cannot read lifetime sponsorship amounts")
                 else
                   $sponsors
                   | map(

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
 
       - name: Fetch sponsors (commit only when sponsors changed)
         env:
@@ -28,7 +30,6 @@ jobs:
                 sponsorshipsAsMaintainer(
                   first: 100
                   after: $endCursor
-                  activeOnly: false
                   includePrivate: false
                 ) {
                   nodes {
@@ -49,31 +50,37 @@ jobs:
                 sponsor: .sponsorEntity,
                 amountInCents: (.tier.monthlyPriceInCents // 0)
               }
-          ]' > /tmp/public-sponsorships.json
+          ]' > /tmp/active-sponsors.json
+
+          git log --reverse --format=%H -- docs/public/sponsors.json |
+            while read -r revision; do
+              git show "$revision:docs/public/sponsors.json" | jq '.sponsors // []'
+            done |
+            jq -s 'add // []' > /tmp/historical-sponsors.json
 
           jq -n \
-            --slurpfile sponsorships /tmp/public-sponsorships.json '
-              ($sponsorships[0]
-                | group_by(.sponsor.login)
-                | map(max_by(.amountInCents))) as $publicSponsors
-              | ($publicSponsors | map(.amountInCents) | max // 0) as $maxAmount
-              | $publicSponsors
-              | map(
-                  {
+            --slurpfile activeSponsors /tmp/active-sponsors.json \
+            --slurpfile historicalSponsors /tmp/historical-sponsors.json '
+              ($activeSponsors[0]
+                | map({
                     login: .sponsor.login,
                     avatarUrl: .sponsor.avatarUrl,
                     name: .sponsor.name,
                     url: .sponsor.url,
-                      weight: (
-                        if $maxAmount > 0 then
-                          ((.amountInCents / $maxAmount * 1000) | round / 1000)
-                        else
-                          1
-                        end
-                      )
+                    amountInCents
+                  })) as $active
+              | ($historicalSponsors[0] + $active)
+              | reduce .[] as $sponsor ({};
+                  .[$sponsor.login] = {
+                    login: $sponsor.login,
+                    avatarUrl: $sponsor.avatarUrl,
+                    name: $sponsor.name,
+                    url: $sponsor.url,
+                    amountInCents: ($sponsor.amountInCents // 0)
                   }
                 )
-              | sort_by([-.weight, (.login | ascii_downcase)])
+              | [.[]]
+              | sort_by([-.amountInCents, (.login | ascii_downcase)])
             ' > /tmp/sponsors.new.json
 
           # Extract the existing sponsors array (or use an empty array if missing)

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -33,7 +33,6 @@ jobs:
                   includePrivate: false
                 ) {
                   nodes {
-                    tier { monthlyPriceInCents }
                     sponsorEntity {
                       ... on User { login avatarUrl name url }
                       ... on Organization { login avatarUrl name url }
@@ -46,12 +45,10 @@ jobs:
           ' | jq -s '[
             .[].data.user.sponsorshipsAsMaintainer.nodes[]
             | select(.sponsorEntity != null)
-            | {
-                sponsor: .sponsorEntity,
-                amountInCents: (.tier.monthlyPriceInCents // 0)
-              }
+            | .sponsorEntity
           ]' > /tmp/active-sponsors.json
 
+          # Preserve historical sponsors and their last recorded tier amount
           git log --reverse --format=%H -- docs/public/sponsors.json |
             while read -r revision; do
               git show "$revision:docs/public/sponsors.json" | jq '.sponsors // []'
@@ -63,20 +60,25 @@ jobs:
             --slurpfile historicalSponsors /tmp/historical-sponsors.json '
               ($activeSponsors[0]
                 | map({
-                    login: .sponsor.login,
-                    avatarUrl: .sponsor.avatarUrl,
-                    name: .sponsor.name,
-                    url: .sponsor.url,
-                    amountInCents
+                    login,
+                    avatarUrl,
+                    name,
+                    url
                   })) as $active
               | ($historicalSponsors[0] + $active)
               | reduce .[] as $sponsor ({};
+                  .[$sponsor.login] as $existing
+                  |
                   .[$sponsor.login] = {
                     login: $sponsor.login,
                     avatarUrl: $sponsor.avatarUrl,
                     name: $sponsor.name,
                     url: $sponsor.url,
-                    amountInCents: ($sponsor.amountInCents // 0)
+                    amountInCents: (
+                      $sponsor.amountInCents
+                      // $existing.amountInCents
+                      // 0
+                    )
                   }
                 )
               | [.[]]

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -69,20 +69,32 @@ jobs:
               | reduce .[] as $sponsor ({};
                   .[$sponsor.login] as $existing
                   |
-                  .[$sponsor.login] = {
-                    login: $sponsor.login,
-                    avatarUrl: $sponsor.avatarUrl,
-                    name: $sponsor.name,
-                    url: $sponsor.url,
-                    amountInCents: (
-                      $sponsor.amountInCents
-                      // $existing.amountInCents
-                      // 0
+                  .[$sponsor.login] = (
+                    {
+                      login: $sponsor.login,
+                      avatarUrl: $sponsor.avatarUrl,
+                      name: $sponsor.name,
+                      url: $sponsor.url,
+                      amountInCents: (
+                        $sponsor.amountInCents
+                        // $existing.amountInCents
+                        // 0
+                      )
+                    }
+                    + (
+                      ($sponsor.displayWeight // $existing.displayWeight) as $displayWeight
+                      | if $displayWeight == null
+                        then {}
+                        else { displayWeight: $displayWeight }
+                        end
                     )
-                  }
+                  )
                 )
               | [.[]]
-              | sort_by([-.amountInCents, (.login | ascii_downcase)])
+              | sort_by([
+                  -(.displayWeight // .amountInCents // 0),
+                  (.login | ascii_downcase)
+                ])
             ' > /tmp/sponsors.new.json
 
           # Extract the existing sponsors array (or use an empty array if missing)

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "arktype": "^2.1.27",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "d3-hierarchy": "^3.1.2",
     "fumadocs-core": "16.10.7",
     "fumadocs-mdx": "15.0.13",
     "fumadocs-ui": "16.10.7",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",
+    "@types/d3-hierarchy": "^3.1.7",
     "@types/mdx": "^2.0.13",
     "@types/node": "^24.9.2",
     "@types/react": "19.2.15",

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -113,6 +113,13 @@
       "amountInCents": 0
     },
     {
+      "login": "kr-yeon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
+      "name": "kr-yeon",
+      "url": "https://github.com/kr-yeon",
+      "amountInCents": 0
+    },
+    {
       "login": "RyuWoong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/36265465?u=916eb9791fb9f9d5efbea5f2ab82f1463af166e2&v=4",
       "name": "RyuWoong",
@@ -127,5 +134,5 @@
       "amountInCents": 0
     }
   ],
-  "updatedAt": "2026-09-02T14:58:00Z"
+  "updatedAt": "2026-09-02T15:03:46Z"
 }

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -5,135 +5,134 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
       "name": "Callstack",
       "url": "https://github.com/callstack",
-      "amountInCents": 0,
-      "displayWeight": 1500
-    },
-    {
-      "login": "diepquynh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13411810?u=9ccec54ec26d43f895665e0d39f584f07d8bb310&v=4",
-      "name": "Diệp Quỳnh",
-      "url": "https://github.com/diepquynh",
-      "amountInCents": 1000
-    },
-    {
-      "login": "sfshine",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3046831?v=4",
-      "name": "SHUAI GAO",
-      "url": "https://github.com/sfshine",
-      "amountInCents": 1000
-    },
-    {
-      "login": "timid-dogs",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/290142700?v=4",
-      "name": null,
-      "url": "https://github.com/timid-dogs",
-      "amountInCents": 1000
-    },
-    {
-      "login": "Alexhamila",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28599364?u=28acfc45897776540c12bbcaddb6a0f75eac3ae4&v=4",
-      "name": "Alexandre Hamila",
-      "url": "https://github.com/Alexhamila",
-      "amountInCents": 500
-    },
-    {
-      "login": "Davescat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47789084?u=011ae9b93ad68924bf2bce311eb102bd6337e00b&v=4",
-      "name": "Davide Catalano",
-      "url": "https://github.com/Davescat",
-      "amountInCents": 500
-    },
-    {
-      "login": "l2hyunwoo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54518925?u=f80bc30256a5ea51de9f8e3c820b227dcf89526e&v=4",
-      "name": "HyunWoo Lee (Nunu Lee)",
-      "url": "https://github.com/l2hyunwoo",
-      "amountInCents": 500
-    },
-    {
-      "login": "LESANF",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54767632?u=cbfb438d2adb43d312f3df83a78772e1e4dd1509&v=4",
-      "name": "LESA",
-      "url": "https://github.com/LESANF",
-      "amountInCents": 500
-    },
-    {
-      "login": "RiedelNicolas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/44354888?u=355d329022734ebc2a7e6d4a1d8a3fe72cc3664c&v=4",
-      "name": "Nicolás Riedel",
-      "url": "https://github.com/RiedelNicolas",
-      "amountInCents": 500
-    },
-    {
-      "login": "soonoo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&v=4",
-      "name": "soonoo",
-      "url": "https://github.com/soonoo",
-      "amountInCents": 500
-    },
-    {
-      "login": "valeriobelli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
-      "name": "Valerio Belli",
-      "url": "https://github.com/valeriobelli",
-      "amountInCents": 500
-    },
-    {
-      "login": "victorsaisse",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/85237893?u=b2a3b07d95f2fa74982a01cca672fe9c8ba0dad6&v=4",
-      "name": "Victor Saisse",
-      "url": "https://github.com/victorsaisse",
-      "amountInCents": 500
+      "weight": 1
     },
     {
       "login": "claudesortwell",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41422239?u=62aa6ed5b4084595175b5fdc42d2edb5598e914b&v=4",
       "name": "Claude",
       "url": "https://github.com/claudesortwell",
-      "amountInCents": 0
-    },
-    {
-      "login": "himanjalsaha",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/84189618?u=f42b709bb52d9c69f97d792d14a3fb4ff94d20ba&v=4",
-      "name": "Himanjal saha",
-      "url": "https://github.com/himanjalsaha",
-      "amountInCents": 0
+      "weight": 0.238
     },
     {
       "login": "iAndrew25",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16413368?u=0e32c0315f111ee0d8729cf5364c6d579f5fb703&v=4",
       "name": "AndreiO",
       "url": "https://github.com/iAndrew25",
-      "amountInCents": 0
+      "weight": 0.238
     },
     {
       "login": "Ikanny",
       "avatarUrl": "https://avatars.githubusercontent.com/u/22442088?u=204aa63d72569f59c7f3f7cebb3ccded6a83c6de&v=4",
       "name": "ikanny",
       "url": "https://github.com/Ikanny",
-      "amountInCents": 0
-    },
-    {
-      "login": "kr-yeon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
-      "name": "kr-yeon",
-      "url": "https://github.com/kr-yeon",
-      "amountInCents": 0
-    },
-    {
-      "login": "RyuWoong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/36265465?u=916eb9791fb9f9d5efbea5f2ab82f1463af166e2&v=4",
-      "name": "RyuWoong",
-      "url": "https://github.com/RyuWoong",
-      "amountInCents": 0
+      "weight": 0.095
     },
     {
       "login": "wes4m",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5308867?v=4",
       "name": "Wesam Alzahir",
       "url": "https://github.com/wes4m",
-      "amountInCents": 0
+      "weight": 0.095
+    },
+    {
+      "login": "diepquynh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13411810?u=9ccec54ec26d43f895665e0d39f584f07d8bb310&v=4",
+      "name": "Diệp Quỳnh",
+      "url": "https://github.com/diepquynh",
+      "weight": 0.048
+    },
+    {
+      "login": "kr-yeon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
+      "name": "kr-yeon",
+      "url": "https://github.com/kr-yeon",
+      "weight": 0.048
+    },
+    {
+      "login": "sfshine",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3046831?v=4",
+      "name": "SHUAI GAO",
+      "url": "https://github.com/sfshine",
+      "weight": 0.048
+    },
+    {
+      "login": "timid-dogs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/290142700?v=4",
+      "name": null,
+      "url": "https://github.com/timid-dogs",
+      "weight": 0.048
+    },
+    {
+      "login": "Alexhamila",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28599364?u=28acfc45897776540c12bbcaddb6a0f75eac3ae4&v=4",
+      "name": "Alexandre Hamila",
+      "url": "https://github.com/Alexhamila",
+      "weight": 0.024
+    },
+    {
+      "login": "Davescat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47789084?u=011ae9b93ad68924bf2bce311eb102bd6337e00b&v=4",
+      "name": "Davide Catalano",
+      "url": "https://github.com/Davescat",
+      "weight": 0.024
+    },
+    {
+      "login": "l2hyunwoo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54518925?u=f80bc30256a5ea51de9f8e3c820b227dcf89526e&v=4",
+      "name": "HyunWoo Lee (Nunu Lee)",
+      "url": "https://github.com/l2hyunwoo",
+      "weight": 0.024
+    },
+    {
+      "login": "LESANF",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54767632?u=cbfb438d2adb43d312f3df83a78772e1e4dd1509&v=4",
+      "name": "LESA",
+      "url": "https://github.com/LESANF",
+      "weight": 0.024
+    },
+    {
+      "login": "RiedelNicolas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/44354888?u=355d329022734ebc2a7e6d4a1d8a3fe72cc3664c&v=4",
+      "name": "Nicolás Riedel",
+      "url": "https://github.com/RiedelNicolas",
+      "weight": 0.024
+    },
+    {
+      "login": "soonoo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&v=4",
+      "name": "soonoo",
+      "url": "https://github.com/soonoo",
+      "weight": 0.024
+    },
+    {
+      "login": "valeriobelli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
+      "name": "Valerio Belli",
+      "url": "https://github.com/valeriobelli",
+      "weight": 0.024
+    },
+    {
+      "login": "victorsaisse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/85237893?u=b2a3b07d95f2fa74982a01cca672fe9c8ba0dad6&v=4",
+      "name": "Victor Saisse",
+      "url": "https://github.com/victorsaisse",
+      "weight": 0.024
+    },
+    {
+      "login": "RyuWoong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36265465?u=916eb9791fb9f9d5efbea5f2ab82f1463af166e2&v=4",
+      "name": "RyuWoong",
+      "url": "https://github.com/RyuWoong",
+      "weight": 0.019
+    },
+    {
+      "login": "himanjalsaha",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84189618?u=f42b709bb52d9c69f97d792d14a3fb4ff94d20ba&v=4",
+      "name": "Himanjal saha",
+      "url": "https://github.com/himanjalsaha",
+      "weight": 0.005
     }
   ],
-  "updatedAt": "2026-09-02T15:33:14Z"
+  "updatedAt": "2026-09-02T16:06:39Z"
 }

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -82,7 +82,8 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
       "name": "Callstack",
       "url": "https://github.com/callstack",
-      "amountInCents": 0
+      "amountInCents": 0,
+      "displayWeight": 1500
     },
     {
       "login": "claudesortwell",

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -8,10 +8,24 @@
       "weight": 1
     },
     {
+      "login": "valeriobelli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
+      "name": "Valerio Belli",
+      "url": "https://github.com/valeriobelli",
+      "weight": 0.452
+    },
+    {
       "login": "claudesortwell",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41422239?u=62aa6ed5b4084595175b5fdc42d2edb5598e914b&v=4",
       "name": "Claude",
       "url": "https://github.com/claudesortwell",
+      "weight": 0.238
+    },
+    {
+      "login": "Davescat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47789084?u=011ae9b93ad68924bf2bce311eb102bd6337e00b&v=4",
+      "name": "Davide Catalano",
+      "url": "https://github.com/Davescat",
       "weight": 0.238
     },
     {
@@ -20,6 +34,20 @@
       "name": "AndreiO",
       "url": "https://github.com/iAndrew25",
       "weight": 0.238
+    },
+    {
+      "login": "kr-yeon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
+      "name": "kr-yeon",
+      "url": "https://github.com/kr-yeon",
+      "weight": 0.19
+    },
+    {
+      "login": "timid-dogs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/290142700?v=4",
+      "name": null,
+      "url": "https://github.com/timid-dogs",
+      "weight": 0.143
     },
     {
       "login": "Ikanny",
@@ -36,17 +64,17 @@
       "weight": 0.095
     },
     {
+      "login": "soonoo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&v=4",
+      "name": "soonoo",
+      "url": "https://github.com/soonoo",
+      "weight": 0.071
+    },
+    {
       "login": "diepquynh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13411810?u=9ccec54ec26d43f895665e0d39f584f07d8bb310&v=4",
       "name": "Diệp Quỳnh",
       "url": "https://github.com/diepquynh",
-      "weight": 0.048
-    },
-    {
-      "login": "kr-yeon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65217664?u=c997206ed89e902b1d15c96d0c0997823c1317fc&v=4",
-      "name": "kr-yeon",
-      "url": "https://github.com/kr-yeon",
       "weight": 0.048
     },
     {
@@ -57,24 +85,10 @@
       "weight": 0.048
     },
     {
-      "login": "timid-dogs",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/290142700?v=4",
-      "name": null,
-      "url": "https://github.com/timid-dogs",
-      "weight": 0.048
-    },
-    {
       "login": "Alexhamila",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28599364?u=28acfc45897776540c12bbcaddb6a0f75eac3ae4&v=4",
       "name": "Alexandre Hamila",
       "url": "https://github.com/Alexhamila",
-      "weight": 0.024
-    },
-    {
-      "login": "Davescat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47789084?u=011ae9b93ad68924bf2bce311eb102bd6337e00b&v=4",
-      "name": "Davide Catalano",
-      "url": "https://github.com/Davescat",
       "weight": 0.024
     },
     {
@@ -99,20 +113,6 @@
       "weight": 0.024
     },
     {
-      "login": "soonoo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&v=4",
-      "name": "soonoo",
-      "url": "https://github.com/soonoo",
-      "weight": 0.024
-    },
-    {
-      "login": "valeriobelli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
-      "name": "Valerio Belli",
-      "url": "https://github.com/valeriobelli",
-      "weight": 0.024
-    },
-    {
       "login": "victorsaisse",
       "avatarUrl": "https://avatars.githubusercontent.com/u/85237893?u=b2a3b07d95f2fa74982a01cca672fe9c8ba0dad6&v=4",
       "name": "Victor Saisse",
@@ -134,5 +134,5 @@
       "weight": 0.005
     }
   ],
-  "updatedAt": "2026-09-02T16:06:39Z"
+  "updatedAt": "2026-09-02T17:13:40Z"
 }

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -1,6 +1,14 @@
 {
   "sponsors": [
     {
+      "login": "callstack",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
+      "name": "Callstack",
+      "url": "https://github.com/callstack",
+      "amountInCents": 0,
+      "displayWeight": 1500
+    },
+    {
       "login": "diepquynh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13411810?u=9ccec54ec26d43f895665e0d39f584f07d8bb310&v=4",
       "name": "Diệp Quỳnh",
@@ -78,14 +86,6 @@
       "amountInCents": 500
     },
     {
-      "login": "callstack",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
-      "name": "Callstack",
-      "url": "https://github.com/callstack",
-      "amountInCents": 0,
-      "displayWeight": 1500
-    },
-    {
       "login": "claudesortwell",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41422239?u=62aa6ed5b4084595175b5fdc42d2edb5598e914b&v=4",
       "name": "Claude",
@@ -135,5 +135,5 @@
       "amountInCents": 0
     }
   ],
-  "updatedAt": "2026-09-02T15:03:46Z"
+  "updatedAt": "2026-09-02T15:33:14Z"
 }

--- a/docs/public/sponsors.json
+++ b/docs/public/sponsors.json
@@ -1,29 +1,131 @@
 {
   "sponsors": [
     {
+      "login": "diepquynh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13411810?u=9ccec54ec26d43f895665e0d39f584f07d8bb310&v=4",
+      "name": "Diệp Quỳnh",
+      "url": "https://github.com/diepquynh",
+      "amountInCents": 1000
+    },
+    {
+      "login": "sfshine",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3046831?v=4",
+      "name": "SHUAI GAO",
+      "url": "https://github.com/sfshine",
+      "amountInCents": 1000
+    },
+    {
+      "login": "timid-dogs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/290142700?v=4",
+      "name": null,
+      "url": "https://github.com/timid-dogs",
+      "amountInCents": 1000
+    },
+    {
+      "login": "Alexhamila",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28599364?u=28acfc45897776540c12bbcaddb6a0f75eac3ae4&v=4",
+      "name": "Alexandre Hamila",
+      "url": "https://github.com/Alexhamila",
+      "amountInCents": 500
+    },
+    {
       "login": "Davescat",
       "avatarUrl": "https://avatars.githubusercontent.com/u/47789084?u=011ae9b93ad68924bf2bce311eb102bd6337e00b&v=4",
       "name": "Davide Catalano",
-      "url": "https://github.com/Davescat"
+      "url": "https://github.com/Davescat",
+      "amountInCents": 500
     },
     {
-      "login": "callstack",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
-      "name": "Callstack",
-      "url": "https://github.com/callstack"
+      "login": "l2hyunwoo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54518925?u=f80bc30256a5ea51de9f8e3c820b227dcf89526e&v=4",
+      "name": "HyunWoo Lee (Nunu Lee)",
+      "url": "https://github.com/l2hyunwoo",
+      "amountInCents": 500
+    },
+    {
+      "login": "LESANF",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54767632?u=cbfb438d2adb43d312f3df83a78772e1e4dd1509&v=4",
+      "name": "LESA",
+      "url": "https://github.com/LESANF",
+      "amountInCents": 500
+    },
+    {
+      "login": "RiedelNicolas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/44354888?u=355d329022734ebc2a7e6d4a1d8a3fe72cc3664c&v=4",
+      "name": "Nicolás Riedel",
+      "url": "https://github.com/RiedelNicolas",
+      "amountInCents": 500
     },
     {
       "login": "soonoo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&v=4",
       "name": "soonoo",
-      "url": "https://github.com/soonoo"
+      "url": "https://github.com/soonoo",
+      "amountInCents": 500
     },
     {
       "login": "valeriobelli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/56547421?u=2a7ead7e22a551021e26e41aef6c7c4b89216ffc&v=4",
       "name": "Valerio Belli",
-      "url": "https://github.com/valeriobelli"
+      "url": "https://github.com/valeriobelli",
+      "amountInCents": 500
+    },
+    {
+      "login": "victorsaisse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/85237893?u=b2a3b07d95f2fa74982a01cca672fe9c8ba0dad6&v=4",
+      "name": "Victor Saisse",
+      "url": "https://github.com/victorsaisse",
+      "amountInCents": 500
+    },
+    {
+      "login": "callstack",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42239399?v=4",
+      "name": "Callstack",
+      "url": "https://github.com/callstack",
+      "amountInCents": 0
+    },
+    {
+      "login": "claudesortwell",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41422239?u=62aa6ed5b4084595175b5fdc42d2edb5598e914b&v=4",
+      "name": "Claude",
+      "url": "https://github.com/claudesortwell",
+      "amountInCents": 0
+    },
+    {
+      "login": "himanjalsaha",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84189618?u=f42b709bb52d9c69f97d792d14a3fb4ff94d20ba&v=4",
+      "name": "Himanjal saha",
+      "url": "https://github.com/himanjalsaha",
+      "amountInCents": 0
+    },
+    {
+      "login": "iAndrew25",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16413368?u=0e32c0315f111ee0d8729cf5364c6d579f5fb703&v=4",
+      "name": "AndreiO",
+      "url": "https://github.com/iAndrew25",
+      "amountInCents": 0
+    },
+    {
+      "login": "Ikanny",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22442088?u=204aa63d72569f59c7f3f7cebb3ccded6a83c6de&v=4",
+      "name": "ikanny",
+      "url": "https://github.com/Ikanny",
+      "amountInCents": 0
+    },
+    {
+      "login": "RyuWoong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36265465?u=916eb9791fb9f9d5efbea5f2ab82f1463af166e2&v=4",
+      "name": "RyuWoong",
+      "url": "https://github.com/RyuWoong",
+      "amountInCents": 0
+    },
+    {
+      "login": "wes4m",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5308867?v=4",
+      "name": "Wesam Alzahir",
+      "url": "https://github.com/wes4m",
+      "amountInCents": 0
     }
   ],
-  "updatedAt": "2026-09-01T09:06:36Z"
+  "updatedAt": "2026-09-02T14:58:00Z"
 }

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -8,9 +8,7 @@ interface Sponsor {
   avatarUrl: string;
   name: string | null;
   url: string;
-  amountInCents?: number;
-  /** Relative size override when GitHub does not expose the sponsor tier. */
-  displayWeight?: number;
+  weight: number;
 }
 
 interface SponsorNode {
@@ -20,17 +18,8 @@ interface SponsorNode {
 
 const PACKING_SIZE = 720;
 const PACKING_PADDING = 5;
-const UNKNOWN_TIER_RATIO = 0.25;
 
 function getPackedSponsors(sponsors: Sponsor[]) {
-  const knownAmounts = sponsors
-    .map((sponsor) => sponsor.amountInCents ?? 0)
-    .filter((amount) => amount > 0);
-  const smallestKnownAmount = Math.min(...knownAmounts);
-  const unknownTierWeight = Number.isFinite(smallestKnownAmount)
-    ? smallestKnownAmount * UNKNOWN_TIER_RATIO
-    : 1;
-
   const root = hierarchy<SponsorNode>(
     {
       children: sponsors.map((sponsor) => ({ sponsor })),
@@ -42,9 +31,7 @@ function getPackedSponsors(sponsors: Sponsor[]) {
         return 0;
       }
 
-      const weight =
-        node.sponsor.displayWeight ?? node.sponsor.amountInCents ?? 0;
-      return weight > 0 ? weight : unknownTierWeight;
+      return node.sponsor.weight;
     })
     .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 
@@ -67,7 +54,6 @@ export function LandingSponsors() {
 
   return (
     <section className="relative overflow-hidden border-b border-fd-border bg-fd-background">
-      <div className="pointer-events-none absolute inset-x-0 top-1/2 mx-auto h-96 max-w-4xl -translate-y-1/2 rounded-full bg-[radial-gradient(circle,rgba(249,115,22,0.09)_0,transparent_68%)] blur-3xl dark:bg-[radial-gradient(circle,rgba(249,115,22,0.12)_0,transparent_68%)]" />
       <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8 lg:py-28">
         <div
           className={hasSponsors ? "mb-8 text-center sm:mb-10" : "text-center"}
@@ -89,8 +75,8 @@ export function LandingSponsors() {
         </div>
 
         {hasSponsors ? (
-          <div className="relative mx-auto aspect-square w-full max-w-[45rem] rounded-full border border-orange-500/20 bg-[radial-gradient(circle_at_40%_35%,rgba(249,115,22,0.12),transparent_68%)] shadow-[inset_0_0_90px_rgba(249,115,22,0.06)] dark:border-orange-400/20 dark:bg-[radial-gradient(circle_at_40%_35%,rgba(249,115,22,0.16),transparent_68%)]">
-            <div className="pointer-events-none absolute inset-[4%] rounded-full border border-dashed border-orange-500/10" />
+          <div className="relative mx-auto aspect-square w-full max-w-[45rem] rounded-full border border-fd-border/70 bg-fd-card/20 shadow-[inset_0_0_80px_rgba(0,0,0,0.025)] dark:bg-fd-card/10 dark:shadow-[inset_0_0_80px_rgba(255,255,255,0.025)]">
+            <div className="pointer-events-none absolute inset-[4%] rounded-full border border-dashed border-fd-border/50" />
             <ul className="absolute inset-0 m-0 list-none p-0">
               {packedSponsors.map(({ sponsor, x, y, radius }) => {
                 const sponsorName = sponsor.name || sponsor.login;
@@ -111,9 +97,9 @@ export function LandingSponsors() {
                       target="_blank"
                       rel="noopener noreferrer"
                       aria-label={`View ${sponsorName}'s GitHub profile`}
-                      className="group relative block size-full rounded-full outline-none transition duration-300 hover:z-10 hover:scale-[1.06] focus-visible:z-10 focus-visible:scale-[1.06] focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-4 focus-visible:ring-offset-fd-background motion-reduce:transition-none"
+                      className="group relative block size-full rounded-full outline-none transition duration-300 hover:z-10 hover:scale-[1.06] focus-visible:z-10 focus-visible:scale-[1.06] focus-visible:ring-2 focus-visible:ring-pink-500 focus-visible:ring-offset-4 focus-visible:ring-offset-fd-background motion-reduce:transition-none"
                     >
-                      <span className="absolute inset-0 overflow-hidden rounded-full border border-white/60 bg-fd-card shadow-[0_12px_35px_-16px_rgba(0,0,0,0.55)] ring-1 ring-black/5 transition-shadow duration-300 group-hover:shadow-[0_16px_45px_-14px_rgba(249,115,22,0.5)] dark:border-white/15 dark:ring-white/10">
+                      <span className="absolute inset-0 overflow-hidden rounded-full border border-white/60 bg-fd-card shadow-[0_12px_35px_-16px_rgba(0,0,0,0.55)] ring-1 ring-black/5 transition-shadow duration-300 group-hover:shadow-[0_16px_45px_-14px_rgba(0,0,0,0.42)] dark:border-white/15 dark:ring-white/10">
                         <img
                           src={sponsor.avatarUrl}
                           alt=""
@@ -140,9 +126,9 @@ export function LandingSponsors() {
         {hasSponsors ? (
           <div className="mt-8 flex items-center justify-center gap-2 text-xs text-fd-muted-foreground">
             <span className="flex items-end gap-0.5" aria-hidden="true">
-              <span className="size-1.5 rounded-full bg-orange-500/45" />
-              <span className="size-2.5 rounded-full bg-orange-500/70" />
-              <span className="size-3.5 rounded-full bg-orange-500" />
+              <span className="size-1.5 rounded-full bg-fd-muted-foreground/35" />
+              <span className="size-2.5 rounded-full bg-fd-muted-foreground/60" />
+              <span className="size-3.5 rounded-full bg-fd-muted-foreground" />
             </span>
             <span>Circle area reflects sponsorship level</span>
           </div>

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -7,7 +7,7 @@ interface Sponsor {
   avatarUrl: string;
   name: string | null;
   url: string;
-  weight?: number;
+  amountInCents?: number;
 }
 
 const MIN_BUBBLE_SIZE = 72;
@@ -21,18 +21,23 @@ const BUBBLE_OFFSETS = [
   "sm:-translate-y-1",
 ];
 
-function getBubbleSize(weight = 1) {
-  const normalizedWeight = Math.min(Math.max(weight, 0), 1);
+function getBubbleSize(amountInCents = 0, maxAmountInCents = 0) {
+  const normalizedAmount =
+    maxAmountInCents > 0 ? amountInCents / maxAmountInCents : 1;
 
   return Math.max(
     MIN_BUBBLE_SIZE,
-    Math.sqrt(normalizedWeight) * MAX_BUBBLE_SIZE,
+    Math.sqrt(normalizedAmount) * MAX_BUBBLE_SIZE,
   );
 }
 
 export function LandingSponsors() {
   const sponsors = sponsorsData.sponsors as Sponsor[];
   const hasSponsors = sponsors.length > 0;
+  const maxAmountInCents = sponsors.reduce(
+    (maxAmount, sponsor) => Math.max(maxAmount, sponsor.amountInCents ?? 0),
+    0,
+  );
 
   return (
     <section className="relative overflow-hidden border-b border-fd-border bg-fd-background">
@@ -64,7 +69,10 @@ export function LandingSponsors() {
             <ul className="relative flex flex-wrap items-center justify-center gap-2 sm:gap-3">
               {sponsors.map((sponsor, index) => {
                 const sponsorName = sponsor.name || sponsor.login;
-                const bubbleSize = getBubbleSize(sponsor.weight);
+                const bubbleSize = getBubbleSize(
+                  sponsor.amountInCents,
+                  maxAmountInCents,
+                );
                 const offset =
                   BUBBLE_OFFSETS[index % BUBBLE_OFFSETS.length] ?? "";
 

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -9,6 +9,7 @@ interface Sponsor {
   name: string | null;
   url: string;
   amountInCents?: number;
+  /** Relative size override when GitHub does not expose the sponsor tier. */
   displayWeight?: number;
 }
 

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -112,7 +112,7 @@ export function LandingSponsors() {
                 <span className="size-2.5 rounded-full bg-orange-500/70" />
                 <span className="size-3.5 rounded-full bg-orange-500" />
               </span>
-              <span>Circle area reflects lifetime support</span>
+              <span>Circle area reflects sponsorship amount</span>
             </div>
           </div>
         ) : null}

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -130,7 +130,7 @@ export function LandingSponsors() {
               <span className="size-2.5 rounded-full bg-fd-muted-foreground/60" />
               <span className="size-3.5 rounded-full bg-fd-muted-foreground" />
             </span>
-            <span>Circle area reflects sponsorship level</span>
+            <span>Circle area reflects lifetime support</span>
           </div>
         ) : null}
 

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -1,3 +1,4 @@
+import { hierarchy, pack } from "d3-hierarchy";
 import { Heart } from "lucide-react";
 
 import sponsorsData from "../../public/sponsors.json";
@@ -8,36 +9,60 @@ interface Sponsor {
   name: string | null;
   url: string;
   amountInCents?: number;
+  displayWeight?: number;
 }
 
-const MIN_BUBBLE_SIZE = 72;
-const MAX_BUBBLE_SIZE = 168;
-const BUBBLE_OFFSETS = [
-  "sm:translate-y-5",
-  "sm:-translate-y-3",
-  "sm:translate-y-1",
-  "sm:-translate-y-5",
-  "sm:translate-y-4",
-  "sm:-translate-y-1",
-];
+interface SponsorNode {
+  sponsor?: Sponsor;
+  children?: SponsorNode[];
+}
 
-function getBubbleSize(amountInCents = 0, maxAmountInCents = 0) {
-  const normalizedAmount =
-    maxAmountInCents > 0 ? amountInCents / maxAmountInCents : 1;
+const PACKING_SIZE = 720;
+const PACKING_PADDING = 5;
+const UNKNOWN_TIER_RATIO = 0.25;
 
-  return Math.max(
-    MIN_BUBBLE_SIZE,
-    Math.sqrt(normalizedAmount) * MAX_BUBBLE_SIZE,
-  );
+function getPackedSponsors(sponsors: Sponsor[]) {
+  const knownAmounts = sponsors
+    .map((sponsor) => sponsor.amountInCents ?? 0)
+    .filter((amount) => amount > 0);
+  const smallestKnownAmount = Math.min(...knownAmounts);
+  const unknownTierWeight = Number.isFinite(smallestKnownAmount)
+    ? smallestKnownAmount * UNKNOWN_TIER_RATIO
+    : 1;
+
+  const root = hierarchy<SponsorNode>(
+    {
+      children: sponsors.map((sponsor) => ({ sponsor })),
+    },
+    (node) => node.children,
+  )
+    .sum((node) => {
+      if (!node.sponsor) {
+        return 0;
+      }
+
+      const weight =
+        node.sponsor.displayWeight ?? node.sponsor.amountInCents ?? 0;
+      return weight > 0 ? weight : unknownTierWeight;
+    })
+    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+  return pack<SponsorNode>()
+    .size([PACKING_SIZE, PACKING_SIZE])
+    .padding(PACKING_PADDING)(root)
+    .leaves()
+    .map((node) => ({
+      sponsor: node.data.sponsor as Sponsor,
+      x: node.x,
+      y: node.y,
+      radius: node.r,
+    }));
 }
 
 export function LandingSponsors() {
   const sponsors = sponsorsData.sponsors as Sponsor[];
   const hasSponsors = sponsors.length > 0;
-  const maxAmountInCents = sponsors.reduce(
-    (maxAmount, sponsor) => Math.max(maxAmount, sponsor.amountInCents ?? 0),
-    0,
-  );
+  const packedSponsors = getPackedSponsors(sponsors);
 
   return (
     <section className="relative overflow-hidden border-b border-fd-border bg-fd-background">
@@ -63,26 +88,21 @@ export function LandingSponsors() {
         </div>
 
         {hasSponsors ? (
-          <div className="relative mx-auto max-w-5xl py-4 sm:py-8">
-            <div className="pointer-events-none absolute inset-8 rounded-[50%] border border-orange-500/10" />
-            <div className="pointer-events-none absolute inset-16 rounded-[50%] border border-dashed border-orange-500/10" />
-            <ul className="relative flex flex-wrap items-center justify-center gap-2 sm:gap-3">
-              {sponsors.map((sponsor, index) => {
+          <div className="relative mx-auto aspect-square w-full max-w-[45rem] rounded-full border border-orange-500/20 bg-[radial-gradient(circle_at_40%_35%,rgba(249,115,22,0.12),transparent_68%)] shadow-[inset_0_0_90px_rgba(249,115,22,0.06)] dark:border-orange-400/20 dark:bg-[radial-gradient(circle_at_40%_35%,rgba(249,115,22,0.16),transparent_68%)]">
+            <div className="pointer-events-none absolute inset-[4%] rounded-full border border-dashed border-orange-500/10" />
+            <ul className="absolute inset-0 m-0 list-none p-0">
+              {packedSponsors.map(({ sponsor, x, y, radius }) => {
                 const sponsorName = sponsor.name || sponsor.login;
-                const bubbleSize = getBubbleSize(
-                  sponsor.amountInCents,
-                  maxAmountInCents,
-                );
-                const offset =
-                  BUBBLE_OFFSETS[index % BUBBLE_OFFSETS.length] ?? "";
 
                 return (
                   <li
                     key={sponsor.login}
-                    className={`relative ${offset}`}
+                    className="absolute"
                     style={{
-                      width: bubbleSize,
-                      height: bubbleSize,
+                      left: `${((x - radius) / PACKING_SIZE) * 100}%`,
+                      top: `${((y - radius) / PACKING_SIZE) * 100}%`,
+                      width: `${((radius * 2) / PACKING_SIZE) * 100}%`,
+                      height: `${((radius * 2) / PACKING_SIZE) * 100}%`,
                     }}
                   >
                     <a
@@ -96,8 +116,8 @@ export function LandingSponsors() {
                         <img
                           src={sponsor.avatarUrl}
                           alt=""
-                          width={MAX_BUBBLE_SIZE}
-                          height={MAX_BUBBLE_SIZE}
+                          width={Math.ceil(radius * 2)}
+                          height={Math.ceil(radius * 2)}
                           loading="lazy"
                           decoding="async"
                           className="size-full object-cover saturate-[0.88] transition duration-300 group-hover:scale-105 group-hover:saturate-100 motion-reduce:transition-none"
@@ -113,15 +133,17 @@ export function LandingSponsors() {
                 );
               })}
             </ul>
+          </div>
+        ) : null}
 
-            <div className="mt-10 flex items-center justify-center gap-2 text-xs text-fd-muted-foreground sm:mt-12">
-              <span className="flex items-end gap-0.5" aria-hidden="true">
-                <span className="size-1.5 rounded-full bg-orange-500/45" />
-                <span className="size-2.5 rounded-full bg-orange-500/70" />
-                <span className="size-3.5 rounded-full bg-orange-500" />
-              </span>
-              <span>Circle area reflects sponsorship amount</span>
-            </div>
+        {hasSponsors ? (
+          <div className="mt-8 flex items-center justify-center gap-2 text-xs text-fd-muted-foreground">
+            <span className="flex items-end gap-0.5" aria-hidden="true">
+              <span className="size-1.5 rounded-full bg-orange-500/45" />
+              <span className="size-2.5 rounded-full bg-orange-500/70" />
+              <span className="size-3.5 rounded-full bg-orange-500" />
+            </span>
+            <span>Circle area reflects sponsorship level</span>
           </div>
         ) : null}
 

--- a/docs/src/components/landing-sponsors.tsx
+++ b/docs/src/components/landing-sponsors.tsx
@@ -1,118 +1,137 @@
-"use client";
-
 import { Heart } from "lucide-react";
-import { useEffect, useState } from "react";
+
+import sponsorsData from "../../public/sponsors.json";
 
 interface Sponsor {
   login: string;
   avatarUrl: string;
   name: string | null;
   url: string;
+  weight?: number;
 }
 
-interface SponsorsData {
-  sponsors: Sponsor[];
-  updatedAt: string;
+const MIN_BUBBLE_SIZE = 72;
+const MAX_BUBBLE_SIZE = 168;
+const BUBBLE_OFFSETS = [
+  "sm:translate-y-5",
+  "sm:-translate-y-3",
+  "sm:translate-y-1",
+  "sm:-translate-y-5",
+  "sm:translate-y-4",
+  "sm:-translate-y-1",
+];
+
+function getBubbleSize(weight = 1) {
+  const normalizedWeight = Math.min(Math.max(weight, 0), 1);
+
+  return Math.max(
+    MIN_BUBBLE_SIZE,
+    Math.sqrt(normalizedWeight) * MAX_BUBBLE_SIZE,
+  );
 }
 
 export function LandingSponsors() {
-  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetch("/sponsors.json")
-      .then((res) => res.json())
-      .then((data: SponsorsData) => {
-        setSponsors(data.sponsors);
-        setLoading(false);
-      })
-      .catch(() => {
-        setLoading(false);
-      });
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="relative border-b border-fd-border bg-fd-background">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
-          <div className="text-center">
-            <div className="animate-pulse h-8 w-48 bg-fd-muted rounded mx-auto" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
+  const sponsors = sponsorsData.sponsors as Sponsor[];
   const hasSponsors = sponsors.length > 0;
 
   return (
-    <div className="relative border-b border-fd-border bg-fd-background">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
-        {/* Section header */}
+    <section className="relative overflow-hidden border-b border-fd-border bg-fd-background">
+      <div className="pointer-events-none absolute inset-x-0 top-1/2 mx-auto h-96 max-w-4xl -translate-y-1/2 rounded-full bg-[radial-gradient(circle,rgba(249,115,22,0.09)_0,transparent_68%)] blur-3xl dark:bg-[radial-gradient(circle,rgba(249,115,22,0.12)_0,transparent_68%)]" />
+      <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8 lg:py-28">
         <div
-          className={hasSponsors ? "mb-10 sm:mb-14 text-center" : "text-center"}
+          className={hasSponsors ? "mb-8 text-center sm:mb-10" : "text-center"}
         >
-          <div className="inline-flex items-center gap-2 mb-4">
-            <Heart className="w-5 h-5 text-pink-500 fill-pink-500" />
-            <span className="text-sm font-medium text-pink-500 uppercase tracking-wider">
-              Sponsors
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-pink-500/20 bg-pink-500/8 px-3 py-1.5">
+            <Heart className="size-3.5 fill-pink-500 text-pink-500" />
+            <span className="text-xs font-semibold uppercase tracking-[0.16em] text-pink-500">
+              Past &amp; present
             </span>
           </div>
-          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-fd-foreground">
-            {hasSponsors ? "Thanks to our sponsors" : "Become a Sponsor"}
+          <h2 className="text-2xl font-bold tracking-tight text-fd-foreground sm:text-3xl lg:text-4xl">
+            {hasSponsors ? "Built with our sponsors" : "Become a Sponsor"}
           </h2>
-          <p className="mt-3 sm:mt-4 text-base sm:text-lg text-fd-muted-foreground max-w-2xl mx-auto">
+          <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-fd-muted-foreground sm:mt-4 sm:text-lg">
             {hasSponsors
-              ? "Hot Updater is made possible by our amazing sponsors. Thank you for supporting open source!"
+              ? "Every person and team who has supported Hot Updater has a place here. Thank you for keeping open source moving."
               : "Support Hot Updater development and help us build the best OTA update solution for React Native."}
           </p>
         </div>
 
-        {/* Sponsors grid */}
-        {hasSponsors && (
-          <div className="flex flex-wrap justify-center gap-4 sm:gap-6">
-            {sponsors.map((sponsor) => (
-              <a
-                key={sponsor.login}
-                href={sponsor.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group flex flex-col items-center gap-2 p-3 sm:p-4 rounded-xl border border-transparent transition-all hover:border-fd-border hover:bg-fd-accent/50"
-              >
-                <div className="relative">
-                  <img
-                    src={sponsor.avatarUrl}
-                    alt={sponsor.name || sponsor.login}
-                    className="w-14 h-14 sm:w-16 sm:h-16 rounded-full border-2 border-fd-border transition-all group-hover:border-orange-500/50 group-hover:scale-105"
-                  />
-                  <div className="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-pink-500 flex items-center justify-center">
-                    <Heart className="w-3 h-3 text-white fill-white" />
-                  </div>
-                </div>
-                <span className="text-sm font-medium text-fd-foreground group-hover:text-orange-500 transition-colors">
-                  {sponsor.name || sponsor.login}
-                </span>
-              </a>
-            ))}
-          </div>
-        )}
+        {hasSponsors ? (
+          <div className="relative mx-auto max-w-5xl py-4 sm:py-8">
+            <div className="pointer-events-none absolute inset-8 rounded-[50%] border border-orange-500/10" />
+            <div className="pointer-events-none absolute inset-16 rounded-[50%] border border-dashed border-orange-500/10" />
+            <ul className="relative flex flex-wrap items-center justify-center gap-2 sm:gap-3">
+              {sponsors.map((sponsor, index) => {
+                const sponsorName = sponsor.name || sponsor.login;
+                const bubbleSize = getBubbleSize(sponsor.weight);
+                const offset =
+                  BUBBLE_OFFSETS[index % BUBBLE_OFFSETS.length] ?? "";
 
-        {/* Become a sponsor CTA */}
+                return (
+                  <li
+                    key={sponsor.login}
+                    className={`relative ${offset}`}
+                    style={{
+                      width: bubbleSize,
+                      height: bubbleSize,
+                    }}
+                  >
+                    <a
+                      href={sponsor.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`View ${sponsorName}'s GitHub profile`}
+                      className="group relative block size-full rounded-full outline-none transition duration-300 hover:z-10 hover:scale-[1.06] focus-visible:z-10 focus-visible:scale-[1.06] focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-4 focus-visible:ring-offset-fd-background motion-reduce:transition-none"
+                    >
+                      <span className="absolute inset-0 overflow-hidden rounded-full border border-white/60 bg-fd-card shadow-[0_12px_35px_-16px_rgba(0,0,0,0.55)] ring-1 ring-black/5 transition-shadow duration-300 group-hover:shadow-[0_16px_45px_-14px_rgba(249,115,22,0.5)] dark:border-white/15 dark:ring-white/10">
+                        <img
+                          src={sponsor.avatarUrl}
+                          alt=""
+                          width={MAX_BUBBLE_SIZE}
+                          height={MAX_BUBBLE_SIZE}
+                          loading="lazy"
+                          decoding="async"
+                          className="size-full object-cover saturate-[0.88] transition duration-300 group-hover:scale-105 group-hover:saturate-100 motion-reduce:transition-none"
+                        />
+                        <span className="absolute inset-0 bg-linear-to-t from-black/30 via-transparent to-white/10 opacity-60 transition-opacity group-hover:opacity-30" />
+                      </span>
+
+                      <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 translate-y-1 whitespace-nowrap rounded-md border border-fd-border bg-fd-popover px-2.5 py-1.5 text-xs font-medium text-fd-popover-foreground opacity-0 shadow-lg transition duration-200 group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100 motion-reduce:transition-none">
+                        {sponsorName}
+                      </span>
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="mt-10 flex items-center justify-center gap-2 text-xs text-fd-muted-foreground sm:mt-12">
+              <span className="flex items-end gap-0.5" aria-hidden="true">
+                <span className="size-1.5 rounded-full bg-orange-500/45" />
+                <span className="size-2.5 rounded-full bg-orange-500/70" />
+                <span className="size-3.5 rounded-full bg-orange-500" />
+              </span>
+              <span>Circle area reflects lifetime support</span>
+            </div>
+          </div>
+        ) : null}
+
         <div
           className={
             hasSponsors
-              ? "mt-12 sm:mt-16 text-center"
-              : "mt-6 sm:mt-8 text-center"
+              ? "mt-10 text-center sm:mt-12"
+              : "mt-6 text-center sm:mt-8"
           }
         >
           <a
             href="https://github.com/sponsors/gronxb"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-pink-500/30 bg-pink-500/10 text-pink-500 font-medium text-sm transition-all hover:bg-pink-500/20 hover:border-pink-500/50"
+            className="inline-flex items-center gap-2 rounded-full border border-pink-500/30 bg-pink-500/10 px-5 py-2.5 text-sm font-semibold text-pink-500 transition-all hover:border-pink-500/50 hover:bg-pink-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500 focus-visible:ring-offset-2 focus-visible:ring-offset-fd-background"
           >
-            <Heart className="w-4 h-4" />
-            Become a Sponsor
+            <Heart className="size-4" />
+            Sponsor on GitHub
           </a>
 
           <div className="mt-6 flex flex-col items-center gap-2">
@@ -123,7 +142,7 @@ export function LandingSponsors() {
               href="https://vercel.com/oss"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex rounded-md border border-fd-border/60 bg-fd-card/40 px-2.5 py-1.5 opacity-80 transition-opacity hover:opacity-100"
+              className="inline-flex rounded-md border border-fd-border/60 bg-fd-card/40 px-2.5 py-1.5 opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
             >
               <img
                 alt="Vercel OSS Program"
@@ -135,6 +154,6 @@ export function LandingSponsors() {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      d3-hierarchy:
+        specifier: ^3.1.2
+        version: 3.1.2
       fumadocs-core:
         specifier: 16.10.7
         version: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@0.552.0(react@19.2.6))(next@16.2.9(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(waku@1.0.0-beta.1(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.107.2(esbuild@0.28.1)))(react@19.2.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3)
@@ -216,6 +219,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/d3-hierarchy':
+        specifier: ^3.1.7
+        version: 3.1.7
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.14
@@ -9595,6 +9601,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
   '@types/datadog-metrics@0.6.1':
     resolution: {integrity: sha512-p6zVpfmNcXwtcXjgpz7do/fKyfndGhU5sGJVtb5Gn5PvLDiQUAgD0mI/itf/99sBi9DRxeyhFQ9dQF6OxxQNbA==}
 
@@ -11639,6 +11648,10 @@ packages:
 
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
 
   dag-map@1.0.2:
     resolution: {integrity: sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw==}
@@ -29873,6 +29886,8 @@ snapshots:
     dependencies:
       '@types/node': 25.9.3
 
+  '@types/d3-hierarchy@3.1.7': {}
+
   '@types/datadog-metrics@0.6.1': {}
 
   '@types/debug@4.1.13':
@@ -32306,6 +32321,8 @@ snapshots:
   csstype@3.2.3: {}
 
   csv-parse@5.6.0: {}
+
+  d3-hierarchy@3.1.2: {}
 
   dag-map@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- crawl current and inactive public sponsorships, then merge profiles found in earlier `docs/public/sponsors.json` revisions so past contributors remain visible
- read selected sponsorship values, including one-time sponsorships, with the private query kept inside the Actions runner
- commit only normalized relative weights; raw contribution amounts and newly private sponsor identities are not published
- size each avatar by its relative contribution, with Callstack as the largest contributor
- use D3 circle packing inside one fixed circular boundary so the composition stays full and rescales as the list changes
- replace the orange backdrop and hover treatment with neutral surfaces and shadows
- keep static rendering, accessible profile labels, keyboard focus states, and reduced-motion handling

## Verification

- `pnpm -w lint`
- `pnpm --filter hot-updater-docs build`
- new `SPONSORS_TOKEN` workflow run succeeded and reported no sponsor changes: https://github.com/gronxb/hot-updater/actions/runs/33655830261
- local workflow reproduction generated the normalized sponsor data and a second run reported no changes
- visually checked at 1440px and 375px: Callstack is largest, all avatars remain inside the circular boundary, circles do not overlap, the cluster fills the boundary, and there is no horizontal overflow

## Known test result

- `pnpm -w test` is not green in the current workspace: 31 unrelated package test files fail, including `mockDatabase is not a function`; 138 files pass. This repository has no docs unit-test project, while the docs production build and lint pass.