### PR TITLE
fix: validate signing for selected deploy platform

### DIFF
--- a/.changeset/sixty-needles-ask.md
+++ b/.changeset/sixty-needles-ask.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Validate signing only for the selected deploy platform.

--- a/packages/hot-updater/src/commands/deploy.spec.ts
+++ b/packages/hot-updater/src/commands/deploy.spec.ts
@@ -1286,6 +1286,7 @@ describe("deploy rollout wiring", () => {
     expect(signFileHash).toHaveBeenCalledWith(TRANSFER_FILE_HASH);
     expect(validateSigningConfig).toHaveBeenCalledWith(expect.anything(), {
       expectedPublicKey: "public-key",
+      platform: "ios",
     });
     expect(mockCli.p.spinner).not.toHaveBeenCalled();
     expect(mockCli.p.note).toHaveBeenCalledWith("LLVM\nHermes", "Build Output");
@@ -1342,6 +1343,7 @@ describe("deploy rollout wiring", () => {
     expect(validateSigningConfig).toHaveBeenCalledWith(expect.anything(), {
       expectedPublicKey: "provider-public-key",
       nativePublicKey: "expo-public-key",
+      platform: "ios",
     });
   });
 

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -747,6 +747,7 @@ const deployPlatform = async ({
   // Validate signing configuration and the native key pinned by the app.
   const signingValidation = await validateSigningConfig(config, {
     expectedPublicKey: signingSession?.publicKey,
+    platform,
     ...(getNativeSigningPublicKey === undefined
       ? {}
       : { nativePublicKey: nativeSigningPublicKey?.publicKey ?? null }),

--- a/packages/hot-updater/src/utils/signing/validateSigningConfig.spec.ts
+++ b/packages/hot-updater/src/utils/signing/validateSigningConfig.spec.ts
@@ -169,6 +169,28 @@ describe("validateSigningConfig", () => {
     });
   });
 
+  it("validates only the selected platform during an Expo deploy", async () => {
+    const publicKey = createPublicKey();
+    parser.android.exists.mockResolvedValue(false);
+    parser.ios.get.mockResolvedValue({
+      paths: ["Info.plist"],
+      value: publicKey,
+    });
+
+    const result = await validateSigningConfig(createConfig(), {
+      expectedPublicKey: publicKey,
+      nativePublicKey: null,
+      platform: "ios",
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.nativePublicKeys).toEqual({
+      android: { exists: false, paths: [] },
+      ios: { exists: true, paths: ["Info.plist"] },
+    });
+  });
+
   it("rejects signed Expo CNG builds without a trust anchor", async () => {
     parser.android.exists.mockResolvedValue(false);
     parser.ios.exists.mockResolvedValue(false);

--- a/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
+++ b/packages/hot-updater/src/utils/signing/validateSigningConfig.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import type { ConfigResponse } from "@hot-updater/cli-tools";
+import type { Platform } from "@hot-updater/plugin-core";
 
 import { AndroidConfigParser } from "../configParser/androidParser";
 import { IosConfigParser } from "../configParser/iosParser";
@@ -58,6 +59,7 @@ export async function validateSigningConfig(
   options: {
     readonly expectedPublicKey?: string;
     readonly nativePublicKey?: string | null;
+    readonly platform?: Platform;
   } = {},
 ): Promise<SigningValidationResult> {
   const signingEnabled = config.signing !== undefined;
@@ -92,6 +94,10 @@ export async function validateSigningConfig(
   }
 
   const issues: SigningConfigIssue[] = [];
+  const validatesIos =
+    options.platform === undefined || options.platform === "ios";
+  const validatesAndroid =
+    options.platform === undefined || options.platform === "android";
 
   const publicKeysMatch = (nativePublicKey: string) => {
     if (!options.expectedPublicKey) {
@@ -111,7 +117,11 @@ export async function validateSigningConfig(
 
   if (signingEnabled) {
     // Signing enabled - check for missing public keys
-    if (!iosResult.value && (iosExists || usesExternalNativeConfig)) {
+    if (
+      validatesIos &&
+      !iosResult.value &&
+      (iosExists || usesExternalNativeConfig)
+    ) {
       issues.push({
         type: "error",
         platform: "ios",
@@ -124,7 +134,11 @@ export async function validateSigningConfig(
           : "Run `npx hot-updater keys export-public` to add the public key, then rebuild your iOS app.",
       });
     }
-    if (!androidResult.value && (androidExists || usesExternalNativeConfig)) {
+    if (
+      validatesAndroid &&
+      !androidResult.value &&
+      (androidExists || usesExternalNativeConfig)
+    ) {
       issues.push({
         type: "error",
         platform: "android",
@@ -139,6 +153,7 @@ export async function validateSigningConfig(
     }
     if (
       iosResult.value &&
+      validatesIos &&
       (iosExists || usesExternalNativeConfig) &&
       !publicKeysMatch(iosResult.value)
     ) {
@@ -154,6 +169,7 @@ export async function validateSigningConfig(
     }
     if (
       androidResult.value &&
+      validatesAndroid &&
       (androidExists || usesExternalNativeConfig) &&
       !publicKeysMatch(androidResult.value)
     ) {


### PR DESCRIPTION
## Summary

- scope deploy signing validation to the selected platform
- keep full iOS and Android validation for callers such as doctor
- add regression coverage for an Expo iOS-only deploy with no Android native project

## Validation

- `pnpm lint`
- `pnpm -w build`
- `pnpm -w test` (2,594 tests)
- `pnpm -w test:type` (34 projects)
- `pnpm vitest run packages/hot-updater/src/utils/signing/validateSigningConfig.spec.ts packages/hot-updater/src/commands/deploy.spec.ts` (49 tests)