### PR TITLE
fix(ci): pull MinIO from Quay after Docker Hub removal

### DIFF
--- a/examples-server/hono-dynamodb/docker-compose.yml
+++ b/examples-server/hono-dynamodb/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "${DYNAMODB_PORT:-8000}:8000"
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
       - "${MINIO_API_PORT:-9000}:9000"

--- a/examples-server/hono-dynamodb/src/infrastructure-contract.spec.ts
+++ b/examples-server/hono-dynamodb/src/infrastructure-contract.spec.ts
@@ -17,7 +17,10 @@ describe("standalone-dynamodb local infrastructure contract", () => {
     const dockerCompose = await readProjectFile("docker-compose.yml");
 
     expect(dockerCompose).toContain("amazon/dynamodb-local:");
-    expect(dockerCompose).toContain("minio/minio:");
+    expect(dockerCompose).toContain(
+      "image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z",
+    );
+    expect(dockerCompose).not.toMatch(/image:\s+minio\/minio/);
     expect(dockerCompose).not.toContain("localstack");
     expect(dockerCompose).not.toContain("amazonaws.com");
   });


### PR DESCRIPTION
Backport of the MinIO CI image fix to `next`.

## Why CI failed

This is not a Docker Hub rate-limit flake.

On 23 Oct 2025 MinIO stopped publishing the community container image (source-only distribution). The Hub listing for `minio/minio` is gone (404). Unauthenticated `docker pull minio/minio:latest` now fails with:

```
pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

Rate-limit errors look like `toomanyrequests` / HTTP 429. This is Hub returning "repository does not exist".

On `next` the Integration MinIO fixture lives in `examples-server/hono-dynamodb` (main's equivalent is `hono-s3`). Same Hub image, same failure mode.

The last public official image is still on Quay as `RELEASE.2025-09-07T16-13-09Z` (the final community release before the cutoff). This PR pins that image so GitHub Actions can pull without login.

## Change

- `examples-server/hono-dynamodb/docker-compose.yml`: `minio/minio:latest` → `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z`
- Same command, ports, and `minioadmin` credentials, so the S3 fixture stays drop-in
- Infrastructure contract test now asserts the Quay image and rejects the Docker Hub `image: minio/minio` form

## Test plan

- [x] `vitest` `infrastructure-contract.spec.ts`
- [x] `docker compose pull minio` of the pinned Quay tag