### PR TITLE
fix(storage): send application/octet-stream for non-archive uploads

### DIFF
--- a/.changeset/plain-hoops-content-type.md
+++ b/.changeset/plain-hoops-content-type.md
@@ -1,0 +1,9 @@
+---
+"@hot-updater/plugin-core": patch
+"@hot-updater/aws": patch
+"@hot-updater/cloudflare": patch
+"@hot-updater/firebase": patch
+"@hot-updater/supabase": patch
+---
+
+Upload non-archive files with `application/octet-stream` instead of `application/zip`. `getContentType` fell through to the compression format table for any name `mime` did not resolve, and that table defaults to zip, so brotli bundle assets (`.br`), extensionless content addressed assets, and `.bsdiff` patches were all labeled `application/zip` on S3, R2, Firebase, and Supabase.

--- a/plugins/plugin-core/src/compressionFormat.spec.ts
+++ b/plugins/plugin-core/src/compressionFormat.spec.ts
@@ -15,4 +15,25 @@ describe("getContentType", () => {
     expect(getContentType("build/bundle.tar.br/")).toBe("application/x-tar");
     expect(getContentType("build\\bundle.tar.br\\")).toBe("application/x-tar");
   });
+
+  it("falls back to application/octet-stream for non-archive uploads", () => {
+    // Brotli compressed JS bundle stored under the content addressed asset root
+    expect(getContentType("assets/sha256/ab/abcd1234.br")).toBe(
+      "application/octet-stream",
+    );
+    // Content addressed asset whose source path carried no extension
+    expect(getContentType("assets/sha256/ab/abcd1234")).toBe(
+      "application/octet-stream",
+    );
+    // bsdiff patch produced by createBundleDiff
+    expect(getContentType("patches/index.android.bundle.bsdiff")).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("keeps types that mime already resolves", () => {
+    expect(getContentType("assets/sha256/ab/abcd1234.png")).toBe("image/png");
+    expect(getContentType("build/update.json")).toBe("application/json");
+    expect(getContentType("build/bundle.zip")).toBe("application/zip");
+  });
 });

--- a/plugins/plugin-core/src/compressionFormat.ts
+++ b/plugins/plugin-core/src/compressionFormat.ts
@@ -37,6 +37,19 @@ const COMPRESSION_FORMATS: Record<CompressionFormat, CompressionFormatInfo> = {
 };
 
 /**
+ * Finds the compression format matching a filename extension
+ * @param filename The filename to match
+ * @returns Compression format information, or undefined when nothing matches
+ */
+function findCompressionFormat(
+  filename: string,
+): CompressionFormatInfo | undefined {
+  return Object.values(COMPRESSION_FORMATS).find((info) =>
+    filename.endsWith(info.fileExtension),
+  );
+}
+
+/**
  * Detects compression format from filename
  * @param filename The filename to detect format from
  * @returns Compression format information
@@ -44,22 +57,17 @@ const COMPRESSION_FORMATS: Record<CompressionFormat, CompressionFormatInfo> = {
 export function detectCompressionFormat(
   filename: string,
 ): CompressionFormatInfo {
-  for (const info of Object.values(COMPRESSION_FORMATS)) {
-    if (filename.endsWith(info.fileExtension)) {
-      return info;
-    }
-  }
   // Default to zip if no match
-  return COMPRESSION_FORMATS.zip;
+  return findCompressionFormat(filename) ?? COMPRESSION_FORMATS.zip;
 }
 
 /**
  * Gets MIME type for a filename
  * @param filename The filename to get MIME type for
- * @returns MIME type string
+ * @returns MIME type string, or undefined when the filename is not an archive
  */
 export function getCompressionMimeType(filename: string): string | undefined {
-  return detectCompressionFormat(filename).mimeType;
+  return findCompressionFormat(filename)?.mimeType;
 }
 
 /**


### PR DESCRIPTION
## Problem

`getContentType` in `plugins/plugin-core/src/compressionFormat.ts` documents a 3-tier fallback ending in `application/octet-stream`, but that last tier is unreachable:

```ts
return (
  mime.getType(bundlePath) ??
  getCompressionMimeType(filename ?? "") ??
  "application/octet-stream"
);
```

`getCompressionMimeType` delegated to `detectCompressionFormat`, which returns `COMPRESSION_FORMATS.zip` when nothing matches. It therefore never returned `undefined`, and every file whose extension `mime` does not resolve was uploaded as `application/zip`.

This is not limited to bundle archives. `storagePlugin.profiles.node.upload` is also the path for assets and patches:

| upload | filename | `mime.getType` | Content-Type sent |
| --- | --- | --- | --- |
| brotli JS bundle (`deploy.ts:956`, via `getContentAddressedAssetStoragePath`) | `sha256/ab/<hash>.br` | `null` | `application/zip` |
| content addressed asset with no extension (same call site) | `sha256/ab/<hash>` | `null` | `application/zip` |
| bsdiff patch (`packages/server/src/db/createBundleDiff.ts:334`) | `index.android.bundle.bsdiff` | `null` | `application/zip` |

All four storage plugins pass the value straight to the provider, so the wrong type is persisted on the object: `plugins/aws/src/s3Storage.ts:152`, `plugins/cloudflare/src/r2S3Storage.ts:91`, `plugins/cloudflare/src/r2WranglerStorage.ts:88`, `plugins/firebase/src/firebaseStorage.ts:61`, `plugins/supabase/src/supabaseStorage.ts:140`.

The brotli compressed JS bundle is the case that matters most: it is uploaded on every deploy that ships an `index.*.bundle`, and it is served to the client with `Content-Type: application/zip`.

The fifth storage plugin already behaves this way. `plugins/standalone/src/standaloneStorage.ts:105` does not use `getContentType` and instead does `mime.getType(filePath) ?? "application/octet-stream"`, and `plugins/js/src/verifyJwtSignedUrl.ts:66` serves objects with `application/octet-stream` when no type is known. Nothing in the repo keys off `application/zip`.

## Fix

Split the extension match out of `detectCompressionFormat` into a helper that returns `undefined` on no match, and have `getCompressionMimeType` use it. `detectCompressionFormat` keeps its zip default, which is what `packages/cli-tools/src/promoteBundle.ts:255` relies on to pick a decompressor. Only the MIME lookup changes, so `.tar.br` still resolves to `application/x-tar` and everything `mime` already knows is untouched.

## Verification

Extended `plugins/plugin-core/src/compressionFormat.spec.ts`. Reverting only `compressionFormat.ts` to its pre-fix state makes the new case fail on behaviour, not compilation:

```
AssertionError: expected 'application/zip' to be 'application/octet-stream'
 ❯ plugins/plugin-core/src/compressionFormat.spec.ts:21:60
```

With the fix, all 5 tests in the file pass. The rest of `pnpm test` is unchanged against `main` in this environment (identical 76/69 pre-existing failures from an unbuilt workspace, plus the 2 new passing tests). `oxfmt --check` and `oxlint` are clean on both files.
