### PR TITLE
fix(cli): exit non-zero when doctor reports an error

### DIFF
--- a/.changeset/doctor-error-exit-code.md
+++ b/.changeset/doctor-error-exit-code.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Exit with code 1 when `hot-updater doctor` fails with an error such as a missing `package.json` or an uninstalled CLI. The default output previously printed "Doctor check failed." and exited 0, so CI treated a failed doctor run as a pass, while `--json` already exited 1 for the same result.

--- a/packages/hot-updater/src/commands/doctor.spec.ts
+++ b/packages/hot-updater/src/commands/doctor.spec.ts
@@ -18,7 +18,20 @@ import {
 vi.mock("@hot-updater/cli-tools", () => ({
   getCwd: vi.fn(() => "/mock/cwd"),
   loadConfig: vi.fn(),
-  p: {},
+  p: {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    cancel: vi.fn(),
+    isCancel: vi.fn(() => false),
+    text: vi.fn(),
+    log: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      message: vi.fn(),
+    },
+  },
   readPackageUp: vi.fn(),
 }));
 
@@ -269,6 +282,38 @@ describe("doctor", () => {
       JSON.stringify({ success: true }, null, 2),
     );
     expect(mockLoadConfig).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("exits non-zero when the default output reports a doctor error", async () => {
+    mockReadPackageUp.mockResolvedValue(null);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await handleDoctor({ serverBaseUrl: "https://example.com/api" }).catch(
+      () => {},
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it("exits non-zero when the JSON output reports a doctor error", async () => {
+    mockReadPackageUp.mockResolvedValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await handleDoctor({ json: true }).catch(() => {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
     logSpy.mockRestore();
   });
 

--- a/packages/hot-updater/src/commands/doctor.ts
+++ b/packages/hot-updater/src/commands/doctor.ts
@@ -824,7 +824,8 @@ export const handleDoctor = async ({
   if (result.error) {
     p.log.error(result.error);
     p.outro("Doctor check failed.");
-    return;
+    // Match the --json path and the issue path below, which both exit non-zero.
+    process.exit(1);
   }
 
   // Handle issues with details


### PR DESCRIPTION
## What breaks

`hot-updater doctor` exits with code 0 even when the check fails.

`packages/hot-updater/src/commands/doctor.ts:824-828` (before this change):

```ts
// Handle errors
if (result.error) {
  p.log.error(result.error);
  p.outro("Doctor check failed.");
  return;
}
```

`doctor()` sets `result.error` (with `success: false`) in three cases:

- `packages/hot-updater/src/commands/doctor.ts:637` no `package.json` found
- `packages/hot-updater/src/commands/doctor.ts:656` `hot-updater` is not in the dependencies
- `packages/hot-updater/src/commands/doctor.ts:753` the check threw

In all three the CLI prints "Doctor check failed." and then returns, leaving the exit code at 0. A CI step that runs `npx hot-updater doctor` goes green on a failed doctor run.

## Why it is wrong

The two sibling paths for the same result both exit non-zero:

- `doctor.ts:806-808`, the `--json` branch, exits 1 on `!result.success`, so `hot-updater doctor --json` and `hot-updater doctor` disagree on the exit code for identical input.
- `doctor.ts:935-937`, further down the same function, exits 1 for version mismatches and native issues, which are the *softer* failures.

So the hard-error path was the only one in `handleDoctor` reporting success to the shell.

## Fix

Exit 1 instead of returning, matching both siblings. One line plus a comment.

## How I proved it

Added two tests to `packages/hot-updater/src/commands/doctor.spec.ts` covering both output modes with the same failing input (`readPackageUp` resolving to `null`, which produces `{ success: false, error: "Could not find package.json" }`).

With the fix, both pass:

```
$ npx vitest run --project="unit:*" packages/hot-updater/src/commands/doctor.spec.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)
```

Counterfactual, reverting only `doctor.ts` and keeping the tests:

```
$ git show HEAD:packages/hot-updater/src/commands/doctor.ts > packages/hot-updater/src/commands/doctor.ts
$ npx vitest run --project="unit:*" packages/hot-updater/src/commands/doctor.spec.ts

 FAIL  packages/hot-updater/src/commands/doctor.spec.ts > doctor > exits non-zero when the default output reports a doctor error
AssertionError: expected "Mock" to be called with arguments: [ 1 ]

Number of calls: 0

 ❯ packages/hot-updater/src/commands/doctor.spec.ts:300:21
    300|     expect(exitSpy).toHaveBeenCalledWith(1);
       |                     ^

 Test Files  1 failed (1)
      Tests  1 failed | 40 passed (41)
```

Only the default-output test goes red. The `--json` test stays green on the reverted source, which is exactly the asymmetry being fixed. The spec imports `./doctor` by relative path, so this red came from the source revert alone with no rebuild.

## CI

```
pnpm build      -> Successfully ran target build for 26 projects
pnpm test:type  -> Successfully ran target test:type for 34 projects
pnpm lint       -> All matched files use the correct format. Found 0 warnings and 0 errors.
pnpm test       -> Test Files 169 passed (169) / Tests 2164 passed (2164)
```

A patch changeset is included.
