### PR TITLE
fix(supabase): pin migration workdir during init

### DIFF
--- a/.changeset/green-pillows-float.md
+++ b/.changeset/green-pillows-float.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/supabase": patch
+---
+
+Fix Supabase init skipping database migrations in npm/Yarn workspaces by explicitly passing the staged migration directory to db push.

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -608,11 +608,82 @@ describe("Supabase CLI authentication", () => {
 
     expect(mockExeca).toHaveBeenCalledWith(
       "npx",
-      ["supabase", "db", "push", "--include-all", "--yes"],
+      [
+        "supabase",
+        "db",
+        "push",
+        "--include-all",
+        "--yes",
+        "--workdir",
+        "/tmp/hot-updater-supabase-push",
+      ],
       expect.objectContaining({
         env: undefined,
       }),
     );
+  });
+});
+
+describe("Supabase migration workdir", () => {
+  it("finds staged migrations when npx runs from the workspace root", async () => {
+    const root = await fs.realpath(
+      await fs.mkdtemp(
+        path.join(os.tmpdir(), "hot-updater-supabase-workspace-"),
+      ),
+    );
+    const appDir = path.join(root, "apps", "mobile");
+    const workdir = path.join(appDir, ".hot-updater");
+    const migration = "supabase/migrations/20250103114225_init.sql";
+    const probePath = path.join(root, "probe.cjs");
+    const { execa } = await vi.importActual<typeof import("execa")>("execa");
+
+    try {
+      await fs.mkdir(path.dirname(path.join(workdir, migration)), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ private: true, workspaces: ["apps/*"] }),
+      );
+      await fs.writeFile(
+        path.join(appDir, "package.json"),
+        JSON.stringify({ name: "mobile", private: true }),
+      );
+      await fs.copyFile(
+        path.resolve("plugins/supabase", migration),
+        path.join(workdir, migration),
+      );
+      await fs.writeFile(
+        probePath,
+        `
+const fs = require("node:fs");
+const path = require("node:path");
+const workdirIndex = process.argv.indexOf("--workdir");
+const workdir = workdirIndex < 0 ? process.cwd() : process.argv[workdirIndex + 1];
+console.log(JSON.stringify({
+  cwd: process.cwd(),
+  migrationExists: fs.existsSync(path.join(workdir, ${JSON.stringify(migration)})),
+}));
+`,
+      );
+      // Run real npx workspace resolution, replacing only the Supabase binary.
+      mockExeca.mockImplementationOnce((_command, args, options) =>
+        execa(
+          "npx",
+          ["--no-install", "--", process.execPath, probePath, ...args.slice(1)],
+          { ...options, stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+        ),
+      );
+
+      const output = await pushDB(workdir, {});
+
+      expect(JSON.parse(output!)).toEqual({
+        cwd: appDir,
+        migrationExists: true,
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });
 
@@ -638,7 +709,15 @@ describe("Supabase database password failures", () => {
     // Then
     expect(mockExeca).toHaveBeenCalledWith(
       "npx",
-      ["supabase", "db", "push", "--include-all", "--yes"],
+      [
+        "supabase",
+        "db",
+        "push",
+        "--include-all",
+        "--yes",
+        "--workdir",
+        "/tmp/hot-updater-supabase-push",
+      ],
       expect.anything(),
     );
   });
@@ -759,7 +838,15 @@ describe("Supabase database password failures", () => {
     expect(output).not.toContain("--password");
     expect(mockExeca).toHaveBeenCalledWith(
       "npx",
-      ["supabase", "db", "push", "--include-all", "--yes"],
+      [
+        "supabase",
+        "db",
+        "push",
+        "--include-all",
+        "--yes",
+        "--workdir",
+        "/tmp/hot-updater-supabase-push",
+      ],
       expect.objectContaining({
         env: {
           SUPABASE_ACCESS_TOKEN: "test-access-token",

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -631,7 +631,7 @@ describe("Supabase migration workdir", () => {
         path.join(os.tmpdir(), "hot-updater-supabase-workspace-"),
       ),
     );
-    const appDir = path.join(root, "apps", "mobile");
+    const appDir = path.join(root, "apps", "모바일 app");
     const workdir = path.join(appDir, ".hot-updater");
     const migration = "supabase/migrations/20250103114225_init.sql";
     const probePath = path.join(root, "probe.cjs");
@@ -670,7 +670,7 @@ console.log(JSON.stringify({
       mockExeca.mockImplementationOnce((_command, args, options) =>
         execa(
           "npx",
-          ["--no-install", "--", process.execPath, probePath, ...args.slice(1)],
+          ["--no-install", "--", "node", probePath, ...args.slice(1)],
           { ...options, stdin: "ignore", stdout: "pipe", stderr: "pipe" },
         ),
       );

--- a/plugins/supabase/iac/supabaseCli.ts
+++ b/plugins/supabase/iac/supabaseCli.ts
@@ -137,7 +137,15 @@ export const pushDB = async (
   try {
     const dbPush = await execa(
       "npx",
-      ["supabase", "db", "push", "--include-all", "--yes"],
+      [
+        "supabase",
+        "db",
+        "push",
+        "--include-all",
+        "--yes",
+        "--workdir",
+        workdir,
+      ],
       {
         cwd: workdir,
         env: getSupabaseCommandEnv(accessToken, dbPassword),


### PR DESCRIPTION
Supabase init can skip every database migration when the app is inside an npm/Yarn workspace. Although Hot Updater starts `npx` in `.hot-updater`, npm's implicit workspace resolution runs the Supabase binary from the app root. `db push` then looks outside the staged migration directory and can report success without creating `public.bundles`.

Pass `--workdir` explicitly to `db push`, matching the existing link and Edge Function deployment commands. Add a regression test that runs real `npx` in a temporary workspace and checks that the staged initial migration remains discoverable after npm changes the process directory. Include a patch changeset for `@hot-updater/supabase`.

Reproduced against `main` at `f9a9f0ff6` using Node 24.15.0, npm 11.12.1, Supabase CLI 2.117.0, and an isolated PostgreSQL 16 container. The migration command used `--db-url` for the local database; hosted project creation/login was not exercised.

| Migration command | Result | Public tables |
| --- | --- | --- |
| Existing command, with only `cwd` set | Exit 0, `Remote database is up to date.`, 0 migrations | None |
| Same command with `--workdir .hot-updater` (absolute path) | Exit 0, all 8 bundled migrations applied | `bundles`, `bundle_patches` |

The issue reporter's exact workspace layout is not provided, but this reproduces the reported missing-table/success-log combination. The doctor's infrastructure check compares the deployed server version, so it does not detect missing database tables.

Validation:
- New regression test fails before the fix and passes afterward.
- Supabase tests: 208 passed.
- `pnpm -w lint`: passed.
- `pnpm -w test`: 170 files / 2,171 tests passed. The first run hit an unrelated Cloudflare temporary-directory `ENOTEMPTY` failure; the complete suite passed on rerun without code changes.
- `pnpm -w build`: passed during baseline setup; rebuilt `@hot-updater/supabase` after the fix.
- `pnpm --filter @hot-updater/supabase test:type`: passed.

Windows compatibility: the production command passes the native workdir path as a separate Execa argument. The regression fixture now includes spaces and non-ASCII characters in its workspace directory, and invokes `node` by name so npm does not have to treat an unquoted `C:\Program Files\...\node.exe` path as the command. The updated test and all 2,171 tests pass locally on macOS. Windows execution remains unverified; the current TypeScript CI job runs on Ubuntu and there is no Windows runner in this repository's workflows.

Fixes #1264.