### PR TITLE
docs: add step-by-step Nitro console deployment guides

### DIFF
--- a/docs/content/docs/(latest)/guides/console-deployment/cloudflare.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/cloudflare.mdx
@@ -1,0 +1,183 @@
+---
+title: "Cloudflare"
+description: "Deploy the console on Workers with existing D1 and R2 bindings."
+---
+
+Complete the [basic setup](/docs/guides/console-deployment) first: clone the template, choose your
+canonical HTTPS origin, and configure an OAuth application and access allowlist.
+This guide connects an existing D1 database and R2 bucket using Worker bindings.
+Modex uses this deployment path for dogfood.
+
+Copy the example into the root of your private deployment checkout:
+
+```bash
+cp examples/cloudflare/hot-updater.config.ts.example hot-updater.config.ts
+cp examples/cloudflare/wrangler.jsonc wrangler.jsonc
+pnpm add --save-exact @hot-updater/cloudflare@1.0.0-rc.5
+pnpm exec wrangler login
+pnpm exec wrangler whoami
+```
+
+Find the resources in your OTA Worker's Wrangler configuration, your mobile
+project's provider settings, or the Cloudflare dashboard. You can also list them:
+
+```bash
+pnpm exec wrangler d1 list
+pnpm exec wrangler r2 bucket list
+```
+
+Edit `wrangler.jsonc`:
+
+| Field                                             | Value                                                      |
+| ------------------------------------------------- | ---------------------------------------------------------- |
+| `name`                                            | A new console Worker name, separate from the OTA Worker    |
+| `account_id`                                      | The account containing the existing resources, when needed |
+| `vars.BETTER_AUTH_URL`                            | The console's exact public HTTPS origin, without a path    |
+| `vars.BUCKET_NAME`                                | Your existing bundle bucket name                           |
+| `d1_databases[0].database_name` and `database_id` | Your existing Hot Updater D1 database                      |
+| `r2_buckets[0].bucket_name`                       | The same bucket as `BUCKET_NAME`                           |
+
+The default URL is `https://<worker-name>.<account-subdomain>.workers.dev`.
+Choose the origin before configuring OAuth. A custom domain also works; use
+that origin consistently in Wrangler and OAuth callbacks.
+
+The copied `hot-updater.config.ts` uses the worker entry point:
+
+```ts
+import { d1Database, r2Storage } from "@hot-updater/cloudflare/worker";
+import { defineConsoleConfig } from "@hot-updater/console";
+
+type CloudflareRequest = Request & {
+  runtime?: { cloudflare?: { env?: Env } };
+};
+
+export default defineConsoleConfig((request) => {
+  const env = (request as CloudflareRequest).runtime?.cloudflare?.env;
+  if (!env) throw new Error("Cloudflare bindings are unavailable.");
+
+  return {
+    console: { gitUrl: "https://github.com/your-org/your-mobile-app" },
+    database: d1Database(env.DB),
+    storage: r2Storage({
+      bucket: env.BUCKET,
+      bucketName: env.BUCKET_NAME,
+      downloadUrlSigningKey: env.STORAGE_DOWNLOAD_URL_SIGNING_KEY,
+    }),
+  };
+});
+```
+
+Generate `Env` from your Wrangler configuration with `pnpm cf:typegen` after
+changing bindings. Do not copy the entire mobile `hot-updater.config.ts`:
+Expo/native build plugins, fingerprint settings, and signing private keys stay
+in the mobile project. D1 and R2 bindings replace Cloudflare API tokens and S3
+credentials inside the hosted Worker.
+
+Do not create a new D1 database or run schema migrations for this console.
+It must connect to the backend already used by the app. Backend upgrades remain
+part of the Hot Updater infrastructure upgrade workflow.
+
+The copied `secrets.required` list includes GitHub's pair. Replace it with
+Google's pair if needed; Wrangler loads only listed names from `.dev.vars`.
+In addition to the shared authentication variables, the R2 plugin needs
+`STORAGE_DOWNLOAD_URL_SIGNING_KEY`: generate a separate random secret for
+storage URL capabilities. It is not a mobile signing private key.
+
+Use the ignored `.secrets.production.json` file for initial deployment:
+
+```json
+{
+  "BETTER_AUTH_SECRET": "REPLACE_WITH_RANDOM_SECRET",
+  "HOT_UPDATER_CONSOLE_ALLOWED_EMAILS": "owner@example.com",
+  "STORAGE_DOWNLOAD_URL_SIGNING_KEY": "REPLACE_WITH_ANOTHER_RANDOM_SECRET",
+  "GITHUB_CLIENT_ID": "REPLACE_WITH_CLIENT_ID",
+  "GITHUB_CLIENT_SECRET": "REPLACE_WITH_CLIENT_SECRET"
+}
+```
+
+Fill real values privately and run `chmod 600 .secrets.production.json`.
+Never commit the file or put secrets in shell command arguments.
+
+### Build and deploy the Worker
+
+```bash
+pnpm test
+pnpm cf:typegen
+pnpm test:type
+pnpm build:cloudflare
+pnpm exec wrangler deploy --dry-run
+pnpm test:cloudflare
+pnpm exec wrangler deploy --secrets-file .secrets.production.json
+```
+
+The last command uploads code and secrets together. Inspect the reported Worker
+name, D1 database, and bucket before confirming any CLI prompt.
+
+Nitro generates `.output/server/wrangler.json` and
+`.wrangler/deploy/config.json`. Wrangler automatically uses that generated
+configuration, which includes the server modules and static assets. Edit the
+root `wrangler.jsonc` and rebuild; do not edit generated configuration or pass
+the root file to deployment with `--config`. The root file is build input.
+
+The Worker smoke check starts the built artifact with test-only authentication
+settings and local resources. It catches runtime failures that a successful
+build or dry run cannot detect, and checks that anonymous reads, writes, and
+downloads are denied.
+
+Keep `preview_urls: false` so version preview addresses are not published with
+an origin that differs from the OAuth configuration. The standard `workers.dev`
+address remains enabled. Use `pnpm exec wrangler tail` to inspect runtime errors.
+
+The default configuration enables Workers logs and samples traces. Follow your
+account's observability retention and sampling requirements.
+
+### Local Worker preview
+
+```bash
+cp examples/cloudflare/.dev.vars.example .dev.vars
+pnpm build:cloudflare
+pnpm preview:cloudflare
+```
+
+Fill `.dev.vars` with a local OAuth client's credentials, random secrets, and
+`BETTER_AUTH_URL=http://localhost:3000`. Register the corresponding localhost
+callback on that OAuth client. The file stays local and is not automatically
+uploaded by deployment.
+
+Wrangler uses local D1 and R2 by default. An empty local database does not mean
+production data was lost. Avoid enabling remote bindings unless you intend to
+operate on the real backend. `pnpm dev` runs Vite on Node and needs a
+Node-compatible provider configuration instead of native Worker bindings.
+
+### Worker updates and rollback
+
+Rebuild and rerun `pnpm test:cloudflare` before `pnpm exec wrangler deploy`.
+Omitting `--secrets-file` preserves existing secrets. Use interactive
+`pnpm exec wrangler secret put NAME` to update a secret privately.
+Record the version ID printed after deployment:
+
+```bash
+pnpm exec wrangler deployments list
+pnpm exec wrangler rollback <previous-version-id>
+```
+
+A Worker rollback restores code/configuration, not D1 rows or R2 objects.
+
+## Troubleshooting
+
+| Symptom                                   | Check                                                                                       |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Sign-in fails before OAuth opens          | Complete provider pair, strong session secret, nonempty exact email allowlist               |
+| OAuth callback is rejected                | Provider callback, `BETTER_AUTH_URL`, and the browser origin must match                     |
+| A signed-in user sees Forbidden           | The provider must return a verified address present in the allowlist                        |
+| Cloudflare bindings are unavailable       | Build with the Cloudflare preset and run the generated Worker through Wrangler              |
+| Insights is empty or queries fail         | Bind the existing database in the correct account; local preview has separate data          |
+| Bundle download reports a bucket mismatch | `BUCKET_NAME`, the R2 binding, and the stored bundle URI must refer to the same bucket      |
+| Deployment has stale bindings             | Update root Wrangler config, rebuild, and inspect the generated deployment before uploading |
+
+## Cloudflare references
+
+- [Nitro on Cloudflare](https://nitro.build/deploy/providers/cloudflare)
+- [Cloudflare Worker secrets](https://developers.cloudflare.com/workers/configuration/secrets/)
+- [Cloudflare binding types](https://developers.cloudflare.com/workers/languages/typescript/#generate-types)
+- [Cloudflare Worker rollback](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)

--- a/docs/content/docs/(latest)/guides/console-deployment/cloudflare.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/cloudflare.mdx
@@ -1,91 +1,65 @@
 ---
 title: "Cloudflare"
-description: "Deploy the console on Workers with existing D1 and R2 bindings."
+description: "Deploy the console on Workers using your existing D1 database and R2 bucket."
 ---
 
-Complete the [basic setup](/docs/guides/console-deployment) first: clone the template, choose your
-canonical HTTPS origin, and configure an OAuth application and access allowlist.
-This guide connects an existing D1 database and R2 bucket using Worker bindings.
-Modex uses this deployment path for dogfood.
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-Copy the example into the root of your private deployment checkout:
+Complete [Basics](/docs/guides/console-deployment) first. This guide uses native D1/R2 bindings.
+
+<Steps>
+<Step>
+
+## Copy the Worker example
 
 ```bash
 cp examples/cloudflare/hot-updater.config.ts.example hot-updater.config.ts
 cp examples/cloudflare/wrangler.jsonc wrangler.jsonc
-pnpm add --save-exact @hot-updater/cloudflare@1.0.0-rc.5
-pnpm exec wrangler login
-pnpm exec wrangler whoami
 ```
 
-Find the resources in your OTA Worker's Wrangler configuration, your mobile
-project's provider settings, or the Cloudflare dashboard. You can also list them:
+The template already includes the Cloudflare plugin and Wrangler.
 
-```bash
-pnpm exec wrangler d1 list
-pnpm exec wrangler r2 bucket list
+```package-install
+npx wrangler login
+npx wrangler whoami
 ```
 
-Edit `wrangler.jsonc`:
+</Step>
+<Step>
 
-| Field                                             | Value                                                      |
-| ------------------------------------------------- | ---------------------------------------------------------- |
-| `name`                                            | A new console Worker name, separate from the OTA Worker    |
-| `account_id`                                      | The account containing the existing resources, when needed |
-| `vars.BETTER_AUTH_URL`                            | The console's exact public HTTPS origin, without a path    |
-| `vars.BUCKET_NAME`                                | Your existing bundle bucket name                           |
-| `d1_databases[0].database_name` and `database_id` | Your existing Hot Updater D1 database                      |
-| `r2_buckets[0].bucket_name`                       | The same bucket as `BUCKET_NAME`                           |
+## Connect your resources
 
-The default URL is `https://<worker-name>.<account-subdomain>.workers.dev`.
-Choose the origin before configuring OAuth. A custom domain also works; use
-that origin consistently in Wrangler and OAuth callbacks.
+Edit the root `wrangler.jsonc` using your existing OTA backend's values:
 
-The copied `hot-updater.config.ts` uses the worker entry point:
+| Field | Set to |
+| --- | --- |
+| `name` | A new console Worker name |
+| `account_id` | Your Cloudflare account ID |
+| `vars.BETTER_AUTH_URL` | Your public console HTTPS origin |
+| `vars.BUCKET_NAME` | Your existing R2 bucket name |
+| `d1_databases[0]` | Your existing D1 database name and ID |
+| `r2_buckets[0].bucket_name` | The same R2 bucket name |
 
-```ts
-import { d1Database, r2Storage } from "@hot-updater/cloudflare/worker";
-import { defineConsoleConfig } from "@hot-updater/console";
+The default origin is `https://<worker-name>.<account-subdomain>.workers.dev`. Register its [OAuth callback](/docs/guides/console-deployment#set-up-sign-in), or use your custom domain consistently.
 
-type CloudflareRequest = Request & {
-  runtime?: { cloudflare?: { env?: Env } };
-};
+To find resource names and IDs:
 
-export default defineConsoleConfig((request) => {
-  const env = (request as CloudflareRequest).runtime?.cloudflare?.env;
-  if (!env) throw new Error("Cloudflare bindings are unavailable.");
-
-  return {
-    console: { gitUrl: "https://github.com/your-org/your-mobile-app" },
-    database: d1Database(env.DB),
-    storage: r2Storage({
-      bucket: env.BUCKET,
-      bucketName: env.BUCKET_NAME,
-      downloadUrlSigningKey: env.STORAGE_DOWNLOAD_URL_SIGNING_KEY,
-    }),
-  };
-});
+```package-install
+npx wrangler d1 list
+npx wrangler r2 bucket list
 ```
 
-Generate `Env` from your Wrangler configuration with `pnpm cf:typegen` after
-changing bindings. Do not copy the entire mobile `hot-updater.config.ts`:
-Expo/native build plugins, fingerprint settings, and signing private keys stay
-in the mobile project. D1 and R2 bindings replace Cloudflare API tokens and S3
-credentials inside the hosted Worker.
+Reuse the existing resources; no new database or console-specific migration is needed.
 
-Do not create a new D1 database or run schema migrations for this console.
-It must connect to the backend already used by the app. Backend upgrades remain
-part of the Hot Updater infrastructure upgrade workflow.
+</Step>
+<Step>
 
-The copied `secrets.required` list includes GitHub's pair. Replace it with
-Google's pair if needed; Wrangler loads only listed names from `.dev.vars`.
-In addition to the shared authentication variables, the R2 plugin needs
-`STORAGE_DOWNLOAD_URL_SIGNING_KEY`: generate a separate random secret for
-storage URL capabilities. It is not a mobile signing private key.
+## Add secrets
 
-Use the ignored `.secrets.production.json` file for initial deployment:
+Create the ignored `.secrets.production.json`:
 
-```json
+```json title=".secrets.production.json"
 {
   "BETTER_AUTH_SECRET": "REPLACE_WITH_RANDOM_SECRET",
   "HOT_UPDATER_CONSOLE_ALLOWED_EMAILS": "owner@example.com",
@@ -95,89 +69,77 @@ Use the ignored `.secrets.production.json` file for initial deployment:
 }
 ```
 
-Fill real values privately and run `chmod 600 .secrets.production.json`.
-Never commit the file or put secrets in shell command arguments.
-
-### Build and deploy the Worker
+Fill the values from [sign-in setup](/docs/guides/console-deployment#set-up-sign-in). Generate a separate storage secret with `openssl rand -base64 32`.
 
 ```bash
-pnpm test
-pnpm cf:typegen
-pnpm test:type
-pnpm build:cloudflare
-pnpm exec wrangler deploy --dry-run
-pnpm test:cloudflare
-pnpm exec wrangler deploy --secrets-file .secrets.production.json
+chmod 600 .secrets.production.json
 ```
 
-The last command uploads code and secrets together. Inspect the reported Worker
-name, D1 database, and bucket before confirming any CLI prompt.
+For Google, replace the GitHub pair in this file **and** `wrangler.jsonc` → `secrets.required`.
 
-Nitro generates `.output/server/wrangler.json` and
-`.wrangler/deploy/config.json`. Wrangler automatically uses that generated
-configuration, which includes the server modules and static assets. Edit the
-root `wrangler.jsonc` and rebuild; do not edit generated configuration or pass
-the root file to deployment with `--config`. The root file is build input.
+</Step>
+<Step>
 
-The Worker smoke check starts the built artifact with test-only authentication
-settings and local resources. It catches runtime failures that a successful
-build or dry run cannot detect, and checks that anonymous reads, writes, and
-downloads are denied.
+## Build and deploy
 
-Keep `preview_urls: false` so version preview addresses are not published with
-an origin that differs from the OAuth configuration. The standard `workers.dev`
-address remains enabled. Use `pnpm exec wrangler tail` to inspect runtime errors.
+```package-install
+npm run cf:typegen
+npm run test:type
+npm run build:cloudflare
+npx wrangler deploy --dry-run
+npm run test:cloudflare
+npx wrangler deploy --secrets-file .secrets.production.json
+```
 
-The default configuration enables Workers logs and samples traces. Follow your
-account's observability retention and sampling requirements.
+Wrangler reports the deployed URL. Open it and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
 
-### Local Worker preview
+Edit only the root Wrangler config, then rebuild. Deployment uses Nitro's generated config automatically; do not pass the root file with `--config`.
+
+</Step>
+</Steps>
+
+## Local preview
+
+Copy the example and fill in local OAuth credentials, secrets, and `BETTER_AUTH_URL=http://localhost:3000`:
 
 ```bash
 cp examples/cloudflare/.dev.vars.example .dev.vars
-pnpm build:cloudflare
-pnpm preview:cloudflare
 ```
 
-Fill `.dev.vars` with a local OAuth client's credentials, random secrets, and
-`BETTER_AUTH_URL=http://localhost:3000`. Register the corresponding localhost
-callback on that OAuth client. The file stays local and is not automatically
-uploaded by deployment.
-
-Wrangler uses local D1 and R2 by default. An empty local database does not mean
-production data was lost. Avoid enabling remote bindings unless you intend to
-operate on the real backend. `pnpm dev` runs Vite on Node and needs a
-Node-compatible provider configuration instead of native Worker bindings.
-
-### Worker updates and rollback
-
-Rebuild and rerun `pnpm test:cloudflare` before `pnpm exec wrangler deploy`.
-Omitting `--secrets-file` preserves existing secrets. Use interactive
-`pnpm exec wrangler secret put NAME` to update a secret privately.
-Record the version ID printed after deployment:
-
-```bash
-pnpm exec wrangler deployments list
-pnpm exec wrangler rollback <previous-version-id>
+```package-install
+npm run build:cloudflare
+npm run preview:cloudflare
 ```
 
-A Worker rollback restores code/configuration, not D1 rows or R2 objects.
+Register the localhost OAuth callback. Preview uses local D1/R2 data by default.
 
-## Troubleshooting
+<Accordions>
+<Accordion title="Update or roll back">
 
-| Symptom                                   | Check                                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Sign-in fails before OAuth opens          | Complete provider pair, strong session secret, nonempty exact email allowlist               |
-| OAuth callback is rejected                | Provider callback, `BETTER_AUTH_URL`, and the browser origin must match                     |
-| A signed-in user sees Forbidden           | The provider must return a verified address present in the allowlist                        |
-| Cloudflare bindings are unavailable       | Build with the Cloudflare preset and run the generated Worker through Wrangler              |
-| Insights is empty or queries fail         | Bind the existing database in the correct account; local preview has separate data          |
-| Bundle download reports a bucket mismatch | `BUCKET_NAME`, the R2 binding, and the stored bundle URI must refer to the same bucket      |
-| Deployment has stale bindings             | Update root Wrangler config, rebuild, and inspect the generated deployment before uploading |
+Rebuild and deploy with the same commands. Omit `--secrets-file` to keep existing secrets. For a secret change, run `wrangler secret put NAME` through your package manager.
 
-## Cloudflare references
+```package-install
+npx wrangler deployments list
+npx wrangler rollback <previous-version-id>
+```
 
-- [Nitro on Cloudflare](https://nitro.build/deploy/providers/cloudflare)
-- [Cloudflare Worker secrets](https://developers.cloudflare.com/workers/configuration/secrets/)
-- [Cloudflare binding types](https://developers.cloudflare.com/workers/languages/typescript/#generate-types)
-- [Cloudflare Worker rollback](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
+Rollback restores Worker code/configuration, not D1 or R2 data.
+
+</Accordion>
+<Accordion title="Troubleshooting">
+
+| Symptom | Check |
+| --- | --- |
+| Bindings unavailable | Build and run the Worker preset, not Vite's Node server |
+| Empty Insights | Correct D1 binding; local preview uses separate data |
+| Bucket mismatch | `BUCKET_NAME`, the R2 binding, and stored bundle URI use the same bucket |
+| Stale bindings | Edit root config, rebuild, and deploy the generated output |
+
+```package-install
+npx wrangler tail
+```
+
+</Accordion>
+</Accordions>
+
+See [Nitro on Cloudflare](https://nitro.build/deploy/providers/cloudflare) and [Worker secrets](https://developers.cloudflare.com/workers/configuration/secrets/).

--- a/docs/content/docs/(latest)/guides/console-deployment/docker.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/docker.mdx
@@ -1,100 +1,46 @@
 ---
 title: "Docker"
-description: "Build and run the Nitro console as a standalone Node container."
+description: "Build and run the Nitro console in a Node container."
 ---
 
-Complete the [basic setup](/docs/guides/console-deployment) first: connect your existing backend,
-configure OAuth, and choose who can sign in. This guide runs Nitro's standalone
-Node server in Docker, on a server or a container platform of your choice.
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-## 1. Configure the backend
+Complete [Basics](/docs/guides/console-deployment) with Node-compatible plugins first. You also need Docker.
 
-Use the Node-compatible plugins for Cloudflare, AWS, Firebase, or Supabase.
-For D1/R2, follow [Cloudflare from Node](/docs/guides/console-deployment#cloudflare-backend-from-node);
-Worker bindings and the `/worker` entry point are not available inside Docker.
-Install the selected plugins and commit the updated lockfile before building.
+<Steps>
+<Step>
 
-The repository includes a multi-stage `Dockerfile`. Its build stage installs
-from the frozen lockfile and runs `pnpm build:node`. The runtime stage copies
-the complete `.output` directory, including server dependencies and public
-assets, and starts Node as the unprivileged `node` user:
-
-```dockerfile
-FROM node:22-bookworm-slim AS build
-WORKDIR /app
-RUN corepack enable
-
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
-COPY . .
-RUN pnpm build:node
-
-FROM node:22-bookworm-slim AS runtime
-WORKDIR /app
-ENV NODE_ENV=production HOST=0.0.0.0 PORT=3000
-COPY --from=build --chown=node:node /app/.output ./.output
-USER node
-EXPOSE 3000
-CMD ["node", ".output/server/index.mjs"]
-```
-
-The included `.dockerignore` only permits the package manifests and console
-configuration files into the build context. It also includes `.gitignore` so
-Tailwind excludes generated files consistently during the client and server
-builds. If your configuration imports additional local modules, add those
-specific paths to its allowlist. Keep credential files out of the image;
-supply them when the container starts.
-
-## 2. Build the image
-
-From the configured repository root:
-
-```bash
-docker build -t hot-updater-console:local .
-```
-
-This build needs no OAuth or backend secrets. Read those settings inside the
-`defineConsoleConfig` callback so they are resolved at runtime.
-
-For a remote container service, tag and push the image to a registry that the
-service can access. Build for the destination architecture: for example,
-`docker build --platform linux/amd64 -t hot-updater-console:local .` produces
-an amd64 image when building on an Apple Silicon machine. Cloud Run requires
-[linux/amd64](https://docs.cloud.google.com/run/docs/container-contract);
-match the task architecture when using ECS.
-
-## 3. Supply runtime settings
-
-For a standalone Docker host, prepare a private environment file:
+## Prepare runtime variables
 
 ```bash
 cp .env.example .env.production
 chmod 600 .env.production
 ```
 
-Edit `.env.production` with the values from [authentication setup](/docs/guides/console-deployment#3-configure-authentication):
-`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`,
-and at least one complete GitHub or Google OAuth pair. Add the environment
-variables read by your backend configuration. Use `KEY=value` entries without
-shell expansion or wrapping quotes; Docker passes these values to the process.
-The repository ignores `.env.production`.
+Fill `.env.production` with the [authentication variables](/docs/guides/console-deployment#set-up-sign-in) and the backend variables used by your plugins. Use plain `KEY=value` entries without wrapping quotes.
 
-Set `BETTER_AUTH_URL` to the public HTTPS origin and register the matching
-`/api/auth/callback/github` or `/api/auth/callback/google` OAuth callback.
-For local sign-in testing, use `http://localhost:3000` and a matching local
-OAuth callback instead.
+Set `BETTER_AUTH_URL` to your public HTTPS origin and register its OAuth callback. For local testing, use `http://localhost:3000` and a matching callback.
 
-On a managed container service, configure these values in its runtime secret
-settings instead of uploading the environment file. Local AWS profiles and
-Google credential files are not copied into the container. Use an attached
-service identity where supported, or provide server credentials at runtime.
-If your Firebase configuration uses a credential JSON file, mount it read-only,
-make it readable by the container's `node` user, and set
-`GOOGLE_APPLICATION_CREDENTIALS` to its path inside the container.
+</Step>
+<Step>
 
-## 4. Run the console
+## Build the image
 
-For Docker on a server with a host-level HTTPS reverse proxy:
+Use the repository's included `Dockerfile` and `.dockerignore`:
+
+```bash
+docker build -t hot-updater-console:local .
+```
+
+The image builds the Node server and runs the complete `.output` as a non-root user. Secrets are supplied at startup.
+
+The Dockerfile uses `pnpm-lock.yaml`. If you add plugins, use the pnpm tab in their installation guide to update that lockfile before building.
+
+</Step>
+<Step>
+
+## Start the container
 
 ```bash
 docker run -d \
@@ -103,33 +49,54 @@ docker run -d \
   --env-file .env.production \
   -p 127.0.0.1:3000:3000 \
   hot-updater-console:local
+```
 
+Open `http://localhost:3000`: you should see the sign-in page.
+
+</Step>
+<Step>
+
+## Connect HTTPS and verify
+
+Point your host's HTTPS reverse proxy at `127.0.0.1:3000`, preserving the original host and scheme. Then open the public URL and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
+
+For a managed container service, supply the same variables through its runtime secret settings. The server listens on `0.0.0.0` and accepts the platform's `PORT` value.
+
+</Step>
+</Steps>
+
+<Accordions>
+<Accordion title="Build inputs and credentials">
+
+Keep `.gitignore` in the `.dockerignore` allowlist: Tailwind uses it to exclude generated files during both client and server builds. Add explicit paths if your config imports other local modules.
+
+Use an attached service identity where available. If Firebase needs a credential JSON file, mount it read-only, allow the container's `node` user to read it, and set `GOOGLE_APPLICATION_CREDENTIALS` to its container path.
+
+</Accordion>
+<Accordion title="AWS, Google Cloud, and CPU architecture">
+
+The same image can run on ECS/Fargate or Cloud Run. Use an [ECS task role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) for AWS credentials or a [Cloud Run service identity](https://docs.cloud.google.com/run/docs/securing/service-identity) for Firebase Admin.
+
+Build for the target CPU. Cloud Run requires [linux/amd64](https://docs.cloud.google.com/run/docs/container-contract):
+
+```bash
+docker build --platform linux/amd64 -t hot-updater-console:local .
+```
+
+Push the image to a registry your container service can access.
+
+</Accordion>
+<Accordion title="Logs and updates">
+
+```bash
 docker logs --tail 100 hot-updater-console
 ```
 
-Open `http://localhost:3000` for a local check. For production, route the public
-HTTPS origin through your reverse proxy to `127.0.0.1:3000`, preserving the
-original host and scheme. The example only publishes the port on the host's
-loopback interface. A proxy in another container should reach the console
-through a shared Docker network instead.
+If your proxy runs in Docker, use a shared Docker network to reach the console instead of host loopback.
 
-The image listens on `0.0.0.0:3000` inside the container. Container platforms
-can override `PORT` with their required listening port. No local mobile app,
-CLI process, or writable bundle volume is needed: the console uses the
-configured backend's database and storage.
+For updates, build a versioned image and recreate the container with the same runtime settings. Keep the previous image for rollback; restoring it does not restore backend data.
 
-## 5. Verify and update
+</Accordion>
+</Accordions>
 
-Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
-on the final HTTPS origin, including allowed sign-in, denied anonymous access,
-and a real bundle download. A successful image build or sign-in page alone
-does not verify backend credentials.
-
-For updates, build a new image from the updated lockfile, give it a versioned
-tag, and recreate the container with the same runtime settings. Keep the
-previous image tag for rollback. Replacing the console image does not revert
-changes already made to backend data.
-
-See [Nitro's Node deployment guide](https://nitro.build/deploy/runtimes/node),
-[Docker's multi-stage build guide](https://docs.docker.com/build/building/multi-stage/),
-and [Docker's container run reference](https://docs.docker.com/engine/containers/run/).
+See [Nitro's Node guide](https://nitro.build/deploy/runtimes/node) and [Docker's run reference](https://docs.docker.com/engine/containers/run/).

--- a/docs/content/docs/(latest)/guides/console-deployment/docker.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/docker.mdx
@@ -1,0 +1,135 @@
+---
+title: "Docker"
+description: "Build and run the Nitro console as a standalone Node container."
+---
+
+Complete the [basic setup](/docs/guides/console-deployment) first: connect your existing backend,
+configure OAuth, and choose who can sign in. This guide runs Nitro's standalone
+Node server in Docker, on a server or a container platform of your choice.
+
+## 1. Configure the backend
+
+Use the Node-compatible plugins for Cloudflare, AWS, Firebase, or Supabase.
+For D1/R2, follow [Cloudflare from Node](/docs/guides/console-deployment#cloudflare-backend-from-node);
+Worker bindings and the `/worker` entry point are not available inside Docker.
+Install the selected plugins and commit the updated lockfile before building.
+
+The repository includes a multi-stage `Dockerfile`. Its build stage installs
+from the frozen lockfile and runs `pnpm build:node`. The runtime stage copies
+the complete `.output` directory, including server dependencies and public
+assets, and starts Node as the unprivileged `node` user:
+
+```dockerfile
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build:node
+
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production HOST=0.0.0.0 PORT=3000
+COPY --from=build --chown=node:node /app/.output ./.output
+USER node
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]
+```
+
+The included `.dockerignore` only permits the package manifests and console
+configuration files into the build context. It also includes `.gitignore` so
+Tailwind excludes generated files consistently during the client and server
+builds. If your configuration imports additional local modules, add those
+specific paths to its allowlist. Keep credential files out of the image;
+supply them when the container starts.
+
+## 2. Build the image
+
+From the configured repository root:
+
+```bash
+docker build -t hot-updater-console:local .
+```
+
+This build needs no OAuth or backend secrets. Read those settings inside the
+`defineConsoleConfig` callback so they are resolved at runtime.
+
+For a remote container service, tag and push the image to a registry that the
+service can access. Build for the destination architecture: for example,
+`docker build --platform linux/amd64 -t hot-updater-console:local .` produces
+an amd64 image when building on an Apple Silicon machine. Cloud Run requires
+[linux/amd64](https://docs.cloud.google.com/run/docs/container-contract);
+match the task architecture when using ECS.
+
+## 3. Supply runtime settings
+
+For a standalone Docker host, prepare a private environment file:
+
+```bash
+cp .env.example .env.production
+chmod 600 .env.production
+```
+
+Edit `.env.production` with the values from [authentication setup](/docs/guides/console-deployment#3-configure-authentication):
+`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`,
+and at least one complete GitHub or Google OAuth pair. Add the environment
+variables read by your backend configuration. Use `KEY=value` entries without
+shell expansion or wrapping quotes; Docker passes these values to the process.
+The repository ignores `.env.production`.
+
+Set `BETTER_AUTH_URL` to the public HTTPS origin and register the matching
+`/api/auth/callback/github` or `/api/auth/callback/google` OAuth callback.
+For local sign-in testing, use `http://localhost:3000` and a matching local
+OAuth callback instead.
+
+On a managed container service, configure these values in its runtime secret
+settings instead of uploading the environment file. Local AWS profiles and
+Google credential files are not copied into the container. Use an attached
+service identity where supported, or provide server credentials at runtime.
+If your Firebase configuration uses a credential JSON file, mount it read-only,
+make it readable by the container's `node` user, and set
+`GOOGLE_APPLICATION_CREDENTIALS` to its path inside the container.
+
+## 4. Run the console
+
+For Docker on a server with a host-level HTTPS reverse proxy:
+
+```bash
+docker run -d \
+  --name hot-updater-console \
+  --restart unless-stopped \
+  --env-file .env.production \
+  -p 127.0.0.1:3000:3000 \
+  hot-updater-console:local
+
+docker logs --tail 100 hot-updater-console
+```
+
+Open `http://localhost:3000` for a local check. For production, route the public
+HTTPS origin through your reverse proxy to `127.0.0.1:3000`, preserving the
+original host and scheme. The example only publishes the port on the host's
+loopback interface. A proxy in another container should reach the console
+through a shared Docker network instead.
+
+The image listens on `0.0.0.0:3000` inside the container. Container platforms
+can override `PORT` with their required listening port. No local mobile app,
+CLI process, or writable bundle volume is needed: the console uses the
+configured backend's database and storage.
+
+## 5. Verify and update
+
+Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
+on the final HTTPS origin, including allowed sign-in, denied anonymous access,
+and a real bundle download. A successful image build or sign-in page alone
+does not verify backend credentials.
+
+For updates, build a new image from the updated lockfile, give it a versioned
+tag, and recreate the container with the same runtime settings. Keep the
+previous image tag for rollback. Replacing the console image does not revert
+changes already made to backend data.
+
+See [Nitro's Node deployment guide](https://nitro.build/deploy/runtimes/node),
+[Docker's multi-stage build guide](https://docs.docker.com/build/building/multi-stage/),
+and [Docker's container run reference](https://docs.docker.com/engine/containers/run/).

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -195,4 +195,3 @@ for a host-level rollback. Reverting console code does not undo database or
 storage changes made through the UI and does not roll back the mobile OTA
 server. Check the Hot Updater infrastructure upgrade requirements separately
 when changing backend versions.
-

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -1,7 +1,6 @@
 ---
-title: "Console deployment"
-description: "Clone and deploy an authenticated Hot Updater Console with Nitro on your infrastructure."
-icon: Cloud
+title: "Basics"
+description: "Configure the backend, authentication, and Nitro deployment target."
 ---
 
 Deploy the Hot Updater console as a standalone HTTPS application using Nitro.
@@ -12,8 +11,16 @@ mobile source checkout are not required after deployment.
 There are two independent choices: **where the console runs** (Nitro preset)
 and **which existing backend it manages** (Hot Updater database and storage
 plugins). Changing the console host does not migrate the backend or change the
-OTA endpoint used by the mobile app. Cloudflare is one deployment example;
-Modex uses it for dogfood because its existing backend uses D1 and R2.
+OTA endpoint used by the mobile app. The provider guides below build on these shared steps.
+
+## Deployment guides
+
+Start with the common setup on this page, then choose your host:
+
+- [Cloudflare Workers](/docs/guides/console-deployment/cloudflare): connect existing D1/R2 resources with native bindings.
+- [Vercel](/docs/guides/console-deployment/vercel): deploy Nitro server functions and static assets.
+- [Netlify](/docs/guides/console-deployment/netlify): deploy Nitro functions with the generated routing configuration.
+- [Node server and containers](#node-server-and-containers): run the standalone server output.
 
 ## 1. Clone and install
 
@@ -64,8 +71,7 @@ This example requires `HOT_UPDATER_SUPABASE_URL`,
 `HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY`, and
 `HOT_UPDATER_SUPABASE_BUCKET_NAME`, taken from the existing backend. Other
 providers use their own plugin settings; you do not need to move to Supabase
-to host the console on Node. For D1/R2 native bindings, use the Cloudflare
-example below.
+to host the console on Node. For D1/R2 native bindings, follow the [Cloudflare guide](/docs/guides/console-deployment/cloudflare).
 
 Hosting portability does not make every provider SDK compatible with every
 runtime. A Node SDK may require a Node preset; native Worker bindings require
@@ -124,9 +130,9 @@ standalone `nitro build` command.
 | Console host                                                          | Build command                      | Deployment artifact and next step                                                                 |
 | --------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [Node server / container](https://nitro.build/deploy/runtimes/node)   | `pnpm build:node`                  | Ship the complete `.output` directory; run `node .output/server/index.mjs`                        |
-| [Vercel](https://nitro.build/deploy/providers/vercel)                 | `NITRO_PRESET=vercel pnpm build`   | Generated `.vercel/output`; use Vercel's Git build/deploy integration                             |
-| [Netlify](https://nitro.build/deploy/providers/netlify)               | `NITRO_PRESET=netlify pnpm build`  | Generated Netlify functions and assets; use Netlify's Git integration and generated configuration |
-| [Cloudflare Workers](https://nitro.build/deploy/providers/cloudflare) | `pnpm build:cloudflare`            | Generated Worker/assets configuration; deploy with Wrangler as below                              |
+| [Vercel](/docs/guides/console-deployment/vercel)                 | `NITRO_PRESET=vercel pnpm build`   | Generated `.vercel/output`; use Vercel's Git build/deploy integration                             |
+| [Netlify](/docs/guides/console-deployment/netlify)               | `NITRO_PRESET=netlify pnpm build`  | Generated Netlify functions and assets; use Netlify's Git integration and generated configuration |
+| [Cloudflare Workers](/docs/guides/console-deployment/cloudflare) | `pnpm build:cloudflare`            | Generated Worker/assets configuration; follow the Cloudflare guide                              |
 | Other Nitro hosts                                                     | `NITRO_PRESET=<preset> pnpm build` | Follow that host's guide in the [Nitro provider catalog](https://nitro.build/deploy)              |
 
 Without an explicit preset or provider detection, Nitro defaults to a Node
@@ -190,181 +196,3 @@ storage changes made through the UI and does not roll back the mobile OTA
 server. Check the Hot Updater infrastructure upgrade requirements separately
 when changing backend versions.
 
-## Cloudflare example: D1 and R2
-
-This optional example is the path used for Modex dogfood. It does not determine
-the console's hosting architecture for other applications.
-
-Copy the example into the root of your private deployment checkout:
-
-```bash
-cp examples/cloudflare/hot-updater.config.ts.example hot-updater.config.ts
-cp examples/cloudflare/wrangler.jsonc wrangler.jsonc
-pnpm add --save-exact @hot-updater/cloudflare@1.0.0-rc.5
-pnpm exec wrangler login
-pnpm exec wrangler whoami
-```
-
-Find the resources in your OTA Worker's Wrangler configuration, your mobile
-project's provider settings, or the Cloudflare dashboard. You can also list them:
-
-```bash
-pnpm exec wrangler d1 list
-pnpm exec wrangler r2 bucket list
-```
-
-Edit `wrangler.jsonc`:
-
-| Field                                             | Value                                                      |
-| ------------------------------------------------- | ---------------------------------------------------------- |
-| `name`                                            | A new console Worker name, separate from the OTA Worker    |
-| `account_id`                                      | The account containing the existing resources, when needed |
-| `vars.BETTER_AUTH_URL`                            | The console's exact public HTTPS origin, without a path    |
-| `vars.BUCKET_NAME`                                | Your existing bundle bucket name                           |
-| `d1_databases[0].database_name` and `database_id` | Your existing Hot Updater D1 database                      |
-| `r2_buckets[0].bucket_name`                       | The same bucket as `BUCKET_NAME`                           |
-
-The default URL is `https://<worker-name>.<account-subdomain>.workers.dev`.
-Choose the origin before configuring OAuth. A custom domain also works; use
-that origin consistently in Wrangler and OAuth callbacks.
-
-The copied `hot-updater.config.ts` uses the worker entry point:
-
-```ts
-import { d1Database, r2Storage } from "@hot-updater/cloudflare/worker";
-import { defineConsoleConfig } from "@hot-updater/console";
-
-type CloudflareRequest = Request & {
-  runtime?: { cloudflare?: { env?: Env } };
-};
-
-export default defineConsoleConfig((request) => {
-  const env = (request as CloudflareRequest).runtime?.cloudflare?.env;
-  if (!env) throw new Error("Cloudflare bindings are unavailable.");
-
-  return {
-    console: { gitUrl: "https://github.com/your-org/your-mobile-app" },
-    database: d1Database(env.DB),
-    storage: r2Storage({
-      bucket: env.BUCKET,
-      bucketName: env.BUCKET_NAME,
-      downloadUrlSigningKey: env.STORAGE_DOWNLOAD_URL_SIGNING_KEY,
-    }),
-  };
-});
-```
-
-Generate `Env` from your Wrangler configuration with `pnpm cf:typegen` after
-changing bindings. Do not copy the entire mobile `hot-updater.config.ts`:
-Expo/native build plugins, fingerprint settings, and signing private keys stay
-in the mobile project. D1 and R2 bindings replace Cloudflare API tokens and S3
-credentials inside the hosted Worker.
-
-Do not create a new D1 database or run schema migrations for this console.
-It must connect to the backend already used by the app. Backend upgrades remain
-part of the Hot Updater infrastructure upgrade workflow.
-
-The copied `secrets.required` list includes GitHub's pair. Replace it with
-Google's pair if needed; Wrangler loads only listed names from `.dev.vars`.
-In addition to the shared authentication variables, the R2 plugin needs
-`STORAGE_DOWNLOAD_URL_SIGNING_KEY`: generate a separate random secret for
-storage URL capabilities. It is not a mobile signing private key.
-
-Use the ignored `.secrets.production.json` file for initial deployment:
-
-```json
-{
-  "BETTER_AUTH_SECRET": "REPLACE_WITH_RANDOM_SECRET",
-  "HOT_UPDATER_CONSOLE_ALLOWED_EMAILS": "owner@example.com",
-  "STORAGE_DOWNLOAD_URL_SIGNING_KEY": "REPLACE_WITH_ANOTHER_RANDOM_SECRET",
-  "GITHUB_CLIENT_ID": "REPLACE_WITH_CLIENT_ID",
-  "GITHUB_CLIENT_SECRET": "REPLACE_WITH_CLIENT_SECRET"
-}
-```
-
-Fill real values privately and run `chmod 600 .secrets.production.json`.
-Never commit the file or put secrets in shell command arguments.
-
-### Build and deploy the Worker
-
-```bash
-pnpm test
-pnpm cf:typegen
-pnpm test:type
-pnpm build:cloudflare
-pnpm exec wrangler deploy --dry-run
-pnpm test:cloudflare
-pnpm exec wrangler deploy --secrets-file .secrets.production.json
-```
-
-The last command uploads code and secrets together. Inspect the reported Worker
-name, D1 database, and bucket before confirming any CLI prompt.
-
-Nitro generates `.output/server/wrangler.json` and
-`.wrangler/deploy/config.json`. Wrangler automatically uses that generated
-configuration, which includes the server modules and static assets. Edit the
-root `wrangler.jsonc` and rebuild; do not edit generated configuration or pass
-the root file to deployment with `--config`. The root file is build input.
-
-The Worker smoke check starts the built artifact with test-only authentication
-settings and local resources. It catches runtime failures that a successful
-build or dry run cannot detect, and checks that anonymous reads, writes, and
-downloads are denied.
-
-Keep `preview_urls: false` so version preview addresses are not published with
-an origin that differs from the OAuth configuration. The standard `workers.dev`
-address remains enabled. Use `pnpm exec wrangler tail` to inspect runtime errors.
-
-The default configuration enables Workers logs and samples traces. Follow your
-account's observability retention and sampling requirements.
-
-### Local Worker preview
-
-```bash
-cp examples/cloudflare/.dev.vars.example .dev.vars
-pnpm build:cloudflare
-pnpm preview:cloudflare
-```
-
-Fill `.dev.vars` with a local OAuth client's credentials, random secrets, and
-`BETTER_AUTH_URL=http://localhost:3000`. Register the corresponding localhost
-callback on that OAuth client. The file stays local and is not automatically
-uploaded by deployment.
-
-Wrangler uses local D1 and R2 by default. An empty local database does not mean
-production data was lost. Avoid enabling remote bindings unless you intend to
-operate on the real backend. `pnpm dev` runs Vite on Node and needs a
-Node-compatible provider configuration instead of native Worker bindings.
-
-### Worker updates and rollback
-
-Rebuild and rerun `pnpm test:cloudflare` before `pnpm exec wrangler deploy`.
-Omitting `--secrets-file` preserves existing secrets. Use interactive
-`pnpm exec wrangler secret put NAME` to update a secret privately.
-Record the version ID printed after deployment:
-
-```bash
-pnpm exec wrangler deployments list
-pnpm exec wrangler rollback <previous-version-id>
-```
-
-A Worker rollback restores code/configuration, not D1 rows or R2 objects.
-
-## Troubleshooting
-
-| Symptom                                   | Check                                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Sign-in fails before OAuth opens          | Complete provider pair, strong session secret, nonempty exact email allowlist               |
-| OAuth callback is rejected                | Provider callback, `BETTER_AUTH_URL`, and the browser origin must match                     |
-| A signed-in user sees Forbidden           | The provider must return a verified address present in the allowlist                        |
-| Cloudflare bindings are unavailable       | Build with the Cloudflare preset and run the generated Worker through Wrangler              |
-| Insights is empty or queries fail         | Bind the existing database in the correct account; local preview has separate data          |
-| Bundle download reports a bucket mismatch | `BUCKET_NAME`, the R2 binding, and the stored bundle URI must refer to the same bucket      |
-| Deployment has stale bindings             | Update root Wrangler config, rebuild, and inspect the generated deployment before uploading |
-
-## Cloudflare references
-
-- [Nitro on Cloudflare](https://nitro.build/deploy/providers/cloudflare)
-- [Cloudflare Worker secrets](https://developers.cloudflare.com/workers/configuration/secrets/)
-- [Cloudflare binding types](https://developers.cloudflare.com/workers/languages/typescript/#generate-types)
-- [Cloudflare Worker rollback](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -20,7 +20,40 @@ Start with the common setup on this page, then choose your host:
 - [Cloudflare Workers](/docs/guides/console-deployment/cloudflare): connect existing D1/R2 resources with native bindings.
 - [Vercel](/docs/guides/console-deployment/vercel): deploy Nitro server functions and static assets.
 - [Netlify](/docs/guides/console-deployment/netlify): deploy Nitro functions with the generated routing configuration.
+- [Docker](/docs/guides/console-deployment/docker): build and run the standalone Node server in a container.
 - [Node server and containers](#node-server-and-containers): run the standalone server output.
+
+## Recommended hosts by managed provider
+
+**Vercel, Netlify, and Docker/Node can connect to all four managed backends.**
+There is no one-to-one mapping between a backend and a console host. Choose a
+host your team already operates, then configure the backend's server plugin
+and credentials for that runtime.
+
+| Existing managed backend | Vercel / Netlify / Docker with Node | Cloudflare Workers |
+| --- | --- | --- |
+| Cloudflare D1 + R2 | `@hot-updater/cloudflare`: D1 REST API token and R2 S3-compatible credentials. See [Cloudflare from Node](#cloudflare-backend-from-node). | Recommended when using native D1/R2 bindings through `@hot-updater/cloudflare/worker`; [deployment guide](/docs/guides/console-deployment/cloudflare). |
+| AWS DynamoDB + S3 | `@hot-updater/aws`: AWS SDK credentials with access to the existing table and bucket. | No complete console/backend verification is provided; use Node as the default. |
+| Firebase Firestore + Storage | `@hot-updater/firebase`: Firebase Admin SDK with server credentials. | Use Node for the current Firebase Admin integration. |
+| Supabase Database + Storage | `@hot-updater/supabase`: project URL and service-role key over HTTPS. | [Workers can connect to Supabase](https://developers.cloudflare.com/workers/databases/third-party-integrations/supabase/), but this console/backend combination still needs verification. |
+
+For a managed Node deployment, start with [Vercel](/docs/guides/console-deployment/vercel) or
+[Netlify](/docs/guides/console-deployment/netlify). Choose [Docker](/docs/guides/console-deployment/docker) when you want to run the
+same Node output on your own server or container platform. For a Cloudflare
+backend, Workers avoids separate D1 API and R2 S3 credentials by using bindings.
+
+If you prefer to keep compute and backend credentials within the same cloud,
+[Node on ECS/Fargate](#aws-backend-on-ecs) can use an AWS task role, and
+[Node on Cloud Run](#firebase-backend-on-cloud-run) can use a Google service
+account. These are additional options, not requirements for those backends.
+Prefer a region near the backend.
+
+This matrix describes plugin/runtime compatibility, not completed remote QA
+for every combination. The template CI checks hosting output and authentication;
+Modex remote dogfood covers Workers with D1/R2. Verify backend access and real
+artifact downloads on your chosen host. Downloads pass through the console,
+so the host's response-size and execution limits also matter; see the
+[Vercel guide](/docs/guides/console-deployment/vercel).
 
 ## 1. Clone and install
 
@@ -83,6 +116,43 @@ Do not copy the entire mobile config. Build plugins, fingerprints, and mobile
 bundle-signing private keys stay in the mobile project. Connect existing
 resources; creating a console does not require a new database, bucket, or schema
 migration.
+
+### Cloudflare backend from Node
+
+To host a Cloudflare backend on Vercel, Netlify, or Docker, use the package's
+root entry point. It queries D1 through the Cloudflare API and R2 through its
+S3-compatible API; no Worker bindings are required.
+
+```bash
+pnpm add --save-exact @hot-updater/cloudflare@rc
+```
+
+```ts
+import { defineConsoleConfig } from "@hot-updater/console";
+import { d1Database, r2Storage } from "@hot-updater/cloudflare";
+
+export default defineConsoleConfig(() => ({
+  database: d1Database({
+    accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
+    databaseId: process.env.HOT_UPDATER_CLOUDFLARE_D1_DATABASE_ID!,
+    cloudflareApiToken: process.env.HOT_UPDATER_CLOUDFLARE_API_TOKEN!,
+  }),
+  storage: r2Storage({
+    accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
+    bucketName: process.env.HOT_UPDATER_CLOUDFLARE_R2_BUCKET_NAME!,
+    credentials: {
+      accessKeyId: process.env.HOT_UPDATER_CLOUDFLARE_R2_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.HOT_UPDATER_CLOUDFLARE_R2_SECRET_ACCESS_KEY!,
+    },
+  }),
+}));
+```
+
+Set all six variables in the console host's private runtime environment.
+Reuse the existing account, database ID, and bucket name. Supply a D1 API token
+with access to that database and R2 S3 credentials with access to the bucket.
+These are server credentials; the console's GitHub/Google OAuth settings are
+configured separately in step 3.
 
 ## 3. Configure authentication
 
@@ -167,6 +237,47 @@ the same process: build with Node and pnpm, copy `.output` into a Node runtime
 image, inject secrets at runtime, and start the entry point. Never bake `.env`
 or credentials into the image. See [Nitro's Node deployment
 reference](https://nitro.build/deploy/runtimes/node).
+
+### AWS backend on ECS
+
+For a console that stays in AWS, deploy the Node output as an ECS service on
+Fargate. Use `dynamoDB` and `s3Storage` from `@hot-updater/aws` with the
+existing table, bucket, and region. Build with `pnpm build:node`, ship the
+complete `.output` directory in a Node container, and start
+`node .output/server/index.mjs` behind your service's HTTPS endpoint.
+
+Give the console's [task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+access to those backend resources. The AWS SDK can obtain temporary credentials
+from that role; a developer's local AWS profile is not available in the
+container. Inject the step 3 authentication variables using the service's
+runtime configuration and [Secrets Manager references](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html).
+Use a separate console service; keep the existing OTA Lambda@Edge and
+CloudFront configuration.
+
+ECS adds container and service configuration. If your team already hosts Node
+applications elsewhere, deploying there with suitable AWS credentials is also
+a reasonable choice.
+
+### Firebase backend on Cloud Run
+
+Deploy the same Node output as a Cloud Run service in the existing Firebase
+project. Install `@hot-updater/firebase` and its declared Firebase peer
+dependencies, and configure `firebaseDatabase` and `firebaseStorage` for
+the existing project and bucket.
+
+Use a service account with the required Firestore and Storage permissions.
+[Firebase recommends Application Default Credentials](https://firebase.google.com/docs/admin/setup#initialize_the_sdk)
+in Google environments, including Cloud Run, so `applicationDefault()` can
+use the service identity without copying a developer's credential file.
+Supply OAuth and allowlist values through the service's runtime environment
+and [Secret Manager integration](https://docs.cloud.google.com/run/docs/configuring/services/secrets).
+
+Build with `pnpm build:node`, include the complete `.output` in the
+container, and run `node .output/server/index.mjs`. Set `HOST=0.0.0.0`
+and let Nitro use the `PORT` provided by Cloud Run, as required by its
+[container contract](https://docs.cloud.google.com/run/docs/container-contract).
+Use the public console origin for the OAuth callbacks in step 3. A static
+Firebase Hosting upload alone does not run this Node server.
 
 ## 5. Verify the deployed console
 

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -8,7 +8,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 Host the console with [Nitro](https://nitro.build/deploy) and connect it to your existing Hot Updater backend.
 
-You need Node.js 22+, backend credentials, and a GitHub or Google OAuth application.
+You need Node.js 22+ (npm 11+ if using npm), backend credentials, and a GitHub or Google OAuth application.
 
 <Steps>
 <Step>

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -33,7 +33,7 @@ Keep your deployment configuration in a private repository and commit its lockfi
 
 ## Add your plugins
 
-Replace `hot-updater.config.ts` with your database and storage plugins:
+Start with an [AWS, Firebase, Supabase, or Cloudflare example](https://github.com/hot-updater/console/tree/main/examples), or configure your own database and storage plugins:
 
 ```ts title="hot-updater.config.ts"
 import { defineConsoleConfig } from "@hot-updater/console";

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -1,308 +1,157 @@
 ---
 title: "Basics"
-description: "Configure the backend, authentication, and Nitro deployment target."
+description: "Connect your backend, set up sign-in, and choose a console host."
 ---
 
-Deploy the Hot Updater console as a standalone HTTPS application using Nitro.
-The same console package can run on a Node server, container, or a hosting
-provider supported by Nitro. A running `hot-updater console` process and a
-mobile source checkout are not required after deployment.
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-There are two independent choices: **where the console runs** (Nitro preset)
-and **which existing backend it manages** (Hot Updater database and storage
-plugins). Changing the console host does not migrate the backend or change the
-OTA endpoint used by the mobile app. The provider guides below build on these shared steps.
+Host the console with [Nitro](https://nitro.build/deploy) and connect it to your existing Hot Updater backend.
 
-## Deployment guides
+You need Node.js 22+, backend credentials, and a GitHub or Google OAuth application.
 
-Start with the common setup on this page, then choose your host:
+<Steps>
+<Step>
 
-- [Cloudflare Workers](/docs/guides/console-deployment/cloudflare): connect existing D1/R2 resources with native bindings.
-- [Vercel](/docs/guides/console-deployment/vercel): deploy Nitro server functions and static assets.
-- [Netlify](/docs/guides/console-deployment/netlify): deploy Nitro functions with the generated routing configuration.
-- [Docker](/docs/guides/console-deployment/docker): build and run the standalone Node server in a container.
-- [Node server and containers](#node-server-and-containers): run the standalone server output.
-
-## Recommended hosts by managed provider
-
-**Vercel, Netlify, and Docker/Node can connect to all four managed backends.**
-There is no one-to-one mapping between a backend and a console host. Choose a
-host your team already operates, then configure the backend's server plugin
-and credentials for that runtime.
-
-| Existing managed backend | Vercel / Netlify / Docker with Node | Cloudflare Workers |
-| --- | --- | --- |
-| Cloudflare D1 + R2 | `@hot-updater/cloudflare`: D1 REST API token and R2 S3-compatible credentials. See [Cloudflare from Node](#cloudflare-backend-from-node). | Recommended when using native D1/R2 bindings through `@hot-updater/cloudflare/worker`; [deployment guide](/docs/guides/console-deployment/cloudflare). |
-| AWS DynamoDB + S3 | `@hot-updater/aws`: AWS SDK credentials with access to the existing table and bucket. | No complete console/backend verification is provided; use Node as the default. |
-| Firebase Firestore + Storage | `@hot-updater/firebase`: Firebase Admin SDK with server credentials. | Use Node for the current Firebase Admin integration. |
-| Supabase Database + Storage | `@hot-updater/supabase`: project URL and service-role key over HTTPS. | [Workers can connect to Supabase](https://developers.cloudflare.com/workers/databases/third-party-integrations/supabase/), but this console/backend combination still needs verification. |
-
-For a managed Node deployment, start with [Vercel](/docs/guides/console-deployment/vercel) or
-[Netlify](/docs/guides/console-deployment/netlify). Choose [Docker](/docs/guides/console-deployment/docker) when you want to run the
-same Node output on your own server or container platform. For a Cloudflare
-backend, Workers avoids separate D1 API and R2 S3 credentials by using bindings.
-
-If you prefer to keep compute and backend credentials within the same cloud,
-[Node on ECS/Fargate](#aws-backend-on-ecs) can use an AWS task role, and
-[Node on Cloud Run](#firebase-backend-on-cloud-run) can use a Google service
-account. These are additional options, not requirements for those backends.
-Prefer a region near the backend.
-
-This matrix describes plugin/runtime compatibility, not completed remote QA
-for every combination. The template CI checks hosting output and authentication;
-Modex remote dogfood covers Workers with D1/R2. Verify backend access and real
-artifact downloads on your chosen host. Downloads pass through the console,
-so the host's response-size and execution limits also matter; see the
-[Vercel guide](/docs/guides/console-deployment/vercel).
-
-## 1. Clone and install
-
-Use Node.js 22 or later and the pnpm version declared in `package.json`.
-Keep your deployment configuration in a private fork or infrastructure repo.
+## Clone the console
 
 ```bash
 git clone https://github.com/hot-updater/console.git my-app-console
 cd my-app-console
-corepack enable
-pnpm install --frozen-lockfile
 ```
 
-The template uses published npm RC packages. Its default
-`hot-updater.config.ts` deliberately requires you to connect your backend; it
-does not select an infrastructure provider for you.
+Install dependencies with the package manager used by your deployment repository.
 
-## 2. Connect your existing backend
-
-Replace `hot-updater.config.ts` with `defineConsoleConfig` and the database and
-storage plugins for your existing Hot Updater backend. Select plugin entry
-points compatible with the console's runtime. For example, a Node-compatible
-Supabase configuration is:
-
-```bash
-pnpm add --save-exact @hot-updater/supabase@rc
+```package-install
+npm install
 ```
 
-```ts
+Keep your deployment configuration in a private repository and commit its lockfile.
+
+</Step>
+<Step>
+
+## Add your plugins
+
+Replace `hot-updater.config.ts` with your database and storage plugins:
+
+```ts title="hot-updater.config.ts"
 import { defineConsoleConfig } from "@hot-updater/console";
-import { supabaseDatabase, supabaseStorage } from "@hot-updater/supabase";
+// Import your database and storage plugins here.
 
 export default defineConsoleConfig(() => ({
-  database: supabaseDatabase({
-    supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
-    supabaseServiceRoleKey: process.env.HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY!,
-  }),
-  storage: supabaseStorage({
-    supabaseUrl: process.env.HOT_UPDATER_SUPABASE_URL!,
-    supabaseServiceRoleKey: process.env.HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY!,
-    bucketName: process.env.HOT_UPDATER_SUPABASE_BUCKET_NAME!,
-  }),
+  // Add your configured database plugin:
+  // database: yourDatabasePlugin({ ... }),
+
+  // Add your configured storage plugin:
+  // storage: yourStoragePlugin({ ... }),
 }));
 ```
 
-Set the provider variables in the host's private **runtime** environment store.
-This example requires `HOT_UPDATER_SUPABASE_URL`,
-`HOT_UPDATER_SUPABASE_SERVICE_ROLE_KEY`, and
-`HOT_UPDATER_SUPABASE_BUCKET_NAME`, taken from the existing backend. Other
-providers use their own plugin settings; you do not need to move to Supabase
-to host the console on Node. For D1/R2 native bindings, follow the [Cloudflare guide](/docs/guides/console-deployment/cloudflare).
+Replace the commented lines before building. Reuse the existing database and bucket; leave mobile build plugins and signing private keys in the app project.
 
-Hosting portability does not make every provider SDK compatible with every
-runtime. A Node SDK may require a Node preset; native Worker bindings require
-Cloudflare. Confirm both the Nitro preset and provider entry points before
-deploying. The template's Cloudflare package is a development dependency for
-its optional example and CI, not the default runtime configuration.
+Install your chosen [database plugin](/docs/concepts/plugin-system#database-plugin) and [storage plugin](/docs/concepts/plugin-system#storage-plugin). Read credentials from runtime environment variables inside the callback.
 
-Do not copy the entire mobile config. Build plugins, fingerprints, and mobile
-bundle-signing private keys stay in the mobile project. Connect existing
-resources; creating a console does not require a new database, bucket, or schema
-migration.
+</Step>
+<Step>
 
-### Cloudflare backend from Node
+## Set up sign-in
 
-To host a Cloudflare backend on Vercel, Netlify, or Docker, use the package's
-root entry point. It queries D1 through the Cloudflare API and R2 through its
-S3-compatible API; no Worker bindings are required.
+GitHub and Google sign-in are included. Fill in the environment variables below to use either provider without changing the authentication code. For other authentication systems, [customize the cloned code](#custom-authentication).
 
-```bash
-pnpm add --save-exact @hot-updater/cloudflare@rc
-```
+Choose your public HTTPS URL, then register its OAuth callback:
 
-```ts
-import { defineConsoleConfig } from "@hot-updater/console";
-import { d1Database, r2Storage } from "@hot-updater/cloudflare";
+| Provider | Callback |
+| --- | --- |
+| GitHub | `https://<console-host>/api/auth/callback/github` |
+| Google | `https://<console-host>/api/auth/callback/google` |
 
-export default defineConsoleConfig(() => ({
-  database: d1Database({
-    accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
-    databaseId: process.env.HOT_UPDATER_CLOUDFLARE_D1_DATABASE_ID!,
-    cloudflareApiToken: process.env.HOT_UPDATER_CLOUDFLARE_API_TOKEN!,
-  }),
-  storage: r2Storage({
-    accountId: process.env.HOT_UPDATER_CLOUDFLARE_ACCOUNT_ID!,
-    bucketName: process.env.HOT_UPDATER_CLOUDFLARE_R2_BUCKET_NAME!,
-    credentials: {
-      accessKeyId: process.env.HOT_UPDATER_CLOUDFLARE_R2_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.HOT_UPDATER_CLOUDFLARE_R2_SECRET_ACCESS_KEY!,
-    },
-  }),
-}));
-```
+Add these values to your host's **runtime** environment:
 
-Set all six variables in the console host's private runtime environment.
-Reuse the existing account, database ID, and bucket name. Supply a D1 API token
-with access to that database and R2 S3 credentials with access to the bucket.
-These are server credentials; the console's GitHub/Google OAuth settings are
-configured separately in step 3.
+| Variable | Value |
+| --- | --- |
+| `BETTER_AUTH_URL` | Your HTTPS origin, without a path |
+| `BETTER_AUTH_SECRET` | A random secret of at least 32 characters |
+| `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS` | Comma-separated full, verified email addresses |
+| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | Your GitHub OAuth credentials, if using GitHub |
+| `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Your Google OAuth credentials, if using Google |
 
-## 3. Configure authentication
-
-Choose the console's canonical HTTPS origin, then create a GitHub OAuth App or
-Google OAuth client with that origin as its homepage and the matching callback:
-
-```text
-https://<console-host>/api/auth/callback/github
-https://<console-host>/api/auth/callback/google
-```
-
-GitHub login requests `user:email` to check verified addresses, without repository
-access. For Google, permit your test users when the OAuth client is in testing.
-Configure at least one complete provider pair in the host's private runtime
-environment store:
-
-| Variable                                   | Required | Purpose                                                                    |
-| ------------------------------------------ | -------- | -------------------------------------------------------------------------- |
-| `BETTER_AUTH_URL`                          | Yes      | Exact public HTTPS origin, without a path                                  |
-| `BETTER_AUTH_SECRET`                       | Yes      | Random secret of at least 32 characters; encrypts OAuth state and sessions |
-| `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`       | Yes      | Comma-separated exact verified addresses permitted to manage the backend   |
-| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | One pair | GitHub OAuth App credentials                                               |
-| `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | One pair | Google OAuth client credentials                                            |
-
-Generate a session secret with `openssl rand -base64 32`. Do not use `VITE_`
-prefixes: authentication and backend credentials belong only on the server.
-The included adapter uses encrypted cookie sessions, so there is no separate
-authentication database. Access checks precede provider initialization, reads,
-writes, and downloads. Removing an address blocks its next protected request;
-rotating the session secret invalidates sessions.
-
-For local Node development, copy `.env.example` to `.env`, add the selected
-provider variables, and use `pnpm dev`. Use a localhost OAuth callback and
-`BETTER_AUTH_URL=http://localhost:3000`. Production hosting must inject runtime
-variables explicitly; the built Node server does not automatically load `.env`.
-
-## 4. Select a Nitro deployment target
-
-Nitro produces a deployment artifact for the selected infrastructure. Its
-[deployment guide](https://nitro.build/deploy) describes preset selection and
-provider detection. This repository builds through Vite's console plugin, so
-set `NITRO_PRESET` on **`pnpm build`**, rather than replacing the build with a
-standalone `nitro build` command.
-
-| Console host                                                          | Build command                      | Deployment artifact and next step                                                                 |
-| --------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [Node server / container](https://nitro.build/deploy/runtimes/node)   | `pnpm build:node`                  | Ship the complete `.output` directory; run `node .output/server/index.mjs`                        |
-| [Vercel](/docs/guides/console-deployment/vercel)                 | `NITRO_PRESET=vercel pnpm build`   | Generated `.vercel/output`; use Vercel's Git build/deploy integration                             |
-| [Netlify](/docs/guides/console-deployment/netlify)               | `NITRO_PRESET=netlify pnpm build`  | Generated Netlify functions and assets; use Netlify's Git integration and generated configuration |
-| [Cloudflare Workers](/docs/guides/console-deployment/cloudflare) | `pnpm build:cloudflare`            | Generated Worker/assets configuration; follow the Cloudflare guide                              |
-| Other Nitro hosts                                                     | `NITRO_PRESET=<preset> pnpm build` | Follow that host's guide in the [Nitro provider catalog](https://nitro.build/deploy)              |
-
-Without an explicit preset or provider detection, Nitro defaults to a Node
-server. On Vercel or Netlify, import your configured repository, set install to
-`pnpm install --frozen-lockfile`, build to the corresponding command above, and
-supply the server runtime variables from steps 2–3. Follow the linked Nitro
-provider guide for the generated output and platform deployment settings.
-Do not override its server output with a static Vite `dist` deployment.
-
-The console needs a server for OAuth, data queries, and mutations. Static-only
-hosting cannot run it. The lockfile pins Nitro with the console package; newer
-Nitro documentation may describe behavior unavailable in that version. Retain
-the lockfile and verify the generated artifact after upgrades. CI builds Node,
-Vercel, Netlify, and Cloudflare, and runs actual Node/Worker runtime smoke checks.
-Those checks do not claim that every provider has been deployed remotely.
-
-### Node server and containers
+Configure at least one complete OAuth pair and your backend's environment variables. Generate the session secret with:
 
 ```bash
-pnpm test
-pnpm test:type
-pnpm build:node
-pnpm test:node
-# Supply production runtime variables through your host, then:
-node .output/server/index.mjs
+openssl rand -base64 32
 ```
 
-Deploy the **entire** `.output` directory, including its public assets and server
-dependencies. Set `PORT` / `NITRO_PORT` and `HOST` / `NITRO_HOST` as required.
-Terminate HTTPS at your hosting platform or reverse proxy. A container follows
-the same process: build with Node and pnpm, copy `.output` into a Node runtime
-image, inject secrets at runtime, and start the entry point. Never bake `.env`
-or credentials into the image. See [Nitro's Node deployment
-reference](https://nitro.build/deploy/runtimes/node).
+Keep secrets server-side; never prefix them with `VITE_`. Google OAuth clients in testing must also allow your test users.
 
-### AWS backend on ECS
+</Step>
+<Step>
 
-For a console that stays in AWS, deploy the Node output as an ECS service on
-Fargate. Use `dynamoDB` and `s3Storage` from `@hot-updater/aws` with the
-existing table, bucket, and region. Build with `pnpm build:node`, ship the
-complete `.output` directory in a Node container, and start
-`node .output/server/index.mjs` behind your service's HTTPS endpoint.
+## Choose a host
 
-Give the console's [task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
-access to those backend resources. The AWS SDK can obtain temporary credentials
-from that role; a developer's local AWS profile is not available in the
-container. Inject the step 3 authentication variables using the service's
-runtime configuration and [Secrets Manager references](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html).
-Use a separate console service; keep the existing OTA Lambda@Edge and
-CloudFront configuration.
+Follow one deployment guide:
 
-ECS adds container and service configuration. If your team already hosts Node
-applications elsewhere, deploying there with suitable AWS credentials is also
-a reasonable choice.
+| Host | Runtime |
+| --- | --- |
+| [Docker](/docs/guides/console-deployment/docker) | Standalone Node container |
+| [Vercel](/docs/guides/console-deployment/vercel) | Node server functions |
+| [Netlify](/docs/guides/console-deployment/netlify) | Node server functions |
+| [Cloudflare](/docs/guides/console-deployment/cloudflare) | Worker with native D1/R2 bindings |
 
-### Firebase backend on Cloud Run
+Hosting and backend providers can differ. Vercel, Netlify, and Docker/Node can connect to all four managed backends:
 
-Deploy the same Node output as a Cloud Run service in the existing Firebase
-project. Install `@hot-updater/firebase` and its declared Firebase peer
-dependencies, and configure `firebaseDatabase` and `firebaseStorage` for
-the existing project and bucket.
+| Backend | Node hosts | Cloudflare Workers |
+| --- | --- | --- |
+| Cloudflare | [D1 API](/docs/database-plugins/cloudflare) + [R2 S3 credentials](/docs/storage-plugins/cloudflare) | Native bindings |
+| AWS | AWS SDK credentials | Console integration unverified |
+| Firebase | Firebase Admin credentials | Use Node |
+| Supabase | Project URL + service-role key | SDK compatible; console integration unverified |
 
-Use a service account with the required Firestore and Storage permissions.
-[Firebase recommends Application Default Credentials](https://firebase.google.com/docs/admin/setup#initialize_the_sdk)
-in Google environments, including Cloud Run, so `applicationDefault()` can
-use the service identity without copying a developer's credential file.
-Supply OAuth and allowlist values through the service's runtime environment
-and [Secret Manager integration](https://docs.cloud.google.com/run/docs/configuring/services/secrets).
+For another host, select its preset from [Nitro's deployment catalog](https://nitro.build/deploy). The console needs a server runtime.
 
-Build with `pnpm build:node`, include the complete `.output` in the
-container, and run `node .output/server/index.mjs`. Set `HOST=0.0.0.0`
-and let Nitro use the `PORT` provided by Cloud Run, as required by its
-[container contract](https://docs.cloud.google.com/run/docs/container-contract).
-Use the public console origin for the OAuth callbacks in step 3. A static
-Firebase Hosting upload alone does not run this Node server.
+</Step>
+<Step>
 
-## 5. Verify the deployed console
+## Verify the deployment
 
-1. Open the HTTPS origin in a private browser. Expect sign-in with no management
-   data; anonymous reads, writes, and downloads must be denied.
-2. Sign in with an allowlisted verified address. Compare Bundles and Insights
-   against the local console using the same platform, channel, and period.
-3. Open Distribution and an app version, follow a bundle to its detail, check
-   events pagination, and download an existing artifact.
-4. Reload a nested URL and check a mobile viewport. Ensure the browser has no
-   failed server requests or missing static assets.
-5. Sign out and verify access is removed. Unapproved and unverified identities
-   must be denied.
+1. Open the HTTPS URL: sign-in should appear before any management data.
+2. Sign in with an allowlisted account: check Bundles and Insights.
+3. Download a bundle, then sign out: management data should no longer be accessible.
 
-An anonymous request to `/api/bundles/<artifact-id>/download` must return `401`,
-even for an unknown ID. Use the Artifact ID in Bundle Detail's Advanced
-diagnostics for a real download. Do not alter a production rollout to test
-hosting; use a dedicated test channel for mutation QA.
+</Step>
+</Steps>
 
-## Updates and recovery
+## Custom authentication
 
-Update the console RC and the backend plugins you use, retain the lockfile,
-and rerun the selected build and runtime checks. Promote the new artifact with
-your host's deployment workflow. Keep the previous artifact/version available
-for a host-level rollback. Reverting console code does not undo database or
-storage changes made through the UI and does not roll back the mobile OTA
-server. Check the Hot Updater infrastructure upgrade requirements separately
-when changing backend versions.
+You can edit or replace `console.auth.ts` in your clone to use your own authentication and access rules. It implements `ConsoleAuthAdapter`:
+
+| Method | Responsibility |
+| --- | --- |
+| `handle(request)` | Handle sign-in, callbacks, and sign-out |
+| `getAccess(request)` | Validate the session and decide who can access the console |
+| `getProviders(request)` | Select the built-in sign-in buttons |
+
+The packaged sign-in screen supports GitHub and Google. A new provider button or login form also needs changes to the UI and provider types in `@hot-updater/console`; adding environment variables alone does not add a new login method.
+
+<Accordions>
+<Accordion title="Local preview">
+
+Copy `.env.example` to `.env`, fill in OAuth and backend values, and use `BETTER_AUTH_URL=http://localhost:3000` with a matching callback.
+
+```package-install
+npm run dev
+```
+
+Use Node-compatible plugins. For native bindings, use the [Worker preview](/docs/guides/console-deployment/cloudflare#local-preview).
+
+</Accordion>
+<Accordion title="Sign-in troubleshooting">
+
+| Symptom | Check |
+| --- | --- |
+| Sign-in fails | Both OAuth values, session secret, and email allowlist are set at runtime |
+| Callback rejected | Browser origin, `BETTER_AUTH_URL`, and OAuth callback match |
+| Forbidden after sign-in | The provider returns a verified email in the allowlist |
+
+</Accordion>
+</Accordions>

--- a/docs/content/docs/(latest)/guides/console-deployment/index.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/index.mdx
@@ -68,13 +68,15 @@ Choose your public HTTPS URL, then register its OAuth callback:
 
 Add these values to your host's **runtime** environment:
 
-| Variable | Value |
-| --- | --- |
-| `BETTER_AUTH_URL` | Your HTTPS origin, without a path |
-| `BETTER_AUTH_SECRET` | A random secret of at least 32 characters |
-| `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS` | Comma-separated full, verified email addresses |
-| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | Your GitHub OAuth credentials, if using GitHub |
-| `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Your Google OAuth credentials, if using Google |
+| Variable | Value | Example |
+| --- | --- | --- |
+| `BETTER_AUTH_URL` | Your HTTPS origin, without a path | `https://console.example.com` |
+| `BETTER_AUTH_SECRET` | A random secret of at least 32 characters | Output of `openssl rand -base64 32` |
+| `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS` | Full, verified email addresses, separated by commas | `alice@example.com,bob@example.com` |
+| `GITHUB_CLIENT_ID` | Client ID from your GitHub OAuth app | `Ov23liExample12345678` |
+| `GITHUB_CLIENT_SECRET` | Client secret from the same GitHub app | `<your-github-client-secret>` |
+| `GOOGLE_CLIENT_ID` | Client ID from your Google OAuth client | `123456789012-example.apps.googleusercontent.com` |
+| `GOOGLE_CLIENT_SECRET` | Client secret from the same Google client | `<your-google-client-secret>` |
 
 Configure at least one complete OAuth pair and your backend's environment variables. Generate the session secret with:
 
@@ -98,14 +100,10 @@ Follow one deployment guide:
 | [Netlify](/docs/guides/console-deployment/netlify) | Node server functions |
 | [Cloudflare](/docs/guides/console-deployment/cloudflare) | Worker with native D1/R2 bindings |
 
-Hosting and backend providers can differ. Vercel, Netlify, and Docker/Node can connect to all four managed backends:
+Your console can run on a different provider from your Hot Updater backend. For example, you can deploy the console to **Vercel** while keeping your database and bundles on **Cloudflare**.
 
-| Backend | Node hosts | Cloudflare Workers |
-| --- | --- | --- |
-| Cloudflare | [D1 API](/docs/database-plugins/cloudflare) + [R2 S3 credentials](/docs/storage-plugins/cloudflare) | Native bindings |
-| AWS | AWS SDK credentials | Console integration unverified |
-| Firebase | Firebase Admin credentials | Use Node |
-| Supabase | Project URL + service-role key | SDK compatible; console integration unverified |
+- **Vercel, Netlify, or Docker:** use these with any managed backend—Cloudflare, AWS, Firebase, or Supabase.
+- **Cloudflare Workers:** follow the Cloudflare guide when your backend also uses Cloudflare. For the other backends, choose one of the hosts above.
 
 For another host, select its preset from [Nitro's deployment catalog](https://nitro.build/deploy). The console needs a server runtime.
 

--- a/docs/content/docs/(latest)/guides/console-deployment/meta.json
+++ b/docs/content/docs/(latest)/guides/console-deployment/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Console deployment",
+  "description": "Host the console with Nitro",
+  "icon": "Cloud",
+  "pages": [
+    "index",
+    "cloudflare",
+    "vercel",
+    "netlify"
+  ]
+}

--- a/docs/content/docs/(latest)/guides/console-deployment/meta.json
+++ b/docs/content/docs/(latest)/guides/console-deployment/meta.json
@@ -6,6 +6,7 @@
     "index",
     "cloudflare",
     "vercel",
-    "netlify"
+    "netlify",
+    "docker"
   ]
 }

--- a/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
@@ -1,0 +1,71 @@
+---
+title: "Netlify"
+description: "Deploy the console with Nitro functions on Netlify."
+---
+
+Complete the [basic setup](/docs/guides/console-deployment) first. The console runs as Nitro functions
+on Netlify and connects to the app's existing backend. Use database and storage
+plugins compatible with this Node runtime; native Cloudflare bindings require
+a Cloudflare host.
+
+## 1. Configure the backend and authentication
+
+Set up `hot-updater.config.ts` with the selected backend plugins and retain the
+resulting lockfile in your private deployment repository. Choose the production
+console domain and register the GitHub or Google callback on that exact origin.
+Use the same origin as `BETTER_AUTH_URL`.
+
+## 2. Import the repository
+
+Import your repository into Netlify. Use the console checkout as the base
+directory and configure:
+
+| Setting | Value |
+| --- | --- |
+| Install | pnpm with the committed lockfile and `packageManager` version |
+| Build command | `NITRO_PRESET=netlify pnpm build` |
+| Publish directory | `dist` |
+| Server functions | Generated under `.netlify/functions-internal` |
+
+The pinned Nitro preset generates both the public assets in `dist` and internal
+server functions, including routing and headers. Keep these together through
+Netlify's build integration. Uploading only `dist` to a static host cannot run
+the console. You do not need to write a separate catch-all function or redirect.
+
+In Netlify's private environment settings, add `BETTER_AUTH_URL`,
+`BETTER_AUTH_SECRET`, `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`, a complete OAuth pair,
+and the backend plugin variables from Basics. Ensure the variables are
+available to **Functions** at runtime, not only to the build. Do not use `VITE_`
+prefixes for secrets. Configure production and deploy-preview contexts
+separately; preview domains need matching OAuth callbacks and trusted origins
+if you want sign-in there.
+
+## 3. Build and deploy
+
+Check the generated output locally:
+
+```bash
+pnpm test
+pnpm test:type
+NITRO_PRESET=netlify pnpm build
+```
+
+Commit your deployment configuration and deploy using Netlify's Git integration.
+The default console configuration intentionally requires a backend; successful
+compilation alone does not prove that authenticated database queries will work.
+
+## 4. Verify and update
+
+Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
+on your production URL. Check function logs for backend connectivity and OAuth
+errors, and verify bundle downloads against your function limits. Reload a
+nested Insights or bundle-detail URL to confirm generated routing is active.
+
+Use the same Git workflow for updates. Restore a previous Netlify deployment
+when the console code needs rollback; database/storage changes are separate.
+The template CI builds this preset, while Modex remote dogfood runs on
+Cloudflare. Verify your own Netlify deployment before relying on it.
+
+See [Nitro's official Netlify deployment guide](https://nitro.build/deploy/providers/netlify)
+for current integration details. Recheck generated paths when updating the
+console's pinned Nitro version.

--- a/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
@@ -10,6 +10,11 @@ a Cloudflare host.
 
 ## 1. Configure the backend and authentication
 
+All four managed backends can use this Node runtime. For a Cloudflare backend,
+use the [D1 API and R2 S3 configuration](/docs/guides/console-deployment#cloudflare-backend-from-node)
+instead of Worker bindings. See the [compatibility table](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
+for the other providers.
+
 Set up `hot-updater.config.ts` with the selected backend plugins and retain the
 resulting lockfile in your private deployment repository. Choose the production
 console domain and register the GitHub or Google callback on that exact origin.

--- a/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
@@ -66,6 +66,9 @@ when the console code needs rollback; database/storage changes are separate.
 The template CI builds this preset, while Modex remote dogfood runs on
 Cloudflare. Verify your own Netlify deployment before relying on it.
 
+See [Netlify's function environment-variable reference](https://docs.netlify.com/build/functions/environment-variables/)
+for runtime scopes and redeployment requirements.
+
 See [Nitro's official Netlify deployment guide](https://nitro.build/deploy/providers/netlify)
 for current integration details. Recheck generated paths when updating the
 console's pinned Nitro version.

--- a/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/netlify.mdx
@@ -1,79 +1,62 @@
 ---
 title: "Netlify"
-description: "Deploy the console with Nitro functions on Netlify."
+description: "Deploy the Nitro console with Netlify Node functions."
 ---
 
-Complete the [basic setup](/docs/guides/console-deployment) first. The console runs as Nitro functions
-on Netlify and connects to the app's existing backend. Use database and storage
-plugins compatible with this Node runtime; native Cloudflare bindings require
-a Cloudflare host.
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-## 1. Configure the backend and authentication
+Complete [Basics](/docs/guides/console-deployment) with Node-compatible plugins first.
 
-All four managed backends can use this Node runtime. For a Cloudflare backend,
-use the [D1 API and R2 S3 configuration](/docs/guides/console-deployment#cloudflare-backend-from-node)
-instead of Worker bindings. See the [compatibility table](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
-for the other providers.
+<Steps>
+<Step>
 
-Set up `hot-updater.config.ts` with the selected backend plugins and retain the
-resulting lockfile in your private deployment repository. Choose the production
-console domain and register the GitHub or Google callback on that exact origin.
-Use the same origin as `BETTER_AUTH_URL`.
+## Import your repository
 
-## 2. Import the repository
+Import your private console repository into Netlify. Set the console checkout as the base directory and keep the detected package manager.
 
-Import your repository into Netlify. Use the console checkout as the base
-directory and configure:
+</Step>
+<Step>
 
-| Setting | Value |
-| --- | --- |
-| Install | pnpm with the committed lockfile and `packageManager` version |
-| Build command | `NITRO_PRESET=netlify pnpm build` |
-| Publish directory | `dist` |
-| Server functions | Generated under `.netlify/functions-internal` |
+## Set the build
 
-The pinned Nitro preset generates both the public assets in `dist` and internal
-server functions, including routing and headers. Keep these together through
-Netlify's build integration. Uploading only `dist` to a static host cannot run
-the console. You do not need to write a separate catch-all function or redirect.
+Use this build command:
 
-In Netlify's private environment settings, add `BETTER_AUTH_URL`,
-`BETTER_AUTH_SECRET`, `HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`, a complete OAuth pair,
-and the backend plugin variables from Basics. Ensure the variables are
-available to **Functions** at runtime, not only to the build. Do not use `VITE_`
-prefixes for secrets. Configure production and deploy-preview contexts
-separately; preview domains need matching OAuth callbacks and trusted origins
-if you want sign-in there.
-
-## 3. Build and deploy
-
-Check the generated output locally:
-
-```bash
-pnpm test
-pnpm test:type
-NITRO_PRESET=netlify pnpm build
+```package-install
+npm run build
 ```
 
-Commit your deployment configuration and deploy using Netlify's Git integration.
-The default console configuration intentionally requires a backend; successful
-compilation alone does not prove that authenticated database queries will work.
+Set `NITRO_PRESET=netlify` for Builds and the publish directory to `dist`. Nitro generates the server functions in `.netlify/functions-internal`; deploy through Netlify's Git integration so both outputs are included.
 
-## 4. Verify and update
+</Step>
+<Step>
 
-Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
-on your production URL. Check function logs for backend connectivity and OAuth
-errors, and verify bundle downloads against your function limits. Reload a
-nested Insights or bundle-detail URL to confirm generated routing is active.
+## Set runtime variables
 
-Use the same Git workflow for updates. Restore a previous Netlify deployment
-when the console code needs rollback; database/storage changes are separate.
-The template CI builds this preset, while Modex remote dogfood runs on
-Cloudflare. Verify your own Netlify deployment before relying on it.
+Choose the production domain. Add the [authentication variables](/docs/guides/console-deployment#set-up-sign-in) and your backend credentials with the **Functions** scope.
 
-See [Netlify's function environment-variable reference](https://docs.netlify.com/build/functions/environment-variables/)
-for runtime scopes and redeployment requirements.
+Set `BETTER_AUTH_URL` to the HTTPS origin and register the matching OAuth callback. Build-only variables are not available to the running functions.
 
-See [Nitro's official Netlify deployment guide](https://nitro.build/deploy/providers/netlify)
-for current integration details. Recheck generated paths when updating the
-console's pinned Nitro version.
+</Step>
+<Step>
+
+## Deploy and check
+
+Deploy the site, open its production URL, and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
+
+Reload a nested Insights URL and download a real bundle to check routing and function limits.
+
+</Step>
+</Steps>
+
+<Accordions>
+<Accordion title="Preview deployments and updates">
+
+Configure production and deploy-preview variables separately. Each sign-in origin needs a matching OAuth callback.
+
+Push updates through the same Git workflow. Restore a previous Netlify deployment to roll back console code; this does not restore backend data.
+
+</Accordion>
+</Accordions>
+
+See [Nitro on Netlify](https://nitro.build/deploy/providers/netlify) and [Netlify function variables](https://docs.netlify.com/build/functions/environment-variables/).

--- a/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
@@ -13,14 +13,20 @@ Complete [Basics](/docs/guides/console-deployment) with Node-compatible plugins 
 
 ## Import your repository
 
-Create a Vercel project from your private console repository. Use the console checkout as its root directory and keep the detected package manager.
+Import your private console repository, or link your local checkout:
+
+```package-install
+npx vercel link
+```
+
+Use the console checkout as the root directory and keep the detected package manager.
 
 </Step>
 <Step>
 
 ## Set the build
 
-Set this as the build command:
+Select **Other** as the framework preset and Node.js 22 or later. Set this as the build command:
 
 ```package-install
 npm run build
@@ -42,7 +48,13 @@ Set `BETTER_AUTH_URL` to that domain's HTTPS origin and register the matching OA
 
 ## Deploy and check
 
-Deploy the project, open its production URL, and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
+Deploy from the dashboard or your linked checkout:
+
+```package-install
+npx vercel deploy --prod
+```
+
+Open the production URL and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
 
 Test a real-sized bundle download: the console proxies it through the function, so [Vercel's payload and execution limits](https://vercel.com/docs/functions/limitations) apply.
 

--- a/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
@@ -9,6 +9,11 @@ plugins. Native Cloudflare D1/R2 bindings are not available in this runtime.
 
 ## 1. Configure the backend and authentication
 
+All four managed backends can use this Node runtime. For a Cloudflare backend,
+use the [D1 API and R2 S3 configuration](/docs/guides/console-deployment#cloudflare-backend-from-node)
+instead of Worker bindings. See the [compatibility table](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
+for the other providers.
+
 Use Node-compatible database and storage plugins in `hot-updater.config.ts`.
 The Supabase example in Basics is one option; retain whichever backend your
 application already uses. Install the selected plugins and commit the lockfile
@@ -64,8 +69,12 @@ downloads, and static assets remain available together.
 
 Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
 on the production origin. Check function logs when authentication, backend
-queries, or downloads fail. Verify that backend network access and function
-limits are suitable for your database and bundle sizes.
+queries, or downloads fail. The console proxies bundle downloads through the
+server, so test with real artifact sizes against
+[Vercel's function payload and execution limits](https://vercel.com/docs/functions/limitations).
+Node plugin compatibility does not establish that every bundle fits those
+limits. Use a [Docker/Node host](/docs/guides/console-deployment/docker) with suitable response limits if
+your downloads exceed the chosen function deployment's limits.
 
 Deploy updates through the same Git workflow. Use Vercel's deployment history
 to promote a previous console deployment if needed; this does not restore

--- a/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
@@ -1,0 +1,76 @@
+---
+title: "Vercel"
+description: "Deploy the console with Nitro server functions on Vercel."
+---
+
+Complete the [basic setup](/docs/guides/console-deployment) first. The console runs as a Nitro server
+on Vercel and connects to your existing Hot Updater backend through compatible
+plugins. Native Cloudflare D1/R2 bindings are not available in this runtime.
+
+## 1. Configure the backend and authentication
+
+Use Node-compatible database and storage plugins in `hot-updater.config.ts`.
+The Supabase example in Basics is one option; retain whichever backend your
+application already uses. Install the selected plugins and commit the lockfile
+in your private deployment repository.
+
+Choose the production console domain and set the matching callback in your
+GitHub or Google OAuth application. Use the same origin for `BETTER_AUTH_URL`.
+The console's OAuth configuration and backend credentials are server secrets.
+
+## 2. Import the repository
+
+In Vercel, create a project from your configured repository. Use the console
+checkout as the project root, and set:
+
+| Setting | Value |
+| --- | --- |
+| Install command | `pnpm install --frozen-lockfile` |
+| Build command | `NITRO_PRESET=vercel pnpm build` |
+| Build output | Nitro's generated `.vercel/output` |
+
+Keep Vercel's Nitro integration and generated Build Output API configuration.
+Do not select a static Vite deployment or replace the server output with `dist`.
+Nitro can detect Vercel's build environment; the explicit preset makes the
+intended target reproducible locally and in CI.
+
+In the project's environment-variable settings, configure the shared
+`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`,
+`HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`, one complete OAuth provider pair, and the
+backend plugin variables from Basics. Make them available to the production
+server functions. Do not expose them through a `VITE_` prefix.
+
+For preview deployments, use a separate permitted origin and OAuth application
+or keep authentication restricted to the canonical production deployment.
+An arbitrary preview URL does not automatically become an allowed OAuth
+callback or trusted console origin.
+
+## 3. Build and deploy
+
+You can check the output before pushing:
+
+```bash
+pnpm test
+pnpm test:type
+NITRO_PRESET=vercel pnpm build
+```
+
+This generates `.vercel/output/config.json`, functions, and static assets.
+Push the configured repository and deploy through Vercel's Git integration.
+Deploy the complete Nitro output so OAuth callbacks, server functions, bundle
+downloads, and static assets remain available together.
+
+## 4. Verify and update
+
+Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
+on the production origin. Check function logs when authentication, backend
+queries, or downloads fail. Verify that backend network access and function
+limits are suitable for your database and bundle sizes.
+
+Deploy updates through the same Git workflow. Use Vercel's deployment history
+to promote a previous console deployment if needed; this does not restore
+backend data or undo management actions. The template CI builds this preset;
+Modex remote dogfood is on Cloudflare, so it is not a Vercel verification record.
+
+See [Nitro's official Vercel deployment guide](https://nitro.build/deploy/providers/vercel)
+for current platform integration and runtime configuration.

--- a/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
@@ -72,5 +72,8 @@ to promote a previous console deployment if needed; this does not restore
 backend data or undo management actions. The template CI builds this preset;
 Modex remote dogfood is on Cloudflare, so it is not a Vercel verification record.
 
+See [Vercel's environment-variable reference](https://vercel.com/docs/environment-variables)
+for deployment scopes and server access.
+
 See [Nitro's official Vercel deployment guide](https://nitro.build/deploy/providers/vercel)
 for current platform integration and runtime configuration.

--- a/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
+++ b/docs/content/docs/(latest)/guides/console-deployment/vercel.mdx
@@ -1,88 +1,62 @@
 ---
 title: "Vercel"
-description: "Deploy the console with Nitro server functions on Vercel."
+description: "Deploy the Nitro console with Vercel Node functions."
 ---
 
-Complete the [basic setup](/docs/guides/console-deployment) first. The console runs as a Nitro server
-on Vercel and connects to your existing Hot Updater backend through compatible
-plugins. Native Cloudflare D1/R2 bindings are not available in this runtime.
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-## 1. Configure the backend and authentication
+Complete [Basics](/docs/guides/console-deployment) with Node-compatible plugins first.
 
-All four managed backends can use this Node runtime. For a Cloudflare backend,
-use the [D1 API and R2 S3 configuration](/docs/guides/console-deployment#cloudflare-backend-from-node)
-instead of Worker bindings. See the [compatibility table](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
-for the other providers.
+<Steps>
+<Step>
 
-Use Node-compatible database and storage plugins in `hot-updater.config.ts`.
-The Supabase example in Basics is one option; retain whichever backend your
-application already uses. Install the selected plugins and commit the lockfile
-in your private deployment repository.
+## Import your repository
 
-Choose the production console domain and set the matching callback in your
-GitHub or Google OAuth application. Use the same origin for `BETTER_AUTH_URL`.
-The console's OAuth configuration and backend credentials are server secrets.
+Create a Vercel project from your private console repository. Use the console checkout as its root directory and keep the detected package manager.
 
-## 2. Import the repository
+</Step>
+<Step>
 
-In Vercel, create a project from your configured repository. Use the console
-checkout as the project root, and set:
+## Set the build
 
-| Setting | Value |
-| --- | --- |
-| Install command | `pnpm install --frozen-lockfile` |
-| Build command | `NITRO_PRESET=vercel pnpm build` |
-| Build output | Nitro's generated `.vercel/output` |
+Set this as the build command:
 
-Keep Vercel's Nitro integration and generated Build Output API configuration.
-Do not select a static Vite deployment or replace the server output with `dist`.
-Nitro can detect Vercel's build environment; the explicit preset makes the
-intended target reproducible locally and in CI.
-
-In the project's environment-variable settings, configure the shared
-`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`,
-`HOT_UPDATER_CONSOLE_ALLOWED_EMAILS`, one complete OAuth provider pair, and the
-backend plugin variables from Basics. Make them available to the production
-server functions. Do not expose them through a `VITE_` prefix.
-
-For preview deployments, use a separate permitted origin and OAuth application
-or keep authentication restricted to the canonical production deployment.
-An arbitrary preview URL does not automatically become an allowed OAuth
-callback or trusted console origin.
-
-## 3. Build and deploy
-
-You can check the output before pushing:
-
-```bash
-pnpm test
-pnpm test:type
-NITRO_PRESET=vercel pnpm build
+```package-install
+npm run build
 ```
 
-This generates `.vercel/output/config.json`, functions, and static assets.
-Push the configured repository and deploy through Vercel's Git integration.
-Deploy the complete Nitro output so OAuth callbacks, server functions, bundle
-downloads, and static assets remain available together.
+Add `NITRO_PRESET=vercel` as a build environment variable. Nitro generates `.vercel/output`; keep the generated server functions and static assets together.
 
-## 4. Verify and update
+</Step>
+<Step>
 
-Run the [remote verification checklist](/docs/guides/console-deployment#5-verify-the-deployed-console)
-on the production origin. Check function logs when authentication, backend
-queries, or downloads fail. The console proxies bundle downloads through the
-server, so test with real artifact sizes against
-[Vercel's function payload and execution limits](https://vercel.com/docs/functions/limitations).
-Node plugin compatibility does not establish that every bundle fits those
-limits. Use a [Docker/Node host](/docs/guides/console-deployment/docker) with suitable response limits if
-your downloads exceed the chosen function deployment's limits.
+## Set runtime variables
 
-Deploy updates through the same Git workflow. Use Vercel's deployment history
-to promote a previous console deployment if needed; this does not restore
-backend data or undo management actions. The template CI builds this preset;
-Modex remote dogfood is on Cloudflare, so it is not a Vercel verification record.
+Choose the production domain. Add the [authentication variables](/docs/guides/console-deployment#set-up-sign-in) and your backend credentials to the project's Production environment.
 
-See [Vercel's environment-variable reference](https://vercel.com/docs/environment-variables)
-for deployment scopes and server access.
+Set `BETTER_AUTH_URL` to that domain's HTTPS origin and register the matching OAuth callback. Use server variables, without a `VITE_` prefix.
 
-See [Nitro's official Vercel deployment guide](https://nitro.build/deploy/providers/vercel)
-for current platform integration and runtime configuration.
+</Step>
+<Step>
+
+## Deploy and check
+
+Deploy the project, open its production URL, and follow [Verify the deployment](/docs/guides/console-deployment#verify-the-deployment).
+
+Test a real-sized bundle download: the console proxies it through the function, so [Vercel's payload and execution limits](https://vercel.com/docs/functions/limitations) apply.
+
+</Step>
+</Steps>
+
+<Accordions>
+<Accordion title="Preview deployments and updates">
+
+Preview URLs need matching OAuth callbacks and `BETTER_AUTH_URL`. Otherwise, use sign-in only on the production origin.
+
+Push updates through the same Git workflow. To restore console code, promote a previous Vercel deployment; backend data is unaffected by that rollback.
+
+</Accordion>
+</Accordions>
+
+See [Nitro on Vercel](https://nitro.build/deploy/providers/vercel) and [Vercel environment variables](https://vercel.com/docs/environment-variables).

--- a/docs/content/docs/(latest)/managed/aws.mdx
+++ b/docs/content/docs/(latest)/managed/aws.mdx
@@ -7,6 +7,11 @@ icon: aws
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
+Host the console on **Vercel, Netlify, or Docker/Node** with AWS SDK credentials
+for the existing DynamoDB and S3 resources. ECS/Fargate is another option when
+you want an AWS task role. See the
+[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider).
+
 ## Prerequisites
 
 Your deployment needs the resources and access below. When using an AI agent,

--- a/docs/content/docs/(latest)/managed/aws.mdx
+++ b/docs/content/docs/(latest)/managed/aws.mdx
@@ -10,7 +10,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 Host the console on **Vercel, Netlify, or Docker/Node** with AWS SDK credentials
 for the existing DynamoDB and S3 resources. ECS/Fargate is another option when
 you want an AWS task role. See the
-[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider).
+[console hosting matrix](/docs/guides/console-deployment#choose-a-host).
 
 ## Prerequisites
 

--- a/docs/content/docs/(latest)/managed/cloudflare.mdx
+++ b/docs/content/docs/(latest)/managed/cloudflare.mdx
@@ -9,8 +9,8 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 The console can run on **Cloudflare Workers, Vercel, Netlify, or Docker/Node**.
 Workers uses native D1/R2 bindings; Node hosts use D1 API and R2 S3 credentials.
-See the [console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
-and [Cloudflare from Node](/docs/guides/console-deployment#cloudflare-backend-from-node).
+See the [console hosting matrix](/docs/guides/console-deployment#choose-a-host)
+and [Cloudflare from Node](/docs/database-plugins/cloudflare).
 
 ## Prerequisites
 

--- a/docs/content/docs/(latest)/managed/cloudflare.mdx
+++ b/docs/content/docs/(latest)/managed/cloudflare.mdx
@@ -7,6 +7,11 @@ icon: cloudflare
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
+The console can run on **Cloudflare Workers, Vercel, Netlify, or Docker/Node**.
+Workers uses native D1/R2 bindings; Node hosts use D1 API and R2 S3 credentials.
+See the [console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
+and [Cloudflare from Node](/docs/guides/console-deployment#cloudflare-backend-from-node).
+
 ## Prerequisites
 
 Your deployment needs the resources and access below. When using an AI agent,

--- a/docs/content/docs/(latest)/managed/firebase.mdx
+++ b/docs/content/docs/(latest)/managed/firebase.mdx
@@ -10,7 +10,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 Host the console on **Vercel, Netlify, or Docker/Node** with Firebase Admin SDK
 credentials. Cloud Run is another option when you want to use the existing
 Google Cloud project and service identity. See the
-[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider).
+[console hosting matrix](/docs/guides/console-deployment#choose-a-host).
 
 ## Prerequisites
 

--- a/docs/content/docs/(latest)/managed/firebase.mdx
+++ b/docs/content/docs/(latest)/managed/firebase.mdx
@@ -7,6 +7,11 @@ icon: firebase
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
+Host the console on **Vercel, Netlify, or Docker/Node** with Firebase Admin SDK
+credentials. Cloud Run is another option when you want to use the existing
+Google Cloud project and service identity. See the
+[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider).
+
 ## Prerequisites
 
 Your deployment needs the resources and access below. When using an AI agent,

--- a/docs/content/docs/(latest)/managed/supabase.mdx
+++ b/docs/content/docs/(latest)/managed/supabase.mdx
@@ -7,6 +7,11 @@ icon: supabase
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
+Host the console on **Vercel, Netlify, or Docker/Node** and connect to the
+existing Supabase project over HTTPS. See the
+[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
+and [Vercel deployment guide](/docs/guides/console-deployment/vercel).
+
 ## Prerequisites
 
 Your deployment needs the resources and access below. When using an AI agent,

--- a/docs/content/docs/(latest)/managed/supabase.mdx
+++ b/docs/content/docs/(latest)/managed/supabase.mdx
@@ -9,7 +9,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 Host the console on **Vercel, Netlify, or Docker/Node** and connect to the
 existing Supabase project over HTTPS. See the
-[console hosting matrix](/docs/guides/console-deployment#recommended-hosts-by-managed-provider)
+[console hosting matrix](/docs/guides/console-deployment#choose-a-host)
 and [Vercel deployment guide](/docs/guides/console-deployment/vercel).
 
 ## Prerequisites

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -39,6 +39,12 @@ const convert = (cmd: string, pm: string): string => {
 
     if (pm === "npm") return line;
 
+    if (/^\s*npm install\s*$/.test(line)) {
+      return line.replace("npm install", `${pm} install`);
+    }
+
+    line = line.replace(/\bnpm run\b/, `${pm} run`);
+
     if (pm === "pnpm") {
       // npx -> pnpm (drop -y/--yes)
       line = line.replace(/^(\s*)npx\s+(?:-y\s+|--yes\s+)?/i, "$1pnpm ");


### PR DESCRIPTION
Console deployment is organized as a short Basics guide with Cloudflare, Vercel, Netlify, and Docker child pages. Each guide uses Fumadocs Steps, package-manager tabs, and collapsible troubleshooting so readers can follow deployment in order. The existing landing-page URL is preserved.

The default configuration contains comments for the reader's database and storage plugins. Basics explains that GitHub and Google sign-in work through runtime environment settings, including callbacks and the verified-email allowlist. It also describes customizing `console.auth.ts` and the additional UI/provider-type changes needed for another login method.

Hosting is independent of the managed backend. A Vercel + Cloudflare example and two short choices explain where to host the console. The environment-variable table includes copyable URL/email examples, OAuth value formats, and the session-secret generation command. Basics also links copyable AWS, Firebase, Supabase, and Cloudflare-on-Node configurations and environment examples in the template. Vercel steps cover Git import or a linked local checkout, with the Other framework preset. Docker instructions use the template's standalone Node image and cover runtime credentials, HTTPS, architecture, and updates. Package-manager conversion now handles dependency installation and `npm run` commands correctly.

Validation:
- `pnpm -w lint` passed; 290 test files and 2,680 tests passed.
- Documentation build and built-in dead-link check passed.
- 67 documentation links and anchors checked across 15 rendered pages.
- Browser checks verified npm/pnpm/yarn command tabs, step layout, authentication guidance, and expandable local preview.

Template and executable Docker assets: https://github.com/hot-updater/console/pull/5. Modex dogfood covers Cloudflare Workers, Docker/Node, and a live Vercel deployment using D1/R2. Vercel QA verified GitHub login, Insights and distribution, event pagination, sign-out, anonymous-access denial, and a 9,376,048-byte download with valid ZIP CRCs; other combinations are described by runtime compatibility, not claimed as deployed QA.

The pagination issue found during QA is fixed separately by #1285 and released in console rc.11 / CLI rc.13. The template version update is hot-updater/console#11.

Documentation-only follow-up to #1275; no release changeset. Leave this PR open for review; do not merge automatically.
