### PR TITLE
fix(ci): pull MinIO from Quay after Docker Hub removal

### DIFF
--- a/examples-server/hono-s3/docker-compose.yml
+++ b/examples-server/hono-s3/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: "hono-s3-minio-${PORT:-3007}"
     restart: unless-stopped
     command: server /data --console-address ":9001"

--- a/examples-server/hono-s3/src/minio-contract.spec.ts
+++ b/examples-server/hono-s3/src/minio-contract.spec.ts
@@ -20,7 +20,10 @@ describe("standalone-s3 local S3 contract", () => {
     // When: the local S3 service contract is inspected.
     // Then: the contract is MinIO, not LocalStack or an external R2/S3 provider.
     expect(dockerCompose).toContain("minio:");
-    expect(dockerCompose).toContain("minio/minio:");
+    expect(dockerCompose).toContain(
+      "image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z",
+    );
+    expect(dockerCompose).not.toMatch(/image:\s+minio\/minio/);
     expect(dockerCompose).toContain("MINIO_ROOT_USER");
     expect(dockerCompose).not.toContain("localstack");
     expect(dockerCompose).not.toContain("4566:4566");


### PR DESCRIPTION
## Why CI failed

This is not a Docker Hub rate-limit flake.

On 23 Oct 2025 MinIO stopped publishing the community container image (source-only distribution). The Hub listing for `minio/minio` is gone (404). Unauthenticated `docker pull minio/minio:latest` now fails with:

```
pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

That is the same error Integration hit in `examples-server/hono-s3` (`docker compose up` in `handler.integration.spec.ts`). Rate-limit errors look like `toomanyrequests` / HTTP 429. This is Hub returning "repository does not exist".

The last public official image is still on Quay as `RELEASE.2025-09-07T16-13-09Z` (the final community release before the cutoff). This PR pins that image so GitHub Actions can pull without login.

## Change

- `examples-server/hono-s3/docker-compose.yml`: `minio/minio:latest` → `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z`
- Same command, ports, and `minioadmin` credentials, so the S3 fixture stays drop-in
- Contract test now asserts the Quay image and rejects the Docker Hub `image: minio/minio` form

## Test plan

- [x] `vitest` `minio-contract.spec.ts`
- [x] `docker compose pull` of the pinned Quay tag
- [x] `docker compose up` — MinIO `/minio/health/live` 200