### PR TITLE
fix(cli): include client configuration in agent setup handoff

### DIFF
--- a/.changeset/tidy-clients-report.md
+++ b/.changeset/tidy-clients-report.md
@@ -1,0 +1,6 @@
+---
+"hot-updater": patch
+---
+
+Finish agent infrastructure setup with a ready-to-copy HotUpdater.init snippet
+containing the verified server URL and registered client API key.

--- a/docs/content/docs/(latest)/guides/agent-infrastructure.mdx
+++ b/docs/content/docs/(latest)/guides/agent-infrastructure.mdx
@@ -210,13 +210,40 @@ For fingerprint updates, use `--fingerprint <fingerprint>` instead of
 the manifest and the same Release Catalog URL without a key (401) and with the
 saved key (valid 200, or the documented empty-catalog 404). It returns sanitized
 JSON and a nonzero exit code on failure. It loads keys from private local storage;
-keys are never command arguments or printed output. The probe does not test
+keys are never command arguments or printed probe output. The probe does not test
 artifact downloads or native integration. The agent separately checks an existing
 artifact when available and runs:
 
 ```bash
 npx hot-updater doctor --json --server-base-url https://updates.example.com
 ```
+
+After setup passes these checks, the agent provides a ready-to-copy configuration
+like the final output of `hot-updater init`:
+
+```ts
+import { HotUpdater } from "@hot-updater/react-native";
+
+HotUpdater.init({
+  baseURL: "https://your-deployed-update-server",
+  requestHeaders: {
+    "x-api-key": "<your-registered-client-api-key>",
+  },
+});
+```
+
+The agent replaces these example values with the verified base URL, including
+any Function path, and the actual client key it registered or reused. It shows
+the client key itself, rather than a masked value or a path to its saved file.
+Provider tokens, service-role keys, admin credentials and signing keys remain
+private.
+
+Place initialization at module scope. `HotUpdater.init` does not start an update
+check; the agent also shows `HotUpdater.checkForUpdate` with your app's
+`appVersion` or `fingerprint` strategy. Preserve existing initialization options
+and use only one initialization API if the app already uses `HotUpdater.wrap`.
+Infrastructure-only setup includes this snippet and identifies app integration
+and native OTA verification as remaining work.
 
 Server deployment, JS/native integration, and an OTA test in a native Release
 build are separate results. Continue with [Connect your app](/docs/get-started/app-setup)

--- a/docs/content/docs/(latest)/guides/ai-agents.mdx
+++ b/docs/content/docs/(latest)/guides/ai-agents.mdx
@@ -52,7 +52,7 @@ to specify the desired app behavior and outcome.
 | Provision infrastructure | Actual resource identifiers, deployed base URL, server version and authenticated client request |
 | Connect the app | Top-level init, explicit check/download/reload flow, native loading, client key, matching strategy/channel and signing key when enabled |
 | Test OTA | Release app launch, visible JavaScript and asset changes after application, matching deployment ID and rollback result |
-| Observe and hand off | Received Insights when enabled; remaining store/native release steps and any specific blockers |
+| Observe and hand off | Ready-to-copy HotUpdater.init configuration with the verified base URL and registered client x-api-key; received Insights when enabled; remaining store/native release steps and any specific blockers |
 
 [Connect your app](/docs/get-started/app-setup) is the canonical integration
 procedure. Prefer its custom `init` flow so check timing and reload behavior
@@ -64,6 +64,12 @@ alone does not prove that a device applied an OTA update.
 
 If the agent cannot build or interact with the native app, it should complete
 available setup work and identify the exact remaining device check.
+
+After infrastructure verification, the agent finishes like `hot-updater init`:
+it shows a `HotUpdater.init(...)` snippet with your deployed `baseURL` and the
+actual client API key it issued or reused in `requestHeaders["x-api-key"]`.
+This handoff also applies to infrastructure-only setup. See the
+[completion example](/docs/guides/agent-infrastructure#verify-completion).
 
 ## Safety Rules
 

--- a/packages/hot-updater/agent/COMMON.md
+++ b/packages/hot-updater/agent/COMMON.md
@@ -41,9 +41,13 @@ Never request token values, passwords, private keys or credential JSON in chat,
 tool arguments or browser URLs. Prefer the provider's login flow and available
 role/session credentials. If user input is needed, ask them to authenticate or
 save the needed secret directly into a local ignored file or provider secret
-store, then report only completion. Do not echo values or read entire credential
-files into tool output. Verify credential presence and access through redacted
-checks. Persist newly generated keys privately before remote registration.
+store, then report only completion. Do not echo provider credentials or read
+entire credential files into tool output. Verify credential presence and access
+through redacted checks. Persist newly generated keys privately before remote
+registration.
+The registered client API key is the only credential to include in the final
+setup handoff described in common.report. Keep provider, service-role, admin and
+signing credentials private; keep client keys out of logs and deployment records.
 
 Pause only the dependent step for missing login, access, billing activation or
 an unresolved consequential choice. Continue independent authorized preparation.
@@ -111,8 +115,9 @@ command or generated files alone do not prove that a remote step is complete.
 2. Use app/hot-updater.config.ts as the merge source for the app's existing
    config. Keep custom settings and the existing update strategy. Read
    ENVIRONMENT.md and fill only the applicable env.example settings in a local ignored
-   .env.hotupdater. Credential values must not enter logs, manifests, instructions,
-   browser URLs, or app bundles. Verify secret files are ignored and not tracked.
+   .env.hotupdater. Provider and signing credential values must not enter logs,
+   manifests, instructions, browser URLs, or app bundles. Verify secret files
+   are ignored and not tracked.
 3. After the schema is ready, use app/api-key.config.ts and
    app/provision-api-key.mjs to register a client key. Run the script from the
    directory whose .env.hotupdater contains the target provider settings, using
@@ -123,9 +128,10 @@ command or generated files alone do not prove that a remote step is complete.
    has HOT_UPDATER_API_KEY, provide that value in the environment or .env.hotupdater
    to reuse it. A revoked or mismatched key needs investigation, not silent rotation.
 4. Copy the saved client key to the app's intended build-time configuration and
-   local HOT_UPDATER_API_KEY setting without printing it. Client requests use
-   x-api-key. Never substitute a provider API token, service-role key, or admin
-   credential. Keep the key across setup retries and server upgrades.
+   local HOT_UPDATER_API_KEY setting without printing it during provisioning.
+   Client requests use x-api-key. Include this registered client key in the final
+   setup handoff below. Never substitute a provider API token, service-role key,
+   or admin credential. Keep the key across setup retries and server upgrades.
 
 ## App integration
 
@@ -156,7 +162,7 @@ separate validation result.
     with `--fingerprint <fingerprint>` for fingerprint updates. Keep the Function
     path in the base URL where applicable. The helper reads HOT_UPDATER_API_KEY
     from the local environment/.env.hotupdater or app/api-key.local; it rejects
-    conflicting keys. Never put the key in command arguments or print it.
+    conflicting keys. Never put the key in command arguments or probe output.
   - Verify/record: exit code 0 and JSON `status: "verified"`. The read-only helper
     requires /version to match manifest serverVersion/infrastructureGeneration,
     then checks the identical catalog URL without a key (401) and with the saved
@@ -193,6 +199,33 @@ separate validation result.
     setup. Complete App integration above when requested: JS initialization and
     update checks, Expo prebuild or Bare/Rock native wiring, and expo-updates
     compatibility. A native release OTA check is a separate result.
+  - For setup, finish with a ready-to-copy client configuration, like the final
+    output of hot-updater init. Read only the saved client key, not the entire
+    environment file. Replace both placeholders below with the actual base URL
+    and registered client key that passed common.verify, escaping them as
+    JavaScript strings. Preserve any Function path in the base URL; do not append
+    a catalog or update-check route. Do not return masked values, environment
+    variable names or a key-file path instead of the client key.
+
+    ```ts
+    import { HotUpdater } from "@hot-updater/react-native";
+
+    HotUpdater.init({
+      baseURL: "<verified-base-url>",
+      requestHeaders: {
+        "x-api-key": "<registered-client-api-key>",
+      },
+    });
+    ```
+
+    Explain that this belongs at module scope and that init does not check for
+    updates. Show the next check call with the app's actual strategy, for example
+    `HotUpdater.checkForUpdate({ updateStrategy: "appVersion" })` or
+    `HotUpdater.checkForUpdate({ updateStrategy: "fingerprint" })`.
+    Preserve existing initialization options; do not add init alongside wrap.
+    Include this handoff for infrastructure-only setup too, with app integration
+    and native OTA checks identified as remaining work. If registration or
+    verification is blocked, report that blocker instead of a completed setup.
   - Verify/record: report created/reused resources, applied local configuration,
     server/catalog checks, artifact checks performed or unavailable, app integration
     completed or out of scope, and any blocker. Do not claim native OTA success

--- a/packages/hot-updater/src/commands/agent/infra.ts
+++ b/packages/hot-updater/src/commands/agent/infra.ts
@@ -22,7 +22,7 @@ export const infraBootstrap = (operation: AgentInfraOperation) =>
     "ENVIRONMENT.md explains each variable's purpose, conditions and source. Never request secrets in chat: use provider login or ask the user to save credentials directly in a private local file, then verify access without printing values. Do not require users to fill fields or create resources the agent can discover or prepare.",
     operation === "upgrade"
       ? "Read upgrades/README.md and all relevant upgrades/<version>.md files in ascending order before applying changes. Include the installed generation's baseline as context and every later requirement through the target. Preserve resource IDs, data, secrets and customizations."
-      : "Discover actual tool capabilities and ask for missing access. Scaffolding does not deploy resources or install packages. Continue with the provider guide to complete deployment and verification.",
+      : 'Discover actual tool capabilities and ask for missing access. Scaffolding does not deploy resources or install packages. Continue with the provider guide to complete deployment and verification. Provision or reuse the client API key. Finish with a ready-to-copy HotUpdater.init snippet containing the verified baseURL and actual registered client key in requestHeaders["x-api-key"], as described in common.report. Keep provider, service-role, admin and signing credentials private.',
   ].join("\n");
 
 export async function handleAgentInfra(


### PR DESCRIPTION
Agent infrastructure setup already registers a client API key, but its instructions prohibit printing the key and omit the client configuration from the completion report. Users can finish setup without the usable configuration shown by `hot-updater init`.

Require the final setup response to include a ready-to-copy `HotUpdater.init(...)` snippet with the verified server base URL and actual registered client `x-api-key`, including infrastructure-only requests. Preserve existing keys and initialization options, show the app's update-check strategy, and keep provider, admin and signing credentials private. Update the onboarding documentation and include a `hot-updater` patch changeset.

Validation:

- `pnpm -w build` — 26 projects passed.
- `pnpm -w lint` — passed.
- `pnpm -w test` — 290 files, 2,680 tests passed.
- Verified the built CLI setup instructions and updated completion guide packaged for Cloudflare, Supabase, AWS and Firebase.
