### PR TITLE
fix(cli): read default iOS target app version from project.pbxproj

### DIFF
--- a/.changeset/ios-default-target-app-version-xcodeproj.md
+++ b/.changeset/ios-default-target-app-version-xcodeproj.md
@@ -1,0 +1,5 @@
+---
+"hot-updater": patch
+---
+
+Read the default iOS target app version from `project.pbxproj` when `Info.plist` holds an unresolved build setting. The React Native template ships `CFBundleShortVersionString` as `$(MARKETING_VERSION)`, which the plist parser cannot resolve, so `getDefaultTargetAppVersion` returned `null` for most iOS projects: `deploy -i` prefilled the "Target app version" prompt with `1.0.0` instead of the real version, and non-interactive `deploy` without `-t` failed outright. `getNativeAppVersion` already falls back to the same parser; this aligns the two.

--- a/packages/hot-updater/src/utils/version/getDefaultTargetAppVersion.spec.ts
+++ b/packages/hot-updater/src/utils/version/getDefaultTargetAppVersion.spec.ts
@@ -1,0 +1,119 @@
+import fs from "fs/promises";
+import path from "path";
+
+import { XcodeProject } from "@bacons/xcode";
+import { getCwd } from "@hot-updater/cli-tools";
+import fg from "fast-glob";
+import plist from "plist";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { getDefaultTargetAppVersion } from "./getDefaultTargetAppVersion";
+
+vi.mock("fs/promises", async () => {
+  const actual =
+    await vi.importActual<typeof import("fs/promises")>("fs/promises");
+  return {
+    ...actual,
+    default: { ...actual, access: vi.fn(), readFile: vi.fn() },
+    access: vi.fn(),
+    readFile: vi.fn(),
+  };
+});
+
+vi.mock("path", async () => {
+  const actual = await vi.importActual<typeof import("path")>("path");
+  return {
+    ...actual,
+    default: { ...actual, join: vi.fn() },
+    join: vi.fn(),
+  };
+});
+
+vi.mock("@bacons/xcode");
+vi.mock("@hot-updater/cli-tools", () => ({ getCwd: vi.fn() }));
+vi.mock("fast-glob", () => ({ default: { globSync: vi.fn() } }));
+vi.mock("find-up-simple");
+vi.mock("plist");
+
+describe("getDefaultTargetAppVersion", () => {
+  const mockGetCwd = getCwd as Mock;
+  const mockGlobbySync = fg.globSync as Mock;
+  const mockXcodeProjectOpen = XcodeProject.open as Mock;
+  const mockPathJoin = path.join as Mock;
+  const mockFsReadFile = fs.readFile as Mock;
+  const mockFsAccess = fs.access as Mock;
+  const mockPlistParse = plist.parse as Mock;
+
+  const plistPath = "/mock/project/root/ios/HotUpdaterExample/Info.plist";
+  const xcodeprojPath = "HotUpdaterExample.xcodeproj/project.pbxproj";
+
+  const mockFileExist = (paths: string[]) => {
+    mockFsAccess.mockImplementation(async (target: string) => {
+      if (paths.includes(target)) return;
+      throw new Error();
+    });
+  };
+
+  const mockMarketingVersion = (marketingVersion: string) => {
+    mockXcodeProjectOpen.mockReturnValue({
+      toJSON: () => ({
+        objects: {
+          "13B07F941A680F5B00A75B9A": {
+            isa: "XCBuildConfiguration",
+            name: "Release",
+            buildSettings: { MARKETING_VERSION: marketingVersion },
+          },
+        },
+      }),
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFsAccess.mockReset();
+
+    mockGetCwd.mockReturnValue("/mock/project/root");
+    mockPathJoin.mockImplementation((...args) => args.join("/"));
+    mockGlobbySync.mockReturnValue([xcodeprojPath]);
+  });
+
+  it("falls back to xcodeproj when Info.plist holds an unresolved $(MARKETING_VERSION)", async () => {
+    mockFileExist([plistPath]);
+    mockFsReadFile.mockResolvedValue(Buffer.from("mock plist"));
+    mockPlistParse.mockReturnValue({
+      CFBundleShortVersionString: "$(MARKETING_VERSION)",
+    });
+    mockMarketingVersion("2.15.0");
+
+    expect(await getDefaultTargetAppVersion("ios")).toBe("2.15.0");
+    expect(mockXcodeProjectOpen).toHaveBeenCalledWith(xcodeprojPath);
+  });
+
+  it("appends .x to a two-segment version read from xcodeproj", async () => {
+    mockFileExist([plistPath]);
+    mockFsReadFile.mockResolvedValue(Buffer.from("mock plist"));
+    mockPlistParse.mockReturnValue({
+      CFBundleShortVersionString: "$(MARKETING_VERSION)",
+    });
+    mockMarketingVersion("2.15");
+
+    expect(await getDefaultTargetAppVersion("ios")).toBe("2.15.x");
+  });
+
+  it("prefers Info.plist and never parses project.pbxproj when it resolves", async () => {
+    mockFileExist([plistPath]);
+    mockFsReadFile.mockResolvedValue(Buffer.from("mock plist"));
+    mockPlistParse.mockReturnValue({ CFBundleShortVersionString: "2.15.0" });
+    mockMarketingVersion("1.0.0");
+
+    expect(await getDefaultTargetAppVersion("ios")).toBe("2.15.0");
+    expect(mockXcodeProjectOpen).not.toHaveBeenCalled();
+  });
+
+  it("returns null when neither source resolves a version", async () => {
+    mockFileExist([]);
+    mockGlobbySync.mockReturnValue([]);
+
+    expect(await getDefaultTargetAppVersion("ios")).toBe(null);
+  });
+});

--- a/packages/hot-updater/src/utils/version/getDefaultTargetAppVersion.ts
+++ b/packages/hot-updater/src/utils/version/getDefaultTargetAppVersion.ts
@@ -1,8 +1,8 @@
 import type { Platform } from "@hot-updater/plugin-core";
 import { normalizeRange } from "verkit";
 
-import { getAndroidVersion } from "@/utils/version/getAndroidVersion";
-import { getIOSVersion } from "@/utils/version/getIOSVersion";
+import { getAndroidVersion } from "./getAndroidVersion";
+import { getIOSVersion } from "./getIOSVersion";
 
 export const getDefaultTargetAppVersion = async (
   platform: Platform,
@@ -11,7 +11,12 @@ export const getDefaultTargetAppVersion = async (
 
   switch (platform) {
     case "ios":
-      version = await getIOSVersion({ parser: "info-plist" });
+      // Mirror getNativeAppVersion: Info.plist first, project.pbxproj as a
+      // fallback. The React Native template ships Info.plist with
+      // CFBundleShortVersionString set to "$(MARKETING_VERSION)", which the
+      // plist parser cannot resolve, so the real version only lives in
+      // project.pbxproj for most projects.
+      version = await getIOSVersion({ parser: ["info-plist", "xcodeproj"] });
       break;
     case "android":
       version = await getAndroidVersion({ parser: "app-build-gradle" });


### PR DESCRIPTION
`getDefaultTargetAppVersion` reads the iOS version from `Info.plist` only:

```ts
case "ios":
  version = await getIOSVersion({ parser: "info-plist" });
```

The React Native template ships `Info.plist` with

```xml
<key>CFBundleShortVersionString</key>
<string>$(MARKETING_VERSION)</string>
```

`getIOSVersionFromInfoPlist` rejects any value containing `$(` — correctly, since it cannot resolve Xcode build settings — so it returns `null`, and `getDefaultTargetAppVersion` returns `null` with it. The actual version only lives in `project.pbxproj` as `MARKETING_VERSION`, which `getIOSVersionFromXcodeProject` already knows how to read.

Two visible consequences in `deploy`, for any iOS project left on the template's `Info.plist`:

- `deploy -i` prefills the "Target app version" prompt with the hardcoded `1.0.0` fallback instead of the project's version, so anyone who accepts the default publishes the bundle against the wrong app version.
- `deploy` without `-t` and without `-i` has no value to fall back to and exits with "Target app version not found in native files".

`getNativeAppVersion` already handles this exact case:

```ts
// Info.plist first, project.pbxproj as a fallback.
return getIOSVersion({ parser: ["info-plist", "xcodeproj"] });
```

This PR gives `getDefaultTargetAppVersion` the same parser chain. The ordering and its rationale are preserved — `Info.plist` still wins when it resolves, and `project.pbxproj` is only opened when it does not, so the synchronous pbxproj parse stays off the common path.

Android is untouched: `build.gradle` stores `versionName` literally, so it never had this problem.

### Test plan

`packages/hot-updater/src/utils/version/getDefaultTargetAppVersion.spec.ts` (new), covering:

- `$(MARKETING_VERSION)` in `Info.plist` → falls back to `MARKETING_VERSION` from `project.pbxproj`
- the same path with a two-segment version → `2.15` normalizes to `2.15.x`
- a resolvable `Info.plist` → wins, and `XcodeProject.open` is never called
- neither source resolving → `null`

### Note on the import change

`getDefaultTargetAppVersion.ts` imported its two siblings through the `@/` alias. Vitest's project configs do not pick up the root `resolve.tsconfigPaths`, so importing this module from a spec fails to resolve, and the module could not be unit tested at all. The two imports now point at the same files relatively, matching `getNativeAppVersion.ts` next to it. Happy to drop this and fix the alias in `vitest.workspace.mts` instead if you would rather keep the alias.
