### PR TITLE
fix(cli): report occupied console ports

### DIFF
--- a/.changeset/upset-colts-fix.md
+++ b/.changeset/upset-colts-fix.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Report the configured console port when it is already in use and exit before starting another server.

--- a/packages/hot-updater/src/cliConsole.spec.ts
+++ b/packages/hot-updater/src/cliConsole.spec.ts
@@ -1,0 +1,58 @@
+import { once } from "node:events";
+import fs from "node:fs";
+import { createServer as createHttpServer } from "node:http";
+import { type AddressInfo, createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { execa } from "execa";
+import { describe, expect, it } from "vitest";
+
+const cliPath = path.resolve(__dirname, "../dist/index.mjs");
+
+describe("CLI console", () => {
+  it.each(["HTTP", "TCP"])(
+    "reports an occupied port and exits when a %s server is already listening",
+    async (protocol) => {
+      const server =
+        protocol === "HTTP"
+          ? createHttpServer((_request, response) => {
+              response.end("Existing server");
+            })
+          : createServer((socket) => socket.destroy());
+      const cwd = fs.mkdtempSync(
+        path.join(os.tmpdir(), "hot-updater-console-"),
+      );
+
+      try {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const { port } = server.address() as AddressInfo;
+
+        fs.writeFileSync(path.join(cwd, "package.json"), '{"private":true}');
+        fs.writeFileSync(
+          path.join(cwd, "hot-updater.config.mjs"),
+          `export default { console: { port: ${port} } };`,
+        );
+
+        const result = await execa(process.execPath, [cliPath, "console"], {
+          cwd,
+          timeout: 10_000,
+          reject: false,
+          env: { NO_COLOR: "1", FORCE_COLOR: "0" },
+        });
+        const output = result.stdout + result.stderr;
+
+        expect(result.timedOut).toBe(false);
+        expect(result.exitCode).toBe(1);
+        expect(output).toContain(`Port ${port} is already in use.`);
+        expect(output).not.toContain("EADDRINUSE");
+        expect(output).not.toContain("Console server exited");
+        expect(server.listening).toBe(true);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/hot-updater/src/index.ts
+++ b/packages/hot-updater/src/index.ts
@@ -8,6 +8,7 @@ import type { AndroidNativeRunOptions } from "@hot-updater/android-helper";
 import type { IosNativeRunOptions } from "@hot-updater/apple-helper";
 import { banner, p } from "@hot-updater/cli-tools";
 import type { NativeBuildOptions } from "@hot-updater/plugin-core";
+import isPortReachable from "is-port-reachable";
 import { normalizeRange } from "verkit";
 
 import {
@@ -663,6 +664,11 @@ program
     printBanner();
 
     const port = await getConsolePort();
+
+    if (await isPortReachable(port, { host: "127.0.0.1" })) {
+      p.log.error(`Port ${port} is already in use.`);
+      process.exit(1);
+    }
 
     await openConsole(port);
   });


### PR DESCRIPTION
When the configured console port is already occupied, `pnpm hot-updater console` now prints `Port <port> is already in use.` and exits with status 1 before starting Nitro. The TCP check uses `127.0.0.1` to match the console's bind address.

Adds regression tests that run the built CLI against existing HTTP and TCP listeners, plus a patch changeset for `hot-updater`. Before the fix, the HTTP case silently exited with status 0 and the TCP case reported a generic startup error.

Validation:

- `pnpm -w build`
- `pnpm -w lint`
- `pnpm --filter hot-updater test:type`
- `pnpm -w test` — 288 files, 2,650 tests passed.
- Started a real console on a free port, then ran `pnpm hot-updater console` again. The second command printed the occupied-port message and exited with status 1; the original console continued serving HTTP 200.

Observed CLI output from the second invocation:

```text
■  Port 52214 is already in use.
```
