### PR TITLE
fix(insights): unify events and simplify console controls

### DIFF
--- a/.changeset/calm-charts-breathe.md
+++ b/.changeset/calm-charts-breathe.md
@@ -1,0 +1,9 @@
+---
+"@hot-updater/console": patch
+---
+
+Refine Insights with a compact platform and channel toolbar, standard shadcn period tabs, and underlined Active/Rollback tabs. Give the activity chart more space and move All events into its footer. Correct card header alignment and remove the custom high-contrast button styles.
+
+Show three event outcomes with visible descriptions: Update applied, No change, and Rolled back. Treat release adoption that reuses the same files as No change, and show its current files once instead of an unchanged From/To pair.
+
+Use a 24-hour, hourly activity chart in Bundle Detail while preserving the 30-day activity summaries in the Bundles list.

--- a/.changeset/three-insights-outcomes.md
+++ b/.changeset/three-insights-outcomes.md
@@ -1,0 +1,15 @@
+---
+"@hot-updater/react-native": patch
+"@hot-updater/server": patch
+"@hot-updater/plugin-core": patch
+"@hot-updater/cloudflare": patch
+"@hot-updater/supabase": patch
+"@hot-updater/postgres": patch
+"@hot-updater/aws": patch
+"@hot-updater/firebase": patch
+"@hot-updater/test-utils": patch
+---
+
+Finalize the unreleased v1 Insights contract with three event types: UPDATE_APPLIED, UNCHANGED, and RECOVERED. Same-file release selection reports UNCHANGED with null source bundle and update strategy while retaining release IDs. Remove RELEASE_ADOPTED from SDK payloads, server ingestion, database validators, and initial v1 schemas. No compatibility alias is accepted.
+
+Replace adopted outcomes and counters with unchanged in the Insights query API. Refresh all v1 SDK and infrastructure packages together; existing prerelease development databases require their obsolete event rows and constraints to be updated before using this contract.

--- a/docs/architecture/release-catalog-plan.md
+++ b/docs/architecture/release-catalog-plan.md
@@ -1142,11 +1142,12 @@ Recovery restores the complete safe selection receipt and channel.
 Launch reports retain #1141 statuses and add optional from/to Release IDs.
 Recovery reports R2/B2 -> R1/B1. Old events keep null Release identity.
 
-Same-Bundle adoption does not emit `UPDATE_APPLIED`. It emits a distinct
-best-effort `RELEASE_ADOPTED` insights event immediately after atomic native
-adoption. Its directional Bundle IDs may be equal. Insights failure never
-rolls back device state. Console labels Release adoption separately from Bundle
-application.
+Insights has three event types: `UPDATE_APPLIED`, `UNCHANGED`, and `RECOVERED`.
+Same-Bundle adoption emits a best-effort `UNCHANGED` event after atomic native
+adoption because the running files did not change. It retains from/to Release
+IDs while `fromBundleId` and `updateStrategy` are null. Insights failure never
+rolls back device state. Console labels these outcomes Update applied, No change,
+and Rolled back.
 
 ## Legacy endpoint compatibility
 

--- a/docs/content/docs/(latest)/database-plugins/custom-database.mdx
+++ b/docs/content/docs/(latest)/database-plugins/custom-database.mdx
@@ -201,7 +201,7 @@ exclusive key: return strictly smaller tuples. The fixed filter is one of:
 { kind: "installationMovement", installId }
 { kind: "bundle", platform, channel, type: "RECOVERED", fromBundleId }
 { kind: "bundle", platform, channel,
-  type: "UPDATE_APPLIED" | "RELEASE_ADOPTED", toBundleId }
+  type: "UPDATE_APPLIED" | "UNCHANGED", toBundleId }
 ```
 
 Installation movement means `UPDATE_APPLIED` or `RECOVERED`. Apply filters
@@ -228,7 +228,7 @@ last-seen index can double-count moving rows. Never derive it from event history
 `countEvents({ filter, sinceMs, beforeReceivedAtMs })` counts a fixed raw bundle
 filter in the same receipt interval as `listEvents`. The filter has platform,
 channel, type, and `fromBundleId` for `RECOVERED` or `toBundleId` for
-`UPDATE_APPLIED`/`RELEASE_ADOPTED`; it has no `kind`. Recovery B → A therefore
+`UPDATE_APPLIED`/`UNCHANGED`; it has no `kind`. `UNCHANGED` means the running files did not change, including selecting another Release for those same files. Its `from_bundle_id` and `update_strategy` must be null. Recovery B → A therefore
 counts against B while latest state names A. Counts concern reports, not
 unique attempts or installations. Count all native pages or propagate failure.
 

--- a/docs/release-catalog-plan.md
+++ b/docs/release-catalog-plan.md
@@ -1102,11 +1102,12 @@ Recovery restores the complete safe selection receipt and channel.
 Launch reports retain #1141 statuses and add optional from/to Release IDs.
 Recovery reports R2/B2 -> R1/B1. Old events keep null Release identity.
 
-Same-Bundle adoption does not emit `UPDATE_APPLIED`. It emits a distinct
-best-effort `RELEASE_ADOPTED` insights event immediately after atomic native
-adoption. Its directional Bundle IDs may be equal. Insights failure never
-rolls back device state. Console labels Release adoption separately from Bundle
-application.
+Insights has three event types: `UPDATE_APPLIED`, `UNCHANGED`, and `RECOVERED`.
+Same-Bundle adoption emits a best-effort `UNCHANGED` event after atomic native
+adoption because the running files did not change. It retains from/to Release
+IDs while `fromBundleId` and `updateStrategy` are null. Insights failure never
+rolls back device state. Console labels these outcomes Update applied, No change,
+and Rolled back.
 
 ## Legacy endpoint compatibility
 

--- a/e2e/detox/console-insights-qa.spec.ts
+++ b/e2e/detox/console-insights-qa.spec.ts
@@ -49,7 +49,7 @@ const createClient = (): ConsoleInsightsQaClient => ({
       },
       appliedReports: { count: 1, measuredAtMs: event.receivedAtMs + 1 },
       recoveredReports: { count: 0, measuredAtMs: event.receivedAtMs + 1 },
-      adoptedReports: { count: 0, measuredAtMs: event.receivedAtMs + 1 },
+      unchangedReports: { count: 0, measuredAtMs: event.receivedAtMs + 1 },
     },
   })),
   getInstallation: vi.fn(async () => ({
@@ -213,6 +213,19 @@ describe("console insights E2E QA", () => {
 
     // When / Then: ingestion and current state are checked, while the
     // transition-only movement endpoint is intentionally not queried.
+    const overview = await client.getReportingOverview({
+      bundleId,
+      channel: event.channel,
+      platform: event.platform,
+      window: "24h",
+    });
+    vi.mocked(client.getReportingOverview).mockResolvedValue({
+      ...overview,
+      bundle: {
+        ...overview.bundle!,
+        unchangedReports: { count: 1, measuredAtMs: event.receivedAtMs + 1 },
+      },
+    });
     await expect(
       verifyConsoleInsights(client, { observedEvents: [unchanged] }),
     ).resolves.toMatchObject({ eventType: "UNCHANGED" });
@@ -232,16 +245,16 @@ describe("console insights E2E QA", () => {
     );
   });
 
-  it("verifies Release adoption without requiring a bundle movement", async () => {
+  it("verifies same-file selection as no change without a bundle movement", async () => {
     const client = createClient();
-    const adopted = {
+    const unchangedSelection = {
       ...observedTransition,
-      fromBundleId: bundleId,
-      type: "RELEASE_ADOPTED" as const,
+      fromBundleId: null,
+      type: "UNCHANGED" as const,
     };
     vi.mocked(client.listEvents).mockResolvedValue({
       ...emptyEventPage,
-      data: [{ ...event, fromBundleId: bundleId, type: "RELEASE_ADOPTED" }],
+      data: [{ ...event, fromBundleId: null, type: "UNCHANGED" }],
     });
     const overview = await client.getReportingOverview({
       bundleId,
@@ -254,15 +267,15 @@ describe("console insights E2E QA", () => {
       bundle: {
         ...overview.bundle!,
         appliedReports: { count: 0, measuredAtMs: event.receivedAtMs + 1 },
-        adoptedReports: { count: 1, measuredAtMs: event.receivedAtMs + 1 },
+        unchangedReports: { count: 1, measuredAtMs: event.receivedAtMs + 1 },
       },
     });
 
     await expect(
-      verifyConsoleInsights(client, { observedEvents: [adopted] }),
+      verifyConsoleInsights(client, { observedEvents: [unchangedSelection] }),
     ).resolves.toMatchObject({
-      eventType: "RELEASE_ADOPTED",
-      outcomes: [{ bundleId, count: 1, outcome: "adopted" }],
+      eventType: "UNCHANGED",
+      outcomes: [{ bundleId, count: 1, outcome: "unchanged" }],
     });
     expect(client.listInstallationEvents).not.toHaveBeenCalled();
   });

--- a/e2e/detox/console-insights-qa.ts
+++ b/e2e/detox/console-insights-qa.ts
@@ -12,11 +12,7 @@ type InsightsEvent = {
   readonly platform: "ios" | "android";
   readonly receivedAtMs: number;
   readonly toBundleId: string;
-  readonly type:
-    | "RECOVERED"
-    | "RELEASE_ADOPTED"
-    | "UNCHANGED"
-    | "UPDATE_APPLIED";
+  readonly type: "RECOVERED" | "UNCHANGED" | "UPDATE_APPLIED";
 };
 
 type Installation = {
@@ -60,7 +56,6 @@ export const readObservedInsightsEvent = (
     typeof event.toBundleId !== "string" ||
     typeof event.userId !== "string" ||
     (event.type !== "RECOVERED" &&
-      event.type !== "RELEASE_ADOPTED" &&
       event.type !== "UNCHANGED" &&
       event.type !== "UPDATE_APPLIED")
   ) {
@@ -271,7 +266,6 @@ export const verifyConsoleInsights = async (
   ]);
   const outcomeEvidence = [];
   for (const observedOutcome of observedEvents) {
-    if (observedOutcome.type === "UNCHANGED") continue;
     const bundleId =
       observedOutcome.type === "RECOVERED"
         ? observedOutcome.fromBundleId!
@@ -279,8 +273,8 @@ export const verifyConsoleInsights = async (
     const outcome =
       observedOutcome.type === "RECOVERED"
         ? "recovered"
-        : observedOutcome.type === "RELEASE_ADOPTED"
-          ? "adopted"
+        : observedOutcome.type === "UNCHANGED"
+          ? "unchanged"
           : "applied";
     const bundle: InsightsBundleSelection = {
       bundleId,

--- a/e2e/detox/insights-http-client.spec.ts
+++ b/e2e/detox/insights-http-client.spec.ts
@@ -117,8 +117,9 @@ describe("Detox Insights HTTP client", () => {
           toBundleId: "bundle-b",
         },
         {
-          type: "RELEASE_ADOPTED",
-          fromBundleId: "bundle-b",
+          type: "UNCHANGED",
+          fromBundleId: null,
+          updateStrategy: null,
           toBundleId: "bundle-b",
         },
         { type: "RECOVERED", fromBundleId: "bundle-b", toBundleId: "bundle-a" },
@@ -172,8 +173,9 @@ describe("Detox Insights HTTP client", () => {
         selectedBundleInstallations: 1,
         eventType: "UNCHANGED",
         outcomes: [
+          { bundleId: "bundle-a", count: 1, outcome: "unchanged" },
           { bundleId: "bundle-b", count: 1, outcome: "recovered" },
-          { bundleId: "bundle-b", count: 1, outcome: "adopted" },
+          { bundleId: "bundle-b", count: 1, outcome: "unchanged" },
           { bundleId: "bundle-b", count: 1, outcome: "applied" },
         ],
       });
@@ -187,7 +189,7 @@ describe("Detox Insights HTTP client", () => {
         reportingInstallations: { count: 0 },
         appliedReports: { count: 1 },
         recoveredReports: { count: 1 },
-        adoptedReports: { count: 1 },
+        unchangedReports: { count: 1 },
       });
       const destination = await client.getReportingOverview({
         platform: "ios",
@@ -199,7 +201,7 @@ describe("Detox Insights HTTP client", () => {
         reportingInstallations: { count: 1 },
         appliedReports: { count: 0 },
         recoveredReports: { count: 0 },
-        adoptedReports: { count: 0 },
+        unchangedReports: { count: 1 },
       });
       await expect(
         client.listEvents({

--- a/packages/console/hot-updater.config.ts
+++ b/packages/console/hot-updater.config.ts
@@ -1006,7 +1006,7 @@ const bundleEvents: readonly BundleEventRow[] = [
       ],
       [
         "0008",
-        "RELEASE_ADOPTED",
+        "UNCHANGED",
         "demo-zeta",
         iosProdCorePatchB.id,
         iosProdCorePatchB.id,

--- a/packages/console/src/components/features/bundles/BundleActivityChart.spec.tsx
+++ b/packages/console/src/components/features/bundles/BundleActivityChart.spec.tsx
@@ -17,14 +17,14 @@ afterEach(cleanup);
 it("shows a single observed active value without inventing observations in earlier intervals", () => {
   const series: RecoverySeries = {
     releaseId: "bundle-a",
-    firstAdoptedAtMs: 2 * 86_400_000,
+    firstAppliedAtMs: 2 * 3_600_000,
     activeInstallations: 2,
     recoveredInstallations: 0,
     points: [null, null, 2].map((active, index) => ({
-      startMs: index * 86_400_000,
+      startMs: index * 3_600_000,
       active,
       recoveredInstallations: 0,
-      adopted: active ?? 0,
+      applied: active ?? 0,
       recovered: 0,
       rate: active === null ? null : 0,
       spike: false,

--- a/packages/console/src/components/features/bundles/BundleActivityChart.tsx
+++ b/packages/console/src/components/features/bundles/BundleActivityChart.tsx
@@ -20,6 +20,7 @@ const formatDate = (ms: number) =>
   new Intl.DateTimeFormat("en", {
     month: "short",
     day: "numeric",
+    hour: "numeric",
     timeZone: "UTC",
   }).format(ms);
 
@@ -31,13 +32,13 @@ export function BundleActivityChart({
   if (!series)
     return (
       <p className="flex h-16 items-center justify-center border-t text-xs text-muted-foreground sm:h-20">
-        No reports in 30 days. Check again after the app reports activity.
+        No reports in 24 hours. Check again after the app reports activity.
       </p>
     );
   return (
     <div className="border-t pt-3">
       <ChartContainer
-        aria-label="Bundle activity over 30 days, UTC"
+        aria-label="Bundle activity over 24 hours, UTC"
         className="h-32 w-full aspect-auto sm:h-40"
         config={config}
       >

--- a/packages/console/src/components/features/bundles/BundleInsightsSummary.tsx
+++ b/packages/console/src/components/features/bundles/BundleInsightsSummary.tsx
@@ -1,11 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  useBundleActivityQuery,
-  type BundleActivityInput,
-} from "@/lib/bundle-activity";
+import type { BundleActivityInput } from "@/lib/bundle-activity";
 import type { RecoveryReport } from "@/lib/insights-recovery";
+import { getRecoveryReportRpc } from "@/lib/insights-recovery-rpc";
 
 import { BundleActivityChart } from "./BundleActivityChart";
 
@@ -63,14 +63,19 @@ export function BundleInsightsSummary({
 }: {
   readonly input: BundleActivityInput;
 }) {
-  const query = useBundleActivityQuery([input]);
-  const report = query.data?.[input.releaseId];
+  const activityInput = { ...input, window: "24h" } as const;
+  const query = useQuery({
+    queryKey: ["rollout-activity", activityInput],
+    queryFn: () => getRecoveryReportRpc({ data: activityInput }),
+    staleTime: 30_000,
+  });
+  const report = query.data;
   const series = report?.series[0];
   return (
     <Card>
       <CardHeader className="px-4 pt-4 pb-3">
         <CardTitle className="text-sm font-medium">
-          Activity · 30 days
+          Activity · 24 hours
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3 px-4 pb-4">
@@ -101,7 +106,7 @@ export function BundleInsightsSummary({
               </div>
               <div className="pl-4">
                 <dt className="text-xs text-muted-foreground">
-                  Rollback · 30d
+                  Rollback · 24h
                 </dt>
                 <dd className="mt-1 text-xl font-semibold tabular-nums">
                   {series?.recoveredInstallations ?? 0}
@@ -110,7 +115,7 @@ export function BundleInsightsSummary({
             </dl>
             <BundleActivityChart series={series} />
             <p className="text-xs text-muted-foreground">
-              Last observed active installations · daily rollbacks
+              Last observed active installations · hourly rollbacks
               {report?.truncated ? " · Partial history" : ""}
             </p>
           </>

--- a/packages/console/src/components/features/insights/EventDetails.spec.tsx
+++ b/packages/console/src/components/features/insights/EventDetails.spec.tsx
@@ -1,7 +1,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { EventTimestamp, EventTypeBadge } from "./EventDetails";
+import {
+  EventBundleTransition,
+  EventTimestamp,
+  EventTypeDetails,
+} from "./EventDetails";
 
 describe("Insights event details", () => {
   afterEach(cleanup);
@@ -30,24 +34,46 @@ describe("Insights event details", () => {
     expect(screen.getByText("2026-07-18 00:00:00.000 UTC")).toBeDefined();
   });
 
+  it("shows no change without implying a file transition", () => {
+    const type = "UNCHANGED";
+    render(
+      <>
+        <EventTypeDetails type={type} />
+        <EventBundleTransition
+          event={{
+            type,
+            fromBundleId: null,
+            toBundleId: "same-file",
+          }}
+        />
+      </>,
+    );
+    expect(screen.getByText("No change")).toBeDefined();
+    expect(
+      screen.getByText("The app continues using the same bundle files."),
+    ).toBeDefined();
+    expect(screen.getByText("Current")).toBeDefined();
+    expect(screen.queryByText("From")).toBeNull();
+    expect(screen.queryByText("To")).toBeNull();
+    expect(screen.queryByTitle(type)).toBeNull();
+  });
+
   it("uses distinct product labels for event meaning", () => {
-    const view = render(<EventTypeBadge type="UPDATE_APPLIED" />);
-    expect(screen.getByText("Bundle applied")).toBeDefined();
-    expect(screen.getByText("Bundle applied").className).toContain(
+    const view = render(<EventTypeDetails type="UPDATE_APPLIED" />);
+    expect(screen.getByText("Update applied")).toBeDefined();
+    expect(screen.getByText("Update applied").className).toContain(
       "text-success",
     );
 
-    view.rerender(<EventTypeBadge type="RELEASE_ADOPTED" />);
-    expect(screen.getByText("Bundle adopted")).toBeDefined();
+    view.rerender(<EventTypeDetails type="RECOVERED" />);
+    expect(screen.getByText("Rolled back")).toBeDefined();
+    expect(screen.getByText("Rolled back").className).toContain("text-warning");
 
-    view.rerender(<EventTypeBadge type="RECOVERED" />);
-    expect(screen.getByText("Recovered")).toBeDefined();
-    expect(screen.getByText("Recovered").className).toContain("text-warning");
-
-    view.rerender(<EventTypeBadge type="UNCHANGED" />);
-    expect(screen.getByText("Activity reported")).toBeDefined();
-    expect(screen.getByText("Activity reported").className).toContain(
-      "bg-secondary",
-    );
+    view.rerender(<EventTypeDetails type="UNCHANGED" />);
+    expect(screen.getByText("No change")).toBeDefined();
+    expect(
+      screen.getByText("The app continues using the same bundle files."),
+    ).toBeDefined();
+    expect(screen.getByText("No change").className).toContain("bg-secondary");
   });
 });

--- a/packages/console/src/components/features/insights/EventDetails.tsx
+++ b/packages/console/src/components/features/insights/EventDetails.tsx
@@ -1,10 +1,4 @@
-import {
-  Activity,
-  Check,
-  ChevronDown,
-  PackageCheck,
-  RotateCcw,
-} from "lucide-react";
+import { Activity, Check, ChevronDown, RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { HashValueDisplay } from "@/components/HashValueDisplay";
@@ -14,15 +8,21 @@ import type { InsightsEventRow } from "@/lib/insights-view";
 type EventHistoryRow = InsightsEventRow;
 
 const eventTypes = {
-  UPDATE_APPLIED: { label: "Bundle applied", variant: "success", icon: Check },
-  RECOVERED: { label: "Recovered", variant: "warning", icon: RotateCcw },
-  RELEASE_ADOPTED: {
-    label: "Bundle adopted",
+  UPDATE_APPLIED: {
+    label: "Update applied",
+    description: "The app started using the downloaded update.",
     variant: "success",
-    icon: PackageCheck,
+    icon: Check,
+  },
+  RECOVERED: {
+    label: "Rolled back",
+    description: "The app recovered to a previous working bundle.",
+    variant: "warning",
+    icon: RotateCcw,
   },
   UNCHANGED: {
-    label: "Activity reported",
+    label: "No change",
+    description: "The app continues using the same bundle files.",
     variant: "secondary",
     icon: Activity,
   },
@@ -92,7 +92,7 @@ export function EventTimestamp({
   );
 }
 
-export function EventTypeBadge({
+export function EventTypeDetails({
   type,
 }: {
   readonly type: EventHistoryRow["type"];
@@ -100,20 +100,18 @@ export function EventTypeBadge({
   const eventType = eventTypes[type];
   const Icon = eventType.icon;
   return (
-    <Badge
-      variant={eventType.variant}
-      className="gap-1 whitespace-nowrap [&_svg]:size-3"
-      title={
-        type === "UNCHANGED"
-          ? "App activity reported on the current bundle without a bundle transition."
-          : type === "RELEASE_ADOPTED"
-            ? "A different release was adopted without changing the bundle."
-            : undefined
-      }
-    >
-      <Icon aria-hidden="true" />
-      {eventType.label}
-    </Badge>
+    <div className="flex min-w-0 flex-col items-start gap-2">
+      <Badge
+        variant={eventType.variant}
+        className="gap-1 whitespace-nowrap [&_svg]:size-3"
+      >
+        <Icon aria-hidden="true" />
+        {eventType.label}
+      </Badge>
+      <p className="max-w-56 whitespace-normal text-xs text-muted-foreground">
+        {eventType.description}
+      </p>
+    </div>
   );
 }
 
@@ -124,9 +122,10 @@ export function EventBundleTransition({
   readonly event: Pick<EventHistoryRow, "type" | "fromBundleId" | "toBundleId">;
   readonly touch?: boolean;
 }) {
+  const changed = event.type === "UPDATE_APPLIED" || event.type === "RECOVERED";
   return (
     <dl className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-2 gap-y-2">
-      {event.fromBundleId ? (
+      {event.fromBundleId && changed ? (
         <>
           <dt className="text-muted-foreground">From</dt>
           <dd>
@@ -137,9 +136,7 @@ export function EventBundleTransition({
           </dd>
         </>
       ) : null}
-      <dt className="text-muted-foreground">
-        {event.type === "UNCHANGED" ? "Current" : "To"}
-      </dt>
+      <dt className="text-muted-foreground">{changed ? "To" : "Current"}</dt>
       <dd>
         <HashValueDisplay
           value={event.toBundleId}

--- a/packages/console/src/components/features/insights/EventHistoryCard.tsx
+++ b/packages/console/src/components/features/insights/EventHistoryCard.tsx
@@ -19,7 +19,7 @@ import type { InsightsEventRow, InsightsViewPage } from "@/lib/insights-view";
 import {
   EventBundleTransition,
   EventTimestamp,
-  EventTypeBadge,
+  EventTypeDetails,
   useInsightsTimeFormat,
 } from "./EventDetails";
 import { EventHistoryList } from "./EventHistoryList";
@@ -189,7 +189,7 @@ export function EventHistoryCard({
                             />
                           </TableCell>
                           <TableCell>
-                            <EventTypeBadge type={event.type} />
+                            <EventTypeDetails type={event.type} />
                           </TableCell>
                           <TableCell>
                             <EventIdentity

--- a/packages/console/src/components/features/insights/EventHistoryList.tsx
+++ b/packages/console/src/components/features/insights/EventHistoryList.tsx
@@ -5,7 +5,7 @@ import type { InsightsEventRow } from "@/lib/insights-view";
 import {
   EventBundleTransition,
   EventTimestamp,
-  EventTypeBadge,
+  EventTypeDetails,
 } from "./EventDetails";
 
 export function EventHistoryList<T extends InsightsEventRow>({
@@ -29,7 +29,7 @@ export function EventHistoryList<T extends InsightsEventRow>({
             className="flex min-w-0 flex-col gap-3 px-4 py-4 sm:px-6"
           >
             <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
-              <EventTypeBadge type={event.type} />
+              <EventTypeDetails type={event.type} />
               <div className="text-xs tabular-nums">
                 <EventTimestamp
                   value={event.receivedAtMs}

--- a/packages/console/src/components/features/insights/InsightsControls.spec.tsx
+++ b/packages/console/src/components/features/insights/InsightsControls.spec.tsx
@@ -6,36 +6,18 @@ import { InsightsControls } from "./InsightsControls";
 describe("InsightsControls", () => {
   afterEach(cleanup);
 
-  it("changes the overview reporting period", () => {
-    const onWindowChange = vi.fn();
-    render(
-      <InsightsControls
-        scope={{ platform: "ios", channel: "production" }}
-        onScopeChange={vi.fn()}
-        window="30d"
-        onWindowChange={onWindowChange}
-      />,
-    );
-
-    expect(
-      screen
-        .getByRole("button", { name: "30 days" })
-        .getAttribute("aria-pressed"),
-    ).toBe("true");
-    fireEvent.click(screen.getByRole("button", { name: "7 days" }));
-    expect(onWindowChange).toHaveBeenCalledWith("7d");
-  });
-  it("submits an explicit scope without querying on each input change", () => {
+  it("submits an explicit scope without querying on each input change", async () => {
     const onScopeChange = vi.fn();
     render(
       <InsightsControls
         scope={{ platform: "ios", channel: "production" }}
         onScopeChange={onScopeChange}
-        window="30d"
-        onWindowChange={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Android" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Platform" }));
+    const android = await screen.findByRole("option", { name: "Android" });
+    fireEvent.pointerDown(android);
+    fireEvent.click(android);
     fireEvent.change(screen.getByLabelText("Channel"), {
       target: { value: "beta" },
     });

--- a/packages/console/src/components/features/insights/InsightsControls.tsx
+++ b/packages/console/src/components/features/insights/InsightsControls.tsx
@@ -1,121 +1,82 @@
-import { CheckIcon } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import type { InsightsOverviewInput, InsightsWindow } from "@/lib/insights-api";
-
-const windows = [
-  { value: "24h", label: "24 hours", shortLabel: "24h" },
-  { value: "7d", label: "7 days", shortLabel: "7d" },
-  { value: "30d", label: "30 days", shortLabel: "30d" },
-] as const;
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { InsightsOverviewInput } from "@/lib/insights-api";
 
 export function InsightsControls({
-  onWindowChange,
   onScopeChange,
   scope,
-  window,
 }: {
-  readonly onWindowChange: (window: InsightsWindow) => void;
   readonly onScopeChange: (
     scope: Omit<InsightsOverviewInput, "window">,
   ) => void;
   readonly scope: Omit<InsightsOverviewInput, "window">;
-  readonly window: InsightsWindow;
 }) {
   const [platform, setPlatform] = useState(scope.platform);
   const [channel, setChannel] = useState(scope.channel);
 
   return (
-    <section aria-label="Insights controls" className="flex flex-col gap-4">
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          onScopeChange({ platform, channel });
-        }}
-      >
-        <FieldGroup className="items-end sm:flex-row">
-          <Field className="w-full sm:w-auto">
-            <FieldLabel>Platform</FieldLabel>
-            <ToggleGroup
-              aria-label="Platform"
-              value={[platform]}
-              onValueChange={(value) => {
-                if (value[0] === "ios" || value[0] === "android")
-                  setPlatform(value[0]);
-              }}
-              variant="contrast"
-            >
-              <ToggleGroupItem className="h-11 lg:h-8" value="ios">
-                <CheckIcon
-                  aria-hidden="true"
-                  className="invisible group-aria-pressed/toggle:visible"
-                  data-icon="inline-start"
-                />
-                iOS
-              </ToggleGroupItem>
-              <ToggleGroupItem className="h-11 lg:h-8" value="android">
-                <CheckIcon
-                  aria-hidden="true"
-                  className="invisible group-aria-pressed/toggle:visible"
-                  data-icon="inline-start"
-                />
-                Android
-              </ToggleGroupItem>
-            </ToggleGroup>
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="insights-channel">Channel</FieldLabel>
-            <Input
-              className="h-11 lg:h-8"
-              id="insights-channel"
-              value={channel}
-              onChange={(event) => setChannel(event.target.value)}
-              required
-              maxLength={1024}
-            />
-          </Field>
-          <Button
-            className="h-11 w-full sm:w-auto lg:h-8"
-            type="submit"
-            variant="outline"
+    <form
+      aria-label="Insights controls"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onScopeChange({ platform, channel });
+      }}
+    >
+      <FieldGroup className="grid grid-cols-[1fr_2fr] items-end gap-4 sm:flex-row sm:flex">
+        <Field className="sm:w-36">
+          <FieldLabel htmlFor="insights-platform">Platform</FieldLabel>
+          <Select
+            items={{ ios: "iOS", android: "Android" }}
+            value={platform}
+            onValueChange={(value) => {
+              if (value === "ios" || value === "android") setPlatform(value);
+            }}
           >
-            Apply filters
-          </Button>
-        </FieldGroup>
-      </form>
-      <Field orientation="horizontal" className="w-full">
-        <FieldLabel className="sr-only">Reporting period</FieldLabel>
-        <ToggleGroup
-          aria-label="Reporting period"
-          className="w-full sm:w-fit"
-          onValueChange={(value) => {
-            if (value[0]) onWindowChange(value[0] as InsightsWindow);
-          }}
-          size="lg"
-          value={[window]}
-          variant="contrast"
-        >
-          {windows.map((item) => (
-            <ToggleGroupItem
-              aria-label={item.label}
-              className="h-11 flex-1 px-4 sm:flex-none lg:h-8 lg:px-2.5"
-              key={item.value}
-              value={item.value}
+            <SelectTrigger
+              id="insights-platform"
+              className="min-h-11 w-full sm:min-h-9"
             >
-              <CheckIcon
-                aria-hidden="true"
-                className="invisible group-aria-pressed/toggle:visible"
-                data-icon="inline-start"
-              />
-              {item.shortLabel}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
-      </Field>
-    </section>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="ios">iOS</SelectItem>
+                <SelectItem value="android">Android</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field className="min-w-0 sm:max-w-xs">
+          <FieldLabel htmlFor="insights-channel">Channel</FieldLabel>
+          <Input
+            className="h-11 sm:h-9"
+            id="insights-channel"
+            value={channel}
+            onChange={(event) => setChannel(event.target.value)}
+            required
+            maxLength={1024}
+          />
+        </Field>
+        <Button
+          className="col-span-2 h-11 sm:h-9 sm:w-auto"
+          size="lg"
+          type="submit"
+          variant="outline"
+        >
+          Apply filters
+        </Button>
+      </FieldGroup>
+    </form>
   );
 }

--- a/packages/console/src/components/features/insights/InsightsOverview.spec.tsx
+++ b/packages/console/src/components/features/insights/InsightsOverview.spec.tsx
@@ -46,14 +46,14 @@ const report: RecoveryReport = {
   unattributedInstallations: 0,
   series: ["new-id", "old-id"].map((releaseId, index) => ({
     releaseId,
-    firstAdoptedAtMs: 0,
+    firstAppliedAtMs: 0,
     activeInstallations: index === 0 ? 90 : 10,
     recoveredInstallations: index === 0 ? 3 : 0,
     points: [10, 50, 90].map((active, i) => ({
       startMs: i * DAY,
       active: index === 0 ? active : 100 - active,
       recoveredInstallations: index === 0 && i === 2 ? 3 : 0,
-      adopted: 7,
+      applied: 7,
       recovered: index === 0 && i === 2 ? 3 : 0,
       rate: index === 0 && i === 2 ? 30 : 0,
       spike: index === 0 && i === 2,
@@ -80,7 +80,7 @@ describe("bundle trends", () => {
     expect(
       screen.getByRole("link", { name: "Review bundle" }).getAttribute("href"),
     ).toBe("/?releaseId=new-id");
-    fireEvent.click(screen.getByRole("button", { name: "Rollback" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Rollback" }));
     expect(
       screen.getByLabelText("Rollback trend for all reported bundle IDs"),
     ).toBeDefined();
@@ -127,16 +127,28 @@ describe("bundle trends", () => {
       window: "30d",
     } as const;
     const refetch = vi.fn();
+    const onWindowChange = vi.fn();
     mocks.query.mockReturnValue({ isPending: true, refetch });
-    const view = render(<InsightsOverview input={input} />);
+    const view = render(
+      <InsightsOverview input={input} onWindowChange={onWindowChange} />,
+    );
     expect(screen.getByLabelText("Loading bundle activity")).toBeDefined();
+    expect(
+      screen
+        .getByRole("tab", { name: "30 days" })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    fireEvent.click(screen.getByRole("tab", { name: "7 days" }));
+    expect(onWindowChange).toHaveBeenCalledWith("7d");
     expect(
       within(screen.getByRole("region", { name: "Bundle activity" }))
         .getByRole("link", { name: "All events" })
         .getAttribute("href"),
     ).toBe("/installations");
     mocks.query.mockReturnValue({ error: new Error("Offline"), refetch });
-    view.rerender(<InsightsOverview input={input} />);
+    view.rerender(
+      <InsightsOverview input={input} onWindowChange={onWindowChange} />,
+    );
     expect(screen.getByText("Bundle activity unavailable")).toBeDefined();
     fireEvent.click(
       screen.getByRole("button", { name: "Refresh bundle activity" }),
@@ -151,7 +163,9 @@ describe("bundle trends", () => {
       },
       refetch,
     });
-    view.rerender(<InsightsOverview input={input} />);
+    view.rerender(
+      <InsightsOverview input={input} onWindowChange={onWindowChange} />,
+    );
     expect(screen.getByText(/No bundle reports in this period/)).toBeDefined();
     expect(screen.getByText(/Partial history/)).toBeDefined();
     expect(

--- a/packages/console/src/components/features/insights/InsightsOverview.tsx
+++ b/packages/console/src/components/features/insights/InsightsOverview.tsx
@@ -1,19 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import {
-  ArrowUpRight,
-  CheckIcon,
-  ListIcon,
-  RotateCw,
-  TriangleAlert,
-} from "lucide-react";
+import { ArrowUpRight, ListIcon, RotateCw, TriangleAlert } from "lucide-react";
 import { useState } from "react";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
-  CardAction,
   CardContent,
   CardFooter,
   CardHeader,
@@ -25,7 +18,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { RecoveryInput, RecoveryReport } from "@/lib/insights-recovery";
 import { getRecoveryReportRpc } from "@/lib/insights-recovery-rpc";
 import { cn } from "@/lib/utils";
@@ -92,281 +85,365 @@ export function ActivityChart({ report }: { readonly report: RecoveryReport }) {
       : report.series.filter((series) => series.recoveredInstallations > 0)
           .length;
   return (
-    <>
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
+    <Tabs
+      value={metric}
+      onValueChange={(value) => {
+        if (value === "active" || value === "rollback") setMetric(value);
+      }}
+      className="gap-6"
+    >
+      <TabsList
+        aria-label="Activity metric"
+        variant="line"
+        className="min-h-11 sm:min-h-9"
+      >
+        <TabsTrigger className="min-w-24 px-4" value="active">
+          Active
+        </TabsTrigger>
+        <TabsTrigger className="min-w-24 px-4" value="rollback">
+          Rollback
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value={metric} className="flex flex-col gap-6">
+        <div className="flex items-baseline gap-3">
+          <p className="text-4xl font-semibold tracking-tight tabular-nums">
+            {total.toLocaleString()}
+          </p>
           <p className="text-sm text-muted-foreground">
             {metric === "active"
               ? "Active installations"
               : "Bundles with rollbacks"}
           </p>
-          <p className="mt-1 text-4xl font-semibold tracking-tight tabular-nums">
-            {total.toLocaleString()}
-          </p>
         </div>
-        <ToggleGroup
-          aria-label="Activity metric"
-          value={[metric]}
-          onValueChange={(values) => {
-            if (values[0] === "active" || values[0] === "rollback")
-              setMetric(values[0]);
-          }}
-          variant="contrast"
-        >
-          <ToggleGroupItem className="h-11 lg:h-8" value="active">
-            <CheckIcon
-              aria-hidden="true"
-              className="invisible group-aria-pressed/toggle:visible"
-              data-icon="inline-start"
-            />
-            Active
-          </ToggleGroupItem>
-          <ToggleGroupItem className="h-11 lg:h-8" value="rollback">
-            <CheckIcon
-              aria-hidden="true"
-              className="invisible group-aria-pressed/toggle:visible"
-              data-icon="inline-start"
-            />
-            Rollback
-          </ToggleGroupItem>
-        </ToggleGroup>
-      </div>
-      {report.series.length === 0 ? (
-        <div className="flex h-48 items-center justify-center text-center text-sm text-muted-foreground">
-          No bundle reports in this period. Try another channel or check again
-          after the app reports activity.
-        </div>
-      ) : (
-        <>
-          <div>
-            <p className="mb-2 text-right text-xs text-muted-foreground">
-              {metric === "active"
-                ? "Installations"
-                : "Recovered installations per interval"}{" "}
-              · UTC
-            </p>
-            <ChartContainer
-              aria-label={`${metric === "active" ? "Active" : "Rollback"} trend for all reported bundle IDs`}
-              className="h-48 w-full aspect-auto sm:h-56"
-              config={config}
-            >
-              <LineChart
-                accessibilityLayer
-                data={data}
-                margin={{ left: -12, right: 12, top: 8 }}
+        {report.series.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-center text-sm text-muted-foreground">
+            No bundle reports in this period. Try another channel or check again
+            after the app reports activity.
+          </div>
+        ) : (
+          <>
+            <div>
+              <p className="mb-2 text-right text-xs text-muted-foreground">
+                {metric === "active"
+                  ? "Installations"
+                  : "Recovered installations per interval"}{" "}
+                · UTC
+              </p>
+              <ChartContainer
+                aria-label={`${metric === "active" ? "Active" : "Rollback"} trend for all reported bundle IDs`}
+                className="h-56 w-full aspect-auto sm:h-64"
+                config={config}
               >
-                <CartesianGrid vertical={false} />
-                <XAxis
-                  axisLine={false}
-                  dataKey="startMs"
-                  minTickGap={40}
-                  tickFormatter={formatTick}
-                  tickLine={false}
-                />
-                <YAxis
-                  allowDecimals={false}
-                  axisLine={false}
-                  tickLine={false}
-                  width={48}
-                />
-                <ChartTooltip
-                  content={
-                    <ChartTooltipContent
-                      className="max-h-64 max-w-[calc(100vw-3rem)] overflow-auto"
-                      labelFormatter={(_, payload) =>
-                        `${times.format(payload[0]?.payload.startMs)} · UTC`
+                <LineChart
+                  accessibilityLayer
+                  data={data}
+                  margin={{ left: -12, right: 12, top: 8 }}
+                >
+                  <CartesianGrid vertical={false} />
+                  <XAxis
+                    axisLine={false}
+                    dataKey="startMs"
+                    minTickGap={40}
+                    tickFormatter={formatTick}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    axisLine={false}
+                    tickLine={false}
+                    width={48}
+                  />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        className="max-h-64 max-w-[calc(100vw-3rem)] overflow-auto"
+                        labelFormatter={(_, payload) =>
+                          `${times.format(payload[0]?.payload.startMs)} · UTC`
+                        }
+                      />
+                    }
+                  />
+                  {report.series.map((series, index) => (
+                    <Line
+                      key={series.releaseId}
+                      dataKey={`bundle${index}`}
+                      type="linear"
+                      stroke={`var(--color-bundle${index})`}
+                      strokeWidth={selectedId === series.releaseId ? 3 : 2}
+                      strokeOpacity={!selected || selected === series ? 1 : 0.4}
+                      strokeDasharray={
+                        dashes[
+                          Math.floor(index / colors.length) % dashes.length
+                        ]
+                      }
+                      dot={{ r: 2 }}
+                      activeDot={{ r: 4 }}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              </ChartContainer>
+            </div>
+            <div
+              aria-label="Reported bundles"
+              className="grid max-h-48 grid-cols-1 gap-1 overflow-y-auto xl:grid-cols-2"
+            >
+              {report.series.map((series, index) => (
+                <button
+                  type="button"
+                  key={series.releaseId}
+                  aria-label={`Highlight bundle ${series.releaseId}`}
+                  aria-pressed={selectedId === series.releaseId}
+                  title={series.releaseId}
+                  onClick={() =>
+                    setSelectedId(
+                      selectedId === series.releaseId ? null : series.releaseId,
+                    )
+                  }
+                  className="flex min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-pressed:bg-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    width="20"
+                    height="8"
+                    className="shrink-0"
+                  >
+                    <line
+                      x1="0"
+                      x2="20"
+                      y1="4"
+                      y2="4"
+                      stroke={colors[index % colors.length]}
+                      strokeWidth="2"
+                      strokeDasharray={
+                        dashes[
+                          Math.floor(index / colors.length) % dashes.length
+                        ]
                       }
                     />
-                  }
-                />
-                {report.series.map((series, index) => (
-                  <Line
-                    key={series.releaseId}
-                    dataKey={`bundle${index}`}
-                    type="linear"
-                    stroke={`var(--color-bundle${index})`}
-                    strokeWidth={selectedId === series.releaseId ? 3 : 2}
-                    strokeOpacity={!selected || selected === series ? 1 : 0.4}
-                    strokeDasharray={
-                      dashes[Math.floor(index / colors.length) % dashes.length]
-                    }
-                    dot={{ r: 2 }}
-                    activeDot={{ r: 4 }}
-                    isAnimationActive={false}
-                  />
-                ))}
-              </LineChart>
-            </ChartContainer>
-          </div>
-          <div
-            aria-label="Reported bundles"
-            className="grid max-h-48 grid-cols-1 gap-1 overflow-y-auto sm:grid-cols-2"
-          >
-            {report.series.map((series, index) => (
-              <button
-                type="button"
-                key={series.releaseId}
-                aria-label={`Highlight bundle ${series.releaseId}`}
-                aria-pressed={selectedId === series.releaseId}
-                title={series.releaseId}
-                onClick={() =>
-                  setSelectedId(
-                    selectedId === series.releaseId ? null : series.releaseId,
-                  )
-                }
-                className="flex min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-pressed:bg-muted"
-              >
-                <svg
-                  aria-hidden="true"
-                  width="20"
-                  height="8"
-                  className="shrink-0"
-                >
-                  <line
-                    x1="0"
-                    x2="20"
-                    y1="4"
-                    y2="4"
-                    stroke={colors[index % colors.length]}
-                    strokeWidth="2"
-                    strokeDasharray={
-                      dashes[Math.floor(index / colors.length) % dashes.length]
-                    }
-                  />
-                </svg>
-                <span className="min-w-0 truncate font-mono">
-                  {series.releaseId}
-                </span>
-                {series.points.some((point) => point.spike) ? (
-                  <TriangleAlert
-                    aria-label="Rollback spike"
-                    className="size-3 shrink-0"
-                  />
-                ) : null}
-                <span className="ml-auto tabular-nums">
-                  {(metric === "active"
-                    ? series.activeInstallations
-                    : series.recoveredInstallations
-                  ).toLocaleString()}
-                </span>
-              </button>
-            ))}
-          </div>
-          {selected ? (
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
-              <div className="min-w-0 flex-1">
-                <p className="break-all font-mono text-xs">
-                  {selected.releaseId}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Active {selected.activeInstallations.toLocaleString()} ·
-                  Rollback {selected.recoveredInstallations.toLocaleString()} in
-                  this period
-                </p>
-                {metric === "rollback" && lastSpike ? (
-                  <p className="mt-2 flex items-center gap-2 text-xs">
+                  </svg>
+                  <span className="min-w-0 truncate font-mono">
+                    {series.releaseId}
+                  </span>
+                  {series.points.some((point) => point.spike) ? (
                     <TriangleAlert
+                      aria-label="Rollback spike"
                       className="size-3 shrink-0"
-                      aria-hidden="true"
                     />
-                    Rollback spike on {dates.format(lastSpike.startMs)}. Review
-                    this bundle’s delivery settings.
-                  </p>
-                ) : null}
-              </div>
-              <Link
-                className={buttonVariants({ variant: "outline", size: "sm" })}
-                to="/"
-                search={{ releaseId: selected.releaseId }}
-              >
-                Review bundle
-                <ArrowUpRight aria-hidden="true" />
-              </Link>
+                  ) : null}
+                  <span className="ml-auto tabular-nums">
+                    {(metric === "active"
+                      ? series.activeInstallations
+                      : series.recoveredInstallations
+                    ).toLocaleString()}
+                  </span>
+                </button>
+              ))}
             </div>
-          ) : null}
-          <details className="text-xs text-muted-foreground">
-            <summary className="cursor-pointer">View chart data</summary>
-            <div className="mt-2 max-h-64 overflow-auto">
-              <table className="w-full text-left">
-                <caption className="sr-only">
-                  {metric === "active"
-                    ? "Active installations"
-                    : "Recovered installations"}{" "}
-                  by bundle ID, UTC
-                </caption>
-                <thead>
-                  <tr>
-                    <th scope="col" className="pr-4">
-                      Date (UTC)
-                    </th>
-                    {report.series.map((series) => (
-                      <th
-                        scope="col"
-                        className="px-2 font-mono"
-                        key={series.releaseId}
-                      >
-                        {series.releaseId}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.map((point, i) => (
-                    <tr key={point.startMs}>
-                      <th
-                        scope="row"
-                        className="whitespace-nowrap pr-4 font-normal"
-                      >
-                        {times.format(point.startMs)}
+            {selected ? (
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
+                <div className="min-w-0 flex-1">
+                  <p className="break-all font-mono text-xs">
+                    {selected.releaseId}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Active {selected.activeInstallations.toLocaleString()} ·
+                    Rollback {selected.recoveredInstallations.toLocaleString()}{" "}
+                    in this period
+                  </p>
+                  {metric === "rollback" && lastSpike ? (
+                    <p className="mt-2 flex items-center gap-2 text-xs">
+                      <TriangleAlert
+                        className="size-3 shrink-0"
+                        aria-hidden="true"
+                      />
+                      Rollback spike on {dates.format(lastSpike.startMs)}.
+                      Review this bundle’s delivery settings.
+                    </p>
+                  ) : null}
+                </div>
+                <Link
+                  className={buttonVariants({ variant: "outline", size: "sm" })}
+                  to="/"
+                  search={{ releaseId: selected.releaseId }}
+                >
+                  Review bundle
+                  <ArrowUpRight aria-hidden="true" />
+                </Link>
+              </div>
+            ) : null}
+            <details className="text-xs text-muted-foreground">
+              <summary className="cursor-pointer">View chart data</summary>
+              <div className="mt-2 max-h-64 overflow-auto">
+                <table className="w-full text-left">
+                  <caption className="sr-only">
+                    {metric === "active"
+                      ? "Active installations"
+                      : "Recovered installations"}{" "}
+                    by bundle ID, UTC
+                  </caption>
+                  <thead>
+                    <tr>
+                      <th scope="col" className="pr-4">
+                        Date (UTC)
                       </th>
                       {report.series.map((series) => (
-                        <td
-                          className="px-2 tabular-nums"
+                        <th
+                          scope="col"
+                          className="px-2 font-mono"
                           key={series.releaseId}
                         >
-                          {(metric === "active"
-                            ? series.points[i].active
-                            : series.points[i].recoveredInstallations) ?? "—"}
-                        </td>
+                          {series.releaseId}
+                        </th>
                       ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </details>
-        </>
-      )}
-    </>
+                  </thead>
+                  <tbody>
+                    {data.map((point, i) => (
+                      <tr key={point.startMs}>
+                        <th
+                          scope="row"
+                          className="whitespace-nowrap pr-4 font-normal"
+                        >
+                          {times.format(point.startMs)}
+                        </th>
+                        {report.series.map((series) => (
+                          <td
+                            className="px-2 tabular-nums"
+                            key={series.releaseId}
+                          >
+                            {(metric === "active"
+                              ? series.points[i].active
+                              : series.points[i].recoveredInstallations) ?? "—"}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          </>
+        )}
+      </TabsContent>
+    </Tabs>
   );
 }
 
-export function InsightsOverview({ input }: { readonly input: RecoveryInput }) {
+export function InsightsOverview({
+  input,
+  onWindowChange,
+}: {
+  readonly input: RecoveryInput;
+  readonly onWindowChange: (window: RecoveryInput["window"]) => void;
+}) {
   const query = useQuery({
     queryKey: ["rollout-activity", input],
     queryFn: () => getRecoveryReportRpc({ data: input }),
     staleTime: 30_000,
   });
   return (
-    <Card
-      aria-label="Bundle activity"
-      className="min-w-0 overflow-hidden shadow-sm"
-      role="region"
+    <Tabs
+      value={input.window}
+      onValueChange={(value) => {
+        if (value === "24h" || value === "7d" || value === "30d")
+          onWindowChange(value);
+      }}
     >
-      <CardHeader className="flex-row flex-wrap items-center justify-between gap-4 px-4 pt-4 pb-2 sm:px-6 sm:pt-6">
-        <CardTitle className="text-sm font-medium">
-          Bundle activity ·{" "}
-          {input.window === "30d"
-            ? "30 days"
-            : input.window === "7d"
-              ? "7 days"
-              : "24 hours"}
-        </CardTitle>
-        <CardAction className="flex items-center gap-2 self-center">
+      <Card
+        aria-label="Bundle activity"
+        className="min-w-0 overflow-hidden shadow-sm"
+        role="region"
+      >
+        <CardHeader className="flex-row flex-wrap items-center justify-between gap-4 p-6 sm:p-8">
+          <CardTitle>Bundle activity</CardTitle>
+          <div className="flex w-full items-center justify-between gap-4 sm:w-auto">
+            <TabsList
+              aria-label="Reporting period"
+              className="min-h-11 sm:min-h-9"
+            >
+              <TabsTrigger
+                className="min-w-12 px-3"
+                aria-label="24 hours"
+                value="24h"
+              >
+                24h
+              </TabsTrigger>
+              <TabsTrigger
+                className="min-w-12 px-3"
+                aria-label="7 days"
+                value="7d"
+              >
+                7d
+              </TabsTrigger>
+              <TabsTrigger
+                className="min-w-12 px-3"
+                aria-label="30 days"
+                value="30d"
+              >
+                30d
+              </TabsTrigger>
+            </TabsList>
+            <Button
+              aria-label="Refresh bundle activity"
+              className="size-11 sm:size-9"
+              variant="ghost"
+              size="icon-lg"
+              disabled={query.isFetching}
+              onClick={() => void query.refetch()}
+            >
+              <RotateCw aria-hidden="true" />
+            </Button>
+          </div>
+        </CardHeader>
+        <TabsContent value={input.window}>
+          <CardContent className="px-6 pb-6 sm:px-8 sm:pb-8">
+            {query.isPending ? (
+              <Skeleton
+                aria-label="Loading bundle activity"
+                className="h-80 w-full"
+              />
+            ) : query.error ? (
+              <InsightsErrorAlert
+                error={query.error}
+                fallbackTitle="Bundle activity unavailable"
+              />
+            ) : query.data ? (
+              <ActivityChart key={JSON.stringify(input)} report={query.data} />
+            ) : null}
+          </CardContent>
+        </TabsContent>
+        <CardFooter className="flex-wrap items-center justify-between gap-4 border-t px-6 py-5 sm:px-8">
+          <div className="flex min-w-0 basis-64 flex-1 flex-col gap-2 text-xs text-muted-foreground">
+            {query.data && !query.error ? (
+              <>
+                <p>
+                  Active follows each installation’s last reported ID in this
+                  period. Rollbacks count recovered installations per interval.
+                </p>
+                {query.data.unattributedInstallations > 0 ? (
+                  <p>
+                    {query.data.unattributedInstallations.toLocaleString()}{" "}
+                    reporting installations have no observed bundle ID and are
+                    excluded.
+                  </p>
+                ) : null}
+                {query.data.truncated ? (
+                  <p>
+                    Partial history — only reports since{" "}
+                    {times.format(query.data.sinceMs)} UTC are included. Choose
+                    a shorter period to see more complete counts.
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <p>Browse individual reports in the event log.</p>
+            )}
+          </div>
           <Link
             className={cn(
               buttonVariants({
-                className: "h-11 lg:h-8",
+                className: "h-11 px-4 sm:h-9",
                 size: "lg",
                 variant: "outline",
               }),
@@ -376,53 +453,8 @@ export function InsightsOverview({ input }: { readonly input: RecoveryInput }) {
             <ListIcon aria-hidden="true" data-icon="inline-start" />
             All events
           </Link>
-          <Button
-            aria-label="Refresh bundle activity"
-            variant="ghost"
-            size="icon-sm"
-            disabled={query.isFetching}
-            onClick={() => void query.refetch()}
-          >
-            <RotateCw aria-hidden="true" />
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 px-4 pb-4 sm:px-6 sm:pb-6">
-        {query.isPending ? (
-          <Skeleton
-            aria-label="Loading bundle activity"
-            className="h-64 w-full"
-          />
-        ) : query.error ? (
-          <InsightsErrorAlert
-            error={query.error}
-            fallbackTitle="Bundle activity unavailable"
-          />
-        ) : query.data ? (
-          <ActivityChart key={JSON.stringify(input)} report={query.data} />
-        ) : null}
-      </CardContent>
-      {query.data && !query.error ? (
-        <CardFooter className="flex-col items-start gap-2 border-t bg-muted/15 px-4 py-3 text-xs text-muted-foreground sm:px-6">
-          <p>
-            Active follows each installation’s last reported ID in this period.
-            Rollbacks count installations recovered from each ID per interval.
-          </p>
-          {query.data.unattributedInstallations > 0 ? (
-            <p>
-              {query.data.unattributedInstallations.toLocaleString()} reporting
-              installations have no observed bundle ID and are excluded.
-            </p>
-          ) : null}
-          {query.data.truncated ? (
-            <p>
-              Partial history — only reports since{" "}
-              {times.format(query.data.sinceMs)} UTC are included. Choose a
-              shorter period to see more complete counts.
-            </p>
-          ) : null}
         </CardFooter>
-      ) : null}
-    </Card>
+      </Card>
+    </Tabs>
   );
 }

--- a/packages/console/src/components/features/insights/InsightsPageHeader.tsx
+++ b/packages/console/src/components/features/insights/InsightsPageHeader.tsx
@@ -27,7 +27,7 @@ export function InsightsPageHeader({
             buttonVariants({
               className: "h-11 px-3 lg:h-8 lg:px-2.5",
               size: "lg",
-              variant: view === "overview" ? "contrast" : "outline",
+              variant: view === "overview" ? "secondary" : "ghost",
             }),
           )}
           to="/insights"
@@ -40,7 +40,7 @@ export function InsightsPageHeader({
             buttonVariants({
               className: "h-11 px-3 lg:h-8 lg:px-2.5",
               size: "lg",
-              variant: view === "events" ? "contrast" : "outline",
+              variant: view === "events" ? "secondary" : "ghost",
             }),
           )}
           to="/installations"

--- a/packages/console/src/components/features/insights/InstallationHistoryCard.spec.tsx
+++ b/packages/console/src/components/features/insights/InstallationHistoryCard.spec.tsx
@@ -39,7 +39,7 @@ describe("InstallationHistoryCard", () => {
     );
 
     expect(screen.getByText("user-1")).toBeDefined();
-    expect(screen.getAllByText("Bundle applied").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Update applied").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(onNext).toHaveBeenCalledOnce();
   });

--- a/packages/console/src/components/features/insights/InstallationHistoryCard.tsx
+++ b/packages/console/src/components/features/insights/InstallationHistoryCard.tsx
@@ -22,7 +22,7 @@ import type {
 import {
   EventBundleTransition,
   EventTimestamp,
-  EventTypeBadge,
+  EventTypeDetails,
   useInsightsTimeFormat,
 } from "./EventDetails";
 import { EventHistoryList } from "./EventHistoryList";
@@ -192,7 +192,7 @@ export function InstallationHistoryCard({
                           />
                         </TableCell>
                         <TableCell>
-                          <EventTypeBadge type={event.type} />
+                          <EventTypeDetails type={event.type} />
                         </TableCell>
                         <TableCell className="whitespace-normal text-xs">
                           <div className="flex flex-col gap-2">

--- a/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
+++ b/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
@@ -24,16 +24,15 @@ export function ReportingDevicesSummary({
       className="flex items-center justify-between"
       role="region"
     >
-      <CardHeader className="min-w-0 gap-2 p-4 sm:px-6">
+      <CardHeader className="min-w-0 gap-2 p-6 sm:px-8">
         <CardTitle className="text-sm font-medium">
           Reporting devices · 30d
         </CardTitle>
         <CardDescription>
-          Latest report in this platform and channel within 30 days. Each
-          installation is counted once.
+          Installations last seen in this scope within 30 days.
         </CardDescription>
       </CardHeader>
-      <CardContent className="shrink-0 p-4 sm:px-6">
+      <CardContent className="shrink-0 p-6 sm:px-8">
         {query.isPending ? (
           <Skeleton
             aria-label="Loading reporting devices"

--- a/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
+++ b/packages/console/src/components/features/releases/ReleaseEditorSheet.spec.tsx
@@ -21,7 +21,7 @@ const recovery = vi.fn();
 vi.mock("@/components/features/bundles/BundleInsightsSummary", () => ({
   BundleInsightsSummary: (props: unknown) => {
     recovery(props);
-    return <div>Activity · 30 days</div>;
+    return <div>Activity · 24 hours</div>;
   },
 }));
 
@@ -201,7 +201,7 @@ describe("ReleaseEditorSheet", () => {
     expect(screen.queryByText("Rollout activity")).toBeNull();
     expect(
       screen
-        .getByText("Activity · 30 days")
+        .getByText("Activity · 24 hours")
         .compareDocumentPosition(screen.getByText("Delivery settings")) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();

--- a/packages/console/src/components/ui/button.tsx
+++ b/packages/console/src/components/ui/button.tsx
@@ -13,7 +13,6 @@ const buttonVariants = cva(
           "border-border dark:bg-input/30 hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        contrast: "bg-foreground text-background hover:bg-foreground/90",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/packages/console/src/components/ui/card.tsx
+++ b/packages/console/src/components/ui/card.tsx
@@ -19,7 +19,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      className={cn("flex flex-col gap-1.5 p-6", className)}
       {...props}
     />
   );

--- a/packages/console/src/components/ui/tabs.tsx
+++ b/packages/console/src/components/ui/tabs.tsx
@@ -1,0 +1,81 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      orientation={orientation}
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start group-data-vertical/tabs:py-[calc(--spacing(1.25))] hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-xs/relaxed outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/packages/console/src/components/ui/toggle.tsx
+++ b/packages/console/src/components/ui/toggle.tsx
@@ -10,8 +10,6 @@ const toggleVariants = cva(
       variant: {
         default: "bg-transparent",
         outline: "border border-input bg-transparent hover:bg-muted",
-        contrast:
-          "border border-input bg-transparent aria-pressed:border-foreground aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground aria-pressed:hover:text-background",
       },
       size: {
         default:

--- a/packages/console/src/lib/insights-recovery.ts
+++ b/packages/console/src/lib/insights-recovery.ts
@@ -11,7 +11,7 @@ export type RecoveryPoint = {
   readonly startMs: number;
   readonly active: number | null;
   readonly recoveredInstallations: number;
-  readonly adopted: number;
+  readonly applied: number;
   readonly recovered: number;
   readonly rate: number | null;
   readonly spike: boolean;
@@ -19,7 +19,7 @@ export type RecoveryPoint = {
 
 export type RecoverySeries = {
   readonly releaseId: string;
-  readonly firstAdoptedAtMs: number | null;
+  readonly firstAppliedAtMs: number | null;
   readonly activeInstallations: number;
   readonly recoveredInstallations: number;
   readonly points: readonly RecoveryPoint[];

--- a/packages/console/src/lib/insights-view.ts
+++ b/packages/console/src/lib/insights-view.ts
@@ -11,5 +11,5 @@ export type InsightsViewPage<TRow> = {
 export const outcomeLabels = {
   applied: "Applied reports",
   recovered: "Recovered-from reports",
-  adopted: "Adopted reports",
+  unchanged: "No-change reports",
 } as const;

--- a/packages/console/src/lib/server/insightsRecovery.spec.ts
+++ b/packages/console/src/lib/server/insightsRecovery.spec.ts
@@ -25,7 +25,7 @@ const event = (
     install_id: `install-${sequence}`,
     type,
     received_at_ms: hour * HOUR,
-    from_bundle_id: "same-file",
+    from_bundle_id: type === "UNCHANGED" ? null : "same-file",
     to_bundle_id: "same-file",
     from_release_id: type === "RECOVERED" ? releaseId : null,
     to_release_id: type === "RECOVERED" ? "stable-release" : releaseId,
@@ -37,16 +37,16 @@ const event = (
     cohort: "default",
     fingerprint_hash: null,
     sdk_version: null,
-    update_strategy: "appVersion",
+    update_strategy: type === "UNCHANGED" ? null : "appVersion",
     ...overrides,
   }) as BundleEventRow;
 const reports = (
-  adopted: number,
+  applied: number,
   recovered: number,
   hour: number,
   id = "release-a",
 ) => [
-  ...Array.from({ length: adopted }, () => event("UPDATE_APPLIED", hour, id)),
+  ...Array.from({ length: applied }, () => event("UPDATE_APPLIED", hour, id)),
   ...Array.from({ length: recovered }, () =>
     event("RECOVERED", hour + 0.001, id),
   ),
@@ -89,13 +89,13 @@ describe("observed bundle activity", () => {
         event("UPDATE_APPLIED", 25, "old-id", { install_id: `device-${i}` }),
       ),
       ...Array.from({ length: 5 }, (_, i) =>
-        event("RELEASE_ADOPTED", 26, "new-id", {
+        event("UNCHANGED", 26, "new-id", {
           install_id: `device-${i}`,
           from_release_id: "old-id",
         }),
       ),
       ...Array.from({ length: 4 }, (_, i) =>
-        event("RELEASE_ADOPTED", 27, "new-id", {
+        event("UNCHANGED", 27, "new-id", {
           install_id: `device-${i + 5}`,
           from_release_id: "old-id",
         }),
@@ -117,6 +117,9 @@ describe("observed bundle activity", () => {
     expect(
       [25, 26, 27].map((hour) => pointAt(hourly, hour, "new-id").active),
     ).toEqual([0, 5, 9]);
+    // Same-file selection reports move Active counts without counting a new update.
+    expect(pointAt(hourly, 26, "new-id").applied).toBe(0);
+    expect(seriesFor(hourly, "new-id").firstAppliedAtMs).toBeNull();
     expect(pointAt(hourly, 24, "new-id").active).toBeNull();
     expect(pointAt(hourly, 28, "old-id").active).toBe(1);
     const detail = await getRecoveryReport(
@@ -208,7 +211,7 @@ describe("observed bundle activity", () => {
         ...reports(7, 3, 28),
         ...reports(7, 3, 29),
         ...reports(5, 5, 30),
-        event("RELEASE_ADOPTED", 28, "other-id"),
+        event("UNCHANGED", 28, "other-id"),
       ]),
       input,
       now,
@@ -220,7 +223,7 @@ describe("observed bundle activity", () => {
     ).toEqual([28 * HOUR, 30 * HOUR]);
     expect(pointAt(report, 27).rate).toBeNull();
     expect(pointAt(report, 28)).toMatchObject({
-      adopted: 7,
+      applied: 7,
       recovered: 3,
       rate: 30,
     });
@@ -250,9 +253,7 @@ describe("observed bundle activity", () => {
   it("reads timestamp ties once and batches visible bundles without one scan per row", async () => {
     const model = modelFor([
       ...reports(198, 3, 25),
-      ...Array.from({ length: 105 }, () =>
-        event("RELEASE_ADOPTED", 25, "other-id"),
-      ),
+      ...Array.from({ length: 105 }, () => event("UNCHANGED", 25, "other-id")),
     ]);
     const batch = await getBundleActivity(
       model,
@@ -284,7 +285,7 @@ describe("observed bundle activity", () => {
     expect(seriesFor(report).points).toHaveLength(1);
     expect(pointAt(report, 47)).toMatchObject({
       active: 7,
-      adopted: 7,
+      applied: 7,
       recovered: 3,
       recoveredInstallations: 3,
       rate: 30,

--- a/packages/console/src/lib/server/insightsRecovery.ts
+++ b/packages/console/src/lib/server/insightsRecovery.ts
@@ -31,12 +31,12 @@ export function buildRecoveryReport(
   const releases = new Map<
     string,
     {
-      firstAdoptedAtMs: number | null;
+      firstAppliedAtMs: number | null;
       recovered: Set<string>;
       buckets: Map<
         number,
         {
-          adopted: number;
+          applied: number;
           recovered: number;
           installations: Set<string>;
           lastRecoveredAtMs: number;
@@ -48,7 +48,7 @@ export function buildRecoveryReport(
     let release = releases.get(id);
     if (!release) {
       release = {
-        firstAdoptedAtMs: null,
+        firstAppliedAtMs: null,
         recovered: new Set(),
         buckets: new Map(),
       };
@@ -78,7 +78,7 @@ export function buildRecoveryReport(
       const inScope =
         row.platform === input.platform && row.channel === input.channel;
       const previous = latest.get(row.install_id);
-      // Older SDKs omit the ID on UNCHANGED. Only retain an observed ID for the same file and scope.
+      // Lifecycle reports can omit the ID on UNCHANGED. Only retain an observed ID for the same file and scope.
       const releaseId =
         row.to_release_id ??
         (row.type === "UNCHANGED" &&
@@ -110,14 +110,12 @@ export function buildRecoveryReport(
         row.type === "RECOVERED" ? row.from_release_id : row.to_release_id;
       if (
         !outcomeId ||
-        (row.type !== "RECOVERED" &&
-          row.type !== "RELEASE_ADOPTED" &&
-          row.type !== "UPDATE_APPLIED")
+        (row.type !== "RECOVERED" && row.type !== "UPDATE_APPLIED")
       )
         continue;
       const release = ensureRelease(outcomeId);
       const bucket = release.buckets.get(startMs) ?? {
-        adopted: 0,
+        applied: 0,
         recovered: 0,
         installations: new Set<string>(),
         lastRecoveredAtMs: -1,
@@ -128,8 +126,8 @@ export function buildRecoveryReport(
         bucket.lastRecoveredAtMs = row.received_at_ms;
         release.recovered.add(row.install_id);
       } else {
-        bucket.adopted += 1;
-        release.firstAdoptedAtMs ??= row.received_at_ms;
+        bucket.applied += 1;
+        release.firstAppliedAtMs ??= row.received_at_ms;
       }
       release.buckets.set(startMs, bucket);
     }
@@ -142,13 +140,13 @@ export function buildRecoveryReport(
     let previousRate: number | null = null;
     const points = Array.from(snapshots, ([startMs, snapshot]) => {
       const bucket = release.buckets.get(startMs);
-      const adopted = bucket?.adopted ?? 0;
+      const applied = bucket?.applied ?? 0;
       const recovered = bucket?.recovered ?? 0;
-      const total = adopted + recovered;
+      const total = applied + recovered;
       const rate = total === 0 ? null : (recovered / total) * 100;
       const spike =
-        release.firstAdoptedAtMs !== null &&
-        (bucket?.lastRecoveredAtMs ?? -1) >= release.firstAdoptedAtMs &&
+        release.firstAppliedAtMs !== null &&
+        (bucket?.lastRecoveredAtMs ?? -1) >= release.firstAppliedAtMs &&
         (!truncated || previousRate !== null) &&
         rate !== null &&
         total >= 10 &&
@@ -160,7 +158,7 @@ export function buildRecoveryReport(
         startMs,
         active: snapshot ? (snapshot.get(releaseId) ?? 0) : null,
         recoveredInstallations: bucket?.installations.size ?? 0,
-        adopted,
+        applied,
         recovered,
         rate,
         spike,
@@ -168,7 +166,7 @@ export function buildRecoveryReport(
     });
     series.push({
       releaseId,
-      firstAdoptedAtMs: release.firstAdoptedAtMs,
+      firstAppliedAtMs: release.firstAppliedAtMs,
       activeInstallations: active.get(releaseId) ?? 0,
       recoveredInstallations: release.recovered.size,
       points,

--- a/packages/console/src/routes/-insights.spec.tsx
+++ b/packages/console/src/routes/-insights.spec.tsx
@@ -6,9 +6,17 @@ vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (options: unknown) => ({ options }),
 }));
 vi.mock("@/components/features/insights/InsightsOverview", () => ({
-  InsightsOverview: (props: unknown) => {
-    mocks.activity(props);
-    return <div>Bundle activity</div>;
+  InsightsOverview: (props: {
+    input: unknown;
+    onWindowChange: (window: string) => void;
+  }) => {
+    mocks.activity({ input: props.input });
+    return (
+      <div>
+        Bundle activity
+        <button onClick={() => props.onWindowChange("7d")}>7 days</button>
+      </div>
+    );
   },
 }));
 vi.mock("@/components/features/insights/InsightsPageHeader", () => ({
@@ -30,7 +38,7 @@ afterEach(() => {
 });
 
 describe("Insights overview", () => {
-  it("defaults to all IDs over 24 hours and changes only the period or platform/channel scope", () => {
+  it("defaults to all IDs over 24 hours and changes only the period or platform/channel scope", async () => {
     render(<InsightsPage />);
     expect(mocks.activity).toHaveBeenLastCalledWith({
       input: { platform: "ios", channel: "production", window: "24h" },
@@ -45,7 +53,10 @@ describe("Insights overview", () => {
       platform: "ios",
       channel: "production",
     });
-    fireEvent.click(screen.getByRole("button", { name: "Android" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Platform" }));
+    const android = await screen.findByRole("option", { name: "Android" });
+    fireEvent.pointerDown(android);
+    fireEvent.click(android);
     fireEvent.change(screen.getByLabelText("Channel"), {
       target: { value: "beta" },
     });

--- a/packages/console/src/routes/-installations.spec.tsx
+++ b/packages/console/src/routes/-installations.spec.tsx
@@ -129,7 +129,7 @@ describe("InstallationsPage", () => {
       true,
     );
     expect(screen.getByRole("heading", { name: "All events" })).toBeDefined();
-    for (const label of ["Activity reported", "Bundle applied", "Recovered"]) {
+    for (const label of ["No change", "Update applied", "Rolled back"]) {
       expect(screen.getAllByText(label).length).toBeGreaterThan(0);
     }
 

--- a/packages/console/src/routes/insights.tsx
+++ b/packages/console/src/routes/insights.tsx
@@ -24,20 +24,19 @@ function InsightsPage() {
   return (
     <div className="flex h-svh min-h-0 flex-col">
       <InsightsPageHeader view="overview" />
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-muted/5 p-3 sm:p-6">
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 sm:gap-6">
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-muted/5 px-4 py-6 sm:p-8">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 sm:gap-8">
           <InsightsControls
             scope={scope}
             onScopeChange={(next) => {
               setScope(next);
             }}
-            onWindowChange={(next) => {
-              setWindow(next);
-            }}
-            window={window}
           />
           <ReportingDevicesSummary scope={scope} />
-          <InsightsOverview input={{ ...scope, window }} />
+          <InsightsOverview
+            input={{ ...scope, window }}
+            onWindowChange={setWindow}
+          />
         </div>
       </div>
     </div>

--- a/packages/react-native/src/checkForUpdate.releaseCatalog.spec.ts
+++ b/packages/react-native/src/checkForUpdate.releaseCatalog.spec.ts
@@ -208,7 +208,7 @@ describe("checkForUpdate Release catalog protocol", () => {
     });
   });
 
-  it("sends RELEASE_ADOPTED only when insights is enabled", async () => {
+  it("reports same-file selection as UNCHANGED with the selected release identity", async () => {
     const active: PersistedSelectionReceipt = {
       catalogId: CATALOG_ID,
       bundleId: TARGET_BUNDLE_ID,
@@ -239,11 +239,12 @@ describe("checkForUpdate Release catalog protocol", () => {
 
     expect(sendInsightsEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        fromBundleId: TARGET_BUNDLE_ID,
+        fromBundleId: null,
+        updateStrategy: null,
         fromReleaseId: MINIMUM_RELEASE_ID,
         toBundleId: TARGET_BUNDLE_ID,
         toReleaseId: RELEASE_ID,
-        type: "RELEASE_ADOPTED",
+        type: "UNCHANGED",
       }),
     );
   });

--- a/packages/react-native/src/checkForUpdate.ts
+++ b/packages/react-native/src/checkForUpdate.ts
@@ -128,7 +128,7 @@ const resetProgress = () => {
   });
 };
 
-const notifyReleaseAdoption = async (input: {
+const notifyUnchangedSelection = async (input: {
   readonly active: PersistedSelectionReceipt | null;
   readonly desired: PersistedSelectionReceipt;
   readonly appVersion: string;
@@ -138,7 +138,6 @@ const notifyReleaseAdoption = async (input: {
   readonly session: HotUpdaterHttpSession;
   readonly requestHeaders?: Record<string, string>;
   readonly requestTimeout?: number;
-  readonly updateStrategy: "appVersion" | "fingerprint";
 }): Promise<void> => {
   const { userId, username } = getPersistedUserIdentity();
   try {
@@ -147,7 +146,7 @@ const notifyReleaseAdoption = async (input: {
       channel: input.desired.channel,
       cohort: input.cohort,
       fingerprintHash: input.fingerprintHash,
-      fromBundleId: input.desired.bundleId,
+      fromBundleId: null,
       fromReleaseId: input.active?.releaseId ?? null,
       installId: getInstallId(),
       platform: input.platform,
@@ -155,13 +154,13 @@ const notifyReleaseAdoption = async (input: {
       requestTimeout: input.requestTimeout,
       toBundleId: input.desired.bundleId,
       toReleaseId: input.desired.releaseId,
-      type: "RELEASE_ADOPTED",
-      updateStrategy: input.updateStrategy,
+      type: "UNCHANGED",
+      updateStrategy: null,
       ...(userId === undefined ? {} : { userId }),
       ...(username === undefined ? {} : { username }),
     });
   } catch (error) {
-    console.warn("[HotUpdater] Release adoption insights failed:", error);
+    console.warn("[HotUpdater] Unchanged selection insights failed:", error);
   }
 };
 
@@ -341,7 +340,7 @@ async function checkForReleaseCatalogUpdate(input: {
         selection: receipt,
       });
       if (committed && transitionKind === "ADOPT_RELEASE" && options.insights) {
-        await notifyReleaseAdoption({
+        await notifyUnchangedSelection({
           active,
           appVersion: input.currentAppVersion,
           cohort: input.cohort,
@@ -351,7 +350,6 @@ async function checkForReleaseCatalogUpdate(input: {
           requestHeaders: options.requestHeaders,
           requestTimeout: options.requestTimeout,
           session,
-          updateStrategy: options.updateStrategy,
         });
       }
       return committed;

--- a/packages/react-native/src/httpClient.ts
+++ b/packages/react-native/src/httpClient.ts
@@ -43,7 +43,7 @@ interface InsightsEventCommonParams {
 }
 
 type InsightsTransitionEventParams = InsightsEventCommonParams & {
-  readonly type: "UPDATE_APPLIED" | "RECOVERED" | "RELEASE_ADOPTED";
+  readonly type: "UPDATE_APPLIED" | "RECOVERED";
   readonly fromBundleId: string;
   readonly toBundleId: string;
   readonly updateStrategy: "fingerprint" | "appVersion";

--- a/packages/server/src/adapters/prismaRows.ts
+++ b/packages/server/src/adapters/prismaRows.ts
@@ -168,9 +168,7 @@ export const parsePrismaBundleEventRow = (value: unknown): BundleEventRow => {
   if (
     (platform !== "ios" && platform !== "android") ||
     !(
-      ((type === "UPDATE_APPLIED" ||
-        type === "RECOVERED" ||
-        type === "RELEASE_ADOPTED") &&
+      ((type === "UPDATE_APPLIED" || type === "RECOVERED") &&
         typeof fromBundleId === "string" &&
         (updateStrategy === "fingerprint" ||
           updateStrategy === "appVersion")) ||
@@ -210,10 +208,7 @@ export const parsePrismaInsightsInstallationRow = (
   const type = readString(value, "type");
   if (
     (platform !== "ios" && platform !== "android") ||
-    (type !== "UPDATE_APPLIED" &&
-      type !== "RECOVERED" &&
-      type !== "RELEASE_ADOPTED" &&
-      type !== "UNCHANGED")
+    (type !== "UPDATE_APPLIED" && type !== "RECOVERED" && type !== "UNCHANGED")
   ) {
     throw new PrismaAdapterError("invalid installation fields");
   }

--- a/packages/server/src/insights/domain.ts
+++ b/packages/server/src/insights/domain.ts
@@ -15,7 +15,7 @@ export type CreateBundleEventRequestBase = {
 
 export type CreateBundleEventRequest =
   | (CreateBundleEventRequestBase & {
-      readonly type: "UPDATE_APPLIED" | "RECOVERED" | "RELEASE_ADOPTED";
+      readonly type: "UPDATE_APPLIED" | "RECOVERED";
       readonly fromBundleId: string;
       readonly updateStrategy: "fingerprint" | "appVersion";
     })
@@ -30,11 +30,7 @@ export type ActiveInstallationWindow = "24h" | "7d" | "30d";
 export type EventHistoryRow = {
   readonly id: string;
   readonly installId: string;
-  readonly type:
-    | "UPDATE_APPLIED"
-    | "RECOVERED"
-    | "RELEASE_ADOPTED"
-    | "UNCHANGED";
+  readonly type: "UPDATE_APPLIED" | "RECOVERED" | "UNCHANGED";
   readonly fromBundleId: string | null;
   readonly toBundleId: string;
   readonly username: string | null;
@@ -80,7 +76,7 @@ export type InsightsScope = {
 
 export type InsightsBundleSelection = InsightsScope & {
   readonly bundleId: string;
-  readonly outcome: "applied" | "recovered" | "adopted";
+  readonly outcome: "applied" | "recovered" | "unchanged";
 };
 
 export type InsightsCountMeasurement = {
@@ -98,6 +94,6 @@ export type ReportingOverview = InsightsScope & {
     readonly reportingInstallations: InsightsCountMeasurement;
     readonly appliedReports: InsightsCountMeasurement;
     readonly recoveredReports: InsightsCountMeasurement;
-    readonly adoptedReports: InsightsCountMeasurement;
+    readonly unchangedReports: InsightsCountMeasurement;
   };
 };

--- a/packages/server/src/insights/eventInput.ts
+++ b/packages/server/src/insights/eventInput.ts
@@ -147,8 +147,7 @@ function requireEvent(payload: unknown): CreateBundleEventRequest {
   const type = requireStringField(payload, "type");
   switch (type) {
     case "UPDATE_APPLIED":
-    case "RECOVERED":
-    case "RELEASE_ADOPTED": {
+    case "RECOVERED": {
       const updateStrategy = requireStringField(payload, "updateStrategy");
       if (updateStrategy !== "fingerprint" && updateStrategy !== "appVersion") {
         throw new InsightsBadRequestError(
@@ -207,7 +206,6 @@ export function createBundleEventRow(
   switch (input.type) {
     case "UPDATE_APPLIED":
     case "RECOVERED":
-    case "RELEASE_ADOPTED":
       return {
         ...base,
         from_bundle_id: input.fromBundleId,

--- a/packages/server/src/insights/insights.integration.spec.ts
+++ b/packages/server/src/insights/insights.integration.spec.ts
@@ -140,10 +140,10 @@ describe("createHotUpdater Insights", () => {
     });
     await report(300, {
       installId: "install-2",
-      type: "RELEASE_ADOPTED",
-      fromBundleId: "B",
+      type: "UNCHANGED",
+      fromBundleId: null,
       toBundleId: "B",
-      updateStrategy: "appVersion",
+      updateStrategy: null,
     });
     await report(400, {
       installId: "install-3",
@@ -166,7 +166,7 @@ describe("createHotUpdater Insights", () => {
         reportingInstallations: { count: 1 },
         appliedReports: { count: 1 },
         recoveredReports: { count: 1 },
-        adoptedReports: { count: 1 },
+        unchangedReports: { count: 1 },
       },
     });
     const drilldown = await hotUpdater.handlers.admin(
@@ -253,6 +253,44 @@ describe("createHotUpdater Insights", () => {
     expect(adminIngestion.status).toBe(404);
     expect(adminQuery.status).toBe(200);
     expect(adminQuery.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("records same-file selection as no change and rejects a fourth event type", async () => {
+    const database = createInMemoryDatabasePlugin();
+    const record = vi.spyOn(database.models.insights, "record");
+    const hotUpdater = createHotUpdater({
+      database,
+      clientAccess: { type: "public" },
+    });
+    const selection = {
+      ...event,
+      fromReleaseId: "previous-release",
+      toReleaseId: "selected-release",
+    };
+    expect(
+      (await hotUpdater.handlers.client(eventRequest(selection))).status,
+    ).toBe(204);
+    expect(record).toHaveBeenCalledWith({
+      event: expect.objectContaining({
+        type: "UNCHANGED",
+        from_bundle_id: null,
+        update_strategy: null,
+        from_release_id: "previous-release",
+        to_release_id: "selected-release",
+        to_bundle_id: event.toBundleId,
+      }),
+      installation: expect.objectContaining({ type: "UNCHANGED" }),
+    });
+    const response = await hotUpdater.handlers.client(
+      eventRequest({
+        ...selection,
+        type: "RELEASE_ADOPTED",
+        fromBundleId: event.toBundleId,
+        updateStrategy: "appVersion",
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(record).toHaveBeenCalledTimes(1);
   });
 
   it("returns a stable client error for malformed event payloads", async () => {

--- a/packages/server/src/insights/provider.spec.ts
+++ b/packages/server/src/insights/provider.spec.ts
@@ -13,7 +13,7 @@ const eventId = (index: number) =>
 
 type TransitionEventRow = Extract<
   BundleEventRow,
-  { readonly type: "UPDATE_APPLIED" | "RECOVERED" | "RELEASE_ADOPTED" }
+  { readonly type: "UPDATE_APPLIED" | "RECOVERED" }
 >;
 
 const eventRow = (
@@ -269,13 +269,13 @@ describe("createInsightsProvider", () => {
     expect(result.bundle?.reportingInstallations.count).toBe(2);
     expect(result.bundle?.appliedReports.count).toBe(5);
     expect(result.bundle?.recoveredReports.count).toBe(3);
-    expect(result.bundle?.adoptedReports.count).toBe(1);
+    expect(result.bundle?.unchangedReports.count).toBe(1);
     expect(
       fixture.countEvents.mock.calls.map(([input]) => input.filter),
     ).toEqual([
       { ...scope, type: "UPDATE_APPLIED", toBundleId: "B" },
       { ...scope, type: "RECOVERED", fromBundleId: "B" },
-      { ...scope, type: "RELEASE_ADOPTED", toBundleId: "B" },
+      { ...scope, type: "UNCHANGED", toBundleId: "B" },
     ]);
     await provider.listEvents({
       bundle: { ...scope, bundleId: "B", outcome: "recovered" },

--- a/packages/server/src/insights/provider.ts
+++ b/packages/server/src/insights/provider.ts
@@ -157,8 +157,8 @@ const bundleFilter = (
       return { ...scope, type: "UPDATE_APPLIED", toBundleId: bundleId };
     case "recovered":
       return { ...scope, type: "RECOVERED", fromBundleId: bundleId };
-    case "adopted":
-      return { ...scope, type: "RELEASE_ADOPTED", toBundleId: bundleId };
+    case "unchanged":
+      return { ...scope, type: "UNCHANGED", toBundleId: bundleId };
     default:
       throw new InsightsBadRequestError("Invalid Insights outcome.");
   }
@@ -565,13 +565,13 @@ export const createInsightsProvider = (
         bundleInstallations,
         appliedReports,
         recoveredReports,
-        adoptedReports,
+        unchangedReports,
       ] = await Promise.all([
         reporting,
         measure(model.countInstallations({ ...scope, sinceMs, bundleId })),
         countOutcome("applied"),
         countOutcome("recovered"),
-        countOutcome("adopted"),
+        countOutcome("unchanged"),
       ]);
       return {
         ...scope,
@@ -584,7 +584,7 @@ export const createInsightsProvider = (
           reportingInstallations: bundleInstallations,
           appliedReports,
           recoveredReports,
-          adoptedReports,
+          unchangedReports,
         },
       };
     },

--- a/packages/server/src/insights/queryInput.ts
+++ b/packages/server/src/insights/queryInput.ts
@@ -87,7 +87,7 @@ export const parseEventPageInput = (
     if (
       outcome !== "applied" &&
       outcome !== "recovered" &&
-      outcome !== "adopted"
+      outcome !== "unchanged"
     ) {
       throw new InsightsBadRequestError("Invalid 'outcome' query parameter.");
     }

--- a/packages/server/src/schema/v1_0_0.ts
+++ b/packages/server/src/schema/v1_0_0.ts
@@ -433,8 +433,7 @@ export const bundleEventsV100 = table(
     checks: [
       check({
         name: "bundle_events_type_check",
-        expression:
-          "type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')",
+        expression: "type in ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')",
         sqliteInline: true,
       }),
       check({
@@ -445,7 +444,7 @@ export const bundleEventsV100 = table(
       check({
         name: "bundle_events_shape_check",
         expression:
-          "((type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED')) and from_bundle_id is not null and update_strategy is not null and update_strategy in ('fingerprint', 'appVersion')) or (type = 'UNCHANGED' and from_bundle_id is null and update_strategy is null)",
+          "((type in ('UPDATE_APPLIED', 'RECOVERED')) and from_bundle_id is not null and update_strategy is not null and update_strategy in ('fingerprint', 'appVersion')) or (type = 'UNCHANGED' and from_bundle_id is null and update_strategy is null)",
         sqliteInline: true,
       }),
       check({
@@ -494,8 +493,7 @@ export const bundleInstallationsV100 = table(
     checks: [
       check({
         name: "bundle_installations_type_check",
-        expression:
-          "type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')",
+        expression: "type in ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')",
         sqliteInline: true,
       }),
       check({

--- a/packages/test-utils/src/databasePluginInsightsTests.ts
+++ b/packages/test-utils/src/databasePluginInsightsTests.ts
@@ -146,12 +146,12 @@ export const registerDatabasePluginInsightsTests = (
         to_bundle_id: bundleA,
         update_strategy: "appVersion",
       };
-      const adopted: BundleEventRow = {
+      const unchanged: BundleEventRow = {
         ...createBundleEventRowFixture("932", 130),
-        type: "RELEASE_ADOPTED",
-        from_bundle_id: bundleB,
+        type: "UNCHANGED",
+        from_bundle_id: null,
         to_bundle_id: bundleB,
-        update_strategy: "appVersion",
+        update_strategy: null,
       };
       const excluded = [
         {
@@ -186,8 +186,22 @@ export const registerDatabasePluginInsightsTests = (
           to_bundle_id: bundleB,
         },
       ];
-      for (const row of [applied, recovered, adopted, ...excluded])
+      for (const row of [applied, recovered, unchanged, ...excluded])
         await record(plugin, row);
+      await expect(async () =>
+        record(plugin, {
+          ...applied,
+          type: "RELEASE_ADOPTED",
+        } as unknown as BundleEventRow),
+      ).rejects.toThrow();
+      await expect(async () =>
+        record(plugin, {
+          ...applied,
+          type: "UNCHANGED",
+          from_bundle_id: bundleB,
+          update_strategy: "appVersion",
+        } as unknown as BundleEventRow),
+      ).rejects.toThrow();
       await expect(
         plugin.models.insights.findInstallations({ installId: "target" }),
       ).resolves.toEqual([toInsightsInstallationRow(recovered)]);
@@ -214,10 +228,10 @@ export const registerDatabasePluginInsightsTests = (
           {
             platform: "ios",
             channel: "production",
-            type: "RELEASE_ADOPTED",
+            type: "UNCHANGED",
             toBundleId: bundleB,
           },
-          adopted,
+          unchanged,
         ],
       ];
       for (const [filter, expected] of cases) {

--- a/packages/test-utils/src/databasePluginOfficialDomainTests.ts
+++ b/packages/test-utils/src/databasePluginOfficialDomainTests.ts
@@ -17,7 +17,7 @@ type OfficialDomainTestState = DatabasePluginTestState<DatabasePlugin>;
 const createMovementEvent = (
   suffix: string,
   receivedAtMs: number,
-  type: "UPDATE_APPLIED" | "RECOVERED" | "RELEASE_ADOPTED",
+  type: "UPDATE_APPLIED" | "RECOVERED",
   installId: string,
 ): BundleEventRow => {
   const row = createBundleEventRowFixture(suffix, receivedAtMs);
@@ -269,12 +269,13 @@ export const registerDatabasePluginOfficialDomainTests = (
 
     it("filters installation movements before applying the page limit", async () => {
       const plugin = state.getPlugin();
-      const adopted = createMovementEvent(
-        "711",
-        300,
-        "RELEASE_ADOPTED",
-        "install-target",
-      );
+      const unchanged: BundleEventRow = {
+        ...createBundleEventRowFixture("711", 300),
+        type: "UNCHANGED",
+        install_id: "install-target",
+        from_bundle_id: null,
+        update_strategy: null,
+      };
       const unrelated = createMovementEvent(
         "712",
         250,
@@ -293,7 +294,7 @@ export const registerDatabasePluginOfficialDomainTests = (
         "RECOVERED",
         "install-target",
       );
-      for (const row of [adopted, unrelated, applied, recovered]) {
+      for (const row of [unchanged, unrelated, applied, recovered]) {
         await plugin.models.insights.record({
           event: row,
           installation: toInsightsInstallationRow(row),

--- a/plugins/aws/src/dynamoDB.ts
+++ b/plugins/aws/src/dynamoDB.ts
@@ -2941,9 +2941,7 @@ const hasValidBundleEventShape = (value: object): boolean => {
   const fromBundleId = field(value, "from_bundle_id");
   const updateStrategy = field(value, "update_strategy");
   return (
-    ((type === "UPDATE_APPLIED" ||
-      type === "RECOVERED" ||
-      type === "RELEASE_ADOPTED") &&
+    ((type === "UPDATE_APPLIED" || type === "RECOVERED") &&
       typeof fromBundleId === "string" &&
       (updateStrategy === "fingerprint" || updateStrategy === "appVersion")) ||
     (type === "UNCHANGED" && fromBundleId === null && updateStrategy === null)
@@ -2975,7 +2973,6 @@ const isInsightsInstallationRow = (
   typeof field(value, "to_bundle_id") === "string" &&
   (field(value, "type") === "UPDATE_APPLIED" ||
     field(value, "type") === "RECOVERED" ||
-    field(value, "type") === "RELEASE_ADOPTED" ||
     field(value, "type") === "UNCHANGED") &&
   (field(value, "platform") === "ios" ||
     field(value, "platform") === "android") &&
@@ -3036,23 +3033,19 @@ const insightsBundlePartition = (filter: InsightsBundleEventFilter): string => {
   return `${DYNAMODB_INSIGHTS_BUNDLE_PREFIX}${createHash("sha256").update(scope, "utf8").digest("hex")}`;
 };
 
-const toInsightsBundleItem = (
-  row: BundleEventRow,
-): Record<string, unknown> | null =>
-  row.type === "UNCHANGED"
-    ? null
-    : boundedDynamoDBMetadataItem({
-        pk: insightsBundlePartition({
-          platform: row.platform,
-          channel: row.channel,
-          ...(row.type === "RECOVERED"
-            ? { type: row.type, fromBundleId: row.from_bundle_id }
-            : { type: row.type, toBundleId: row.to_bundle_id }),
-        }),
-        sk: insightsSortKey(row),
-        version: 1,
-        row,
-      });
+const toInsightsBundleItem = (row: BundleEventRow): Record<string, unknown> =>
+  boundedDynamoDBMetadataItem({
+    pk: insightsBundlePartition({
+      platform: row.platform,
+      channel: row.channel,
+      ...(row.type === "RECOVERED"
+        ? { type: row.type, fromBundleId: row.from_bundle_id }
+        : { type: row.type, toBundleId: row.to_bundle_id }),
+    }),
+    sk: insightsSortKey(row),
+    version: 1,
+    row,
+  });
 
 const toInsightsEventItem = (row: BundleEventRow): Record<string, unknown> => {
   const orderKey = insightsSortKey(row);
@@ -3180,9 +3173,7 @@ const recordDynamoDBInsightsEvent = async (
         },
       },
       { Put: { TableName: store.tableName, Item: eventItem } },
-      ...(bundleItem === null
-        ? []
-        : [{ Put: { TableName: store.tableName, Item: bundleItem } }]),
+      { Put: { TableName: store.tableName, Item: bundleItem } },
     ];
     if (current === null || advancesInsightsInstallation(next, current.row)) {
       actions.push({

--- a/plugins/cloudflare/sql/bundles.sql
+++ b/plugins/cloudflare/sql/bundles.sql
@@ -129,14 +129,14 @@ CREATE TABLE bundle_events (
   sdk_version TEXT,
   received_at_ms REAL NOT NULL,
   CONSTRAINT bundle_events_type_check CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   CONSTRAINT bundle_events_platform_check CHECK (
     platform IN ('ios', 'android')
   ),
   CONSTRAINT bundle_events_shape_check CHECK (
     (
-      type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED')
+      type IN ('UPDATE_APPLIED', 'RECOVERED')
       AND from_bundle_id IS NOT NULL
       AND update_strategy IS NOT NULL
       AND update_strategy IN ('fingerprint', 'appVersion')
@@ -162,7 +162,7 @@ CREATE TABLE bundle_installations (
   cohort TEXT NOT NULL,
   received_at_ms REAL NOT NULL,
   CONSTRAINT bundle_installations_type_check CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   CONSTRAINT bundle_installations_platform_check CHECK (
     platform IN ('ios', 'android')

--- a/plugins/cloudflare/src/d1Rows.ts
+++ b/plugins/cloudflare/src/d1Rows.ts
@@ -157,9 +157,7 @@ const eventRow = (row: Record<string, unknown>): BundleEventRow => {
   if (
     (platform !== "ios" && platform !== "android") ||
     !(
-      ((type === "UPDATE_APPLIED" ||
-        type === "RECOVERED" ||
-        type === "RELEASE_ADOPTED") &&
+      ((type === "UPDATE_APPLIED" || type === "RECOVERED") &&
         typeof fromBundleId === "string" &&
         (updateStrategy === "fingerprint" ||
           updateStrategy === "appVersion")) ||
@@ -195,9 +193,7 @@ const installationRow = (
   const type = stringValue(row, "type", "bundle_installations");
   const platform = stringValue(row, "platform", "bundle_installations");
   if (
-    !["UPDATE_APPLIED", "RECOVERED", "RELEASE_ADOPTED", "UNCHANGED"].includes(
-      type,
-    ) ||
+    !["UPDATE_APPLIED", "RECOVERED", "UNCHANGED"].includes(type) ||
     (platform !== "ios" && platform !== "android")
   ) {
     throw new InvalidD1RowError("bundle_installations");

--- a/plugins/cloudflare/worker/migrations/0001_hot-updater_1.0.0.sql
+++ b/plugins/cloudflare/worker/migrations/0001_hot-updater_1.0.0.sql
@@ -131,14 +131,14 @@ CREATE TABLE bundle_events (
   sdk_version TEXT,
   received_at_ms REAL NOT NULL,
   CONSTRAINT bundle_events_type_check CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   CONSTRAINT bundle_events_platform_check CHECK (
     platform IN ('ios', 'android')
   ),
   CONSTRAINT bundle_events_shape_check CHECK (
     (
-      type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED')
+      type IN ('UPDATE_APPLIED', 'RECOVERED')
       AND from_bundle_id IS NOT NULL
       AND update_strategy IS NOT NULL
       AND update_strategy IN ('fingerprint', 'appVersion')
@@ -164,7 +164,7 @@ CREATE TABLE bundle_installations (
   cohort TEXT NOT NULL,
   received_at_ms REAL NOT NULL,
   CONSTRAINT bundle_installations_type_check CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   CONSTRAINT bundle_installations_platform_check CHECK (
     platform IN ('ios', 'android')

--- a/plugins/firebase/src/firebaseDatabaseParser.ts
+++ b/plugins/firebase/src/firebaseDatabaseParser.ts
@@ -114,9 +114,7 @@ export const parseFirebaseBundleEventRow = (
   );
   if (
     !(
-      ((type === "UPDATE_APPLIED" ||
-        type === "RECOVERED" ||
-        type === "RELEASE_ADOPTED") &&
+      ((type === "UPDATE_APPLIED" || type === "RECOVERED") &&
         typeof fromBundleId === "string" &&
         (updateStrategy === "fingerprint" ||
           updateStrategy === "appVersion")) ||
@@ -158,7 +156,6 @@ export const parseFirebaseInsightsInstallationRow = (
   if (
     type !== "UPDATE_APPLIED" &&
     type !== "RECOVERED" &&
-    type !== "RELEASE_ADOPTED" &&
     type !== "UNCHANGED"
   ) {
     throw new FirebaseDatabaseDataError(source);

--- a/plugins/plugin-core/src/databasePluginCrudValidationFields.ts
+++ b/plugins/plugin-core/src/databasePluginCrudValidationFields.ts
@@ -137,7 +137,6 @@ export const modelValidators: ValidatorMap = {
     type: (value) =>
       value === "UPDATE_APPLIED" ||
       value === "RECOVERED" ||
-      value === "RELEASE_ADOPTED" ||
       value === "UNCHANGED",
     install_id: isInsightsIdentityText,
     user_id: isNullableInsightsIdentityText,
@@ -166,7 +165,6 @@ export const modelValidators: ValidatorMap = {
     type: (value) =>
       value === "UPDATE_APPLIED" ||
       value === "RECOVERED" ||
-      value === "RELEASE_ADOPTED" ||
       value === "UNCHANGED",
     platform: (value) => value === "ios" || value === "android",
     app_version: (value) => typeof value === "string",

--- a/plugins/plugin-core/src/databasePluginCrudValidationRows.ts
+++ b/plugins/plugin-core/src/databasePluginCrudValidationRows.ts
@@ -34,9 +34,7 @@ const hasValidReleaseInvariants = (
 const hasValidBundleEventInvariants = (
   data: Readonly<Record<string, unknown>>,
 ): boolean =>
-  ((data.type === "UPDATE_APPLIED" ||
-    data.type === "RECOVERED" ||
-    data.type === "RELEASE_ADOPTED") &&
+  ((data.type === "UPDATE_APPLIED" || data.type === "RECOVERED") &&
     typeof data.from_bundle_id === "string" &&
     (data.update_strategy === "fingerprint" ||
       data.update_strategy === "appVersion")) ||

--- a/plugins/plugin-core/src/insightsContract.ts
+++ b/plugins/plugin-core/src/insightsContract.ts
@@ -59,7 +59,7 @@ const isBundleFilter = (value: unknown, withKind = false): boolean => {
   return value.type === "RECOVERED"
     ? isText(value.fromBundleId) &&
         hasOnlyKeys(value, [...keys, "fromBundleId"])
-    : (value.type === "UPDATE_APPLIED" || value.type === "RELEASE_ADOPTED") &&
+    : (value.type === "UPDATE_APPLIED" || value.type === "UNCHANGED") &&
         isText(value.toBundleId) &&
         hasOnlyKeys(value, [...keys, "toBundleId"]);
 };
@@ -118,7 +118,7 @@ export const toInsightsInstallationRow = (
   };
 };
 
-/** Release adoption and unchanged lifecycle reports are not bundle movements. */
+/** Unchanged reports are not bundle movements. */
 export const isInsightsMovementEvent = (
   event: Pick<BundleEventRow, "type">,
 ): boolean => event.type === "UPDATE_APPLIED" || event.type === "RECOVERED";

--- a/plugins/plugin-core/src/types/databasePlugin.ts
+++ b/plugins/plugin-core/src/types/databasePlugin.ts
@@ -76,7 +76,7 @@ export type InsightsBundleEventFilter = InsightsScope &
   (
     | { readonly type: "RECOVERED"; readonly fromBundleId: string }
     | {
-        readonly type: "UPDATE_APPLIED" | "RELEASE_ADOPTED";
+        readonly type: "UPDATE_APPLIED" | "UNCHANGED";
         readonly toBundleId: string;
       }
   );

--- a/plugins/plugin-core/src/types/databaseRows.ts
+++ b/plugins/plugin-core/src/types/databaseRows.ts
@@ -102,7 +102,7 @@ export type BundleEventRowBase = {
 
 export type BundleEventRow =
   | (BundleEventRowBase & {
-      readonly type: "UPDATE_APPLIED" | "RECOVERED" | "RELEASE_ADOPTED";
+      readonly type: "UPDATE_APPLIED" | "RECOVERED";
       readonly from_bundle_id: string;
       readonly update_strategy: "fingerprint" | "appVersion";
     })

--- a/plugins/postgres/sql/bundles.sql
+++ b/plugins/postgres/sql/bundles.sql
@@ -161,15 +161,15 @@ alter table release_catalogs add constraint release_catalogs_generation_check
 alter table release_catalogs add constraint release_catalogs_byte_size_check
   check (byte_size >= 0 and byte_size <= 262144);
 alter table bundle_events add constraint bundle_events_type_check
-  check (type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED'));
+  check (type in ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED'));
 alter table bundle_events add constraint bundle_events_platform_check
   check (platform in ('ios', 'android'));
 alter table bundle_events add constraint bundle_events_shape_check
-  check (((type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED')) and from_bundle_id is not null and update_strategy is not null and update_strategy in ('fingerprint', 'appVersion')) or (type = 'UNCHANGED' and from_bundle_id is null and update_strategy is null));
+  check (((type in ('UPDATE_APPLIED', 'RECOVERED')) and from_bundle_id is not null and update_strategy is not null and update_strategy in ('fingerprint', 'appVersion')) or (type = 'UNCHANGED' and from_bundle_id is null and update_strategy is null));
 alter table bundle_events add constraint bundle_events_received_at_check
   check (received_at_ms >= 0);
 alter table bundle_installations add constraint bundle_installations_type_check
-  check (type in ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED'));
+  check (type in ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED'));
 alter table bundle_installations add constraint bundle_installations_platform_check
   check (platform in ('ios', 'android'));
 alter table bundle_installations add constraint bundle_installations_received_at_check

--- a/plugins/supabase/supabase/migrations/20260818000000_hot-updater_1.0.0.sql
+++ b/plugins/supabase/supabase/migrations/20260818000000_hot-updater_1.0.0.sql
@@ -117,13 +117,13 @@ CREATE TABLE public.hot_updater_v1_bundle_events (
   sdk_version text,
   received_at_ms double precision NOT NULL,
   CONSTRAINT hot_updater_v1_bundle_events_type_check CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   CONSTRAINT hot_updater_v1_bundle_events_platform_check CHECK (
     platform IN ('ios', 'android')
   ),
   CONSTRAINT hot_updater_v1_bundle_events_shape_check CHECK (
-    (type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED')
+    (type IN ('UPDATE_APPLIED', 'RECOVERED')
       AND from_bundle_id IS NOT NULL
       AND update_strategy IS NOT NULL
       AND update_strategy IN ('fingerprint', 'appVersion'))
@@ -141,7 +141,7 @@ CREATE TABLE public.hot_updater_v1_bundle_installations (
   username text,
   to_bundle_id uuid NOT NULL,
   type text NOT NULL CHECK (
-    type IN ('UPDATE_APPLIED', 'RECOVERED', 'RELEASE_ADOPTED', 'UNCHANGED')
+    type IN ('UPDATE_APPLIED', 'RECOVERED', 'UNCHANGED')
   ),
   platform text COLLATE "C" NOT NULL CHECK (platform IN ('ios', 'android')),
   app_version text NOT NULL,


### PR DESCRIPTION
Same-file release selection appeared as a fourth event outcome even though the app's bundle files did not change. Finalize the unreleased v1 SDK, server, database, and console contract around **Update applied / No change / Rolled back** (`UPDATE_APPLIED`, `UNCHANGED`, `RECOVERED`).

- Remove `RELEASE_ADOPTED` from SDK payloads, server ingestion, validators, and initial v1 SQL schemas. Same-file selection retains release IDs but sends `UNCHANGED` with null source bundle and update strategy. No compatibility alias is accepted.
- Replace adopted query outcomes/counters with unchanged, including DynamoDB's bundle index. Preserve all-ID Active crossovers; rollback review uses applied + recovered reports rather than counting same-file selection as a new update.
- Use native shadcn Select/Tabs, align the platform/channel toolbar, separate period and metric controls, give the chart room, and put All events in its footer. Display explicit event descriptions and only Current for No change.
- Keep Bundles row summaries at 30 days. Insights and the compact Bundle Detail chart default to 24 hours with hourly intervals.

This intentionally finalizes the prerelease v1 schema without adding compatibility migrations. Existing development databases need obsolete rows/constraints updated alongside v1 packages. Modex D1 has been updated: all 22 events and 3 installation snapshots preserved, 6 obsolete events converted to No change, and all other fields retained.

Validation: full build (26 projects), lint, typecheck (34 projects), 2,643 unit tests, and all 355 integration scenarios (DynamoDB rerun after fixing its unchanged index). Real Modex console QA covers Active 2 / monthly reporting 3, 24h detail, 30d list, period/metric filters, keyboard selection, dark/light layouts at 320–1440px, and event pagination 20 + 2. Browser errors and horizontal overflow: none. Actual event UI shows 20 No change and 2 Update applied records; rollback rendering and crossovers are covered by scenario tests.

Relates to [HOT-15](https://linear.app/hot-updater/issue/HOT-15).

| Desktop | Mobile |
| --- | --- |
| ![Desktop](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/73fe6f9d-4c7d-4879-9e9b-5427295743a0/e21624f8-5ea9-4d54-8e04-d10fa2abbfcf) | ![Mobile](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/28e8f4a2-bd91-474e-9a24-562a98e7e550/2bef9ea8-38d1-4d9d-baaa-d50cb64f2979) |
