### PR TITLE
docs: restore landing spacing and simplify setup wording

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -6,7 +6,7 @@ guide; do not duplicate its page inventory here.
 
 ## Scope and structure
 
-- Current v1 documentation lives in `content/docs/(latest)` and is served at
+- Current documentation lives in `content/docs/(latest)` and is served at
   `/docs/...`. Leave `content/docs/v0` unchanged unless explicitly requested.
 - Keep v0/v1 comparisons and transition steps in `guides/upgrade-to-v1.mdx`.
   Preserve literal resource names, API paths and protocol identifiers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,9 @@ The Waku/Fumadocs site serves current documentation from
 `content/docs/v0` at `/docs/v0/...`. Change latest content for current behavior;
 keep version-transition instructions in `guides/upgrade-to-v1.mdx` and preserve
 historical release/architecture records. Use “Hot Updater” without a major-version
-label in general setup, agent workflows and navigation. Reserve “v1” for v0
-migration guidance; keep literal resource names, API paths and protocol identifiers.
+label in general setup and agent workflows. The version selector uses `v1.0` and
+`v0.36`. Reserve “v1” for v0 migration guidance; keep literal resource names, API
+paths and protocol identifiers.
 
 ## Content ownership
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,12 @@
 # Hot Updater documentation
 
-The Waku/Fumadocs site serves current v1 documentation from
+The Waku/Fumadocs site serves current documentation from
 `content/docs/(latest)` at `/docs/...`. Archived v0 content lives in
 `content/docs/v0` at `/docs/v0/...`. Change latest content for current behavior;
 keep version-transition instructions in `guides/upgrade-to-v1.mdx` and preserve
-historical release/architecture records.
+historical release/architecture records. Use “Hot Updater” without a major-version
+label in general setup, agent workflows and navigation. Reserve “v1” for v0
+migration guidance; keep literal resource names, API paths and protocol identifiers.
 
 ## Content ownership
 

--- a/docs/content/docs/(latest)/custom/quick-start.mdx
+++ b/docs/content/docs/(latest)/custom/quick-start.mdx
@@ -14,7 +14,7 @@ then connects a React Native app. For an existing backend, use the
 ## Before you start
 
 Use separate server and React Native project directories. Install a supported
-Node.js version from [Install v1 packages](/docs/get-started/installation), and
+Node.js version from [Install packages](/docs/get-started/installation), and
 prepare an R2 bucket with S3-compatible credentials through your existing
 Cloudflare tooling. An agent can discover or create these resources within
 your setup request. Keep credentials in ignored local configuration.

--- a/docs/content/docs/(latest)/get-started/basic-usage.mdx
+++ b/docs/content/docs/(latest)/get-started/basic-usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Set up manually"
-description: "Install v1 packages, provision your update server, connect the app and verify your first OTA update."
+description: "Install packages, provision your update server, connect the app and verify your first OTA update."
 icon: Terminal
 ---
 

--- a/docs/content/docs/(latest)/get-started/choose-provider.mdx
+++ b/docs/content/docs/(latest)/get-started/choose-provider.mdx
@@ -31,7 +31,7 @@ requirements.
 
 ## Set up a provider preset
 
-1. [Install v1 packages](/docs/get-started/installation), including your app's
+1. [Install packages](/docs/get-started/installation), including your app's
    build plugin and the chosen provider package.
 2. Open the provider guide above and choose **AI agent** or **Terminal**.
    An agent discovers or creates resources; interactive init walks you through

--- a/docs/content/docs/(latest)/get-started/installation.mdx
+++ b/docs/content/docs/(latest)/get-started/installation.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Install packages"
-description: "Install the v1 CLI, SDK, build plugin and provider package before setup."
+description: "Install the CLI, SDK, build plugin and provider package before setup."
 icon: Download
 ---
 
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-## Use compatible v1 packages
+## Use compatible packages
 
-These pages target the latest stable v1 release. Install the CLI, SDK and
+These pages target the latest stable release. Install the CLI, SDK and
 required plugins using the commands below. Commit the resulting lockfile to
 reproduce the installed versions.
 

--- a/docs/content/docs/(latest)/get-started/introduction.mdx
+++ b/docs/content/docs/(latest)/get-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Start here"
-description: "Set up Hot Updater v1 with an agent or your terminal, then verify an OTA update on a native app."
+description: "Set up Hot Updater with an agent or your terminal, then verify an OTA update on a native app."
 icon: Rocket
 ---
 
@@ -24,13 +24,13 @@ native app build.
 | Connect an app to infrastructure you already prepared | [Connect your app](/docs/get-started/app-setup) |
 | Prove that an integrated app receives updates | [Test an OTA update](/docs/get-started/test-ota) |
 
-## Use the published v1 release
+## Install the latest stable release
 
-These pages describe the latest stable v1 release.
+These pages describe the latest stable release.
 [Install packages](/docs/get-started/installation) lists the CLI, SDK, required
 build/provider plugins and runtime prerequisites.
 
-v1 uses Release Catalog infrastructure. For an existing v0 app, follow the
+For an existing v0 app, follow the
 [migration guide](/docs/guides/upgrade-to-v1) before changing the SDK or server.
 
 <a id="how-it-works" />
@@ -39,7 +39,7 @@ v1 uses Release Catalog infrastructure. For an existing v0 app, follow the
 
 Both the agent and manual paths lead to the same verified result:
 
-1. The app has compatible v1 SDK, CLI and plugins.
+1. The app has compatible SDK, CLI and plugins.
 2. The deployed server has a known base URL and working client authentication.
 3. A native Release build loads Hot Updater and uses the intended channel and
    compatibility target.

--- a/docs/content/docs/(latest)/get-started/meta.json
+++ b/docs/content/docs/(latest)/get-started/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Start here",
-  "description": "Set up v1 with an agent or manually, then verify an OTA update.",
+  "description": "Set up Hot Updater with an agent or manually, then verify an OTA update.",
   "icon": "Rocket",
   "pages": [
     "introduction",

--- a/docs/content/docs/(latest)/guides/ai-agents.mdx
+++ b/docs/content/docs/(latest)/guides/ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Set up with an agent"
-description: "Ask a coding agent to install v1, provision infrastructure, connect your app and verify an OTA update."
+description: "Ask a coding agent to install Hot Updater, provision infrastructure, connect your app and verify an OTA update."
 icon: Bot
 ---
 
@@ -20,7 +20,7 @@ from the app's project directory:
 npx skills@latest add hot-updater/skills
 ```
 
-The skill gives the agent the workflow. Setup requires a compatible v1 CLI and
+The skill gives the agent the workflow. Setup requires a compatible CLI and
 access to your provider account. The request below authorizes package installation;
 the agent verifies the CLI's version and commands before provisioning.
 
@@ -29,7 +29,7 @@ the agent verifies the CLI's version and commands before provisioning.
 Ask for the complete setup and test:
 
 ```text
-$hot-updater Install Hot Updater v1 and set up this app, including its infrastructure.
+$hot-updater Install Hot Updater and set up this app, including its infrastructure.
 Use HotUpdater.init with a custom flow; verify OTA and rollback in a native Release build on a test channel.
 ```
 
@@ -79,10 +79,10 @@ available setup work and identify the exact remaining device check.
 
 ## Upgrade existing infrastructure
 
-For an existing v1 server, ask:
+To update an existing server, ask:
 
 ```text
-$hot-updater Upgrade this project's existing server to the latest stable v1, preserving resources and verifying authenticated client access.
+$hot-updater Upgrade this project's existing server to the latest stable release, preserving resources and verifying authenticated client access.
 ```
 
 The agent follows

--- a/docs/content/docs/(latest)/guides/doctor.mdx
+++ b/docs/content/docs/(latest)/guides/doctor.mdx
@@ -185,7 +185,7 @@ To preview a proposed change to one Bundle's policy, use
 ## Update Package Versions
 
 If `doctor` reports version mismatches, update the CLI, SDK and required
-plugins to compatible stable v1 versions using
+plugins to compatible stable versions using
 [Install packages](/docs/get-started/installation). Keep the lockfile and rerun
 doctor after installation.
 

--- a/docs/content/docs/(latest)/guides/infrastructure-templates.mdx
+++ b/docs/content/docs/(latest)/guides/infrastructure-templates.mdx
@@ -10,7 +10,7 @@ icon: Server
 the CLI. Use it directly in your terminal or scripts, then fill and deploy the
 files with your provider tools.
 
-Use the v1 CLI. In a server-only directory, install `hot-updater` before
+In a server-only directory, install `hot-updater` before
 running these commands. For app onboarding, follow the
 [complete package installation](/docs/get-started/installation) first.
 

--- a/docs/content/docs/(latest)/guides/insights.mdx
+++ b/docs/content/docs/(latest)/guides/insights.mdx
@@ -93,7 +93,7 @@ in [Security](/docs/policy/security).
 
 ## Verify reporting
 
-1. Launch a native build configured with the v1 SDK, reachable client handler,
+1. Launch a native build configured with the SDK, reachable client handler,
    and valid client key. Copy its `getInstallId()` value.
 2. Open the Console's **Insights → All events** and find that installation.
    Confirm the report's app version, channel, and platform. An `UNCHANGED`

--- a/docs/content/docs/(latest)/managed/aws.mdx
+++ b/docs/content/docs/(latest)/managed/aws.mdx
@@ -69,7 +69,7 @@ AccessDenied: User: arn:aws:sts::***:assumed-role/***/*** is not authorized to p
 
 ## Step 1: Install Required Packages
 
-Complete [Install v1 packages](/docs/get-started/installation) in the React
+Complete [Install packages](/docs/get-started/installation) in the React
 Native project before running init or an agent scaffold. Install the CLI, React
 Native SDK, and the build plugin that matches your app, then install this provider:
 

--- a/docs/content/docs/(latest)/managed/cloudflare.mdx
+++ b/docs/content/docs/(latest)/managed/cloudflare.mdx
@@ -25,7 +25,7 @@ it can prepare missing resources through its available provider tools.
 
 ## Step 1: Install Required Packages
 
-Complete [Install v1 packages](/docs/get-started/installation) in the React
+Complete [Install packages](/docs/get-started/installation) in the React
 Native project before running init or an agent scaffold. Install the CLI, React
 Native SDK, and the build plugin that matches your app, then install this provider:
 

--- a/docs/content/docs/(latest)/managed/firebase.mdx
+++ b/docs/content/docs/(latest)/managed/firebase.mdx
@@ -26,7 +26,7 @@ it can prepare missing resources through its available provider tools.
 
 ## Step 1: Install Required Packages
 
-Complete [Install v1 packages](/docs/get-started/installation) in the React
+Complete [Install packages](/docs/get-started/installation) in the React
 Native project before running init or an agent scaffold. Install the CLI, React
 Native SDK, and the build plugin that matches your app, then install this provider:
 

--- a/docs/content/docs/(latest)/managed/supabase.mdx
+++ b/docs/content/docs/(latest)/managed/supabase.mdx
@@ -28,7 +28,7 @@ managed remote init flow does not require a local container runtime.
 
 ## Step 1: Install Required Packages
 
-Complete [Install v1 packages](/docs/get-started/installation) in the React
+Complete [Install packages](/docs/get-started/installation) in the React
 Native project before running init or an agent scaffold. Install the CLI, React
 Native SDK, and the build plugin that matches your app, then install this provider:
 

--- a/docs/content/docs/(latest)/meta.json
+++ b/docs/content/docs/(latest)/meta.json
@@ -1,9 +1,9 @@
 {
-  "title": "v1 (Latest)",
-  "description": "Hot Updater 1.x documentation",
+  "title": "Latest",
+  "description": "Current Hot Updater documentation",
   "icon": "Book",
   "root": true,
-  "pagesIndex": "[v1 (Latest)](/docs/get-started/introduction)",
+  "pagesIndex": "[Latest](/docs/get-started/introduction)",
   "pages": [
     "get-started",
     "---Hosting---",

--- a/docs/content/docs/(latest)/meta.json
+++ b/docs/content/docs/(latest)/meta.json
@@ -1,9 +1,9 @@
 {
-  "title": "Latest",
+  "title": "v1.0",
   "description": "Current Hot Updater documentation",
   "icon": "Book",
   "root": true,
-  "pagesIndex": "[Latest](/docs/get-started/introduction)",
+  "pagesIndex": "[v1.0](/docs/get-started/introduction)",
   "pages": [
     "get-started",
     "---Hosting---",

--- a/docs/content/docs/v0/meta.json
+++ b/docs/content/docs/v0/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "v0",
+  "title": "v0.36",
   "description": "Hot Updater 0.x documentation",
   "root": true,
   "pagesIndex": "get-started/introduction",

--- a/docs/plugins/llms-txt-plugin.ts
+++ b/docs/plugins/llms-txt-plugin.ts
@@ -38,7 +38,7 @@ export function llmsIndex(documentation: Documentation, baseUrl: string) {
     };
   }
   const lines = [
-    "# Hot Updater v1 Documentation",
+    "# Hot Updater Documentation",
     "",
     "> Set up, deliver, and operate React Native OTA updates on your infrastructure.",
     "",

--- a/docs/src/components/landing-hero.tsx
+++ b/docs/src/components/landing-hero.tsx
@@ -44,7 +44,7 @@ export function LandingHero() {
                     <span className="text-orange-500">2.</span> Your agent
                   </p>
                   <code className="block text-xs sm:text-sm font-mono text-fd-foreground break-words">
-                    $hot-updater Install v1, set up and test OTA.
+                    $hot-updater Set up this app and test OTA.
                   </code>
                 </div>
               </div>
@@ -88,7 +88,7 @@ export function LandingHero() {
               </div>
 
               {/* XTerm Terminal */}
-              <div className="p-2 sm:p-4 min-h-[250px] sm:min-h-[286px]">
+              <div className="p-2 sm:p-4 min-h-[300px] sm:min-h-[392px]">
                 <TerminalEmulator onReady={runDeployDemo} />
               </div>
             </div>

--- a/docs/src/components/terminal/clack-renderer.tsx
+++ b/docs/src/components/terminal/clack-renderer.tsx
@@ -46,33 +46,34 @@ export class ClackRenderer {
   }
 
   note(title: string, lines: string[]): void {
-    this.write(`${S_BAR}\n${S_STEP_SUBMIT} ${title}\n`);
-    for (const line of lines) this.write(`${S_BAR} ${line}\n`);
+    this.write(`${S_BAR}\n${S_STEP_SUBMIT}  ${title}\n`);
+    for (const line of lines) this.write(`${S_BAR}  ${line}\n`);
   }
 
   async task(text: string, completed: string, duration: number): Promise<void> {
     const frames = ["◒", "◐", "◓", "◑"] as const;
     const startTime = Date.now();
     let frameIndex = 0;
+    this.write(`${S_BAR}\n`);
     while (Date.now() - startTime < duration && !this.signal?.aborted) {
       const available = Math.max(1, this.terminal.cols - 3);
       const label =
         text.length > available ? `${text.slice(0, available - 1)}…` : text;
       const frame = frames[frameIndex++ % frames.length]!;
-      this.write(`\r\x1b[K${magenta(frame)} ${label}`);
+      this.write(`\r\x1b[K${magenta(frame)}  ${label}`);
       await this.pause(80);
     }
-    this.write(`\r\x1b[K${S_STEP_SUBMIT} ${completed}\n`);
+    this.write(`\r\x1b[K${S_STEP_SUBMIT}  ${completed}\n`);
   }
 
   outro(message: string): void {
-    this.write(`${S_BAR}\n${S_BAR_END} ${message}\n`);
+    this.write(`${S_BAR}\n${S_BAR_END}  ${message}\n`);
   }
 
   async finish(): Promise<void> {
     if (this.signal?.aborted) return;
     await new Promise<void>((resolve) => {
-      this.terminal.write("\x1b[0m$ ", () => {
+      this.terminal.write("\r\n\x1b[0m$ ", () => {
         this.terminal.scrollToBottom();
         resolve();
       });

--- a/docs/src/components/terminal/deploy-demo.tsx
+++ b/docs/src/components/terminal/deploy-demo.tsx
@@ -38,9 +38,9 @@ export async function runDeployDemo(
   clack.write("\n\n");
   await clack.pause(200);
   clack.note("Deployment", [
-    `Platform: ${cyan("iOS")}`,
-    `Channel: ${blue(DEMO_CONFIG.channel)}`,
-    `Rollout: ${green("100%")}`,
+    `Platform:           ${cyan("iOS")}`,
+    `Channel:            ${blue(DEMO_CONFIG.channel)}`,
+    `Rollout:            ${green("100%")}`,
     `Target app version: ${magenta(DEMO_CONFIG.appVersion)}`,
   ]);
 
@@ -60,7 +60,10 @@ export async function runDeployDemo(
     500,
   );
 
-  const id = `${gray("  ID:")}\n${yellow(DEMO_UPDATE_ID)}`;
+  const id =
+    terminal.cols >= 43
+      ? `   ${gray("ID:")} ${yellow(DEMO_UPDATE_ID)}`
+      : `   ${gray("ID:")}\n${yellow(DEMO_UPDATE_ID)}`;
   clack.outro(`${green("Deployment successful")}\n${id}`);
   await clack.finish();
 }

--- a/docs/src/components/terminal/terminal-emulator.tsx
+++ b/docs/src/components/terminal/terminal-emulator.tsx
@@ -37,7 +37,7 @@ export function TerminalEmulator({ config, onReady }: TerminalEmulatorProps) {
         Math.floor((container.clientWidth - 2) / cellWidth),
       );
       term.options.fontSize = fontSize;
-      term.resize(Math.min(config?.cols ?? cols, cols), config?.rows ?? 16);
+      term.resize(Math.min(config?.cols ?? cols, cols), config?.rows ?? 20);
       term.scrollToBottom();
     };
 
@@ -54,7 +54,8 @@ export function TerminalEmulator({ config, onReady }: TerminalEmulatorProps) {
         disableStdin: true,
         fontFamily: "Geist Mono, monospace",
         fontSize: 13,
-        rows: 16,
+        lineHeight: 1.2,
+        rows: 20,
         cols: 50,
         ...config,
         theme: { ...DEFAULT_THEME, ...config?.theme },


### PR DESCRIPTION
Restore readable spacing in the landing page deployment demo after the onboarding update compressed the output. Separate deployment phases, align metadata and the result ID, and keep the complete command and result visible on narrow screens.

Remove `v1` labels from general installation and agent workflows across the landing page, current documentation, and generated LLM documentation. Label the documentation version selector `v1.0` and `v0.36`. Keep version-specific wording for v0 migration guidance and preserve actual resource names, API paths, and protocol identifiers. Document this convention for future edits.

Validation:

- `pnpm -w build` — all 26 projects passed.
- `pnpm -w lint` — passed.
- `pnpm -w test` — 2,680 tests passed across 290 files after initializing the local Bun runtime.
- `pnpm --dir docs build` — passed after the version selector update.
- `pnpm --dir docs test:docs --testTimeout=30000` — 10 tests passed.
- `pnpm --dir docs test:type` — passed.
- Checked desktop, 320px, 390px, and tablet layouts, plus the rendered agent guide and generated Markdown.
- `pnpm changeset status --since=next` — no package version changes; the docs package is excluded from releases.

No breaking changes.

Desktop:

![Landing desktop](https://github.com/user-attachments/assets/06e36f2e-fea4-42b4-a0d1-302da3f693f4)

<details>
<summary>320px and 390px layouts</summary>

![Landing mobile](https://github.com/user-attachments/assets/42ddc7c4-7bc3-47ad-8bac-fb8bb472fd73)

</details>

