### PR TITLE
fix(console): clarify MAU and add searchable channel filter

### DIFF
--- a/.changeset/monthly-active-installations.md
+++ b/.changeset/monthly-active-installations.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Label the Insights 30-day reporting installation count as MAU, with its installation-based definition available from an info tooltip on hover, keyboard focus, or tap. Replace the channel text field with a searchable shadcn combobox. Keep the existing platform/channel scope and rolling 30-day calculation.

--- a/docs/content/docs/(latest)/guides/console.mdx
+++ b/docs/content/docs/(latest)/guides/console.mdx
@@ -111,10 +111,17 @@ Insights opens a 24-hour chart with hourly intervals, so recent activity remains
 visible. Select **7d** or **30d** to compare a longer period. The chart includes
 every bundle ID observed in the selected platform and channel.
 
-**Reporting devices · 30d** counts each installation whose latest report belongs
-to the selected platform and channel within the last 30 days, including reports
-without a known bundle ID. It stays on 30 days when the chart period changes.
-This is a device count, not a monthly active user count.
+Search and select a channel from the channel combobox, then choose **Apply
+filters** to update the chart and MAU count.
+
+**MAU · 30d** (monthly active users) counts unique app installations that reported
+activity in the last 30 days. A user is identified by installation ID; multiple
+installations belonging to the same person count separately. Each installation's
+latest report must belong to the selected platform and channel. All event types
+count, including **No change**, as do reports without a known bundle ID. The
+metric uses a rolling 30-day window and stays on 30 days when the chart period
+changes.
+Hover over, focus, or tap the info icon beside **MAU · 30d** to see its definition.
 
 **Active** follows each installation’s last reported ID
 within that period, so moving to a new bundle reduces the old bundle’s count.

--- a/packages/console/src/components/features/insights/InsightsControls.spec.tsx
+++ b/packages/console/src/components/features/insights/InsightsControls.spec.tsx
@@ -1,10 +1,24 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InsightsControls } from "./InsightsControls";
 
+const mocks = vi.hoisted(() => ({ channels: vi.fn() }));
+vi.mock("@/lib/api", () => ({ useChannelsQuery: mocks.channels }));
+
 describe("InsightsControls", () => {
   afterEach(cleanup);
+  beforeEach(() => {
+    mocks.channels.mockReturnValue({
+      data: [{ name: "production" }, { name: "beta" }],
+    });
+  });
 
   it("submits an explicit scope without querying on each input change", async () => {
     const onScopeChange = vi.fn();
@@ -16,10 +30,20 @@ describe("InsightsControls", () => {
     );
     fireEvent.click(screen.getByRole("combobox", { name: "Platform" }));
     const android = await screen.findByRole("option", { name: "Android" });
-    fireEvent.pointerDown(android);
-    fireEvent.click(android);
-    fireEvent.change(screen.getByLabelText("Channel"), {
-      target: { value: "beta" },
+    await act(async () => {
+      fireEvent.pointerDown(android);
+      fireEvent.click(android);
+    });
+    act(() => screen.getByLabelText("Channel").focus());
+    fireEvent.input(screen.getByLabelText("Channel"), {
+      inputType: "insertText",
+      target: { value: "bet" },
+    });
+    const beta = await screen.findByRole("option", { name: "beta" });
+    expect(screen.queryByRole("option", { name: "production" })).toBeNull();
+    await act(async () => {
+      fireEvent.pointerDown(beta);
+      fireEvent.click(beta);
     });
     expect(onScopeChange).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }));
@@ -27,5 +51,25 @@ describe("InsightsControls", () => {
       platform: "android",
       channel: "beta",
     });
+  });
+
+  it("lets the user retry an unavailable channel list", async () => {
+    const refetch = vi.fn();
+    mocks.channels.mockReturnValue({ isError: true, refetch });
+    render(
+      <InsightsControls
+        scope={{ platform: "ios", channel: "production" }}
+        onScopeChange={vi.fn()}
+      />,
+    );
+    act(() => screen.getByLabelText("Channel").focus());
+    fireEvent.input(screen.getByLabelText("Channel"), {
+      inputType: "insertText",
+      target: { value: "beta" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Retry channels" }),
+    );
+    expect(refetch).toHaveBeenCalledOnce();
   });
 });

--- a/packages/console/src/components/features/insights/InsightsControls.tsx
+++ b/packages/console/src/components/features/insights/InsightsControls.tsx
@@ -1,8 +1,15 @@
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -11,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useChannelsQuery } from "@/lib/api";
 import type { InsightsOverviewInput } from "@/lib/insights-api";
 
 export function InsightsControls({
@@ -24,6 +32,8 @@ export function InsightsControls({
 }) {
   const [platform, setPlatform] = useState(scope.platform);
   const [channel, setChannel] = useState(scope.channel);
+  const channelsQuery = useChannelsQuery();
+  const channels = channelsQuery.data?.map((item) => item.name) ?? [];
 
   return (
     <form
@@ -59,14 +69,51 @@ export function InsightsControls({
         </Field>
         <Field className="min-w-0 sm:max-w-xs">
           <FieldLabel htmlFor="insights-channel">Channel</FieldLabel>
-          <Input
-            className="h-11 sm:h-9"
-            id="insights-channel"
+          <Combobox
+            items={channels}
             value={channel}
-            onChange={(event) => setChannel(event.target.value)}
-            required
-            maxLength={1024}
-          />
+            onValueChange={(value) => {
+              if (value !== null) setChannel(value);
+            }}
+          >
+            <ComboboxInput
+              className="h-11 w-full sm:h-9 [&_input]:h-full"
+              id="insights-channel"
+              placeholder="Search channels"
+              maxLength={1024}
+            />
+            <ComboboxContent>
+              <ComboboxEmpty>
+                {channelsQuery.isPending ? (
+                  "Loading channels…"
+                ) : channelsQuery.isError ? (
+                  <div className="flex flex-col items-center gap-2 p-2">
+                    Couldn't load channels.
+                    <Button
+                      onClick={() => void channelsQuery.refetch()}
+                      size="sm"
+                      variant="outline"
+                    >
+                      Retry channels
+                    </Button>
+                  </div>
+                ) : (
+                  "No channels found."
+                )}
+              </ComboboxEmpty>
+              <ComboboxList>
+                {(item: string) => (
+                  <ComboboxItem
+                    className="min-h-11 pr-8 sm:min-h-8"
+                    key={item}
+                    value={item}
+                  >
+                    <span className="truncate">{item}</span>
+                  </ComboboxItem>
+                )}
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
         </Field>
         <Button
           className="col-span-2 h-11 sm:h-9 sm:w-auto"

--- a/packages/console/src/components/features/insights/ReportingDevicesSummary.spec.tsx
+++ b/packages/console/src/components/features/insights/ReportingDevicesSummary.spec.tsx
@@ -12,7 +12,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-it("counts reporting devices over 30 days in the applied platform and channel", () => {
+it("counts monthly active users by installation in the applied platform and channel", () => {
   mocks.reporting.mockReturnValue({
     data: { reportingInstallations: { count: 3 } },
   });
@@ -44,14 +44,14 @@ it("distinguishes loading and a failed count from a measured zero and permits re
   const refetch = vi.fn();
   mocks.reporting.mockReturnValue({ isPending: true });
   const view = render(<ReportingDevicesSummary scope={scope} />);
-  expect(screen.getByLabelText("Loading reporting devices")).toBeDefined();
+  expect(screen.getByLabelText("Loading monthly active users")).toBeDefined();
   expect(screen.queryByText("0", { exact: true })).toBeNull();
   mocks.reporting.mockReturnValue({ error: new Error("Offline"), refetch });
   view.rerender(<ReportingDevicesSummary scope={scope} />);
   expect(screen.getByText("Unavailable")).toBeDefined();
   expect(screen.queryByText("0", { exact: true })).toBeNull();
   fireEvent.click(
-    screen.getByRole("button", { name: "Retry reporting device count" }),
+    screen.getByRole("button", { name: "Retry monthly active user count" }),
   );
   expect(refetch).toHaveBeenCalledOnce();
   mocks.reporting.mockReturnValue({
@@ -60,4 +60,22 @@ it("distinguishes loading and a failed count from a measured zero and permits re
   view.rerender(<ReportingDevicesSummary scope={scope} />);
   expect(screen.getByText("0", { exact: true })).toBeDefined();
   expect(screen.queryByText("Unavailable")).toBeNull();
+});
+
+it("discloses the MAU definition on tap and dismisses it with Escape", async () => {
+  mocks.reporting.mockReturnValue({
+    data: { reportingInstallations: { count: 3 } },
+  });
+  render(
+    <ReportingDevicesSummary
+      scope={{ platform: "ios", channel: "production" }}
+    />,
+  );
+  expect(screen.queryByRole("tooltip")).toBeNull();
+  fireEvent.click(screen.getByRole("button", { name: "How MAU is counted" }));
+  expect((await screen.findByRole("tooltip")).textContent).toContain(
+    "Unique app installations",
+  );
+  fireEvent.keyDown(document.body, { key: "Escape" });
+  expect(screen.queryByRole("tooltip")).toBeNull();
 });

--- a/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
+++ b/packages/console/src/components/features/insights/ReportingDevicesSummary.tsx
@@ -1,12 +1,14 @@
+import { InfoIcon } from "lucide-react";
+import { useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   useReportingInstallationsQuery,
   type InsightsOverviewInput,
@@ -18,31 +20,62 @@ export function ReportingDevicesSummary({
   readonly scope: Omit<InsightsOverviewInput, "window" | "bundleId">;
 }) {
   const query = useReportingInstallationsQuery({ ...scope, window: "30d" });
+  const infoId = useId();
+  const [infoOpen, setInfoOpen] = useState(false);
   return (
     <Card
-      aria-label="Reporting devices over 30 days"
+      aria-label="Monthly active users over 30 days"
       className="flex items-center justify-between"
       role="region"
     >
       <CardHeader className="min-w-0 gap-2 p-6 sm:px-8">
-        <CardTitle className="text-sm font-medium">
-          Reporting devices · 30d
+        <CardTitle className="flex items-center gap-1 text-sm font-medium">
+          <span className="whitespace-nowrap">MAU · 30d</span>
+          <Tooltip
+            open={infoOpen}
+            onOpenChange={setInfoOpen}
+            triggerId={infoId}
+          >
+            <TooltipTrigger
+              id={infoId}
+              aria-describedby={infoOpen ? `${infoId}-description` : undefined}
+              closeOnClick={false}
+              onClick={() => setInfoOpen((open) => !open)}
+              render={
+                <Button
+                  aria-label="How MAU is counted"
+                  className="size-11 sm:size-7"
+                  size="icon"
+                  variant="ghost"
+                />
+              }
+            >
+              <InfoIcon />
+            </TooltipTrigger>
+            <TooltipContent
+              className="max-w-64"
+              id={`${infoId}-description`}
+              role="tooltip"
+              side="bottom"
+            >
+              Unique app installations that reported activity in the last 30
+              days, including no-change reports. Filtered by platform and
+              channel.
+            </TooltipContent>
+          </Tooltip>
         </CardTitle>
-        <CardDescription>
-          Installations last seen in this scope within 30 days.
-        </CardDescription>
       </CardHeader>
       <CardContent className="shrink-0 p-6 sm:px-8">
         {query.isPending ? (
           <Skeleton
-            aria-label="Loading reporting devices"
+            aria-label="Loading monthly active users"
             className="h-9 w-12"
           />
         ) : query.error ? (
           <div className="flex flex-col items-end gap-2">
             <span className="text-xs text-muted-foreground">Unavailable</span>
             <Button
-              aria-label="Retry reporting device count"
+              aria-label="Retry monthly active user count"
               onClick={() => void query.refetch()}
               size="sm"
               variant="outline"

--- a/packages/console/src/routes/-insights.spec.tsx
+++ b/packages/console/src/routes/-insights.spec.tsx
@@ -1,7 +1,18 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({ activity: vi.fn(), reporting: vi.fn() }));
+vi.mock("@/lib/api", () => ({
+  useChannelsQuery: () => ({
+    data: [{ name: "production" }, { name: "beta" }],
+  }),
+}));
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (options: unknown) => ({ options }),
 }));
@@ -25,7 +36,7 @@ vi.mock("@/components/features/insights/InsightsPageHeader", () => ({
 vi.mock("@/components/features/insights/ReportingDevicesSummary", () => ({
   ReportingDevicesSummary: ({ scope }: { scope: unknown }) => {
     mocks.reporting(scope);
-    return <div>Reporting devices · 30d</div>;
+    return <div>MAU · 30d</div>;
   },
 }));
 
@@ -55,10 +66,19 @@ describe("Insights overview", () => {
     });
     fireEvent.click(screen.getByRole("combobox", { name: "Platform" }));
     const android = await screen.findByRole("option", { name: "Android" });
-    fireEvent.pointerDown(android);
-    fireEvent.click(android);
-    fireEvent.change(screen.getByLabelText("Channel"), {
+    await act(async () => {
+      fireEvent.pointerDown(android);
+      fireEvent.click(android);
+    });
+    act(() => screen.getByLabelText("Channel").focus());
+    fireEvent.input(screen.getByLabelText("Channel"), {
+      inputType: "insertText",
       target: { value: "beta" },
+    });
+    const beta = await screen.findByRole("option", { name: "beta" });
+    await act(async () => {
+      fireEvent.pointerDown(beta);
+      fireEvent.click(beta);
     });
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }));
     expect(mocks.activity).toHaveBeenLastCalledWith({


### PR DESCRIPTION
The Insights summary now shows **MAU · 30d**, defined as unique app installations reporting activity within the rolling 30-day window, including no-change reports. Its definition is available from an adjacent info icon on hover, keyboard focus, or tap.

The channel filter uses the existing shadcn Base UI Combobox to search and select stored channels before applying filters. Mobile inputs, options, and the info trigger have 44 px touch targets.

Validation: workspace build (26 projects), type checks (34 projects), lint, 2,650 unit tests, and 154 console tests passed. Browser QA against Modex data covered keyboard selection, hover/focus/tap disclosure, dismissal, unchanged 30-day MAU when switching chart periods, and 320/390 px layouts without overflow. Documentation and a console patch changeset are included.

Related: HOT-15. No SDK, database, or infrastructure changes.

| Desktop | Mobile |
| --- | --- |
| ![Insights with MAU and channel combobox](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/60b785d3-e84a-4d06-90f8-f9fc520ee971/e397d645-b1e5-4020-bf0d-9cb2bae7e566) | ![MAU definition on mobile](https://uploads.linear.app/409b017e-5857-495f-b037-aef5b5c6d645/a519f090-b1dc-4a42-ac3d-ba4f5571eb02/0af69a0d-4de3-4c40-ada7-d7a0707a36d8) |

