### PR TITLE
feat(console): clarify insights filters and show monthly reporting devices

### DIFF
--- a/.changeset/tidy-insights-filters.md
+++ b/.changeset/tidy-insights-filters.md
@@ -3,3 +3,5 @@
 ---
 
 Default Insights to hourly activity over 24 hours and make selected platform, reporting period, and activity filters clear in both themes. Make All events navigation visible and show 20 reports per page. Keep Bundles summaries and Bundle Detail on 30 days.
+
+Show a 30-day reporting device count above the graph using the existing installation count query.

--- a/.changeset/tidy-insights-filters.md
+++ b/.changeset/tidy-insights-filters.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Default Insights to hourly activity over 24 hours and make selected platform, reporting period, and activity filters clear in both themes. Make All events navigation visible and show 20 reports per page. Keep Bundles summaries and Bundle Detail on 30 days.

--- a/docs/content/docs/(latest)/guides/console.mdx
+++ b/docs/content/docs/(latest)/guides/console.mdx
@@ -110,6 +110,12 @@ Delivery settings.
 Insights opens a 24-hour chart with hourly intervals, so recent activity remains
 visible. Select **7d** or **30d** to compare a longer period. The chart includes
 every bundle ID observed in the selected platform and channel.
+
+**Reporting devices · 30d** counts each installation whose latest report belongs
+to the selected platform and channel within the last 30 days, including reports
+without a known bundle ID. It stays on 30 days when the chart period changes.
+This is a device count, not a monthly active user count.
+
 **Active** follows each installation’s last reported ID
 within that period, so moving to a new bundle reduces the old bundle’s count.
 Select **Rollback** to compare installations recovered from each bundle per

--- a/docs/content/docs/(latest)/guides/console.mdx
+++ b/docs/content/docs/(latest)/guides/console.mdx
@@ -107,11 +107,16 @@ The Bundles list shows compact **Active** and **Rollback** counts over the last
 30 days. Bundle Detail keeps these counts and a small activity graph above
 Delivery settings.
 
-Insights opens a 30-day chart with every bundle ID observed in the selected
-platform and channel. **Active** follows each installation’s last reported ID
+Insights opens a 24-hour chart with hourly intervals, so recent activity remains
+visible. Select **7d** or **30d** to compare a longer period. The chart includes
+every bundle ID observed in the selected platform and channel.
+**Active** follows each installation’s last reported ID
 within that period, so moving to a new bundle reduces the old bundle’s count.
 Select **Rollback** to compare installations recovered from each bundle per
 interval. Highlighting an ID keeps the other lines visible.
+
+Open **All events** on the activity card to browse reports from newest to oldest,
+20 per page.
 
 These counts reflect received reports, not the full installed population.
 Reports without a known bundle ID are excluded from the per-ID chart. History

--- a/packages/console/src/components/features/insights/InsightsControls.tsx
+++ b/packages/console/src/components/features/insights/InsightsControls.tsx
@@ -1,3 +1,4 @@
+import { CheckIcon } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -46,13 +47,22 @@ export function InsightsControls({
                 if (value[0] === "ios" || value[0] === "android")
                   setPlatform(value[0]);
               }}
-              spacing={0}
-              variant="outline"
+              variant="contrast"
             >
               <ToggleGroupItem className="h-11 lg:h-8" value="ios">
+                <CheckIcon
+                  aria-hidden="true"
+                  className="invisible group-aria-pressed/toggle:visible"
+                  data-icon="inline-start"
+                />
                 iOS
               </ToggleGroupItem>
               <ToggleGroupItem className="h-11 lg:h-8" value="android">
+                <CheckIcon
+                  aria-hidden="true"
+                  className="invisible group-aria-pressed/toggle:visible"
+                  data-icon="inline-start"
+                />
                 Android
               </ToggleGroupItem>
             </ToggleGroup>
@@ -85,10 +95,9 @@ export function InsightsControls({
           onValueChange={(value) => {
             if (value[0]) onWindowChange(value[0] as InsightsWindow);
           }}
-          spacing={0}
           size="lg"
           value={[window]}
-          variant="outline"
+          variant="contrast"
         >
           {windows.map((item) => (
             <ToggleGroupItem
@@ -97,6 +106,11 @@ export function InsightsControls({
               key={item.value}
               value={item.value}
             >
+              <CheckIcon
+                aria-hidden="true"
+                className="invisible group-aria-pressed/toggle:visible"
+                data-icon="inline-start"
+              />
               {item.shortLabel}
             </ToggleGroupItem>
           ))}

--- a/packages/console/src/components/features/insights/InsightsOverview.spec.tsx
+++ b/packages/console/src/components/features/insights/InsightsOverview.spec.tsx
@@ -21,10 +21,16 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({
     children,
     search,
+    to,
   }: {
     children: ReactNode;
-    search: { releaseId: string };
-  }) => <a href={`/?releaseId=${search.releaseId}`}>{children}</a>,
+    search?: { releaseId: string };
+    to: string;
+  }) => (
+    <a href={search?.releaseId ? `/?releaseId=${search.releaseId}` : to}>
+      {children}
+    </a>
+  ),
 }));
 vi.mock("recharts", async (importOriginal) => ({
   ...(await importOriginal<typeof import("recharts")>()),
@@ -124,6 +130,11 @@ describe("bundle trends", () => {
     mocks.query.mockReturnValue({ isPending: true, refetch });
     const view = render(<InsightsOverview input={input} />);
     expect(screen.getByLabelText("Loading bundle activity")).toBeDefined();
+    expect(
+      within(screen.getByRole("region", { name: "Bundle activity" }))
+        .getByRole("link", { name: "All events" })
+        .getAttribute("href"),
+    ).toBe("/installations");
     mocks.query.mockReturnValue({ error: new Error("Offline"), refetch });
     view.rerender(<InsightsOverview input={input} />);
     expect(screen.getByText("Bundle activity unavailable")).toBeDefined();

--- a/packages/console/src/components/features/insights/InsightsOverview.tsx
+++ b/packages/console/src/components/features/insights/InsightsOverview.tsx
@@ -1,12 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { ArrowUpRight, RotateCw, TriangleAlert } from "lucide-react";
+import {
+  ArrowUpRight,
+  CheckIcon,
+  ListIcon,
+  RotateCw,
+  TriangleAlert,
+} from "lucide-react";
 import { useState } from "react";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
+  CardAction,
   CardContent,
   CardFooter,
   CardHeader,
@@ -21,6 +28,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { RecoveryInput, RecoveryReport } from "@/lib/insights-recovery";
 import { getRecoveryReportRpc } from "@/lib/insights-recovery-rpc";
+import { cn } from "@/lib/utils";
 
 import { InsightsErrorAlert } from "./InsightsErrorAlert";
 
@@ -103,13 +111,22 @@ export function ActivityChart({ report }: { readonly report: RecoveryReport }) {
             if (values[0] === "active" || values[0] === "rollback")
               setMetric(values[0]);
           }}
-          spacing={0}
-          variant="outline"
+          variant="contrast"
         >
           <ToggleGroupItem className="h-11 lg:h-8" value="active">
+            <CheckIcon
+              aria-hidden="true"
+              className="invisible group-aria-pressed/toggle:visible"
+              data-icon="inline-start"
+            />
             Active
           </ToggleGroupItem>
           <ToggleGroupItem className="h-11 lg:h-8" value="rollback">
+            <CheckIcon
+              aria-hidden="true"
+              className="invisible group-aria-pressed/toggle:visible"
+              data-icon="inline-start"
+            />
             Rollback
           </ToggleGroupItem>
         </ToggleGroup>
@@ -331,8 +348,12 @@ export function InsightsOverview({ input }: { readonly input: RecoveryInput }) {
     staleTime: 30_000,
   });
   return (
-    <Card className="min-w-0 overflow-hidden shadow-sm">
-      <CardHeader className="flex-row items-center justify-between gap-4 px-4 pt-4 pb-2 sm:px-6 sm:pt-6">
+    <Card
+      aria-label="Bundle activity"
+      className="min-w-0 overflow-hidden shadow-sm"
+      role="region"
+    >
+      <CardHeader className="flex-row flex-wrap items-center justify-between gap-4 px-4 pt-4 pb-2 sm:px-6 sm:pt-6">
         <CardTitle className="text-sm font-medium">
           Bundle activity ·{" "}
           {input.window === "30d"
@@ -341,15 +362,30 @@ export function InsightsOverview({ input }: { readonly input: RecoveryInput }) {
               ? "7 days"
               : "24 hours"}
         </CardTitle>
-        <Button
-          aria-label="Refresh bundle activity"
-          variant="ghost"
-          size="icon-sm"
-          disabled={query.isFetching}
-          onClick={() => void query.refetch()}
-        >
-          <RotateCw aria-hidden="true" />
-        </Button>
+        <CardAction className="flex items-center gap-2 self-center">
+          <Link
+            className={cn(
+              buttonVariants({
+                className: "h-11 lg:h-8",
+                size: "lg",
+                variant: "outline",
+              }),
+            )}
+            to="/installations"
+          >
+            <ListIcon aria-hidden="true" data-icon="inline-start" />
+            All events
+          </Link>
+          <Button
+            aria-label="Refresh bundle activity"
+            variant="ghost"
+            size="icon-sm"
+            disabled={query.isFetching}
+            onClick={() => void query.refetch()}
+          >
+            <RotateCw aria-hidden="true" />
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent className="flex flex-col gap-4 px-4 pb-4 sm:px-6 sm:pb-6">
         {query.isPending ? (

--- a/packages/console/src/components/features/insights/InsightsPageHeader.tsx
+++ b/packages/console/src/components/features/insights/InsightsPageHeader.tsx
@@ -1,8 +1,9 @@
 import { Link } from "@tanstack/react-router";
-import { ChartNoAxesCombined } from "lucide-react";
+import { ChartNoAxesCombined, ListIcon } from "lucide-react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 
 export function InsightsPageHeader({
   view,
@@ -19,28 +20,33 @@ export function InsightsPageHeader({
         />
         <h1 className="text-sm font-medium">Insights</h1>
       </div>
-      <nav aria-label="Insights views" className="ml-auto flex gap-1">
+      <nav aria-label="Insights views" className="ml-auto flex gap-2">
         <Link
           aria-current={view === "overview" ? "page" : undefined}
-          className={buttonVariants({
-            className: "h-11 px-3 lg:h-8 lg:px-2.5",
-            size: "lg",
-            variant: view === "overview" ? "secondary" : "ghost",
-          })}
+          className={cn(
+            buttonVariants({
+              className: "h-11 px-3 lg:h-8 lg:px-2.5",
+              size: "lg",
+              variant: view === "overview" ? "contrast" : "outline",
+            }),
+          )}
           to="/insights"
         >
           Overview
         </Link>
         <Link
           aria-current={view === "events" ? "page" : undefined}
-          className={buttonVariants({
-            className: "h-11 px-3 lg:h-8 lg:px-2.5",
-            size: "lg",
-            variant: view === "events" ? "secondary" : "ghost",
-          })}
+          className={cn(
+            buttonVariants({
+              className: "h-11 px-3 lg:h-8 lg:px-2.5",
+              size: "lg",
+              variant: view === "events" ? "contrast" : "outline",
+            }),
+          )}
           to="/installations"
         >
-          Events
+          <ListIcon aria-hidden="true" data-icon="inline-start" />
+          All events
         </Link>
       </nav>
     </header>

--- a/packages/console/src/components/features/insights/ReportingDevicesSummary.spec.tsx
+++ b/packages/console/src/components/features/insights/ReportingDevicesSummary.spec.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { ReportingDevicesSummary } from "./ReportingDevicesSummary";
+
+const mocks = vi.hoisted(() => ({ reporting: vi.fn() }));
+vi.mock("@/lib/insights-api", () => ({
+  useReportingInstallationsQuery: mocks.reporting,
+}));
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("counts reporting devices over 30 days in the applied platform and channel", () => {
+  mocks.reporting.mockReturnValue({
+    data: { reportingInstallations: { count: 3 } },
+  });
+  const view = render(
+    <ReportingDevicesSummary
+      scope={{ platform: "ios", channel: "production" }}
+    />,
+  );
+  expect(screen.getByText("3", { exact: true })).toBeDefined();
+  expect(mocks.reporting).toHaveBeenLastCalledWith({
+    platform: "ios",
+    channel: "production",
+    window: "30d",
+  });
+  view.rerender(
+    <ReportingDevicesSummary
+      scope={{ platform: "android", channel: "beta" }}
+    />,
+  );
+  expect(mocks.reporting).toHaveBeenLastCalledWith({
+    platform: "android",
+    channel: "beta",
+    window: "30d",
+  });
+});
+
+it("distinguishes loading and a failed count from a measured zero and permits retry", () => {
+  const scope = { platform: "ios", channel: "production" } as const;
+  const refetch = vi.fn();
+  mocks.reporting.mockReturnValue({ isPending: true });
+  const view = render(<ReportingDevicesSummary scope={scope} />);
+  expect(screen.getByLabelText("Loading reporting devices")).toBeDefined();
+  expect(screen.queryByText("0", { exact: true })).toBeNull();
+  mocks.reporting.mockReturnValue({ error: new Error("Offline"), refetch });
+  view.rerender(<ReportingDevicesSummary scope={scope} />);
+  expect(screen.getByText("Unavailable")).toBeDefined();
+  expect(screen.queryByText("0", { exact: true })).toBeNull();
+  fireEvent.click(
+    screen.getByRole("button", { name: "Retry reporting device count" }),
+  );
+  expect(refetch).toHaveBeenCalledOnce();
+  mocks.reporting.mockReturnValue({
+    data: { reportingInstallations: { count: 0 } },
+  });
+  view.rerender(<ReportingDevicesSummary scope={scope} />);
+  expect(screen.getByText("0", { exact: true })).toBeDefined();
+  expect(screen.queryByText("Unavailable")).toBeNull();
+});

--- a/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
+++ b/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useReportingInstallationsQuery,
+  type InsightsOverviewInput,
+} from "@/lib/insights-api";
+
+export function ReportingDevicesSummary({
+  scope,
+}: {
+  readonly scope: Omit<InsightsOverviewInput, "window" | "bundleId">;
+}) {
+  const query = useReportingInstallationsQuery({ ...scope, window: "30d" });
+  return (
+    <Card
+      aria-label="Reporting devices over 30 days"
+      className="flex items-center justify-between"
+      role="region"
+    >
+      <CardHeader className="min-w-0 gap-2 p-4 sm:px-6">
+        <CardTitle className="text-sm font-medium">
+          Reporting devices · 30d
+        </CardTitle>
+        <CardDescription>
+          Latest report in this platform and channel within 30 days. Each
+          installation is counted once.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="shrink-0 p-4 sm:px-6">
+        {query.isPending ? (
+          <Skeleton
+            aria-label="Loading reporting devices"
+            className="h-9 w-12"
+          />
+        ) : query.error ? (
+          <div className="flex flex-col items-end gap-2">
+            <span className="text-xs text-muted-foreground">Unavailable</span>
+            <Button
+              aria-label="Retry reporting device count"
+              onClick={() => void query.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              Retry
+            </Button>
+          </div>
+        ) : (
+          <p className="text-4xl font-semibold tabular-nums">
+            {query.data?.reportingInstallations.count.toLocaleString() ?? "—"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/console/src/components/ui/button.tsx
+++ b/packages/console/src/components/ui/button.tsx
@@ -13,6 +13,7 @@ const buttonVariants = cva(
           "border-border dark:bg-input/30 hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        contrast: "bg-foreground text-background hover:bg-foreground/90",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/packages/console/src/components/ui/toggle.tsx
+++ b/packages/console/src/components/ui/toggle.tsx
@@ -10,6 +10,8 @@ const toggleVariants = cva(
       variant: {
         default: "bg-transparent",
         outline: "border border-input bg-transparent hover:bg-muted",
+        contrast:
+          "border border-input bg-transparent aria-pressed:border-foreground aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground aria-pressed:hover:text-background",
       },
       size: {
         default:

--- a/packages/console/src/routes/-insights.spec.tsx
+++ b/packages/console/src/routes/-insights.spec.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ activity: vi.fn() }));
+const mocks = vi.hoisted(() => ({ activity: vi.fn(), reporting: vi.fn() }));
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (options: unknown) => ({ options }),
 }));
@@ -13,6 +13,12 @@ vi.mock("@/components/features/insights/InsightsOverview", () => ({
 }));
 vi.mock("@/components/features/insights/InsightsPageHeader", () => ({
   InsightsPageHeader: () => <a href="/installations">All events</a>,
+}));
+vi.mock("@/components/features/insights/ReportingDevicesSummary", () => ({
+  ReportingDevicesSummary: ({ scope }: { scope: unknown }) => {
+    mocks.reporting(scope);
+    return <div>Reporting devices · 30d</div>;
+  },
 }));
 
 import { Route } from "./insights";
@@ -35,6 +41,10 @@ describe("Insights overview", () => {
     expect(mocks.activity).toHaveBeenLastCalledWith({
       input: { platform: "ios", channel: "production", window: "7d" },
     });
+    expect(mocks.reporting).toHaveBeenLastCalledWith({
+      platform: "ios",
+      channel: "production",
+    });
     fireEvent.click(screen.getByRole("button", { name: "Android" }));
     fireEvent.change(screen.getByLabelText("Channel"), {
       target: { value: "beta" },
@@ -42,6 +52,10 @@ describe("Insights overview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }));
     expect(mocks.activity).toHaveBeenLastCalledWith({
       input: { platform: "android", channel: "beta", window: "7d" },
+    });
+    expect(mocks.reporting).toHaveBeenLastCalledWith({
+      platform: "android",
+      channel: "beta",
     });
     expect(
       screen.getByRole("link", { name: "All events" }).getAttribute("href"),

--- a/packages/console/src/routes/-insights.spec.tsx
+++ b/packages/console/src/routes/-insights.spec.tsx
@@ -12,7 +12,7 @@ vi.mock("@/components/features/insights/InsightsOverview", () => ({
   },
 }));
 vi.mock("@/components/features/insights/InsightsPageHeader", () => ({
-  InsightsPageHeader: () => <a href="/installations">Events</a>,
+  InsightsPageHeader: () => <a href="/installations">All events</a>,
 }));
 
 import { Route } from "./insights";
@@ -24,10 +24,10 @@ afterEach(() => {
 });
 
 describe("Insights overview", () => {
-  it("defaults to all IDs over 30 days and changes only the period or platform/channel scope", () => {
+  it("defaults to all IDs over 24 hours and changes only the period or platform/channel scope", () => {
     render(<InsightsPage />);
     expect(mocks.activity).toHaveBeenLastCalledWith({
-      input: { platform: "ios", channel: "production", window: "30d" },
+      input: { platform: "ios", channel: "production", window: "24h" },
     });
     expect(screen.queryByLabelText("Bundle ID (optional)")).toBeNull();
     expect(screen.getAllByText("Bundle activity")).toHaveLength(1);
@@ -44,7 +44,7 @@ describe("Insights overview", () => {
       input: { platform: "android", channel: "beta", window: "7d" },
     });
     expect(
-      screen.getByRole("link", { name: "Events" }).getAttribute("href"),
+      screen.getByRole("link", { name: "All events" }).getAttribute("href"),
     ).toBe("/installations");
   });
 });

--- a/packages/console/src/routes/-installations.spec.tsx
+++ b/packages/console/src/routes/-installations.spec.tsx
@@ -121,11 +121,11 @@ describe("InstallationsPage", () => {
     vi.clearAllMocks();
   });
 
-  it("opens on filter-free events and advances with an opaque cursor", () => {
+  it("opens on 20 filter-free events and advances with an opaque cursor", () => {
     render(<InstallationsPage />);
 
     expect(mocks.events).toHaveBeenCalledWith(
-      { beforeReceivedAtMs: 100, cursor: undefined, limit: 50 },
+      { beforeReceivedAtMs: 100, cursor: undefined, limit: 20 },
       true,
     );
     expect(screen.getByRole("heading", { name: "All events" })).toBeDefined();

--- a/packages/console/src/routes/insights.tsx
+++ b/packages/console/src/routes/insights.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { InsightsControls } from "@/components/features/insights/InsightsControls";
 import { InsightsOverview } from "@/components/features/insights/InsightsOverview";
 import { InsightsPageHeader } from "@/components/features/insights/InsightsPageHeader";
+import { ReportingDevicesSummary } from "@/components/features/insights/ReportingDevicesSummary";
 import {
   type InsightsWindow,
   type InsightsOverviewInput,
@@ -35,6 +36,7 @@ function InsightsPage() {
             }}
             window={window}
           />
+          <ReportingDevicesSummary scope={scope} />
           <InsightsOverview input={{ ...scope, window }} />
         </div>
       </div>

--- a/packages/console/src/routes/insights.tsx
+++ b/packages/console/src/routes/insights.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute("/insights")({
 });
 
 function InsightsPage() {
-  const [window, setWindow] = useState<InsightsWindow>("30d");
+  const [window, setWindow] = useState<InsightsWindow>("24h");
   const [scope, setScope] = useState<Omit<InsightsOverviewInput, "window">>({
     platform: "ios",
     channel: "production",

--- a/packages/console/src/routes/installations.tsx
+++ b/packages/console/src/routes/installations.tsx
@@ -88,7 +88,7 @@ function InstallationsPage() {
     {
       beforeReceivedAtMs: eventsBefore,
       cursor: search.eventsCursor,
-      limit: EVENT_LIMIT,
+      limit: 20,
     },
     !hasLookup,
   );


### PR DESCRIPTION
Insights now opens a 24-hour chart with hourly intervals so reports from a new deployment remain visible as a trend. The 7d and 30d options remain available; Bundles row summaries and Bundle Detail retain their compact 30-day view.

A summary above the graph shows **Reporting devices · 30d** using the existing installation count query. It counts installations whose latest report is in the applied platform/channel within 30 days, including installations without an observed bundle ID. This is a device metric, not user MAU, and remains a 30-day count when changing the graph period. Loading, failed counts with retry, and measured zero are distinct.

Selected platform, period, and activity filters use a shared shadcn contrast variant with check marks, stable hover colors, and existing theme tokens. The activity card now exposes an **All events** link alongside refresh, in addition to clearer page navigation. The existing event browser shows the latest 20 reports per page using its existing cursor pagination.

Related: [HOT-15](https://linear.app/hot-updater/issue/HOT-15). Includes a console patch changeset and documentation updates. No database, collection, or delivery changes.

Validation:
- Workspace build (26 projects), lint and 2,643 unit tests passed.
- Console: 152 tests, typecheck and production build passed. Tests cover monthly scope, fixed 30-day counting, loading/error/retry/zero, default graph period and pagination.
- Real Modex D1 data: 3 monthly reporting devices, 2 attributed active devices, and 0 rollbacks.
- Real Modex D1 data: hourly Active trend; 30-day Bundles and Detail preserved; Rollback filter; card-to-events navigation; 20 reports on page 1, remaining 2 on page 2, and return to the unchanged first page.
- Dark/light and 390px browser QA, keyboard selection, selected hover state, and zero browser errors. Selected text contrast measured 18.92:1 dark and 19.76:1 light.

<details>
<summary>StyleSeed review — 97/100 (A)</summary>

| Category | Score | Evidence |
| --- | --- | --- |
| Coherence | 20/20 | Existing ToggleGroup, Button, CardAction and Lucide; shared contrast variants in `toggle.tsx` and `button.tsx` |
| Color discipline | 16/16 | Foreground/background tokens, visible check marks; no new palette. Measured text contrast exceeds 18:1 in both themes |
| Hierarchy and typography | 16/16 | Compact monthly summary above activity; consistent 36px counts |
| Layout and spacing | 9/12 | Consistent 8px group gaps; preserve existing 12px compact padding outside the strict 8px rubric (−3) |
| States | 12/12 | Distinct loading, failure with retry, zero and empty states; All events available during loading |
| UX writing | 12/12 | Explicit All events action in the content, 24h/7d/30d options, Active/Rollback labels |
| Motion and polish | 12/12 | Native shadcn keyboard selection, check marks reserve space, selected hover stays distinct; desktop/mobile verified |

Keep the established compact spacing rather than changing unrelated layout.
</details>

Screenshots use real Modex data:

![Dark desktop: monthly reporting devices and hourly bundle activity](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/ff49e71a-b584-46de-bf28-9590500e40f5/e6672fe5-11a0-4120-acc4-b625d93bccc7)

![Light mobile: reporting device summary, selected filters and All events](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/7cb9542f-2fa6-4035-8bea-e58d17bcd96b/416c06a5-58a6-4257-9063-9b24544a4104)
