### PR TITLE
fix(console): send JSON when signing out

### DIFF
--- a/.changeset/strict-console-signout.md
+++ b/.changeset/strict-console-signout.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Send JSON sign-out requests so hosted authentication handlers accept logout from the sidebar and access-denied screen.

--- a/packages/console/src/components/AppSidebar.spec.tsx
+++ b/packages/console/src/components/AppSidebar.spec.tsx
@@ -120,6 +120,8 @@ describe("AppSidebar navigation", () => {
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith("/api/auth/sign-out", {
+      body: "{}",
+      headers: { "content-type": "application/json" },
       method: "POST",
     });
     finish(new Response(null, { status: 503 }));

--- a/packages/console/src/components/AppSidebar.tsx
+++ b/packages/console/src/components/AppSidebar.tsx
@@ -45,7 +45,11 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
   const signOut = async () => {
     setSigningOut(true);
     try {
-      const response = await fetch("/api/auth/sign-out", { method: "POST" });
+      const response = await fetch("/api/auth/sign-out", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
       if (!response.ok) throw new Error("Sign-out failed. Please try again.");
       window.location.reload();
     } catch {

--- a/packages/console/src/components/ConsoleAccessPage.spec.tsx
+++ b/packages/console/src/components/ConsoleAccessPage.spec.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/ui/button", () => ({
@@ -15,6 +21,45 @@ afterEach(() => {
 });
 
 describe("ConsoleAccessPage", () => {
+  it("sends JSON when signing a forbidden identity out of a strict auth handler", async () => {
+    const reload = vi.fn();
+    vi.stubGlobal(
+      "window",
+      new Proxy(window, {
+        get: (target, key) =>
+          key === "location" ? { reload } : Reflect.get(target, key),
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url, init: RequestInit) => {
+        const request = new Request(
+          "https://console.example/api/auth/sign-out",
+          init,
+        );
+        const acceptsRequest =
+          request.method === "POST" &&
+          request.headers.get("content-type") === "application/json" &&
+          (await request.text()) === "{}";
+        return new Response(null, { status: acceptsRequest ? 200 : 415 });
+      }),
+    );
+    render(
+      <ConsoleAccessPage
+        access={{
+          status: "forbidden",
+          principal: { email: "viewer@example.com" },
+        }}
+        providers={["github"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledOnce());
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("explains why an authenticated email was rejected", () => {
     render(
       <ConsoleAccessPage

--- a/packages/console/src/components/ConsoleAccessPage.tsx
+++ b/packages/console/src/components/ConsoleAccessPage.tsx
@@ -48,7 +48,11 @@ export function ConsoleAccessPage({
     setSigningOut(true);
     setError(null);
     try {
-      const response = await fetch("/api/auth/sign-out", { method: "POST" });
+      const response = await fetch("/api/auth/sign-out", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
       if (!response.ok) {
         throw new Error("Sign-out failed.");
       }


### PR DESCRIPTION
Hosted consoles rejected sign-out with HTTP 415 because the browser sent an empty POST without a JSON content type. Both the sidebar and access-denied screen now send an empty JSON object, allowing the authentication handler to clear the session and return to sign-in.

Validation: reproduced the missing-content-type rejection on Modex's deployed HTTPS console; focused regression checks fail before the fix and pass afterward. Workspace build, lint and 2,680 unit tests passed. Includes a console patch changeset; final RC receives authenticated remote sign-out QA.
