### PR TITLE
fix(console): repair mobile Safari sidebar with shadcn Sheet

### DIFF
--- a/.changeset/tidy-mobile-sidebar.md
+++ b/.changeset/tidy-mobile-sidebar.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Fix mobile Safari sidebar rendering by using the shared shadcn Sheet, with accessible dismissal and automatic closing when a navigation link is selected.

--- a/packages/console/src/components/AppSidebar.spec.tsx
+++ b/packages/console/src/components/AppSidebar.spec.tsx
@@ -14,6 +14,7 @@ import { AppSidebar } from "./AppSidebar";
 
 let pathname = "/";
 let apiKeysSupported = false;
+const setOpenMobile = vi.fn();
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
@@ -66,6 +67,7 @@ vi.mock("@/components/ui/sidebar", () => {
       </button>
     );
   return {
+    useSidebar: () => ({ setOpenMobile }),
     Sidebar: Wrapper,
     SidebarContent: Wrapper,
     SidebarFooter: Wrapper,
@@ -86,6 +88,19 @@ describe("AppSidebar navigation", () => {
     vi.clearAllMocks();
     pathname = "/";
     apiKeysSupported = false;
+  });
+
+  it.each([
+    /hot updater/i,
+    /bundles/i,
+    /insights/i,
+    /api keys/i,
+    /bundle signing/i,
+  ])("closes the mobile sidebar when selecting %s", (name) => {
+    apiKeysSupported = true;
+    render(<AppSidebar />);
+    fireEvent.click(screen.getByRole("link", { name }));
+    expect(setOpenMobile).toHaveBeenCalledWith(false);
   });
 
   it("always exposes the canonical Insights destination", () => {

--- a/packages/console/src/components/AppSidebar.tsx
+++ b/packages/console/src/components/AppSidebar.tsx
@@ -24,10 +24,13 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { useApiKeyCapabilityQuery } from "@/lib/api-keys-api";
 
 export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
+  const { setOpenMobile } = useSidebar();
+  const closeMobileSidebar = () => setOpenMobile(false);
   const [signingOut, setSigningOut] = useState(false);
   const apiKeyCapability = useApiKeyCapabilityQuery();
   const { theme, setTheme } = useTheme();
@@ -63,6 +66,7 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
       <SidebarHeader className="h-12 justify-center">
         <Link
           to="/"
+          onClick={closeMobileSidebar}
           search={{
             afterReleaseId: undefined,
             beforeReleaseId: undefined,
@@ -99,6 +103,7 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
                   render={
                     <Link
                       to="/"
+                      onClick={closeMobileSidebar}
                       search={{
                         afterReleaseId: undefined,
                         beforeReleaseId: undefined,
@@ -121,7 +126,7 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   isActive={isInsightsActive}
-                  render={<Link to="/insights" />}
+                  render={<Link to="/insights" onClick={closeMobileSidebar} />}
                   tooltip="Insights"
                 >
                   <ChartNoAxesCombined />
@@ -132,7 +137,9 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     isActive={isApiKeysActive}
-                    render={<Link to="/api-keys" />}
+                    render={
+                      <Link to="/api-keys" onClick={closeMobileSidebar} />
+                    }
                     tooltip="API keys"
                   >
                     <KeyRound />
@@ -143,7 +150,7 @@ export function AppSidebar({ canSignOut = false }: { canSignOut?: boolean }) {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   isActive={isSigningActive}
-                  render={<Link to="/signing" />}
+                  render={<Link to="/signing" onClick={closeMobileSidebar} />}
                   tooltip="Bundle signing"
                 >
                   <ShieldCheck />

--- a/packages/console/src/components/ui/sidebar.spec.tsx
+++ b/packages/console/src/components/ui/sidebar.spec.tsx
@@ -1,0 +1,62 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Sidebar, SidebarProvider, SidebarTrigger } from "./sidebar";
+
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => true }));
+
+describe("Mobile sidebar", () => {
+  afterEach(cleanup);
+
+  it("opens outside the layout and dismisses with Escape", async () => {
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <a href="/insights">Insights</a>
+        </Sidebar>
+        <SidebarTrigger />
+      </SidebarProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const dialog = await screen.findByRole("dialog", { name: "Sidebar" });
+    // The modal must escape any layout clipping or stacking context.
+    expect(container.contains(dialog)).toBe(false);
+    expect(
+      dialog.contains(screen.getByRole("link", { name: "Insights" })),
+    ).toBe(true);
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("can be closed and reopened using the visible close button", async () => {
+    render(
+      <SidebarProvider>
+        <Sidebar>Navigation</Sidebar>
+        <SidebarTrigger />
+      </SidebarProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    expect(
+      await screen.findByRole("dialog", { name: "Sidebar" }),
+    ).toBeDefined();
+  });
+});

--- a/packages/console/src/components/ui/sidebar.tsx
+++ b/packages/console/src/components/ui/sidebar.tsx
@@ -9,6 +9,13 @@ import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
@@ -220,44 +227,30 @@ function Sidebar({
   }
 
   if (isMobile) {
-    if (!openMobile) {
-      return null;
-    }
-
     return (
-      <div
-        data-sidebar="sidebar"
-        data-slot="sidebar"
-        data-mobile="true"
-        className="fixed inset-0 z-50 md:hidden"
-        {...props}
-      >
-        <button
-          type="button"
-          aria-label="Close sidebar"
-          className="absolute inset-0 bg-sidebar/55 supports-backdrop-filter:backdrop-blur-sm"
-          onClick={() => setOpenMobile(false)}
-        />
-        <dialog
-          open
-          aria-modal="true"
-          aria-label="Sidebar"
-          className={cn(
-            "bg-sidebar text-sidebar-foreground absolute inset-y-0 z-10 flex w-(--sidebar-width) flex-col shadow-lg",
-            side === "left" ? "left-0" : "right-0",
-          )}
+      <Sheet open={openMobile} onOpenChange={setOpenMobile}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) max-w-[calc(100vw-2rem)] p-0"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
             } as React.CSSProperties
           }
+          side={side}
+          {...props}
         >
-          <div className="pointer-events-none absolute inset-x-0 top-full h-32 bg-sidebar" />
-          <div className="flex h-full w-full flex-col overflow-y-auto bg-sidebar">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Console navigation.</SheetDescription>
+          </SheetHeader>
+          <div className="flex size-full min-h-0 flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
             {children}
           </div>
-        </dialog>
-      </div>
+        </SheetContent>
+      </Sheet>
     );
   }
 


### PR DESCRIPTION
Mobile Safari could open the console navigation as a blank or obscured panel. Replace the custom inline `<dialog>` and backdrop with the existing shadcn Sheet so the sidebar is portaled above the page and receives modal focus, scroll locking, and dismissal behavior. Keep navigation within the viewport and safe areas, provide a close button, and close the panel when a navigation link is selected.

Validation:
- Regression tests cover portal placement, Escape with focus restoration, closing/reopening, and all navigation destinations.
- WebKit and Chrome: 320px, 390px, 430px, and 1024px viewports; light/dark themes, backdrop dismissal, navigation, Escape, viewport resizing, and desktop collapse/expand.
- Full ordered workspace CI passed: `pnpm -w build`, `pnpm -w test:type`, `pnpm -w lint`, `pnpm -w test` (2,680 tests), and `pnpm -w test:integration`.
- Patch changeset for `@hot-updater/console`; no API or breaking changes.

WebKit mobile screenshots (390 × 844):

| Dark | Light |
| --- | --- |
| <img width="300" alt="Mobile sidebar in dark mode" src="https://github.com/user-attachments/assets/42bd351c-615c-4140-9047-927e6b1c2eca" /> | <img width="300" alt="Mobile sidebar in light mode" src="https://github.com/user-attachments/assets/a8f8dd1f-b1fc-4619-8334-0aecf484e5ab" /> |
