### PR TITLE
fix(console): preserve Insights pagination across reloads

### DIFF
--- a/.changeset/steady-events-return.md
+++ b/.changeset/steady-events-return.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Preserve Insights pagination history across browser reloads so page numbers and Previous buttons stay correct for events, installation searches, and installation history.

--- a/packages/console/src/components/features/insights/EventHistoryCard.tsx
+++ b/packages/console/src/components/features/insights/EventHistoryCard.tsx
@@ -62,6 +62,11 @@ function EventIdentity({
           query: event.installId || undefined,
           installId: event.installId,
         }}
+        state={(previous) => ({
+          insightsPagination: {
+            eventsBack: previous.insightsPagination?.eventsBack,
+          },
+        })}
         aria-label={`View history for ${event.userId ?? event.username ?? "anonymous installation"} (${event.installId})`}
       >
         <span

--- a/packages/console/src/routes/-installations-pagination.spec.tsx
+++ b/packages/console/src/routes/-installations-pagination.spec.tsx
@@ -1,0 +1,186 @@
+import {
+  createBrowserHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/ui/sidebar", () => ({ SidebarTrigger: () => null }));
+
+vi.mock("@/lib/insights-api", () => {
+  const installation = {
+    installId: "install-1",
+    userId: "user-1",
+    username: null,
+    appVersion: "1.5.0",
+    channel: "production",
+    platform: "ios",
+    receivedAtMs: 100,
+    lastKnownBundleId: "bundle-1",
+    latestStatus: "UNCHANGED",
+  };
+  const page = ({ cursor }: { cursor?: string }) => ({
+    data: {
+      data: [
+        {
+          ...installation,
+          id: cursor ?? "first",
+          type: "UNCHANGED",
+          toBundleId: "bundle-1",
+          fromBundleId: null,
+        },
+      ],
+      nextCursor:
+        cursor === "third" ? null : cursor === "second" ? "third" : "second",
+      beforeReceivedAtMs: 100,
+    },
+    error: null,
+    isFetching: false,
+    isLoading: false,
+  });
+  return {
+    useInsightsEventsQuery: page,
+    useInsightsInstallationsQuery: page,
+    useInsightsInstallationEventsQuery: page,
+    useInsightsInstallationQuery: () => ({
+      data: installation,
+      error: null,
+      isLoading: false,
+    }),
+  };
+});
+
+import { Route } from "./installations";
+
+async function mountPage() {
+  const root = createRootRoute();
+  const route = createRoute({
+    getParentRoute: () => root,
+    path: "/installations",
+    component: Route.options.component,
+    validateSearch: Route.options.validateSearch,
+  });
+  const history = createBrowserHistory();
+  const router = createRouter({
+    history,
+    routeTree: root.addChildren([route]),
+  });
+  const view = render(<RouterProvider router={router} />);
+  await screen.findByRole("heading", { name: "Insights" });
+  return () => {
+    view.unmount();
+    history.destroy();
+  };
+}
+
+const pagination = (label: string) =>
+  within(screen.getByRole("navigation", { name: `${label} pagination` }));
+async function expectPage(label: string, number: number) {
+  await waitFor(() =>
+    expect(
+      pagination(label).getByText(new RegExp(`Page ${number} ·`)),
+    ).toBeDefined(),
+  );
+  expect(
+    (
+      pagination(label).getByRole("button", {
+        name: "Previous",
+      }) as HTMLButtonElement
+    ).disabled,
+  ).toBe(number === 1);
+}
+const next = (label: string) =>
+  fireEvent.click(pagination(label).getByRole("button", { name: "Next" }));
+const previous = (label: string) =>
+  fireEvent.click(pagination(label).getByRole("button", { name: "Previous" }));
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, "", "/");
+});
+
+describe("Insights pagination across browser reloads", () => {
+  it.each([
+    ["All events", "eventsCursor", ""],
+    [
+      "Installation results",
+      "searchCursor",
+      "&query=user-1&installId=install-1&historyBefore=200",
+    ],
+    [
+      "Installation history",
+      "historyCursor",
+      "&installId=install-1&historyBefore=200",
+    ],
+  ])(
+    "restores %s page 3 and both previous cursors",
+    async (label, cursorKey, query) => {
+      window.history.replaceState(
+        null,
+        "",
+        `/installations?eventsBefore=100${query}`,
+      );
+      let unmount = await mountPage();
+      next(label);
+      await expectPage(label, 2);
+      next(label);
+      await expectPage(label, 3);
+
+      // Recreate the router and component, preserving only browser history.
+      unmount();
+      unmount = await mountPage();
+      await expectPage(label, 3);
+      previous(label);
+      await expectPage(label, 2);
+      expect(new URLSearchParams(window.location.search).get(cursorKey)).toBe(
+        "second",
+      );
+      previous(label);
+      await expectPage(label, 1);
+      expect(new URLSearchParams(window.location.search).has(cursorKey)).toBe(
+        false,
+      );
+      expect(
+        new URLSearchParams(window.location.search).get("eventsBefore"),
+      ).toBe("100");
+      unmount();
+    },
+  );
+
+  it("keeps the event page when returning from reloaded installation details, then resets on Refresh", async () => {
+    window.history.replaceState(null, "", "/installations?eventsBefore=100");
+    let unmount = await mountPage();
+    next("All events");
+    await expectPage("All events", 2);
+    fireEvent.click(
+      screen.getAllByRole("link", {
+        name: "View history for user-1 (install-1)",
+      })[0],
+    );
+    await expectPage("Installation history", 1);
+    next("Installation history");
+    await expectPage("Installation history", 2);
+
+    unmount();
+    unmount = await mountPage();
+    await expectPage("Installation history", 2);
+    fireEvent.click(screen.getByRole("button", { name: "Back to all events" }));
+    await expectPage("All events", 2);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await expectPage("All events", 1);
+    unmount();
+    unmount = await mountPage();
+    await expectPage("All events", 1);
+    unmount();
+  });
+});

--- a/packages/console/src/routes/-installations-search.ts
+++ b/packages/console/src/routes/-installations-search.ts
@@ -1,5 +1,17 @@
 import type { ParsedLocation } from "@tanstack/react-router";
 
+export type InsightsPaginationState = {
+  readonly eventsBack?: readonly string[];
+  readonly searchBack?: readonly string[];
+  readonly historyBack?: readonly string[];
+};
+
+declare module "@tanstack/react-router" {
+  interface HistoryState {
+    insightsPagination?: InsightsPaginationState;
+  }
+}
+
 const readCursor = (value: unknown): string | undefined =>
   typeof value === "string" && value.length > 0 ? value : undefined;
 

--- a/packages/console/src/routes/-installations.spec.tsx
+++ b/packages/console/src/routes/-installations.spec.tsx
@@ -32,6 +32,7 @@ vi.mock("@tanstack/react-router", () => ({
     readonly to: string;
   }) => <a href={to}>{children}</a>,
   useElementScrollRestoration: () => undefined,
+  useLocation: () => undefined,
 }));
 
 vi.mock("@/components/ui/sidebar", () => ({
@@ -146,6 +147,7 @@ describe("InstallationsPage", () => {
         eventsBefore: 100,
         eventsCursor: "next-events",
       },
+      state: expect.any(Function),
       to: "/installations",
     });
   });
@@ -180,6 +182,7 @@ describe("InstallationsPage", () => {
           installId: "install-1",
           query: "user-1",
         }),
+        state: expect.any(Function),
         to: "/installations",
       }),
     );
@@ -239,6 +242,7 @@ describe("InstallationsPage", () => {
         installId: "install-1",
         query: "user-1",
       },
+      state: expect.any(Function),
       to: "/installations",
     });
   });

--- a/packages/console/src/routes/installations.tsx
+++ b/packages/console/src/routes/installations.tsx
@@ -1,6 +1,7 @@
 import {
   createFileRoute,
   useElementScrollRestoration,
+  useLocation,
 } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -24,6 +25,7 @@ import {
 
 import {
   getInsightsScrollRestorationKey,
+  type InsightsPaginationState,
   validateInstallationsSearch,
 } from "./-installations-search";
 
@@ -50,9 +52,12 @@ function InstallationsPage() {
   const [draftQuery, setDraftQuery] = useState(search.query ?? "");
   const [initialEventsBefore] = useState(freshBefore);
   const [initialHistoryBefore] = useState(freshBefore);
-  const [eventsBack, setEventsBack] = useState<readonly string[]>([]);
-  const [searchBack, setSearchBack] = useState<readonly string[]>([]);
-  const [historyBack, setHistoryBack] = useState<readonly string[]>([]);
+  const pagination = useLocation({
+    select: (location) => location.state.insightsPagination,
+  });
+  const eventsBack = pagination?.eventsBack ?? [];
+  const searchBack = pagination?.searchBack ?? [];
+  const historyBack = pagination?.historyBack ?? [];
   const query = search.query?.trim() ?? "";
   const hasSearchQuery = query.length > 0;
   const hasSelection = search.installId !== undefined;
@@ -60,10 +65,21 @@ function InstallationsPage() {
   const eventsBefore = search.eventsBefore ?? initialEventsBefore;
   const historyBefore = search.historyBefore ?? initialHistoryBefore;
 
-  const updateSearch = (next: Partial<typeof search>, replace = false) => {
+  const updateSearch = (
+    next: Partial<typeof search>,
+    replace = false,
+    nextPagination: InsightsPaginationState = {},
+  ) => {
     void navigate({
       to: "/installations",
       search: { ...search, ...next },
+      state: (previous) => ({
+        ...previous,
+        insightsPagination: {
+          ...previous.insightsPagination,
+          ...nextPagination,
+        },
+      }),
       replace,
     });
   };
@@ -104,7 +120,6 @@ function InstallationsPage() {
   useEffect(() => {
     const firstInstallId = matches.data?.data[0]?.installId;
     if (!hasSearchQuery || hasSelection || firstInstallId === undefined) return;
-    setHistoryBack([]);
     updateSearch(
       {
         historyBefore: freshBefore(),
@@ -112,6 +127,7 @@ function InstallationsPage() {
         installId: firstInstallId,
       },
       true,
+      { historyBack: [] },
     );
   }, [hasSearchQuery, hasSelection, matches.data?.data]);
 
@@ -151,15 +167,17 @@ function InstallationsPage() {
 
   const clearLookup = () => {
     setDraftQuery("");
-    setHistoryBack([]);
-    setSearchBack([]);
-    updateSearch({
-      historyBefore: undefined,
-      historyCursor: undefined,
-      installId: undefined,
-      query: undefined,
-      searchCursor: undefined,
-    });
+    updateSearch(
+      {
+        historyBefore: undefined,
+        historyCursor: undefined,
+        installId: undefined,
+        query: undefined,
+        searchCursor: undefined,
+      },
+      false,
+      { historyBack: [], searchBack: [] },
+    );
   };
   const installationLookup = (
     <InstallationSearchPanel
@@ -172,15 +190,17 @@ function InstallationsPage() {
           clearLookup();
           return;
         }
-        setHistoryBack([]);
-        setSearchBack([]);
-        updateSearch({
-          historyBefore: undefined,
-          historyCursor: undefined,
-          installId: undefined,
-          query: nextQuery,
-          searchCursor: undefined,
-        });
+        updateSearch(
+          {
+            historyBefore: undefined,
+            historyCursor: undefined,
+            installId: undefined,
+            query: nextQuery,
+            searchCursor: undefined,
+          },
+          false,
+          { historyBack: [], searchBack: [] },
+        );
       }}
     />
   );
@@ -223,32 +243,32 @@ function InstallationsPage() {
               isLoading={events.isLoading}
               onNext={() => {
                 if (!events.data?.nextCursor) return;
-                setEventsBack(pushCursor(eventsBack, search.eventsCursor));
                 updateSearch(
                   {
                     eventsCursor: events.data.nextCursor,
                   },
                   true,
+                  { eventsBack: pushCursor(eventsBack, search.eventsCursor) },
                 );
               }}
               onPrevious={() => {
                 const previous = popCursor(eventsBack);
-                setEventsBack(previous.stack);
                 updateSearch(
                   {
                     eventsCursor: previous.cursor,
                   },
                   true,
+                  { eventsBack: previous.stack },
                 );
               }}
               onRefresh={() => {
-                setEventsBack([]);
                 updateSearch(
                   {
                     eventsBefore: freshBefore(),
                     eventsCursor: undefined,
                   },
                   true,
+                  { eventsBack: [] },
                 );
               }}
               pageNumber={eventsBack.length + 1}
@@ -266,33 +286,38 @@ function InstallationsPage() {
                   error={matches.error}
                   onNext={() => {
                     if (!matches.data?.nextCursor) return;
-                    setSearchBack(pushCursor(searchBack, search.searchCursor));
                     updateSearch(
                       {
                         installId: undefined,
                         searchCursor: matches.data.nextCursor,
                       },
                       true,
+                      {
+                        searchBack: pushCursor(searchBack, search.searchCursor),
+                      },
                     );
                   }}
                   onPrevious={() => {
                     const previous = popCursor(searchBack);
-                    setSearchBack(previous.stack);
                     updateSearch(
                       {
                         installId: undefined,
                         searchCursor: previous.cursor,
                       },
                       true,
+                      { searchBack: previous.stack },
                     );
                   }}
                   onSelect={(installId) => {
-                    setHistoryBack([]);
-                    updateSearch({
-                      historyBefore: freshBefore(),
-                      historyCursor: undefined,
-                      installId,
-                    });
+                    updateSearch(
+                      {
+                        historyBefore: freshBefore(),
+                        historyCursor: undefined,
+                        installId,
+                      },
+                      false,
+                      { historyBack: [] },
+                    );
                   }}
                   pageNumber={searchBack.length + 1}
                   results={matches.data}
@@ -305,32 +330,37 @@ function InstallationsPage() {
                 isLoading={history.isLoading || selectedInstallation.isLoading}
                 onNext={() => {
                   if (!history.data?.nextCursor) return;
-                  setHistoryBack(pushCursor(historyBack, search.historyCursor));
                   updateSearch(
                     {
                       historyCursor: history.data.nextCursor,
                     },
                     true,
+                    {
+                      historyBack: pushCursor(
+                        historyBack,
+                        search.historyCursor,
+                      ),
+                    },
                   );
                 }}
                 onPrevious={() => {
                   const previous = popCursor(historyBack);
-                  setHistoryBack(previous.stack);
                   updateSearch(
                     {
                       historyCursor: previous.cursor,
                     },
                     true,
+                    { historyBack: previous.stack },
                   );
                 }}
                 onRefresh={() => {
-                  setHistoryBack([]);
                   updateSearch(
                     {
                       historyBefore: freshBefore(),
                       historyCursor: undefined,
                     },
                     true,
+                    { historyBack: [] },
                   );
                 }}
                 pageNumber={historyBack.length + 1}


### PR DESCRIPTION
Reloading Insights after moving to page 2 kept the event cursor but reset the page label to 1 and disabled Previous. Store the three cursor histories in browser history state alongside navigation, so event lists, installation searches, and installation history retain their page and previous cursors after reload.

Preserve the event history when opening an installation and returning to All events. Refresh and a new lookup still reset the relevant pagination. Cursor histories stay out of the URL; backend queries and page sizes are unchanged.

Validation:
- Four browser-history regression scenarios fail on the original implementation and pass with this change. They reconstruct the router, restore page 3, navigate back twice, and return from a reloaded installation detail.
- Workspace build (26 projects), lint, and 2,680 unit tests passed.
- Console TypeScript check and all 178 console tests (55 files) passed.
- Patch changeset for `@hot-updater/console`.

This fixes the issue found during Modex Vercel deployment QA. No visual layout changes. The separate deployment documentation PR #1277 remains open.
