### PR TITLE
fix(console): distinguish downloaded events from no change

### DIFF
--- a/.changeset/tender-boxes-cry.md
+++ b/.changeset/tender-boxes-cry.md
@@ -1,0 +1,5 @@
+---
+"@hot-updater/console": patch
+---
+
+Distinguish downloaded update events from no-change events with the primary badge style.

--- a/packages/console/src/components/features/insights/EventDetails.tsx
+++ b/packages/console/src/components/features/insights/EventDetails.tsx
@@ -18,7 +18,7 @@ const eventTypes = {
     label: "Downloaded",
     description:
       "Download complete. Waiting for the app to restart and apply it.",
-    variant: "secondary",
+    variant: "default",
     icon: Download,
   },
   UPDATE_APPLIED: {


### PR DESCRIPTION
Downloaded events use the same neutral badge as No change, making completed downloads easy to miss while scanning Insights. Use the existing primary badge for Downloaded in both the all-events list and installation history; the download icon and explanatory text remain available alongside the color cue.

Adds a patch changeset for `@hot-updater/console`. No API, event storage, or migration changes.

Validation:
- `pnpm -w lint`
- `pnpm -w test` — 291 files, 2,732 tests passed
- `pnpm --filter @hot-updater/console test:type`
- Checked the running Console with demo events in light and dark themes.

Screenshots from the Console demo data:

| Light | Dark |
| --- | --- |
| ![Light theme](https://github.com/user-attachments/assets/a01e1e57-c410-4859-9630-58e9844c0304) | ![Dark theme](https://github.com/user-attachments/assets/099e5be3-0d59-47f0-91d3-c358b4b6183f) |
