### PR TITLE
fix(console): expose sign out in authenticated hosted consoles

### DIFF
--- a/.changeset/tidy-console-signout.md
+++ b/.changeset/tidy-console-signout.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Expose sign out in the sidebar for authenticated hosted consoles.

--- a/packages/console/src/components/AppSidebar.spec.tsx
+++ b/packages/console/src/components/AppSidebar.spec.tsx
@@ -1,12 +1,21 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import * as React from "react";
+import { toast } from "sonner";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppSidebar } from "./AppSidebar";
 
 let pathname = "/";
 let apiKeysSupported = false;
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
@@ -35,10 +44,13 @@ vi.mock("@/components/ui/sidebar", () => {
     children,
     isActive,
     render,
+    ...props
   }: {
     children?: ReactNode;
     isActive?: boolean;
     render?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
   }) =>
     React.isValidElement(render) ? (
       React.cloneElement(
@@ -49,7 +61,9 @@ vi.mock("@/components/ui/sidebar", () => {
         { children, "data-active": isActive ? "true" : "false" },
       )
     ) : (
-      <div data-active={isActive ? "true" : "false"}>{children}</div>
+      <button data-active={isActive ? "true" : "false"} {...props}>
+        {children}
+      </button>
     );
   return {
     Sidebar: Wrapper,
@@ -68,6 +82,8 @@ vi.mock("@/components/ui/sidebar", () => {
 describe("AppSidebar navigation", () => {
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
     pathname = "/";
     apiKeysSupported = false;
   });
@@ -79,6 +95,43 @@ describe("AppSidebar navigation", () => {
       screen.getByRole("link", { name: /insights/i }).getAttribute("href"),
     ).toBe("/insights");
     expect(screen.queryByRole("link", { name: /installations/i })).toBeNull();
+  });
+
+  it("hides sign out in the local console", () => {
+    render(<AppSidebar />);
+    expect(screen.queryByRole("button", { name: "Sign out" })).toBeNull();
+  });
+
+  it("disables sign out while pending and lets the user retry a failed request", async () => {
+    let finish!: (response: Response) => void;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    render(<AppSidebar canSignOut />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(
+      screen
+        .getByRole("button", { name: "Signing out…" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/sign-out", {
+      method: "POST",
+    });
+    finish(new Response(null, { status: 503 }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Sign-out failed. Please try again.",
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Sign out" }).hasAttribute("disabled"),
+    ).toBe(false);
   });
 
   it.each(["/insights", "/insights/distribution", "/installations"])(

--- a/packages/console/src/components/AppSidebar.tsx
+++ b/packages/console/src/components/AppSidebar.tsx
@@ -2,11 +2,14 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import {
   ChartNoAxesCombined,
   KeyRound,
+  LogOut,
   Moon,
   Package,
   ShieldCheck,
   Sun,
 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { HotUpdaterLogo } from "@/components/HotUpdaterLogo";
 import { useTheme } from "@/components/ThemeProvider";
@@ -24,7 +27,8 @@ import {
 } from "@/components/ui/sidebar";
 import { useApiKeyCapabilityQuery } from "@/lib/api-keys-api";
 
-export function AppSidebar() {
+export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
+  const [signingOut, setSigningOut] = useState(false);
   const apiKeyCapability = useApiKeyCapabilityQuery();
   const { theme, setTheme } = useTheme();
   const routerState = useRouterState();
@@ -37,6 +41,18 @@ export function AppSidebar() {
     currentPath === "/installations";
   const isApiKeysActive = currentPath === "/api-keys";
   const isSigningActive = currentPath === "/signing";
+
+  const signOut = async () => {
+    setSigningOut(true);
+    try {
+      const response = await fetch("/api/auth/sign-out", { method: "POST" });
+      if (!response.ok) throw new Error("Sign-out failed. Please try again.");
+      window.location.reload();
+    } catch {
+      setSigningOut(false);
+      toast.error("Sign-out failed. Please try again.");
+    }
+  };
 
   return (
     <Sidebar collapsible="icon">
@@ -137,6 +153,18 @@ export function AppSidebar() {
 
       <SidebarFooter>
         <SidebarMenu>
+          {canSignOut ? (
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                disabled={signingOut}
+                onClick={() => void signOut()}
+                tooltip="Sign out"
+              >
+                <LogOut />
+                <span>{signingOut ? "Signing out…" : "Sign out"}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ) : null}
           <SidebarMenuItem>
             <SidebarMenuButton
               onClick={() => setTheme(theme === "dark" ? "light" : "dark")}

--- a/packages/console/src/routes/__root.tsx
+++ b/packages/console/src/routes/__root.tsx
@@ -140,10 +140,10 @@ function RootLayout() {
     return <ConsoleAccessPage access={access} providers={providers} />;
   }
 
-  return <AuthorizedConsole />;
+  return <AuthorizedConsole canSignOut={providers.length > 0} />;
 }
 
-function AuthorizedConsole() {
+function AuthorizedConsole({ canSignOut }: { canSignOut: boolean }) {
   useEffect(() => {
     if (
       import.meta.env.DEV &&
@@ -155,7 +155,7 @@ function AuthorizedConsole() {
   }, []);
   return (
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar canSignOut={canSignOut} />
       <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
         <Outlet />
       </SidebarInset>


### PR DESCRIPTION
Authenticated hosted users had no way to end their console session from the sidebar. Add a Sign out action for consoles with an OAuth provider, reload the access gate after successful sign-out, and keep the action available for retry if the request fails. Local consoles keep their current navigation.

Validation: workspace build, lint, and 2,680 tests passed; 166 console tests and console TypeScript passed. Scenario tests cover hiding the action locally and pending/failed requests. Browser QA with a synthetic hosted adapter confirmed Sign out returns to the sign-in page. A console patch changeset is included for the RC release.

![Hosted console sign-out action with synthetic data](https://github.com/user-attachments/assets/39115f9d-ca23-4143-8261-b8aae9a3cf51)