### PR TITLE
fix(console): align App usage and Distribution card heights

### DIFF
--- a/.changeset/bright-insights-cards.md
+++ b/.changeset/bright-insights-cards.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Align the App usage and Distribution card heights in the Insights desktop layout and keep the distribution action at the bottom.

--- a/packages/console/src/components/features/insights/AppUsage.tsx
+++ b/packages/console/src/components/features/insights/AppUsage.tsx
@@ -197,7 +197,7 @@ export function AppUsage({
       <Card
         aria-label="Usage distribution"
         role="region"
-        className="min-w-0 self-start shadow-sm"
+        className="flex min-w-0 flex-col shadow-sm"
       >
         <CardHeader className="flex-row items-center justify-between gap-3">
           <CardTitle className="flex min-h-9 items-center">
@@ -211,7 +211,7 @@ export function AppUsage({
               : ""}
           </InsightsInfo>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex-1">
           {query.isPending ? (
             <Skeleton aria-label="Loading distribution" className="h-48" />
           ) : query.error ? (


### PR DESCRIPTION
App usage and Distribution used different heights because Distribution opted out of grid stretching. Let both cards fill the desktop grid row and keep the distribution action at the bottom using the existing Card composition.

Validation: workspace build/lint and 2,680 tests passed; console TypeScript passed. Browser QA measured equal heights with real Modex data (430px each) and 14-version sample data (548px each). At 320px and 390px the cards stack without horizontal overflow. A console patch changeset is included for the RC release.

![Equal-height cards with synthetic 14-version data](https://github.com/user-attachments/assets/d93cc4f8-f572-4a76-a452-dd8913de96df)