### PR TITLE
fix(storage): normalize slashes in storage basePath

### DIFF
--- a/.changeset/storage-base-path-slashes.md
+++ b/.changeset/storage-base-path-slashes.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/plugin-core": patch
+---
+
+Strip leading and trailing slashes from the storage `basePath` in `createStorageKeyBuilder` so a value like `/releases/` no longer produces object keys with an empty path segment.

--- a/plugins/plugin-core/src/createStorageKeyBuilder.spec.ts
+++ b/plugins/plugin-core/src/createStorageKeyBuilder.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { createStorageKeyBuilder } from "./createStorageKeyBuilder";
+
+describe("createStorageKeyBuilder", () => {
+  it("builds keys under the base path", () => {
+    expect(
+      createStorageKeyBuilder("releases")("bundles/id", "bundle.zip"),
+    ).toBe("releases/bundles/id/bundle.zip");
+  });
+
+  it("strips surrounding slashes from the base path", () => {
+    expect(
+      createStorageKeyBuilder("/releases/")("bundles/id", "bundle.zip"),
+    ).toBe("releases/bundles/id/bundle.zip");
+  });
+
+  it("omits the base path when it is empty or only slashes", () => {
+    expect(createStorageKeyBuilder(undefined)("bundles/id")).toBe("bundles/id");
+    expect(createStorageKeyBuilder("")("bundles/id")).toBe("bundles/id");
+    expect(createStorageKeyBuilder("/")("bundles/id")).toBe("bundles/id");
+  });
+});

--- a/plugins/plugin-core/src/createStorageKeyBuilder.ts
+++ b/plugins/plugin-core/src/createStorageKeyBuilder.ts
@@ -1,5 +1,8 @@
 export const createStorageKeyBuilder =
   (basePath: string | undefined) =>
   (...args: string[]) => {
-    return [basePath || "", ...args].filter(Boolean).join("/");
+    // Surrounding slashes would emit an empty key segment, and the asset
+    // storage URI resolver drops empty segments when it rebuilds those keys.
+    const normalizedBasePath = basePath?.replace(/^\/+|\/+$/g, "") ?? "";
+    return [normalizedBasePath, ...args].filter(Boolean).join("/");
   };

--- a/plugins/supabase/src/supabaseStorage.spec.ts
+++ b/plugins/supabase/src/supabaseStorage.spec.ts
@@ -256,6 +256,40 @@ describe("supabaseStorage", () => {
     await fs.rm(tmpDir, { force: true, recursive: true });
   });
 
+  it("strips surrounding slashes from basePath when building upload keys", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hu-supabase-"));
+    const uploadPath = path.join(tmpDir, "bundle.zip");
+    await fs.writeFile(uploadPath, "bundle");
+    bucket.upload.mockResolvedValueOnce({
+      data: { fullPath: "updates/releases/bundles/bundle.zip" },
+      error: null,
+    });
+    bucket.createSignedUrl.mockResolvedValueOnce({
+      data: { signedUrl: "https://example.supabase.co/signed-url" },
+      error: null,
+    });
+
+    const storage = supabaseStorage({
+      basePath: "/releases/",
+      bucketName: "updates",
+      supabaseAnonKey: "anon-key",
+      supabaseUrl: "https://example.supabase.co",
+    })();
+
+    await storage.profiles.node.upload("bundles", uploadPath);
+
+    expect(bucket.upload).toHaveBeenCalledWith(
+      "releases/bundles/bundle.zip",
+      expect.any(Buffer),
+      expect.objectContaining({
+        cacheControl: "max-age=31536000",
+        contentType: "application/zip",
+      }),
+    );
+
+    await fs.rm(tmpDir, { force: true, recursive: true });
+  });
+
   it("surfaces thrown signed URL generation errors", async () => {
     bucket.createSignedUrls.mockRejectedValueOnce(
       new Error("Failed to generate download URL: Object not found"),


### PR DESCRIPTION
## The bug

`createStorageKeyBuilder` joins the configured storage `basePath` with the rest of the key exactly as given:

```ts
return [basePath || "", ...args].filter(Boolean).join("/");
```

A `basePath` of `/releases/` therefore yields `/releases//bundles/<id>/bundle.zip` instead of `releases/bundles/<id>/bundle.zip`.

`s3Storage` is unaffected because it strips the surrounding slashes itself before building its keys:

```ts
const normalizedBasePath = config.basePath?.replace(/^\/+|\/+$/g, "") ?? "";
const getStorageKey = createStorageKeyBuilder(normalizedBasePath);
```

`r2Storage` (both the S3 and Wrangler profiles), `supabaseStorage` and `firebaseStorage` all pass `config.basePath` straight through, so only those three carry the empty segment. `s3Storage.spec.ts` already uses `basePath: "/releases/"` as a normal input, so this shape is expected to work.

## Reproduce

Configure any of r2 / supabase / firebase storage with `basePath: "/releases/"` and deploy a bundle with shared assets.

The empty segment is not cosmetic, because the bundle `storageUri` is parsed back into a key elsewhere:

1. `upload` writes the bundle to `/releases//bundles/<id>/bundle.zip` and returns `r2://bucket//releases//bundles/<id>/bundle.zip`.
2. `deploy` derives the shared asset root with `createStorageRootUriWithPath`, which splits the pathname and calls `.filter(Boolean)`. That drops the empty segment, giving `r2://bucket/releases/assets`.
3. Each asset URI recorded in the manifest is therefore `r2://bucket/releases/assets/sha256/<aa>/<hash>.png`, whose key parses as `releases/assets/...`.
4. But the asset itself is uploaded through `getStorageKey` again, landing at `/releases//assets/sha256/<aa>/<hash>.png`.

The two keys never agree. `exists` misses on every asset, so deploy re-uploads all of them on every run, and the manifest points at keys that were never written.

## Root cause

The shared key builder does not normalize `basePath`, so a leading or trailing slash becomes an empty path segment that the asset URI resolver later discards.

## The fix

Strip the surrounding slashes in `createStorageKeyBuilder`, matching what `s3Storage` already does. `s3Storage` keeps its own normalization and is unchanged, since the operation is idempotent. Fixing the shared helper also covers custom plugins, which `docs/content/docs/storage-plugins/custom-storage.mdx` tells authors to build on `createStorageKeyBuilder`.

## What the tests assert

`plugins/plugin-core/src/createStorageKeyBuilder.spec.ts` (new) asserts `createStorageKeyBuilder("/releases/")("bundles/id", "bundle.zip")` returns `releases/bundles/id/bundle.zip`, and that a `basePath` of `""` or `"/"` contributes no segment.

`plugins/supabase/src/supabaseStorage.spec.ts` adds an end-to-end case asserting that with `basePath: "/releases/"` the plugin calls `bucket.upload` with `releases/bundles/bundle.zip`. Without the fix it is called with `/releases//bundles/bundle.zip`.

`pnpm -w lint` is clean and the existing storage suites (s3, r2, firebase, supabase, bundle/asset storage layout, `storage prune`) still pass.
