### PR TITLE
feat(console): visualize rollout adoption and recovery signals

### DIFF
--- a/.changeset/strict-webs-thank.md
+++ b/.changeset/strict-webs-thank.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Show deployment adoption crossovers and recovery-rate spikes in Insights, with shared ID and interval selection, rollout markers, and links to delivery settings.

--- a/packages/console/src/components/features/insights/InsightsRolloutCard.spec.tsx
+++ b/packages/console/src/components/features/insights/InsightsRolloutCard.spec.tsx
@@ -1,0 +1,219 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { RecoveryReport } from "@/lib/insights-recovery";
+
+import { InsightsRolloutCard, RolloutChart } from "./InsightsRolloutCard";
+
+const mocks = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock("@tanstack/react-query", () => ({ useQuery: mocks.query }));
+vi.mock("@/lib/insights-recovery-rpc", () => ({
+  getRecoveryReportRpc: vi.fn(),
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    search,
+  }: {
+    children: ReactNode;
+    search: { releaseId: string };
+  }) => <a href={`/?releaseId=${search.releaseId}`}>{children}</a>,
+}));
+vi.mock("recharts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("recharts")>()),
+  ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+    cloneElement(children, { width: 600, height: 224 } as object),
+}));
+
+const HOUR = 3_600_000;
+const report: RecoveryReport = {
+  sinceMs: 0,
+  beforeReceivedAtMs: 4 * HOUR,
+  intervalMs: HOUR,
+  truncated: false,
+  series: [
+    {
+      releaseId: "promoted-id",
+      firstAdoptedAtMs: 0,
+      points: [
+        {
+          startMs: 0,
+          adopted: 100,
+          adoptionShare: 100,
+          recovered: 0,
+          rate: 0,
+          spike: false,
+        },
+        {
+          startMs: HOUR,
+          adopted: 7,
+          adoptionShare: 100,
+          recovered: 3,
+          rate: 30,
+          spike: true,
+        },
+        {
+          startMs: 2 * HOUR,
+          adopted: 0,
+          adoptionShare: null,
+          recovered: 0,
+          rate: null,
+          spike: false,
+        },
+        {
+          startMs: 3 * HOUR,
+          adopted: 10,
+          adoptionShare: 100,
+          recovered: 0,
+          rate: 0,
+          spike: false,
+        },
+      ],
+    },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("recovery trend", () => {
+  it("shows crossing adoption lines and preserves the selected ID and interval when inspecting recovery", () => {
+    const crossing = {
+      ...report,
+      beforeReceivedAtMs: 3 * HOUR,
+      series: ["new-id", "old-id"].map((releaseId, index) => ({
+        releaseId,
+        firstAdoptedAtMs: 0,
+        points: [10, 50, 90].map((share, i) => ({
+          startMs: i * HOUR,
+          adopted: index === 0 ? share : 100 - share,
+          adoptionShare: index === 0 ? share : 100 - share,
+          recovered: 0,
+          rate: 0,
+          spike: false,
+        })),
+      })),
+    };
+    const { container } = render(<RolloutChart report={crossing} />);
+    expect(container.querySelectorAll(".recharts-line-curve")).toHaveLength(2);
+    expect(
+      screen.getByText("New adoption share in selected interval"),
+    ).toBeDefined();
+    expect(screen.getByText("90.0")).toBeDefined();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Inspect ID old-id, .*: 50.0% new adoption/,
+      }),
+    );
+    expect(screen.getByText("50.0")).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Review deployment" })
+        .getAttribute("href"),
+    ).toBe("/?releaseId=old-id");
+    fireEvent.click(screen.getByRole("button", { name: "Recovery rate" }));
+    expect(screen.getByText("0.0")).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Review deployment" })
+        .getAttribute("href"),
+    ).toBe("/?releaseId=old-id");
+    expect(
+      screen
+        .getByRole("button", { name: "Next interval" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+  });
+  it("shows a real time series, selects the spike and links its public ID to delivery settings", () => {
+    const { container } = render(<RolloutChart report={report} />);
+    expect(container.querySelector(".recharts-line-curve")).not.toBeNull();
+    expect(screen.getByText("First adoption")).toBeDefined();
+    expect(screen.getByText("30.0")).toBeDefined();
+    expect(
+      screen.getByText("3 recovered / 10 adoption + recovery reports"),
+    ).toBeDefined();
+    expect(
+      screen.getByText("Consider rolling back this deployment"),
+    ).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Review deployment" })
+        .getAttribute("href"),
+    ).toBe("/?releaseId=promoted-id");
+  });
+
+  it("lets keyboard users inspect other intervals without treating missing reports as zero", () => {
+    render(<RolloutChart report={report} />);
+    fireEvent.click(screen.getByRole("button", { name: "Next interval" }));
+    expect(screen.getByText("—")).toBeDefined();
+    expect(
+      screen.queryByText("Consider rolling back this deployment"),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Next interval" }));
+    expect(screen.getByText("0.0")).toBeDefined();
+    expect(
+      screen
+        .getByRole("button", { name: "Next interval" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("selects a chart point directly by pointer or keyboard", () => {
+    render(<RolloutChart report={report} />);
+    const zeroPoints = screen.getAllByRole("button", {
+      name: /Inspect .*: 0.0% recovered/,
+    });
+    fireEvent.click(zeroPoints[0]);
+    expect(
+      screen
+        .getByRole("button", { name: "Previous interval" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    fireEvent.keyDown(
+      screen.getByRole("button", { name: /Inspect .*: 30.0% recovered/ }),
+      { key: "Enter" },
+    );
+    expect(
+      screen.getByText("Consider rolling back this deployment"),
+    ).toBeDefined();
+  });
+
+  it("keeps the same graph and signal in the deployment sheet without a self-link", () => {
+    render(<RolloutChart report={report} inSheet />);
+    expect(screen.getByText("promoted-id")).toBeDefined();
+    expect(
+      screen.getByText("Consider rolling back this deployment"),
+    ).toBeDefined();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("handles loading, failure, empty and incomplete history with a retry action", () => {
+    const input = {
+      platform: "ios",
+      channel: "production",
+      window: "24h",
+    } as const;
+    const refetch = vi.fn();
+    mocks.query.mockReturnValue({ isPending: true });
+    const view = render(<InsightsRolloutCard input={input} />);
+    expect(screen.getByLabelText("Loading rollout activity")).toBeDefined();
+    mocks.query.mockReturnValue({ error: new Error("Offline"), refetch });
+    view.rerender(<InsightsRolloutCard input={input} />);
+    expect(screen.getByText("Rollout activity unavailable")).toBeDefined();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh rollout activity" }),
+    );
+    expect(refetch).toHaveBeenCalledOnce();
+    mocks.query.mockReturnValue({
+      data: { ...report, series: [], truncated: true },
+      refetch,
+    });
+    view.rerender(<InsightsRolloutCard input={input} />);
+    expect(screen.getByText("No rollout activity yet")).toBeDefined();
+    expect(screen.getByText("Partial history")).toBeDefined();
+  });
+});

--- a/packages/console/src/components/features/insights/InsightsRolloutCard.tsx
+++ b/packages/console/src/components/features/insights/InsightsRolloutCard.tsx
@@ -1,0 +1,505 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight, RotateCcw, TriangleAlert } from "lucide-react";
+import { useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { RecoveryInput, RecoveryReport } from "@/lib/insights-recovery";
+import { getRecoveryReportRpc } from "@/lib/insights-recovery-rpc";
+
+import { useInsightsTimeFormat } from "./EventDetails";
+import { InsightsErrorAlert } from "./InsightsErrorAlert";
+
+const percent = (rate: number | null) =>
+  rate === null ? "No reports" : `${rate.toFixed(1)}%`;
+
+export function RolloutChart({
+  report,
+  inSheet = false,
+}: {
+  readonly report: RecoveryReport;
+  readonly inSheet?: boolean;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedTime, setSelectedTime] = useState<number | null>(null);
+  const [metric, setMetric] = useState<"adoption" | "recovery">(() =>
+    report.series.some(({ points }) => points.some(({ spike }) => spike))
+      ? "recovery"
+      : "adoption",
+  );
+  const formatter = useInsightsTimeFormat();
+  const series =
+    report.series.find(({ releaseId }) => releaseId === selectedId) ??
+    report.series[0];
+  if (!series)
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <RotateCcw aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>No rollout activity yet</EmptyTitle>
+          <EmptyDescription>
+            Try a different time window or check again after this deployment
+            reports adoption or recovery.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+
+  const point =
+    series.points.find(({ startMs }) => startMs === selectedTime) ??
+    [...series.points].reverse().find(({ spike }) => spike) ??
+    [...series.points]
+      .reverse()
+      .find(
+        (item) =>
+          (metric === "adoption" ? item.adoptionShare : item.rate) !== null,
+      ) ??
+    [...series.points].reverse().find(({ rate }) => rate !== null)!;
+  const markerMs =
+    series.firstAdoptedAtMs === null
+      ? null
+      : Math.floor(series.firstAdoptedAtMs / report.intervalMs) *
+        report.intervalMs;
+  const spikeCount = report.series.filter(({ points }) =>
+    points.some(({ spike }) => spike),
+  ).length;
+  // Paint the selected ID last so it stays clickable where lines cross.
+  const plotted =
+    metric === "adoption"
+      ? [...report.series.filter((item) => item !== series), series]
+      : [series];
+  const chartConfig = Object.fromEntries(
+    plotted.map((item, index) => [
+      `series${index}`,
+      {
+        label: `ID ${item.releaseId}`,
+        color:
+          item.releaseId === series.releaseId
+            ? "var(--primary)"
+            : "var(--muted-foreground)",
+      },
+    ]),
+  );
+  const chartData = series.points.map((item, pointIndex) => ({
+    startMs: item.startMs,
+    ...Object.fromEntries(
+      plotted.map((deployment, index) => [
+        `series${index}`,
+        metric === "adoption"
+          ? deployment.points[pointIndex].adoptionShare
+          : deployment.points[pointIndex].rate,
+      ]),
+    ),
+  }));
+  const selectedValue =
+    metric === "adoption" ? point.adoptionShare : point.rate;
+  const tickTime = (value: number) =>
+    new Intl.DateTimeFormat("en", {
+      timeZone: formatter.resolvedOptions().timeZone,
+      ...(report.intervalMs < 21_600_000
+        ? { hour: "2-digit", minute: "2-digit" }
+        : { month: "short", day: "numeric" }),
+    }).format(value);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <ToggleGroup
+        aria-label="Rollout metric"
+        variant="outline"
+        spacing={0}
+        value={[metric]}
+        onValueChange={(values) => {
+          const next = values[0];
+          if (next === "adoption" || next === "recovery") {
+            setSelectedTime(point.startMs);
+            setMetric(next);
+          }
+        }}
+      >
+        <ToggleGroupItem value="adoption">New adoption</ToggleGroupItem>
+        <ToggleGroupItem value="recovery">Recovery rate</ToggleGroupItem>
+      </ToggleGroup>
+      {!inSheet ? (
+        <div className="flex min-w-0 flex-col gap-2">
+          <Select
+            value={series.releaseId}
+            onValueChange={(value) => {
+              setSelectedId(value);
+              setSelectedTime(null);
+            }}
+          >
+            <SelectTrigger
+              aria-label="Deployment ID"
+              className="w-full min-w-0"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {report.series.map((item) => (
+                  <SelectItem key={item.releaseId} value={item.releaseId}>
+                    {item.points.some(({ spike }) => spike)
+                      ? "Review · "
+                      : "ID · "}
+                    {item.releaseId}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          {spikeCount > 1 ? (
+            <p className="text-xs text-muted-foreground">
+              {spikeCount} deployments have recovery spikes. Select an ID to
+              review its trend.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+      {metric === "adoption" && !inSheet ? (
+        <p className="text-xs text-muted-foreground">
+          The highlighted line is the selected ID. Other IDs appear in gray;
+          select a point to compare adoption and recovery.
+        </p>
+      ) : null}
+      <ChartContainer
+        config={chartConfig}
+        className="h-56 w-full"
+        aria-label={`${metric === "adoption" ? "New adoption share" : "Recovery rate"} for ID ${series.releaseId}`}
+      >
+        <LineChart
+          accessibilityLayer
+          data={chartData}
+          margin={{ top: 24, left: -20, right: 16 }}
+          onClick={(state) => {
+            const index = Number(state.activeIndex);
+            if (state.activeIndex != null && series.points[index])
+              setSelectedTime(series.points[index].startMs);
+          }}
+        >
+          <CartesianGrid vertical={false} />
+          <XAxis
+            tick={{ fill: "var(--muted-foreground)" }}
+            dataKey="startMs"
+            tickFormatter={tickTime}
+            tickLine={false}
+            axisLine={false}
+            minTickGap={48}
+          />
+          <YAxis
+            tick={{ fill: "var(--muted-foreground)" }}
+            domain={[0, 100]}
+            tickFormatter={(value: number) => `${value}%`}
+            tickLine={false}
+            axisLine={false}
+            ticks={[0, 25, 50, 75, 100]}
+          />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                labelFormatter={(_, payload) =>
+                  formatter.format(Number(payload[0]?.payload.startMs))
+                }
+                formatter={(value, name) => (
+                  <span className="max-w-64 break-all font-medium tabular-nums">
+                    {name}: {Number(value).toFixed(1)}%
+                  </span>
+                )}
+              />
+            }
+          />
+          {markerMs !== null ? (
+            <ReferenceLine
+              x={markerMs}
+              stroke="var(--muted-foreground)"
+              strokeDasharray="4 4"
+              label={{
+                value: "First adoption",
+                position: "insideTopLeft",
+                fill: "var(--muted-foreground)",
+                fontSize: 11,
+              }}
+            />
+          ) : null}
+          <ReferenceLine x={point.startMs} stroke="var(--border)" />
+          {plotted.map((deployment, seriesIndex) => (
+            <Line
+              key={deployment.releaseId}
+              name={`ID ${deployment.releaseId}`}
+              dataKey={`series${seriesIndex}`}
+              type="linear"
+              stroke={`var(--color-series${seriesIndex})`}
+              strokeWidth={2}
+              connectNulls={false}
+              isAnimationActive={false}
+              dot={({ cx, cy, index }) => {
+                const p = deployment.points[index];
+                const value =
+                  metric === "adoption" ? p?.adoptionShare : p?.rate;
+                if (!p || value === null) return <g key={index} />;
+                // SVG chart points cannot contain native HTML buttons.
+                /* oxlint-disable jsx-a11y/prefer-tag-over-role */
+                return (
+                  <circle
+                    key={index}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Inspect ID ${deployment.releaseId}, ${formatter.format(p.startMs)}: ${percent(value)} ${metric === "adoption" ? "new adoption" : "recovered"}`}
+                    className="cursor-pointer focus-visible:stroke-foreground focus-visible:stroke-2"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setSelectedId(deployment.releaseId);
+                      setSelectedTime(p.startMs);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setSelectedId(deployment.releaseId);
+                        setSelectedTime(p.startMs);
+                      }
+                    }}
+                    cx={cx}
+                    cy={cy}
+                    r={metric === "recovery" && p.spike ? 5 : 3}
+                    fill={
+                      metric === "recovery" && p.spike
+                        ? "var(--destructive)"
+                        : `var(--color-series${seriesIndex})`
+                    }
+                  />
+                );
+                /* oxlint-enable jsx-a11y/prefer-tag-over-role */
+              }}
+            />
+          ))}
+        </LineChart>
+      </ChartContainer>
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-xs text-muted-foreground">
+            {metric === "adoption"
+              ? "New adoption share in selected interval"
+              : "Recovered in selected interval"}
+          </p>
+          <p className="mt-1 text-4xl font-semibold tracking-tight tabular-nums">
+            {selectedValue === null ? "—" : selectedValue.toFixed(1)}
+            <span className="ml-1 text-lg font-medium text-muted-foreground">
+              %
+            </span>
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {metric === "adoption"
+              ? `${point.adopted.toLocaleString()} adoption reports · ${percent(point.rate)} recovered`
+              : `${point.recovered.toLocaleString()} recovered / ${(point.adopted + point.recovered).toLocaleString()} adoption + recovery reports`}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            aria-label="Previous interval"
+            disabled={point === series.points[0]}
+            onClick={() => setSelectedTime(point.startMs - report.intervalMs)}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            aria-label="Next interval"
+            disabled={point === series.points.at(-1)}
+            onClick={() => setSelectedTime(point.startMs + report.intervalMs)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {formatter.format(Math.max(point.startMs, report.sinceMs))} –{" "}
+        {formatter.format(
+          Math.min(
+            point.startMs + report.intervalMs,
+            report.beforeReceivedAtMs,
+          ),
+        )}
+      </p>
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3">
+        <div className="min-w-0">
+          <p className="text-xs text-muted-foreground">ID</p>
+          <p className="mt-1 break-all font-mono text-xs" translate="no">
+            {series.releaseId}
+          </p>
+        </div>
+        {!inSheet ? (
+          <Link
+            to="/"
+            search={{ releaseId: series.releaseId }}
+            className={buttonVariants({ variant: "outline" })}
+          >
+            Review deployment
+            <ArrowUpRight aria-hidden="true" data-icon="inline-end" />
+          </Link>
+        ) : null}
+      </div>
+      {point.spike ? (
+        <Alert variant="destructive">
+          <TriangleAlert aria-hidden="true" />
+          <AlertTitle>Consider rolling back this deployment</AlertTitle>
+          <AlertDescription>
+            Recovery rose to {percent(point.rate)} after adoption began. Review
+            rollout and Enabled settings before deciding to roll back.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {markerMs !== null ? (
+        <p className="text-xs text-muted-foreground">
+          First adoption observed in this window:{" "}
+          {formatter.format(series.firstAdoptedAtMs!)}.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function InsightsRolloutCard({
+  input,
+  inSheet = false,
+}: {
+  readonly input: RecoveryInput;
+  readonly inSheet?: boolean;
+}) {
+  const [sheetWindow, setSheetWindow] = useState(input.window);
+  const queryInput = inSheet ? { ...input, window: sheetWindow } : input;
+  const query = useQuery({
+    queryKey: ["insights", "recovery", queryInput],
+    queryFn: () => getRecoveryReportRpc({ data: queryInput }),
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+  return (
+    <Card className="min-w-0 overflow-hidden shadow-sm">
+      <CardHeader>
+        <CardTitle>Rollout activity</CardTitle>
+        {inSheet ? (
+          <Select
+            value={sheetWindow}
+            onValueChange={(value) => {
+              if (value === "24h" || value === "7d" || value === "30d")
+                setSheetWindow(value);
+            }}
+          >
+            <SelectTrigger aria-label="Rollout time window" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="24h">Last 24 hours</SelectItem>
+                <SelectItem value="7d">Last 7 days</SelectItem>
+                <SelectItem value="30d">Last 30 days</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        ) : null}
+        <CardDescription>
+          See new deployments take over and spot recovery spikes. Select a point
+          to inspect its ID and interval.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {query.isPending ? (
+          <Skeleton
+            aria-label="Loading rollout activity"
+            className="h-80 w-full"
+          />
+        ) : query.error ? (
+          <InsightsErrorAlert
+            error={query.error}
+            fallbackTitle="Rollout activity unavailable"
+          />
+        ) : (
+          <>
+            {query.data.truncated ? (
+              <Alert>
+                <TriangleAlert aria-hidden="true" />
+                <AlertTitle>Partial history</AlertTitle>
+                <AlertDescription>
+                  Only complete intervals from the latest 50,000 reports are
+                  shown. Choose a shorter window to see more detail.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            <RolloutChart
+              key={`${queryInput.platform}:${queryInput.channel}:${queryInput.window}:${queryInput.releaseId ?? ""}`}
+              report={query.data}
+              inSheet={inSheet}
+            />
+          </>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-3">
+        <p className="text-xs text-muted-foreground">
+          New adoption shows each ID’s share of adoption reports in this
+          platform and channel. Recovery is recovered ÷ (adopted + recovered).
+          Only reports with an ID are included. Reports are not unique devices;
+          gaps mean no reports.
+        </p>
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer">
+            When a spike needs review
+          </summary>
+          <p className="mt-2">
+            At least 10 reports, 3 recoveries, a recovery rate of 10% or more,
+            and a rise of 10 percentage points from the previous observed
+            interval (0% at first adoption).
+          </p>
+        </details>
+        <Button
+          variant="outline"
+          disabled={query.isFetching}
+          onClick={() => void query.refetch()}
+        >
+          Refresh rollout activity
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -16,6 +16,14 @@ import { ReleaseEditorSheet } from "./ReleaseEditorSheet";
 const preflight = vi.fn();
 const promote = vi.fn();
 const update = vi.fn();
+const recovery = vi.fn();
+
+vi.mock("@/components/features/insights/InsightsRolloutCard", () => ({
+  InsightsRolloutCard: (props: unknown) => {
+    recovery(props);
+    return <div>Recovery rate</div>;
+  },
+}));
 
 const release = {
   bundle_id: "bundle-1",
@@ -189,6 +197,16 @@ describe("ReleaseEditorSheet", () => {
         releaseId={release.id}
       />,
     );
+
+    expect(recovery).toHaveBeenLastCalledWith({
+      inSheet: true,
+      input: {
+        platform: "ios",
+        channel: "production",
+        releaseId: "release-1",
+        window: "7d",
+      },
+    });
 
     expect(
       screen.getByRole("heading", { name: "Bundle Detail" }),

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.tsx
@@ -17,6 +17,7 @@ import { normalizeRange } from "verkit";
 import { BundleIdDisplay } from "@/components/BundleIdDisplay";
 import { BundleMetadata } from "@/components/features/bundles/BundleMetadata";
 import { RolloutCohortsDialog } from "@/components/features/bundles/RolloutCohortsDialog";
+import { InsightsRolloutCard } from "@/components/features/insights/InsightsRolloutCard";
 import { PlatformIcon } from "@/components/PlatformIcon";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
@@ -584,6 +585,18 @@ export function ReleaseEditorSheet({
                       : "Save changes"}
                   </Button>
                 </section>
+
+                {channelName ? (
+                  <InsightsRolloutCard
+                    inSheet
+                    input={{
+                      platform: release.platform,
+                      channel: channelName,
+                      releaseId: release.id,
+                      window: "7d",
+                    }}
+                  />
+                ) : null}
 
                 <Separator className="my-2" />
 

--- a/packages/console/src/components/ui/empty.tsx
+++ b/packages/console/src/components/ui/empty.tsx
@@ -1,0 +1,101 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn("flex max-w-sm flex-col items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-sm font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-xs/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-2 text-xs/relaxed text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+};

--- a/packages/console/src/lib/insights-recovery-rpc.spec.ts
+++ b/packages/console/src/lib/insights-recovery-rpc.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ prepare: vi.fn(), report: vi.fn() }));
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => ({
+    validator() {
+      return this;
+    },
+    handler(handler: (input: unknown) => unknown) {
+      return handler;
+    },
+  }),
+}));
+vi.mock("./server/config.server", () => ({ prepareConfig: mocks.prepare }));
+vi.mock("./server/insightsRecovery", () => ({
+  getRecoveryReport: mocks.report,
+}));
+
+import { getRecoveryReportRpc } from "./insights-recovery-rpc";
+
+afterEach(() => vi.resetAllMocks());
+
+describe("recovery report access", () => {
+  const data = {
+    platform: "ios",
+    channel: "production",
+    window: "7d",
+    releaseId: "promoted-id",
+  } as const;
+
+  it("uses the authenticated console database and preserves the requested ID", async () => {
+    const model = {};
+    mocks.prepare.mockResolvedValue({
+      config: { database: { models: { insights: model } } },
+    });
+    mocks.report.mockResolvedValue({ series: [] });
+    await expect(getRecoveryReportRpc({ data })).resolves.toEqual({
+      series: [],
+    });
+    expect(mocks.report).toHaveBeenCalledWith(model, data);
+  });
+
+  it("does not read report history when console access is denied", async () => {
+    const denied = new Response("Unauthorized", { status: 401 });
+    mocks.prepare.mockRejectedValue(denied);
+    await expect(getRecoveryReportRpc({ data })).rejects.toBe(denied);
+    expect(mocks.report).not.toHaveBeenCalled();
+  });
+});

--- a/packages/console/src/lib/insights-recovery-rpc.ts
+++ b/packages/console/src/lib/insights-recovery-rpc.ts
@@ -1,0 +1,14 @@
+import { createServerFn } from "@tanstack/react-start";
+
+import { readRecoveryInput } from "./insights-recovery";
+
+export const getRecoveryReportRpc = createServerFn({ method: "GET" })
+  .validator(readRecoveryInput)
+  .handler(async ({ data }) => {
+    const [{ prepareConfig }, { getRecoveryReport }] = await Promise.all([
+      import("./server/config.server"),
+      import("./server/insightsRecovery"),
+    ]);
+    const { config } = await prepareConfig();
+    return getRecoveryReport(config.database.models.insights, data);
+  });

--- a/packages/console/src/lib/insights-recovery.ts
+++ b/packages/console/src/lib/insights-recovery.ts
@@ -1,0 +1,55 @@
+import type { InsightsWindow } from "./insights-rpc";
+
+export type RecoveryInput = {
+  readonly platform: "ios" | "android";
+  readonly channel: string;
+  readonly window: InsightsWindow;
+  readonly releaseId?: string;
+};
+
+export type RecoveryPoint = {
+  readonly startMs: number;
+  readonly adopted: number;
+  readonly adoptionShare: number | null;
+  readonly recovered: number;
+  readonly rate: number | null;
+  readonly spike: boolean;
+};
+
+export type RecoverySeries = {
+  readonly releaseId: string;
+  readonly firstAdoptedAtMs: number | null;
+  readonly points: readonly RecoveryPoint[];
+};
+
+export type RecoveryReport = {
+  readonly sinceMs: number;
+  readonly beforeReceivedAtMs: number;
+  readonly intervalMs: number;
+  readonly truncated: boolean;
+  readonly series: readonly RecoverySeries[];
+};
+
+export const recoveryWindows = {
+  "24h": { durationMs: 86_400_000, intervalMs: 3_600_000 },
+  "7d": { durationMs: 7 * 86_400_000, intervalMs: 6 * 3_600_000 },
+  "30d": { durationMs: 30 * 86_400_000, intervalMs: 86_400_000 },
+} as const;
+
+export function readRecoveryInput(input: RecoveryInput): RecoveryInput {
+  if (
+    !input ||
+    (input.platform !== "ios" && input.platform !== "android") ||
+    typeof input.channel !== "string" ||
+    !input.channel.trim() ||
+    input.channel.length > 1_024 ||
+    !Object.hasOwn(recoveryWindows, input.window) ||
+    (input.releaseId !== undefined &&
+      (typeof input.releaseId !== "string" ||
+        !input.releaseId.trim() ||
+        input.releaseId.length > 1_024))
+  ) {
+    throw new Error("Choose a platform, channel, and time window.");
+  }
+  return input;
+}

--- a/packages/console/src/lib/server/insightsRecovery.spec.ts
+++ b/packages/console/src/lib/server/insightsRecovery.spec.ts
@@ -1,0 +1,251 @@
+// @vitest-environment node
+
+import type { BundleEventRow, InsightsModel } from "@hot-updater/plugin-core";
+import { describe, expect, it, vi } from "vitest";
+
+import { getRecoveryReport } from "./insightsRecovery";
+
+const HOUR = 3_600_000;
+const now = 48 * HOUR;
+const input = {
+  platform: "ios",
+  channel: "production",
+  window: "24h",
+} as const;
+let sequence = 0;
+const event = (
+  type: "RELEASE_ADOPTED" | "RECOVERED" | "UPDATE_APPLIED",
+  time: number,
+  releaseId = "release-a",
+  overrides: Partial<BundleEventRow> = {},
+): BundleEventRow =>
+  ({
+    id: String(++sequence).padStart(10, "0"),
+    install_id: `install-${sequence}`,
+    type,
+    received_at_ms: time,
+    from_bundle_id: "same-file",
+    to_bundle_id: "same-file",
+    from_release_id: type === "RECOVERED" ? releaseId : "previous-release",
+    to_release_id: type === "RECOVERED" ? "stable-release" : releaseId,
+    platform: "ios",
+    channel: "production",
+    user_id: null,
+    username: null,
+    app_version: "1.0.0",
+    cohort: "default",
+    fingerprint_hash: null,
+    sdk_version: null,
+    update_strategy: "appVersion",
+    ...overrides,
+  }) as BundleEventRow;
+const reports = (
+  adopted: number,
+  recovered: number,
+  hour: number,
+  releaseId = "release-a",
+) => [
+  ...Array.from({ length: adopted }, (_, i) =>
+    event("RELEASE_ADOPTED", hour * HOUR + i, releaseId),
+  ),
+  ...Array.from({ length: recovered }, (_, i) =>
+    event("RECOVERED", hour * HOUR + 1_000 + i, releaseId),
+  ),
+];
+function modelFor(events: BundleEventRow[]): InsightsModel {
+  const ordered = events.sort(
+    (a, b) => b.received_at_ms - a.received_at_ms || b.id.localeCompare(a.id),
+  );
+  return {
+    listEvents: vi.fn(
+      async ({ after, sinceMs = 0, beforeReceivedAtMs, limit }) =>
+        ordered
+          .filter(
+            (row) =>
+              row.received_at_ms >= sinceMs &&
+              row.received_at_ms < beforeReceivedAtMs &&
+              (!after ||
+                row.received_at_ms < after.receivedAtMs ||
+                (row.received_at_ms === after.receivedAtMs &&
+                  row.id < after.id)),
+          )
+          .slice(0, limit),
+    ),
+  } as unknown as InsightsModel;
+}
+
+describe("recovery rollout series", () => {
+  it("attributes recovery to the source ID and keeps promotions of the same file separate", async () => {
+    const report = await getRecoveryReport(
+      modelFor([
+        ...reports(100, 0, 25),
+        ...reports(7, 3, 26),
+        ...reports(20, 0, 26, "release-b"),
+        event("UPDATE_APPLIED", 26 * HOUR),
+        event("RECOVERED", 26 * HOUR, "release-a", { platform: "android" }),
+        event("RECOVERED", 26 * HOUR, "release-a", { channel: "staging" }),
+        event("RECOVERED", 26 * HOUR, "release-a", { from_release_id: null }),
+        event("RECOVERED", now),
+        event("RECOVERED", 24 * HOUR - 1),
+      ]),
+      input,
+      now,
+    );
+    expect(report.series.map((s) => s.releaseId)).toEqual([
+      "release-a",
+      "release-b",
+    ]);
+    expect(report.series[0].firstAdoptedAtMs).toBe(25 * HOUR);
+    expect(
+      report.series[0].points.find((p) => p.startMs === 26 * HOUR),
+    ).toEqual({
+      startMs: 26 * HOUR,
+      adopted: 7,
+      adoptionShare: (7 / 27) * 100,
+      recovered: 3,
+      rate: 30,
+      spike: true,
+    });
+    expect(
+      report.series[1].points.find((p) => p.startMs === 26 * HOUR)?.rate,
+    ).toBe(0);
+    expect(report.series[0].points[0].rate).toBeNull();
+  });
+
+  it("filters the sheet by its exact ID and marks first-interval rollout failures", async () => {
+    const report = await getRecoveryReport(
+      modelFor([...reports(7, 3, 25), ...reports(1, 30, 25, "release-b")]),
+      { ...input, releaseId: "release-a" },
+      now,
+    );
+    expect(report.series).toHaveLength(1);
+    expect(report.series[0].releaseId).toBe("release-a");
+    expect(
+      report.series[0].points.find((p) => p.startMs === 25 * HOUR)?.spike,
+    ).toBe(true);
+  });
+
+  it("requires the agreed sample, rate and increase, and compares across gaps", async () => {
+    const report = await getRecoveryReport(
+      modelFor([
+        ...reports(7, 2, 25), // under ten reports and three recoveries
+        ...reports(97, 3, 26), // below ten percent
+        ...reports(7, 3, 28), // 27 percentage point rise across an empty interval
+        ...reports(7, 3, 29), // high but flat
+        ...reports(5, 5, 30), // another spike
+      ]),
+      input,
+      now,
+    );
+    expect(
+      report.series[0].points.filter((p) => p.spike).map((p) => p.startMs),
+    ).toEqual([28 * HOUR, 30 * HOUR]);
+    expect(
+      report.series[0].points.find((p) => p.startMs === 27 * HOUR)?.rate,
+    ).toBeNull();
+  });
+
+  it("shows recovery reports without claiming a rollout spike when no adoption was observed", async () => {
+    const report = await getRecoveryReport(
+      modelFor(reports(0, 10, 25)),
+      input,
+      now,
+    );
+    expect(report.series[0].firstAdoptedAtMs).toBeNull();
+    expect(
+      report.series[0].points.find((p) => p.startMs === 25 * HOUR),
+    ).toMatchObject({ rate: 100, spike: false });
+  });
+
+  it("pages through timestamp ties without dropping or double-counting reports", async () => {
+    const model = modelFor([
+      ...reports(198, 3, 25),
+      ...Array.from({ length: 105 }, () => event("RELEASE_ADOPTED", 25 * HOUR)),
+    ]);
+    const report = await getRecoveryReport(model, input, now);
+    expect(model.listEvents).toHaveBeenCalledTimes(4);
+    expect(report.truncated).toBe(false);
+    expect(
+      report.series[0].points.find((p) => p.startMs === 25 * HOUR),
+    ).toMatchObject({ adopted: 303, recovered: 3, rate: (3 / 306) * 100 });
+  });
+
+  it("does not call recoveries before the first adoption a rollout spike", async () => {
+    const report = await getRecoveryReport(
+      modelFor([
+        ...Array.from({ length: 3 }, () => event("RECOVERED", 25 * HOUR)),
+        ...Array.from({ length: 7 }, () =>
+          event("RELEASE_ADOPTED", 25 * HOUR + 1_000),
+        ),
+      ]),
+      input,
+      now,
+    );
+    expect(
+      report.series[0].points.find((p) => p.startMs === 25 * HOUR),
+    ).toMatchObject({ rate: 30, spike: false });
+  });
+
+  it("omits the incomplete boundary interval at the 50,000-row cap", async () => {
+    const model = modelFor([
+      ...reports(7, 3, 47),
+      ...Array.from({ length: 49_991 }, () => event("RECOVERED", 46 * HOUR)),
+    ]);
+    const report = await getRecoveryReport(model, input, now);
+    expect(model.listEvents).toHaveBeenCalledTimes(500);
+    expect(report.truncated).toBe(true);
+    expect(report.sinceMs).toBe(47 * HOUR);
+    expect(report.series[0].points).toEqual([
+      {
+        startMs: 47 * HOUR,
+        adopted: 7,
+        adoptionShare: 100,
+        recovered: 3,
+        rate: 30,
+        spike: false,
+      },
+    ]);
+  });
+
+  it("validates scope before reading events", async () => {
+    const model = modelFor([]);
+    await expect(
+      getRecoveryReport(model, { ...input, channel: "" }, now),
+    ).rejects.toThrow("Choose a platform");
+    expect(model.listEvents).not.toHaveBeenCalled();
+  });
+
+  it("shows the adoption crossover of two IDs sharing a file and keeps the same denominator in the sheet", async () => {
+    const events = [
+      ...reports(90, 0, 25, "old-id"),
+      ...reports(10, 0, 25, "new-id"),
+      ...reports(50, 0, 26, "old-id"),
+      ...reports(50, 0, 26, "new-id"),
+      ...reports(10, 0, 27, "old-id"),
+      ...reports(90, 10, 27, "new-id"),
+      event("RELEASE_ADOPTED", 27 * HOUR, "other-platform", {
+        platform: "android",
+      }),
+      event("RELEASE_ADOPTED", 27 * HOUR, "legacy", { to_release_id: null }),
+    ];
+    const report = await getRecoveryReport(modelFor(events), input, now);
+    const shares = (id: string) =>
+      report.series
+        .find((s) => s.releaseId === id)
+        ?.points.filter((p) => p.adoptionShare !== null)
+        .map((p) => p.adoptionShare);
+    expect(shares("old-id")).toEqual([90, 50, 10]);
+    expect(shares("new-id")).toEqual([10, 50, 90]);
+    const sheet = await getRecoveryReport(
+      modelFor(events),
+      { ...input, releaseId: "new-id" },
+      now,
+    );
+    expect(sheet.series).toHaveLength(1);
+    expect(
+      sheet.series[0].points
+        .filter((p) => p.adoptionShare !== null)
+        .map((p) => p.adoptionShare),
+    ).toEqual([10, 50, 90]);
+  });
+});

--- a/packages/console/src/lib/server/insightsRecovery.ts
+++ b/packages/console/src/lib/server/insightsRecovery.ts
@@ -1,0 +1,157 @@
+import type {
+  InsightsEventCursor,
+  InsightsModel,
+} from "@hot-updater/plugin-core";
+
+import {
+  readRecoveryInput,
+  recoveryWindows,
+  type RecoveryInput,
+  type RecoveryReport,
+  type RecoverySeries,
+} from "../insights-recovery";
+
+const MAX_SCAN_ROWS = 50_000;
+
+export async function getRecoveryReport(
+  model: InsightsModel,
+  input: RecoveryInput,
+  beforeReceivedAtMs = Date.now(),
+): Promise<RecoveryReport> {
+  readRecoveryInput(input);
+  const { durationMs, intervalMs } = recoveryWindows[input.window];
+  const sinceMs = Math.max(0, beforeReceivedAtMs - durationMs);
+  const bucketStart = (time: number) =>
+    Math.floor(time / intervalMs) * intervalMs;
+  const releases = new Map<
+    string,
+    {
+      firstAdoptedAtMs: number | null;
+      buckets: Map<
+        number,
+        { adopted: number; recovered: number; lastRecoveredAtMs: number }
+      >;
+    }
+  >();
+  const adoptionTotals = new Map<number, number>();
+  let after: InsightsEventCursor | undefined;
+  let scanned = 0;
+  let truncated = false;
+  let completeSinceMs = sinceMs;
+
+  while (scanned < MAX_SCAN_ROWS) {
+    // Keep the existing bounded scan; native adapters own cursor pagination.
+    const limit = Math.min(100, MAX_SCAN_ROWS - scanned);
+    const rows = await model.listEvents({
+      filter: { kind: "all" },
+      sinceMs,
+      beforeReceivedAtMs,
+      after,
+      limit: limit + 1,
+    });
+    const page = rows.slice(0, limit);
+    for (const row of page) {
+      if (row.platform !== input.platform || row.channel !== input.channel)
+        continue;
+      if (row.type !== "RECOVERED" && row.type !== "RELEASE_ADOPTED") continue;
+      const releaseId =
+        row.type === "RECOVERED" ? row.from_release_id : row.to_release_id;
+      // Legacy reports without an ID cannot be attributed to a deployment.
+      if (!releaseId) continue;
+      const startMs = bucketStart(row.received_at_ms);
+      if (row.type === "RELEASE_ADOPTED") {
+        adoptionTotals.set(startMs, (adoptionTotals.get(startMs) ?? 0) + 1);
+      }
+      if (input.releaseId && releaseId !== input.releaseId) continue;
+      let release = releases.get(releaseId);
+      if (!release) {
+        release = { firstAdoptedAtMs: null, buckets: new Map() };
+        releases.set(releaseId, release);
+      }
+      const bucket = release.buckets.get(startMs) ?? {
+        adopted: 0,
+        recovered: 0,
+        lastRecoveredAtMs: -1,
+      };
+      if (row.type === "RECOVERED") {
+        bucket.recovered += 1;
+        bucket.lastRecoveredAtMs = Math.max(
+          bucket.lastRecoveredAtMs,
+          row.received_at_ms,
+        );
+      } else {
+        bucket.adopted += 1;
+        release.firstAdoptedAtMs = Math.min(
+          release.firstAdoptedAtMs ?? Infinity,
+          row.received_at_ms,
+        );
+      }
+      release.buckets.set(startMs, bucket);
+    }
+    scanned += page.length;
+    const last = page.at(-1);
+    if (!last || rows.length <= limit) break;
+    after = { id: last.id, receivedAtMs: last.received_at_ms };
+    if (scanned === MAX_SCAN_ROWS) {
+      truncated = true;
+      // The boundary bucket may contain an incomplete denominator. Omit it.
+      completeSinceMs = bucketStart(last.received_at_ms) + intervalMs;
+    }
+  }
+
+  const series: RecoverySeries[] = [];
+  for (const [releaseId, release] of releases) {
+    const firstAdoptedAtMs =
+      release.firstAdoptedAtMs !== null &&
+      release.firstAdoptedAtMs >= completeSinceMs
+        ? release.firstAdoptedAtMs
+        : null;
+    const points = [];
+    let previousRate: number | null = null;
+    for (
+      let startMs = bucketStart(completeSinceMs);
+      startMs < beforeReceivedAtMs;
+      startMs += intervalMs
+    ) {
+      const {
+        adopted = 0,
+        recovered = 0,
+        lastRecoveredAtMs = -1,
+      } = release.buckets.get(startMs) ?? {};
+      const total = adopted + recovered;
+      const totalAdopted = adoptionTotals.get(startMs) ?? 0;
+      const adoptionShare =
+        totalAdopted === 0 ? null : (adopted / totalAdopted) * 100;
+      const rate = total === 0 ? null : (recovered / total) * 100;
+      const afterAdoption =
+        firstAdoptedAtMs !== null && lastRecoveredAtMs >= firstAdoptedAtMs;
+      const spike =
+        afterAdoption &&
+        (!truncated || previousRate !== null) &&
+        rate !== null &&
+        total >= 10 &&
+        recovered >= 3 &&
+        rate >= 10 &&
+        rate - (previousRate ?? 0) >= 10;
+      points.push({ startMs, adopted, adoptionShare, recovered, rate, spike });
+      if (rate !== null) previousRate = rate;
+    }
+    if (points.some(({ rate }) => rate !== null))
+      series.push({ releaseId, firstAdoptedAtMs, points });
+  }
+  // Surface the most recent rollback signal first, then the newest ID.
+  series.sort((a, b) => {
+    const latestSpike = (s: RecoverySeries) =>
+      [...s.points].reverse().find((p) => p.spike)?.startMs ?? -1;
+    return (
+      latestSpike(b) - latestSpike(a) || b.releaseId.localeCompare(a.releaseId)
+    );
+  });
+  return {
+    sinceMs: completeSinceMs,
+    beforeReceivedAtMs,
+    intervalMs,
+    truncated,
+    series,
+  };
+}

--- a/packages/console/src/routes/-insights.spec.tsx
+++ b/packages/console/src/routes/-insights.spec.tsx
@@ -6,6 +6,14 @@ const mocks = vi.hoisted(() => ({
   controls: vi.fn(),
   overview: vi.fn(),
   reporting: vi.fn(),
+  recovery: vi.fn(),
+}));
+
+vi.mock("@/components/features/insights/InsightsRolloutCard", () => ({
+  InsightsRolloutCard: (props: unknown) => {
+    mocks.recovery(props);
+    return <div>Recovery rate</div>;
+  },
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -72,7 +80,7 @@ describe("InsightsPage", () => {
     vi.clearAllMocks();
   });
 
-  it("loads only the reporting-installation headline for the selected window", () => {
+  it("loads reporting installations and the recovery trend for the selected window", () => {
     render(<InsightsPage />);
 
     expect(mocks.reporting).toHaveBeenCalledWith({
@@ -95,6 +103,9 @@ describe("InsightsPage", () => {
       platform: "ios",
       channel: "production",
       window: "7d",
+    });
+    expect(mocks.recovery).toHaveBeenLastCalledWith({
+      input: { platform: "ios", channel: "production", window: "7d" },
     });
     expect(mocks.controls).toHaveBeenLastCalledWith(
       expect.objectContaining({ window: "7d" }),

--- a/packages/console/src/routes/insights.tsx
+++ b/packages/console/src/routes/insights.tsx
@@ -8,6 +8,7 @@ import {
 import { InsightsControls } from "@/components/features/insights/InsightsControls";
 import { InsightsOverview } from "@/components/features/insights/InsightsOverview";
 import { InsightsPageHeader } from "@/components/features/insights/InsightsPageHeader";
+import { InsightsRolloutCard } from "@/components/features/insights/InsightsRolloutCard";
 import { Button } from "@/components/ui/button";
 import {
   type InsightsWindow,
@@ -47,6 +48,7 @@ function InsightsPage() {
             }}
             window={window}
           />
+          <InsightsRolloutCard input={{ ...scope, window }} />
           <Button
             className="h-11 self-end lg:h-8"
             variant="outline"


### PR DESCRIPTION
Adds rollout activity to Insights and the deployment sheet so operators can see a new deployment gain adoption, inspect recovery spikes, and open the affected ID’s delivery settings.

Closes [HOT-15](https://linear.app/hot-updater/issue/HOT-15/insights-롤아웃-중-recovered-급증을-롤백-시그널로).

- Plot each public release ID’s share of `RELEASE_ADOPTED` reports within the same platform, channel, and interval. Old/new deployments can cross; switching to recovery preserves the selected ID and interval.
- Attribute recovery to `from_release_id` and adoption to `to_release_id`, keeping promotions of the same file separate. The sheet uses the same adoption denominator as the overview.
- Mark first observed adoption and flag recovery when an interval has ≥10 adoption + recovery reports, ≥3 recoveries, ≥10% recovery, and a ≥10 percentage point rise from the previous observed interval (0% at first adoption). The selected ID links to existing rollout and Enabled controls.

Uses the existing database plugin `listEvents` contract. No schema or ingest changes, automatic rollback, or breaking changes. Adoption share represents reports, not installed-device market share. Scans are capped at 50,000 reports; incomplete boundary intervals are omitted and partial history is disclosed. Existing overview reports remain available.

Validation: `pnpm -w lint`; `pnpm -w test` (2,593 tests); console tests (151), type check, and production build. Chrome verified crossover point selection, metric switching, delivery-sheet navigation, and 390px mobile layouts without horizontal overflow or page errors. Added a console patch changeset.

<details>
<summary>StyleSeed design review — 93/100 (A)</summary>

Reviewed the new Rollout activity UI against the requested StyleSeed rubric and checked desktop/mobile renders. Evidence below refers to `packages/console/src/components/features/insights/InsightsRolloutCard.tsx`.

| Category | Score | Evidence |
| --- | --- | --- |
| Coherence | 20/20 | Existing Card, Button, Select, ToggleGroup, Alert, and Lucide components |
| Color discipline | 16/16 | Semantic primary/gray chart lines; recovery warning also has text and icon (lines 269–274, 383–391) |
| Hierarchy and typography | 12/16 | Clear 36px/18px metric hierarchy (325–328); 11px annotation is outside the type scale (260), −4 |
| Layout and spacing | 9/12 | Responsive card grouping; 12px padding/gaps depart from the rubric’s 8px grid (365, 478), −3 |
| States | 12/12 | Empty, loading, error, and partial-history states (74–86, 448–475) |
| UX writing | 12/12 | Named review/refresh actions and explicit metric definitions (378, 480–485) |
| Motion and polish | 12/12 | No delayed chart animation; keyboard-selectable points (274–304) |

Optional follow-ups, ordered by score gain: use the existing 12px annotation scale (+4), then align the compact ID/footer spacing with the 8px grid (+3). Both are below the shipping gate; existing console density is preserved.

</details>

Screenshots use local synthetic report data; the fixtures are excluded from this PR.

**Adoption crossover**

![New and previous deployment adoption lines crossing at 50%](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/cd12bfb8-ec5c-4643-88ed-2b0277ef6d21/c0b450f2-91ac-4f68-bb2f-1a2ded603cf7)

**Recovery spike and review action**

![Recovery rate spike with the selected public ID and review action](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/63ca72ed-36e0-4063-8b6c-2e1e73cfd41c/51998257-bd77-4200-9770-6fbcb7099c1e)

<details>
<summary>Mobile adoption view</summary>

![390px mobile adoption view](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/37edf063-58c7-4530-9c04-6652c413aa89/3c3cc718-474a-404e-8d04-f4c31438ba69)

</details>

