### PR TITLE
fix(console): show single Active observations in bundle charts

### DIFF
--- a/.changeset/quiet-bundles-appear.md
+++ b/.changeset/quiet-bundles-appear.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Display observed Active points in the compact bundle chart even when reports exist in only one time interval.

--- a/packages/console/src/components/features/bundles/BundleActivityChart.spec.tsx
+++ b/packages/console/src/components/features/bundles/BundleActivityChart.spec.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render } from "@testing-library/react";
+import { cloneElement, type ReactElement } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import type { RecoverySeries } from "@/lib/insights-recovery";
+
+import { BundleActivityChart } from "./BundleActivityChart";
+
+vi.mock("recharts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("recharts")>()),
+  ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+    cloneElement(children, { width: 400, height: 160 } as object),
+}));
+
+afterEach(cleanup);
+
+it("shows a single observed active value without inventing observations in earlier intervals", () => {
+  const series: RecoverySeries = {
+    releaseId: "bundle-a",
+    firstAdoptedAtMs: 2 * 86_400_000,
+    activeInstallations: 2,
+    recoveredInstallations: 0,
+    points: [null, null, 2].map((active, index) => ({
+      startMs: index * 86_400_000,
+      active,
+      recoveredInstallations: 0,
+      adopted: active ?? 0,
+      recovered: 0,
+      rate: active === null ? null : 0,
+      spike: false,
+    })),
+  };
+  const { container } = render(<BundleActivityChart series={series} />);
+  const dots = container.querySelectorAll(".recharts-area-dot");
+  expect(dots).toHaveLength(1);
+  expect(dots[0].getAttribute("r")).toBe("2");
+  expect(Number(dots[0].getAttribute("cx"))).toBeGreaterThan(300);
+  expect(Number(dots[0].getAttribute("cy"))).toBeGreaterThan(0);
+});

--- a/packages/console/src/components/features/bundles/BundleActivityChart.tsx
+++ b/packages/console/src/components/features/bundles/BundleActivityChart.tsx
@@ -72,6 +72,7 @@ export function BundleActivityChart({
           />
           <Area
             dataKey="active"
+            dot={{ r: 2 }}
             fill="var(--color-active)"
             fillOpacity={0.12}
             isAnimationActive={false}


### PR DESCRIPTION
When reports exist in only one time interval, Bundle Detail shows the correct Active count but its compact chart appears empty because an area needs multiple points. Render Active observation dots so the observed value remains visible without filling earlier intervals with invented activity.

Found during real Modex QA of #1258. Includes a console patch changeset; no database or API changes.

Validation:
- Regression test reproduces the missing observation before the fix and passes after it, using the actual Recharts area renderer.
- Console: 150 tests, typecheck and build passed.
- Workspace lint and all 2,596 tests passed.
- Browser QA against Modex's real D1 reports: Active 2 / Rollback 0, compact details, Insights filters, desktop and mobile, no browser errors. The dataset has one observed bundle ID; multi-bundle crossover is covered by the existing scenario tests.

![Real Modex Bundle Detail with the single Active observation visible](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/98616ec6-2c6b-4368-b53e-1c411434f658/8e82b01a-f01e-4690-bbb6-908a8d1dccbc)

Related: HOT-15. No documentation changes or breaking changes.
