### PR TITLE
fix(supabase): allow init without migration history

### DIFF
--- a/.changeset/afraid-maps-laugh.md
+++ b/.changeset/afraid-maps-laugh.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/supabase": patch
+---
+
+Allow Supabase init to apply its first database migration when the remote migration history table has not been created yet.

--- a/plugins/supabase/iac/index.spec.ts
+++ b/plugins/supabase/iac/index.spec.ts
@@ -752,6 +752,73 @@ describe("Supabase CLI authentication", () => {
   });
 });
 
+describe("Supabase empty migration history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExeca.mockReset();
+    expectExit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(["stderr", "stdout"])(
+    "pushes initial migrations when the missing history error is reported on %s",
+    async (stream) => {
+      const message =
+        'ERROR: relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42P01)';
+      const error = await createExecaError(
+        ["node", "-e", "process.exit(1)"],
+        stream === "stderr" ? message : "",
+      );
+      Object.defineProperty(error, "stdout", {
+        value:
+          stream === "stdout" ? JSON.stringify({ error: { message } }) : "",
+      });
+      mockExeca
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({ stdout: "migrations applied" });
+
+      await expect(pushDB("/tmp/hot-updater-supabase-push", {})).resolves.toBe(
+        "migrations applied",
+      );
+
+      expect(mockExeca).toHaveBeenCalledTimes(2);
+      expect(mockExeca.mock.calls[1]?.[1]).toEqual([
+        "supabase",
+        "db",
+        "push",
+        "--include-all",
+        "--yes",
+        "--workdir",
+        "/tmp/hot-updater-supabase-push",
+      ]);
+    },
+  );
+
+  it.each([
+    "failed to connect to postgres: connection refused",
+    'ERROR: permission denied for table "supabase_migrations.schema_migrations" (SQLSTATE 42501)',
+    'ERROR: relation "public.bundles" does not exist (SQLSTATE 42P01)',
+  ])(
+    "does not push after an unrelated history fetch failure: %s",
+    async (message) => {
+      const error = await createExecaError(
+        ["node", "-e", "process.exit(1)"],
+        message,
+      );
+      mockExeca.mockRejectedValueOnce(error);
+
+      await expect(
+        pushDB("/tmp/hot-updater-supabase-push", {}),
+      ).rejects.toThrow("process.exit(1)");
+
+      expect(mockExeca).toHaveBeenCalledOnce();
+    },
+  );
+});
+
 describe("Supabase CLI metadata cleanup", () => {
   it("removes metadata created during a failed init", async () => {
     const cwd = await fs.mkdtemp(

--- a/plugins/supabase/iac/supabaseCli.ts
+++ b/plugins/supabase/iac/supabaseCli.ts
@@ -150,7 +150,22 @@ export const pushDB = async (
         cwd: workdir,
         env: getSupabaseCommandEnv(accessToken, dbPassword),
       },
-    );
+    ).catch((error: unknown) => {
+      // A fresh project has no migration history table until its first db push.
+      if (
+        error instanceof ExecaError &&
+        [error.stderr, error.stdout].some(
+          (output) =>
+            typeof output === "string" &&
+            /relation \\?"supabase_migrations\.schema_migrations\\?" does not exist/.test(
+              output,
+            ),
+        )
+      ) {
+        return;
+      }
+      throw error;
+    });
     const dbPush = await execa(
       "npx",
       [


### PR DESCRIPTION
Supabase init on `next` stops before creating any Hot Updater tables when the target database has no migration history yet. The preceding `supabase migration fetch` fails with `relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42P01)`, so `db push` never gets a chance to initialize the database. Supabase documents that [the history table is created by the first db push](https://supabase.com/docs/guides/troubleshooting/error-relation-supabase_migrationsschema_migrations-does-not-exist-a787d6).

Continue to `db push` only when migration fetch reports that specific missing history relation. Recognize both plain stderr and JSON-escaped stdout errors. Connection failures, permission failures, and other missing relations still abort before pushing. Existing migration history continues to be fetched before the push.

This is a follow-up to #1264 and #1265. `next` already contains the explicit `--workdir` fix; its additional migration-fetch step exposes this separate fresh-database failure.

Reproduced against `next` at `702e05f8e` with the actual `pushDB` function, real npm workspace resolution and Supabase CLI 2.117.0, and an isolated PostgreSQL 16 container. The local verification replaced `--linked` with `--db-url` and captured command output; all migration operations ran through the real CLI. The workspace directory contained spaces and Korean characters.

| Scenario | Result |
| --- | --- |
| Unmodified `next`, no history table | Fetch exits 1; no Hot Updater tables created |
| Fixed `next`, same fresh database | v1 migration applied; 9 public Hot Updater tables; `schema.core=1.0.0` |
| Repeat initialization | History fetch and push succeed; one migration record and existing channel data preserved |

Validation:
- Both missing-history regression cases fail before the fix and pass afterward; three negative cases verify that unrelated errors still stop initialization.
- Supabase init tests: 44 passed.
- `pnpm -w build`: passed.
- `pnpm -w lint`: passed.
- `pnpm -w test`: 287 files / 2,648 tests passed.
- `pnpm --filter @hot-updater/supabase test:type`: passed.
- Patch changeset added for `@hot-updater/supabase`.

Runtime validation was performed on macOS with a local PostgreSQL container. Hosted project creation/login and Windows execution were not exercised.